### PR TITLE
feat: change chain default key to node_idx_parallel_idx style

### DIFF
--- a/compose/chain_test.go
+++ b/compose/chain_test.go
@@ -116,7 +116,11 @@ func TestChainWithException(t *testing.T) {
 			// just pass through
 			t.Log("in view lambda: ", kvs)
 			return kvs, nil
-		}))
+		})).
+		AppendLambda(InvokableLambda(func(ctx context.Context, kvs map[string]any) (map[string]any, error) {
+			t.Log("in view lambda 02: ", kvs)
+			return kvs, nil
+		}), WithNodeKey("xlam"))
 
 	// items with parallels
 	parallel := NewParallel()

--- a/compose/graph_test.go
+++ b/compose/graph_test.go
@@ -423,7 +423,7 @@ func TestValidate(t *testing.T) {
 	p = NewParallel().AddLambda("1", lA).AddLambda("2", lAB)
 	c = NewChain[string, map[string]any]().AppendParallel(p)
 	_, err = c.Compile(context.Background())
-	assert.ErrorContains(t, err, "add parallel edge[start]-[Chain[0]_Parallel[0]_Lambda] to chain failed: graph edge[start]-[Chain[0]_Parallel[0]_Lambda]: start node's output type[string] and end node's input type[compose.A] mismatch")
+	assert.ErrorContains(t, err, "add parallel edge failed, from=start, to=node_0_parallel_0, err: graph edge[start]-[node_0_parallel_0]: start node's output type[string] and end node's input type[compose.A] mismatch")
 
 	// test graph output type check
 	gg := NewGraph[string, A]()


### PR DESCRIPTION
#### What type of PR is this?
feat: A new feature

#### Check the PR title.
- [x] This PR title match the format: \<type\>(optional scope): \<description\>
- [x] The description of this PR title is user-oriented and clear enough for others to understand.
- [ ] Attach the PR updating the user documentation if the current PR requires user awareness at the usage level. [User docs repo](https://github.com/cloudwego/cloudwego.github.io)

#### (Optional) Translate the PR title into Chinese.
change chain default key to "node_idx_parallel_idx" style, for example:
chain key is: node_idx => eg: node_0 => represent the first node of the chain (idx start from 0)
if has parallel: node_idx_parallel_idx => eg: node_0_parallel_1 => represent the first node of the chain, and is a parallel node, and the second node of the parallel
if has branch: node_idx_branch_key => eg: node_1_branch_customkey => represent the second node of the chain, and is a branch node, and the 'customkey' is the key of the branch

#### (Optional) More detailed description for this PR(en: English/zh: Chinese).
![image](https://github.com/user-attachments/assets/ba33c5b1-efcf-4de1-b84c-50af5a206262)

