### PR TITLE
feat: react agent and host multi-agent can be composed directly as AnyGraph

### DIFF
--- a/.github/workflows/pr-check.yml
+++ b/.github/workflows/pr-check.yml
@@ -18,6 +18,10 @@ jobs:
 
   golangci-lint:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+      repository-projects: write
     steps:
       - uses: actions/checkout@v4
       - name: Set up Go

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -13,6 +13,10 @@ jobs:
   unit-test:
     name: eino-unit-test
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+      repository-projects: write
     env:
       COVERAGE_FILE: coverage.out
       BREAKDOWN_FILE: main.breakdown
@@ -100,6 +104,10 @@ jobs:
         run: echo "coverage check failed" && exit 1
   benchmark-test:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+      repository-projects: write
     steps:
       - uses: actions/checkout@v4
       - name: Set up Go
@@ -115,6 +123,10 @@ jobs:
       matrix:
         go: [ "1.19", "1.20", "1.21", "1.22" ]
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+      repository-projects: write
     steps:
       - uses: actions/checkout@v4
       - name: Set up Go
@@ -131,6 +143,10 @@ jobs:
   api-compatibility:
     name: api-compatibility-check
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+      repository-projects: write
     if: github.event_name == 'pull_request'
     
     steps:

--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -1,7 +1,8 @@
 # output configuration options
 output:
   # Format: colored-line-number|line-number|json|tab|checkstyle|code-climate|junit-xml|github-actions
-  formats: colored-line-number
+  formats:
+    - format: colored-line-number
 # All available settings of specific linters.
 # Refer to https://golangci-lint.run/usage/linters
 linters-settings:
@@ -31,4 +32,4 @@ issues:
   exclude-use-default: true
   exclude-files:
     - ".*\\.mock\\.go$"
-  exclude-dirs:
+  # exclude-dirs:


### PR DESCRIPTION
#### What type of PR is this?
feat

#### (Optional) Translate the PR title into Chinese.
react agent 和 host multi-agent 支持导出为 AnyGraph，可直接进入编排。

#### description:

refactor agents to support graph composition

- Implement GraphFlow interface for react.Agent and host.MultiAgent
- Add support for proper node path designation in subgraphs
- Maintain backward compatibility for direct usage