### PR TITLE
feat: add more AgentOption for react agent and a converter function t…

### DIFF
--- a/components/tool/option.go
+++ b/components/tool/option.go
@@ -17,8 +17,8 @@
 package tool
 
 // Option defines call option for InvokableTool or StreamableTool component, which is part of component interface signature.
-// Each tool implementation could define its own options struct and option funcs within its own package,
-// then wrap the impl specific option funcs into this type, before passing to InvokableRun or StreamableRun.
+// Each tool implementation could define its own options struct and option functions within its own package,
+// then wrap the impl specific option functions into this type, before passing to InvokableRun or StreamableRun.
 type Option struct {
 	implSpecificOptFn any
 }

--- a/compose/graph.go
+++ b/compose/graph.go
@@ -28,6 +28,7 @@ import (
 	"github.com/cloudwego/eino/components/model"
 	"github.com/cloudwego/eino/components/prompt"
 	"github.com/cloudwego/eino/components/retriever"
+	"github.com/cloudwego/eino/internal/compose"
 	"github.com/cloudwego/eino/internal/generic"
 	"github.com/cloudwego/eino/internal/gmap"
 	"github.com/cloudwego/eino/schema"
@@ -1121,9 +1122,7 @@ func validateDAG(chanSubscribeTo map[string]*chanCall, invertedEdges map[string]
 }
 
 func NewNodePath(path ...string) *NodePath {
-	return &NodePath{path: path}
+	return compose.NewNodePath(path...)
 }
 
-type NodePath struct {
-	path []string
-}
+type NodePath = compose.NodePath

--- a/compose/graph_call_options.go
+++ b/compose/graph_call_options.go
@@ -80,6 +80,24 @@ func (o Option) DesignateNodeWithPath(path ...*NodePath) Option {
 	return o
 }
 
+// DesignateNodePrependPath prepends the prefix to the path of the node(s) to which the option will be applied to.
+// Useful when you already have an Option designated to a graph's node, and now you want to add this graph as a subgraph.
+// e.g.
+// Your subgraph has a Node with key "A", and your subgraph's NodeKey is "sub_graph", you can specify option to A using:
+//
+// option := WithCallbacks(...).DesignateNode("A").DesignateNodePrependPath("sub_graph")
+// Note: as an End User, you probably don't need to use this method, as DesignateNodeWithPath will be sufficient in most use cases.
+// Note: as a Flow author, if you define your own Option type, and at the same time your flow can be exported to graph and added as GraphNode,
+// you can use this method to prepend your Option's designated path with the GraphNode's path.
+func (o Option) DesignateNodePrependPath(prefix *NodePath) Option {
+	for i := range o.paths {
+		p := o.paths[i]
+		p.path = append(prefix.path, p.path...)
+	}
+
+	return o
+}
+
 // WithEmbeddingOption is a functional option type for embedding component.
 // e.g.
 //

--- a/compose/graph_call_options.go
+++ b/compose/graph_call_options.go
@@ -80,22 +80,8 @@ func (o Option) DesignateNodeWithPath(path ...*NodePath) Option {
 	return o
 }
 
-// DesignateNodePrependPath prepends the prefix to the path of the node(s) to which the option will be applied to.
-// Useful when you already have an Option designated to a graph's node, and now you want to add this graph as a subgraph.
-// e.g.
-// Your subgraph has a Node with key "A", and your subgraph's NodeKey is "sub_graph", you can specify option to A using:
-//
-// option := WithCallbacks(...).DesignateNode("A").DesignateNodePrependPath("sub_graph")
-// Note: as an End User, you probably don't need to use this method, as DesignateNodeWithPath will be sufficient in most use cases.
-// Note: as a Flow author, if you define your own Option type, and at the same time your flow can be exported to graph and added as GraphNode,
-// you can use this method to prepend your Option's designated path with the GraphNode's path.
-func (o Option) DesignateNodePrependPath(prefix *NodePath) Option {
-	for i := range o.paths {
-		p := o.paths[i]
-		p.path = append(prefix.path, p.path...)
-	}
-
-	return o
+func (o Option) Paths() []*NodePath {
+	return o.paths
 }
 
 // WithEmbeddingOption is a functional option type for embedding component.

--- a/compose/utils.go
+++ b/compose/utils.go
@@ -238,7 +238,7 @@ func initNodeCallbacks(ctx context.Context, key string, info *nodeInfo, meta *ex
 		if len(opts[i].handler) != 0 {
 			if len(opts[i].paths) != 0 {
 				for _, k := range opts[i].paths {
-					if len(k.path) == 1 && k.path[0] == key {
+					if len(k.Path()) == 1 && k.Path()[0] == key {
 						cbs = append(cbs, opts[i].handler...)
 						break
 					}
@@ -314,18 +314,18 @@ func extractOption(nodes map[string]*chanCall, opts ...Option) (map[string][]any
 			}
 		}
 		for _, path := range opt.paths {
-			if len(path.path) == 0 {
+			if len(path.Path()) == 0 {
 				return nil, fmt.Errorf("call option has designated an empty path")
 			}
 
 			var curNode *chanCall
 			var ok bool
-			if curNode, ok = nodes[path.path[0]]; !ok {
+			if curNode, ok = nodes[path.Path()[0]]; !ok {
 				return nil, fmt.Errorf("option has designated an unknown node: %s", path)
 			}
-			curNodeKey := path.path[0]
+			curNodeKey := path.Path()[0]
 
-			if len(path.path) == 1 {
+			if len(path.Path()) == 1 {
 				if len(opt.options) == 0 {
 					// sub graph common callbacks has been added to ctx in initNodeCallback and won't be passed to subgraph only pass options
 					// node callback also won't be passed
@@ -350,7 +350,7 @@ func extractOption(nodes map[string]*chanCall, opts ...Option) (map[string][]any
 				}
 				// designate to sub graph's nodes
 				nOpt := opt.deepCopy()
-				nOpt.paths = []*NodePath{NewNodePath(path.path[1:]...)}
+				nOpt.paths = []*NodePath{NewNodePath(path.Path()[1:]...)}
 				optMap[curNodeKey] = append(optMap[curNodeKey], nOpt)
 			}
 		}

--- a/flow/agent/agent_option.go
+++ b/flow/agent/agent_option.go
@@ -19,7 +19,6 @@ package agent
 import "github.com/cloudwego/eino/compose"
 
 // AgentOption is the common option type for various agent and multi-agent implementations.
-// For options intended to use with underlying graph or components, use WithComposeOptions to specify.
 // For options intended to use with particular agent/multi-agent implementations, use WrapImplSpecificOptFn to specify.
 type AgentOption struct {
 	implSpecificOptFn any
@@ -27,6 +26,7 @@ type AgentOption struct {
 }
 
 // GetComposeOptions returns all compose options from the given agent options.
+// Deprecated
 func GetComposeOptions(opts ...AgentOption) []compose.Option {
 	var result []compose.Option
 	for _, opt := range opts {
@@ -37,6 +37,7 @@ func GetComposeOptions(opts ...AgentOption) []compose.Option {
 }
 
 // WithComposeOptions returns an agent option that specifies compose options.
+// Deprecated: use option functions defined by each agent flow implementation instead.
 func WithComposeOptions(opts ...compose.Option) AgentOption {
 	return AgentOption{
 		composeOptions: opts,

--- a/flow/agent/multiagent/host/options.go
+++ b/flow/agent/multiagent/host/options.go
@@ -21,6 +21,7 @@ import (
 	"github.com/cloudwego/eino/components/model"
 	"github.com/cloudwego/eino/compose"
 	"github.com/cloudwego/eino/flow/agent"
+	agent2 "github.com/cloudwego/eino/internal/flow/agent"
 )
 
 type options struct {
@@ -86,7 +87,7 @@ func ConvertOptions(nodePath *compose.NodePath, opts ...agent.AgentOption) []com
 	composeOpts := agent.GetImplSpecificOptions(&options{}, opts...).composeOptions
 	if nodePath != nil {
 		for i := range composeOpts {
-			composeOpts[i] = composeOpts[i].DesignateNodePrependPath(nodePath)
+			composeOpts[i] = agent2.DesignateNodePrependPath(composeOpts[i], nodePath)
 		}
 	}
 
@@ -94,7 +95,7 @@ func ConvertOptions(nodePath *compose.NodePath, opts ...agent.AgentOption) []com
 	if convertedCallbackHandler != nil {
 		callbackOpt := compose.WithCallbacks(convertedCallbackHandler).DesignateNode(defaultHostNodeKey)
 		if nodePath != nil {
-			return append(composeOpts, callbackOpt.DesignateNodePrependPath(nodePath))
+			return append(composeOpts, agent2.DesignateNodePrependPath(callbackOpt, nodePath))
 		}
 		return append(composeOpts, callbackOpt)
 	}

--- a/flow/agent/multiagent/host/options.go
+++ b/flow/agent/multiagent/host/options.go
@@ -16,14 +16,88 @@
 
 package host
 
-import "github.com/cloudwego/eino/flow/agent"
+import (
+	"github.com/cloudwego/eino/callbacks"
+	"github.com/cloudwego/eino/components/model"
+	"github.com/cloudwego/eino/compose"
+	"github.com/cloudwego/eino/flow/agent"
+)
 
 type options struct {
 	agentCallbacks []MultiAgentCallback
+	composeOptions []compose.Option
 }
 
 func WithAgentCallbacks(agentCallbacks ...MultiAgentCallback) agent.AgentOption {
 	return agent.WrapImplSpecificOptFn(func(opts *options) {
 		opts.agentCallbacks = append(opts.agentCallbacks, agentCallbacks...)
 	})
+}
+
+// WithAgentModelOptions returns an agent option that specifies model.Option for the given agent.
+// The given agentName should be the name of the agent in the graph.
+// e.g.
+//
+//	if specifying model.Option for the host agent, use MultiAgent.HostNodeKey() as the agentName.
+//	if specifying model.Option for the specialist agent, use the specialist agent's AgentMeta.Name as the agentName.
+func WithAgentModelOptions(agentName string, opts ...model.Option) agent.AgentOption {
+	return agent.WrapImplSpecificOptFn(func(o *options) {
+		o.composeOptions = append(o.composeOptions, compose.WithChatModelOption(opts...).DesignateNode(agentName))
+	})
+}
+
+// WithAgentModelCallbacks returns an agent option that specifies callbacks.Handler for the given agent's ChatModel.
+// The given agentName should be the name of the agent in the graph.
+// e.g.
+//
+//	if specifying model.Option for the host agent, use MultiAgent.HostNodeKey() as the agentName.
+//	if specifying model.Option for the specialist agent, use the specialist agent's AgentMeta.Name as the agentName.
+func WithAgentModelCallbacks(agentName string, cbs ...callbacks.Handler) agent.AgentOption {
+	return agent.WrapImplSpecificOptFn(func(o *options) {
+		o.composeOptions = append(o.composeOptions, compose.WithCallbacks(cbs...).DesignateNode(agentName))
+	})
+}
+
+// WithSpecialistLambdaOptions returns an agent option that specifies agent.AgentOption for the given specialist's Lambda.
+// The given specialistName should be the name of the specialist in the graph.
+func WithSpecialistLambdaOptions(specialistName string, opts ...agent.AgentOption) agent.AgentOption {
+	anyOpts := make([]any, len(opts))
+	for i, opt := range opts {
+		anyOpts[i] = opt
+	}
+	return agent.WrapImplSpecificOptFn(func(o *options) {
+		o.composeOptions = append(o.composeOptions, compose.WithLambdaOption(anyOpts...).DesignateNode(specialistName))
+	})
+}
+
+// WithSpecialistLambdaCallbacks returns an agent option that specifies callbacks.Handler for the given specialist's Lambda.
+// The given specialistName should be the name of the specialist in the graph.
+func WithSpecialistLambdaCallbacks(specialistName string, cbs ...callbacks.Handler) agent.AgentOption {
+	return agent.WrapImplSpecificOptFn(func(o *options) {
+		o.composeOptions = append(o.composeOptions, compose.WithCallbacks(cbs...).DesignateNode(specialistName))
+	})
+}
+
+// ConvertOptions converts agent options to compose options, and designate them to the Agent sub graph specified by nodePath.
+// Useful when adding MultiAgent's Graph to another Graph.
+// The parameter nodePath is the path to the MultiAgent sub graph within the whole Graph.
+// If nodePath == nil, then MultiAgent's Graph is treated as a stand-alone, top-level Graph.
+func ConvertOptions(nodePath *compose.NodePath, opts ...agent.AgentOption) []compose.Option {
+	composeOpts := agent.GetImplSpecificOptions(&options{}, opts...).composeOptions
+	if nodePath != nil {
+		for i := range composeOpts {
+			composeOpts[i] = composeOpts[i].DesignateNodePrependPath(nodePath)
+		}
+	}
+
+	convertedCallbackHandler := convertCallbacks(opts...)
+	if convertedCallbackHandler != nil {
+		callbackOpt := compose.WithCallbacks(convertedCallbackHandler).DesignateNode(defaultHostNodeKey)
+		if nodePath != nil {
+			return append(composeOpts, callbackOpt.DesignateNodePrependPath(nodePath))
+		}
+		return append(composeOpts, callbackOpt)
+	}
+
+	return composeOpts
 }

--- a/flow/agent/multiagent/host/types.go
+++ b/flow/agent/multiagent/host/types.go
@@ -39,25 +39,11 @@ type MultiAgent struct {
 }
 
 func (ma *MultiAgent) Generate(ctx context.Context, input []*schema.Message, opts ...agent.AgentOption) (*schema.Message, error) {
-	composeOptions := agent.GetComposeOptions(opts...)
-
-	handler := convertCallbacks(opts...)
-	if handler != nil {
-		composeOptions = append(composeOptions, compose.WithCallbacks(handler).DesignateNode(ma.HostNodeKey()))
-	}
-
-	return ma.runnable.Invoke(ctx, input, composeOptions...)
+	return ma.runnable.Invoke(ctx, input, ConvertOptions(nil, opts...)...)
 }
 
 func (ma *MultiAgent) Stream(ctx context.Context, input []*schema.Message, opts ...agent.AgentOption) (*schema.StreamReader[*schema.Message], error) {
-	composeOptions := agent.GetComposeOptions(opts...)
-
-	handler := convertCallbacks(opts...)
-	if handler != nil {
-		composeOptions = append(composeOptions, compose.WithCallbacks(handler).DesignateNode(ma.HostNodeKey()))
-	}
-
-	return ma.runnable.Stream(ctx, input, composeOptions...)
+	return ma.runnable.Stream(ctx, input, ConvertOptions(nil, opts...)...)
 }
 
 // ExportGraph exports the underlying graph from MultiAgent, along with the []compose.GraphAddNodeOpt to be used when adding this graph to another graph.

--- a/flow/agent/react/callback.go
+++ b/flow/agent/react/callback.go
@@ -27,6 +27,8 @@ import (
 //	callback := BuildAgentCallback(modelHandler, toolHandler)
 //	agent, err := react.NewAgent(ctx, &AgentConfig{})
 //	agent.Generate(ctx, input, agent.WithComposeOptions(compose.WithCallbacks(callback)))
+//
+// Deprecated: use WithModelCallbacks and WithToolCallbacks instead.
 func BuildAgentCallback(modelHandler *template.ModelCallbackHandler, toolHandler *template.ToolCallbackHandler) callbacks.Handler {
 	return template.NewHandlerHelper().ChatModel(modelHandler).Tool(toolHandler).Handler()
 }

--- a/flow/agent/react/options.go
+++ b/flow/agent/react/options.go
@@ -22,6 +22,7 @@ import (
 	"github.com/cloudwego/eino/components/tool"
 	"github.com/cloudwego/eino/compose"
 	"github.com/cloudwego/eino/flow/agent"
+	agent2 "github.com/cloudwego/eino/internal/flow/agent"
 )
 
 type options struct {
@@ -78,7 +79,7 @@ func ConvertOptions(nodePath *compose.NodePath, opts ...agent.AgentOption) []com
 	composeOpts := agent.GetImplSpecificOptions(&options{}, opts...).composeOptions
 	if nodePath != nil {
 		for i := range composeOpts {
-			composeOpts[i] = composeOpts[i].DesignateNodePrependPath(nodePath)
+			composeOpts[i] = agent2.DesignateNodePrependPath(composeOpts[i], nodePath)
 		}
 	}
 

--- a/flow/agent/react/options.go
+++ b/flow/agent/react/options.go
@@ -1,0 +1,86 @@
+/*
+ * Copyright 2025 CloudWeGo Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package react
+
+import (
+	"github.com/cloudwego/eino/callbacks"
+	"github.com/cloudwego/eino/components/model"
+	"github.com/cloudwego/eino/components/tool"
+	"github.com/cloudwego/eino/compose"
+	"github.com/cloudwego/eino/flow/agent"
+)
+
+type options struct {
+	composeOptions []compose.Option
+}
+
+// WithChatModelOptions returns an agent option that specifies model.Option for the ChatModel node.
+func WithChatModelOptions(opts ...model.Option) agent.AgentOption {
+	return agent.WrapImplSpecificOptFn(func(o *options) {
+		o.composeOptions = append(o.composeOptions, compose.WithChatModelOption(opts...))
+	})
+}
+
+// WithToolOptions returns an agent option that specifies tool.Option for the ToolsNode node.
+func WithToolOptions(opts ...tool.Option) agent.AgentOption {
+	return agent.WrapImplSpecificOptFn(func(o *options) {
+		o.composeOptions = append(o.composeOptions, compose.WithToolsNodeOption(compose.WithToolOption(opts...)))
+	})
+}
+
+// WithToolList returns an agent option that specifies tool list for the ToolsNode node, overriding default tool list.
+func WithToolList(tool ...tool.BaseTool) agent.AgentOption {
+	return agent.WrapImplSpecificOptFn(func(o *options) {
+		o.composeOptions = append(o.composeOptions, compose.WithToolsNodeOption(compose.WithToolList(tool...)))
+	})
+}
+
+// WithRuntimeMaxSteps returns an agent option that specifies max steps for the agent, overriding default configuration.
+func WithRuntimeMaxSteps(maxSteps int) agent.AgentOption {
+	return agent.WrapImplSpecificOptFn(func(o *options) {
+		o.composeOptions = append(o.composeOptions, compose.WithRuntimeMaxSteps(maxSteps))
+	})
+}
+
+// WithModelCallbacks returns an agent option that specifies callback handlers for the ChatModel node.
+func WithModelCallbacks(cbs ...callbacks.Handler) agent.AgentOption {
+	return agent.WrapImplSpecificOptFn(func(o *options) {
+		o.composeOptions = append(o.composeOptions, compose.WithCallbacks(cbs...).DesignateNode(nodeKeyModel))
+	})
+}
+
+// WithToolCallbacks returns an agent option that specifies callback handlers for the tools executed by ToolsNode node.
+func WithToolCallbacks(cbs ...callbacks.Handler) agent.AgentOption {
+	return agent.WrapImplSpecificOptFn(func(o *options) {
+		o.composeOptions = append(o.composeOptions, compose.WithCallbacks(cbs...).DesignateNode(nodeKeyTools))
+	})
+}
+
+// ConvertOptions converts agent options to compose options, and designate them to the Agent sub graph specified by nodePath.
+// Useful when adding Agent's Graph to another Graph.
+// The parameter nodePath is the path to the Agent sub graph within the whole Graph.
+// If nodePath == nil, then Agent's Graph is treated as a stand-alone, top-level Graph.
+func ConvertOptions(nodePath *compose.NodePath, opts ...agent.AgentOption) []compose.Option {
+	composeOpts := agent.GetImplSpecificOptions(&options{}, opts...).composeOptions
+	if nodePath != nil {
+		for i := range composeOpts {
+			composeOpts[i] = composeOpts[i].DesignateNodePrependPath(nodePath)
+		}
+	}
+
+	return composeOpts
+}

--- a/flow/agent/react/react.go
+++ b/flow/agent/react/react.go
@@ -327,7 +327,7 @@ func getReturnDirectlyToolCallID(input *schema.Message, toolReturnDirectly map[s
 
 // Generate generates a response from the agent.
 func (r *Agent) Generate(ctx context.Context, input []*schema.Message, opts ...agent.AgentOption) (output *schema.Message, err error) {
-	output, err = r.runnable.Invoke(ctx, input, agent.GetComposeOptions(opts...)...)
+	output, err = r.runnable.Invoke(ctx, input, ConvertOptions(nil, opts...)...)
 	if err != nil {
 		return nil, err
 	}
@@ -338,7 +338,7 @@ func (r *Agent) Generate(ctx context.Context, input []*schema.Message, opts ...a
 // Stream calls the agent and returns a stream response.
 func (r *Agent) Stream(ctx context.Context, input []*schema.Message, opts ...agent.AgentOption) (
 	output *schema.StreamReader[*schema.Message], err error) {
-	res, err := r.runnable.Stream(ctx, input, agent.GetComposeOptions(opts...)...)
+	res, err := r.runnable.Stream(ctx, input, ConvertOptions(nil, opts...)...)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/compose/option.go
+++ b/internal/compose/option.go
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2025 CloudWeGo Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package compose
+
+type NodePath struct {
+	path []string
+}
+
+func NewNodePath(path ...string) *NodePath {
+	return &NodePath{path: path}
+}
+
+func (n *NodePath) Path() []string {
+	return n.path
+}
+
+func (n *NodePath) Prepend(n1 *NodePath) *NodePath {
+	n.path = append(n1.path, n.path...)
+	return n
+}

--- a/internal/flow/agent/option.go
+++ b/internal/flow/agent/option.go
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2025 CloudWeGo Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package agent
+
+import (
+	"github.com/cloudwego/eino/compose"
+)
+
+// DesignateNodePrependPath prepends the prefix to the path of the node(s) to which the option will be applied to.
+// Useful when you already have an Option designated to a graph's node, and now you want to add this graph as a subgraph.
+// e.g.
+// Your subgraph has a Node with key "A", and your subgraph's NodeKey is "sub_graph", you can specify option to A using:
+//
+// option := WithCallbacks(...).DesignateNode("A").DesignateNodePrependPath("sub_graph")
+// Note: as an End User, you probably don't need to use this method, as DesignateNodeWithPath will be sufficient in most use cases.
+// Note: as a Flow author, if you define your own Option type, and at the same time your flow can be exported to graph and added as GraphNode,
+// you can use this method to prepend your Option's designated path with the GraphNode's path.
+func DesignateNodePrependPath(o compose.Option, prefix *compose.NodePath) compose.Option {
+	if prefix == nil || len(prefix.Path()) == 0 {
+		return o
+	}
+
+	paths := o.Paths()
+	if len(paths) == 0 {
+		return o.DesignateNodeWithPath(prefix)
+	}
+
+	for i := range paths {
+		paths[i] = paths[i].Prepend(prefix)
+	}
+
+	return o
+}


### PR DESCRIPTION
#### What type of PR is this?

1. Add more AgentOption functions, deprecating and replacing the old WithComposeOptions
2. Provide ConvertOptions function to convert agent options to compose options, making it easier to specify AgentOption for agent as sub graph.
3. Provide DesignateNodePrependPath method to compose.Option to help with converting AgentOption to ComposeOption