### PR TITLE
chore: remove deprecated LoaderSplitter

### DIFF
--- a/components/document/interface.go
+++ b/components/document/interface.go
@@ -31,12 +31,6 @@ type Source struct {
 
 //go:generate  mockgen -destination ../../internal/mock/components/document/document_mock.go --package document -source interface.go
 
-// LoaderSplitter is a document loader and splitter.
-// Deprecated: use Loader instead.
-type LoaderSplitter interface {
-	LoadAndSplit(ctx context.Context, src Source, opts ...LoaderSplitterOption) ([]*schema.Document, error)
-}
-
 // Loader is a document loader.
 type Loader interface {
 	Load(ctx context.Context, src Source, opts ...LoaderOption) ([]*schema.Document, error)

--- a/components/document/option.go
+++ b/components/document/option.go
@@ -16,44 +16,11 @@
 
 package document
 
-// LoaderSplitterOption defines call option for LoaderSplitter component, which is part of the component interface signature.
-// Each LoaderSplitter implementation could define its own options struct and option funcs within its own package,
-// then wrap the impl specific option funcs into this type, before passing to LoadAndSplit.
-// Deprecated: use LoaderOption instead.
-type LoaderSplitterOption struct {
-	implSpecificOptFn any
-}
-
 // LoaderOption defines call option for Loader component, which is part of the component interface signature.
 // Each Loader implementation could define its own options struct and option funcs within its own package,
 // then wrap the impl specific option funcs into this type, before passing to Load.
 type LoaderOption struct {
 	implSpecificOptFn any
-}
-
-// WrapImplSpecificOptFn wraps the impl specific option functions into LoaderSplitterOption type.
-// T: the type of the impl specific options struct.
-// LoaderSplitter implementations are required to use this function to convert its own option functions into the unified LoaderSplitterOption type.
-// For example, if the LoaderSplitter impl defines its own options struct:
-//
-//	type customOptions struct {
-//	    conf string
-//	}
-//
-// Then the impl needs to provide an option function as such:
-//
-//	func WithConf(conf string) Option {
-//	    return WrapImplSpecificOptFn(func(o *customOptions) {
-//			o.conf = conf
-//		}
-//	}
-//
-// .
-// Deprecated: use WrapLoaderImplSpecificOptFn instead.
-func WrapImplSpecificOptFn[T any](optFn func(*T)) LoaderSplitterOption {
-	return LoaderSplitterOption{
-		implSpecificOptFn: optFn,
-	}
 }
 
 // WrapLoaderImplSpecificOptFn wraps the impl specific option functions into LoaderOption type.
@@ -76,29 +43,6 @@ func WrapLoaderImplSpecificOptFn[T any](optFn func(*T)) LoaderOption {
 	return LoaderOption{
 		implSpecificOptFn: optFn,
 	}
-}
-
-// GetImplSpecificOptions provides LoaderSplitter author the ability to extract their own custom options from the unified LoaderSplitterOption type.
-// T: the type of the impl specific options struct.
-// This function should be used within the LoaderSplitter implementation's LoadAndSplit function.
-// It is recommended to provide a base T as the first argument, within which the LoaderSplitter author can provide default values for the impl specific options.
-// Deprecated: use GetLoaderImplSpecificOptions instead.
-func GetImplSpecificOptions[T any](base *T, opts ...LoaderSplitterOption) *T {
-	if base == nil {
-		base = new(T)
-	}
-
-	for i := range opts {
-		opt := opts[i]
-		if opt.implSpecificOptFn != nil {
-			s, ok := opt.implSpecificOptFn.(func(*T))
-			if ok {
-				s(base)
-			}
-		}
-	}
-
-	return base
 }
 
 // GetLoaderImplSpecificOptions provides Loader author the ability to extract their own custom options from the unified LoaderOption type.

--- a/components/types.go
+++ b/components/types.go
@@ -51,13 +51,12 @@ func IsCallbacksEnabled(i any) bool {
 type Component string
 
 const (
-	ComponentOfPrompt         Component = "ChatTemplate"
-	ComponentOfChatModel      Component = "ChatModel"
-	ComponentOfEmbedding      Component = "Embedding"
-	ComponentOfIndexer        Component = "Indexer"
-	ComponentOfRetriever      Component = "Retriever"
-	ComponentOfLoaderSplitter Component = "LoaderSplitter"
-	ComponentOfLoader         Component = "Loader"
-	ComponentOfTransformer    Component = "DocumentTransformer"
-	ComponentOfTool           Component = "Tool"
+	ComponentOfPrompt      Component = "ChatTemplate"
+	ComponentOfChatModel   Component = "ChatModel"
+	ComponentOfEmbedding   Component = "Embedding"
+	ComponentOfIndexer     Component = "Indexer"
+	ComponentOfRetriever   Component = "Retriever"
+	ComponentOfLoader      Component = "Loader"
+	ComponentOfTransformer Component = "DocumentTransformer"
+	ComponentOfTool        Component = "Tool"
 )

--- a/compose/chain.go
+++ b/compose/chain.go
@@ -259,14 +259,6 @@ func (c *Chain[I, O]) AppendRetriever(node retriever.Retriever, opts ...GraphAdd
 	return c
 }
 
-// AppendLoaderSplitter add a LoaderSplitter node to the chain.
-// Deprecated: use AppendLoader instead.
-func (c *Chain[I, O]) AppendLoaderSplitter(node document.LoaderSplitter, opts ...GraphAddNodeOpt) *Chain[I, O] {
-	gNode, options := toLoaderSplitterNode(node, opts...)
-	c.addNode(gNode, options)
-	return c
-}
-
 // AppendLoader adds a Loader node to the chain.
 // e.g.
 //

--- a/compose/chain_branch.go
+++ b/compose/chain_branch.go
@@ -180,13 +180,6 @@ func (cb *ChainBranch) AddRetriever(key string, node retriever.Retriever, opts .
 	return cb.addNode(key, gNode, options)
 }
 
-// AddLoaderSplitter adds a LoaderSplitter node to the branch.
-// Deprecated: use AddLoader instead.
-func (cb *ChainBranch) AddLoaderSplitter(key string, node document.LoaderSplitter, opts ...GraphAddNodeOpt) *ChainBranch {
-	gNode, options := toLoaderSplitterNode(node, opts...)
-	return cb.addNode(key, gNode, options)
-}
-
 // AddLoader adds a Loader node to the branch.
 // eg.
 //

--- a/compose/chain_parallel.go
+++ b/compose/chain_parallel.go
@@ -134,13 +134,6 @@ func (p *Parallel) AddRetriever(outputKey string, node retriever.Retriever, opts
 	return p.addNode(outputKey, gNode, options)
 }
 
-// AddLoaderSplitter adds a loader splitter node to the parallel.
-// Deprecated: use AddLoader instead.
-func (p *Parallel) AddLoaderSplitter(outputKey string, node document.LoaderSplitter, opts ...GraphAddNodeOpt) *Parallel {
-	gNode, options := toLoaderSplitterNode(node, append(opts, WithOutputKey(outputKey))...)
-	return p.addNode(outputKey, gNode, options)
-}
-
 // AddLoader adds a loader node to the parallel.
 // eg.
 //

--- a/compose/component_to_graph_node.go
+++ b/compose/component_to_graph_node.go
@@ -68,17 +68,6 @@ func toRetrieverNode(node retriever.Retriever, opts ...GraphAddNodeOpt) (*graphN
 		opts...)
 }
 
-func toLoaderSplitterNode(node document.LoaderSplitter, opts ...GraphAddNodeOpt) (*graphNode, *graphAddNodeOpts) {
-	return toComponentNode(
-		node,
-		components.ComponentOfLoaderSplitter,
-		node.LoadAndSplit,
-		nil,
-		nil,
-		nil,
-		opts...)
-}
-
 func toLoaderNode(node document.Loader, opts ...GraphAddNodeOpt) (*graphNode, *graphAddNodeOpts) {
 	return toComponentNode(
 		node,

--- a/compose/graph.go
+++ b/compose/graph.go
@@ -354,12 +354,6 @@ func (g *graph) AddRetrieverNode(key string, node retriever.Retriever, opts ...G
 	return g.addNode(key, gNode, options)
 }
 
-// Deprecated: use AddLoaderNode instead.
-func (g *graph) AddLoaderSplitterNode(key string, node document.LoaderSplitter, opts ...GraphAddNodeOpt) error {
-	gNode, options := toLoaderSplitterNode(node, opts...)
-	return g.addNode(key, gNode, options)
-}
-
 // AddLoaderNode adds a node that implements document.Loader.
 // e.g.
 //

--- a/compose/graph_call_options.go
+++ b/compose/graph_call_options.go
@@ -98,11 +98,6 @@ func WithRetrieverOption(opts ...retriever.Option) Option {
 	return withComponentOption(opts...)
 }
 
-// Deprecated: use WithLoaderOption instead.
-func WithLoaderSplitterOption(opts ...document.LoaderSplitterOption) Option {
-	return withComponentOption(opts...)
-}
-
 // WithLoaderOption is a functional option type for loader component.
 // e.g.
 //

--- a/internal/mock/components/document/document_mock.go
+++ b/internal/mock/components/document/document_mock.go
@@ -29,49 +29,6 @@ import (
 	gomock "go.uber.org/mock/gomock"
 )
 
-// MockLoaderSplitter is a mock of LoaderSplitter interface.
-type MockLoaderSplitter struct {
-	ctrl     *gomock.Controller
-	recorder *MockLoaderSplitterMockRecorder
-}
-
-// MockLoaderSplitterMockRecorder is the mock recorder for MockLoaderSplitter.
-type MockLoaderSplitterMockRecorder struct {
-	mock *MockLoaderSplitter
-}
-
-// NewMockLoaderSplitter creates a new mock instance.
-func NewMockLoaderSplitter(ctrl *gomock.Controller) *MockLoaderSplitter {
-	mock := &MockLoaderSplitter{ctrl: ctrl}
-	mock.recorder = &MockLoaderSplitterMockRecorder{mock}
-	return mock
-}
-
-// EXPECT returns an object that allows the caller to indicate expected use.
-func (m *MockLoaderSplitter) EXPECT() *MockLoaderSplitterMockRecorder {
-	return m.recorder
-}
-
-// LoadAndSplit mocks base method.
-func (m *MockLoaderSplitter) LoadAndSplit(ctx context.Context, src document.Source, opts ...document.LoaderSplitterOption) ([]*schema.Document, error) {
-	m.ctrl.T.Helper()
-	varargs := []interface{}{ctx, src}
-	for _, a := range opts {
-		varargs = append(varargs, a)
-	}
-	ret := m.ctrl.Call(m, "LoadAndSplit", varargs...)
-	ret0, _ := ret[0].([]*schema.Document)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// LoadAndSplit indicates an expected call of LoadAndSplit.
-func (mr *MockLoaderSplitterMockRecorder) LoadAndSplit(ctx, src interface{}, opts ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	varargs := append([]interface{}{ctx, src}, opts...)
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "LoadAndSplit", reflect.TypeOf((*MockLoaderSplitter)(nil).LoadAndSplit), varargs...)
-}
-
 // MockLoader is a mock of Loader interface.
 type MockLoader struct {
 	ctrl     *gomock.Controller

--- a/utils/callbacks/template_test.go
+++ b/utils/callbacks/template_test.go
@@ -145,7 +145,6 @@ func TestNewComponentTemplate(t *testing.T) {
 
 		types := []components.Component{
 			components.ComponentOfPrompt,
-			components.ComponentOfLoaderSplitter,
 			components.ComponentOfChatModel,
 			components.ComponentOfEmbedding,
 			components.ComponentOfRetriever,


### PR DESCRIPTION
#### What type of PR is this?
<!--
Add one of the following kinds:

build: Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)
ci: Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
docs: Documentation only changes
feat: A new feature
optimize: A new optimization
fix: A bug fix
perf: A code change that improves performance
refactor: A code change that neither fixes a bug nor adds a feature
style: Changes that do not affect the meaning of the code (white space, formatting, missing semi-colons, etc)
test: Adding missing tests or correcting existing tests
chore: Changes to the build process or auxiliary tools and libraries such as documentation generation
-->

#### Check the PR title.
<!--
The description of the title will be attached in Release Notes, 
so please describe it from user-oriented, what this PR does / why we need it.
Please check your PR title with the below requirements:
-->
- [ ] This PR title match the format: \<type\>(optional scope): \<description\>
- [ ] The description of this PR title is user-oriented and clear enough for others to understand.
- [ ] Attach the PR updating the user documentation if the current PR requires user awareness at the usage level. [User docs repo](https://github.com/cloudwego/cloudwego.github.io)


#### (Optional) Translate the PR title into Chinese.


#### (Optional) More detailed description for this PR(en: English/zh: Chinese).
<!--
Provide more detailed info for review(e.g., it's recommended to provide perf data if this is a perf type PR).
-->
en:
zh(optional): 


#### (Optional) Which issue(s) this PR fixes:
<!--
Automatically closes linked issue when PR is merged.
Eg: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

#### (optional) The PR that updates user documentation:
<!--
If the current PR requires user awareness at the usage level, please submit a PR to update user docs. [User docs repo](https://github.com/cloudwego/cloudwego.github.io)
-->
