### PR TITLE
fix: support any item type when merging streams

### DIFF
--- a/compose/utils.go
+++ b/compose/utils.go
@@ -60,11 +60,6 @@ func mergeValues(vs []any) (any, error) {
 	}
 
 	if s, ok := vs[0].(streamReader); ok {
-		if s.getChunkType().Kind() != reflect.Map {
-			return nil, fmt.Errorf("(mergeValues | stream type)"+
-				" unsupported chunk type: %v", s.getChunkType())
-		}
-
 		ss := make([]streamReader, len(vs)-1)
 		for i := 0; i < len(ss); i++ {
 			s_, ok_ := vs[i+1].(streamReader)


### PR DESCRIPTION
#### What type of PR is this?

fix.

#### Check the PR title.

- [x] This PR title match the format: \<type\>(optional scope): \<description\>
- [x] The description of this PR title is user-oriented and clear enough for others to understand.
- [x] Attach the PR updating the user documentation if the current PR requires user awareness at the usage level. [User docs repo](https://github.com/cloudwego/cloudwego.github.io)

#### (Optional) Translate the PR title into Chinese.

fix: 在流式场景下合并时支持任意元素类型


#### (Optional) More detailed description for this PR(en: English/zh: Chinese).

en:

The old code didn't respect the documentation:

> - 在非流式场景下，上游输出的实际类型必须为 Map，且相互间 key 不可重复。合并后成为一个 Map，包含所有上游的所有键值对。
> - 在流式场景下，将类型相同的多个上游 StreamReader 合并为一个 StreamReader。实际 Recv 时效果为随机选取。

See https://www.cloudwego.io/zh/docs/eino/core_modules/chain_and_graph_orchestration/orchestration_design_principles/#%E6%89%87%E5%85%A5%E4%B8%8E%E5%90%88%E5%B9%B6

(I can't find the English version of the documentation, so I have to paste the Chinese sentences in this section.)

It doesn't say there's a limitation that the item type in the StreamReader must be a map.

And I believe the limitation is unnecessary as long as the stream readers have the same item type, since it works like "appending the items into a longer array" instead of "combining the items into fewer items" when merging streams.

Please note that the changes don't affect merging non-streams, which still require map types.

zh(optional): 

旧的代码实现并没有遵循文档：

> - 在非流式场景下，上游输出的实际类型必须为 Map，且相互间 key 不可重复。合并后成为一个 Map，包含所有上游的所有键值对。
> - 在流式场景下，将类型相同的多个上游 StreamReader 合并为一个 StreamReader。实际 Recv 时效果为随机选取。

See https://www.cloudwego.io/zh/docs/eino/core_modules/chain_and_graph_orchestration/orchestration_design_principles/#%E6%89%87%E5%85%A5%E4%B8%8E%E5%90%88%E5%B9%B6

这里并没有说，在流式场景下也要求上游的 StreamReader 的元素类型必须为 Map.

我认为这个限制是没必要的，只要多个上游 StreamReader 的元素类型相同即可，因为流式场景下的合并，其工作方式类似与”把多个元素拼接成更长的数组“，而不是”把多个元素整合成更少的元素“。

注意这个变更不影响非流式场景下的合并，非流式场景下仍然会要求类型为 map。

#### (Optional) Which issue(s) this PR fixes:

No related issues found.

#### (optional) The PR that updates user documentation:

Not need, the code will match the documentation after this PR.