### PR TITLE
feat: add AppendGlobalHandlers instead of InitCallbackHandlers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,3 +37,5 @@ output/*
 
 /patches
 
+/vendor
+

--- a/callbacks/interface.go
+++ b/callbacks/interface.go
@@ -52,8 +52,17 @@ type Handler = callbacks.Handler
 // InitCallbackHandlers sets the global callback handlers.
 // It should be called BEFORE any callback handler by user.
 // It's useful when you want to inject some basic callbacks to all nodes.
+// Deprecated: Use AppendGlobalHandlers instead. This function overwrites all existing global handlers.
 func InitCallbackHandlers(handlers []Handler) {
 	callbacks.GlobalHandlers = handlers
+}
+
+// AppendGlobalHandlers appends the given handlers to the global callback handlers.
+// This is the preferred way to add global callback handlers as it preserves existing handlers.
+// The global callback handlers will be executed for all nodes BEFORE user-specific handlers in CallOption.
+// Note: This function is not thread-safe and should only be called during process initialization.
+func AppendGlobalHandlers(handlers []Handler) {
+	callbacks.GlobalHandlers = append(callbacks.GlobalHandlers, handlers...)
 }
 
 // CallbackTiming enumerates all the timing of callback aspects.

--- a/callbacks/interface.go
+++ b/callbacks/interface.go
@@ -61,7 +61,7 @@ func InitCallbackHandlers(handlers []Handler) {
 // This is the preferred way to add global callback handlers as it preserves existing handlers.
 // The global callback handlers will be executed for all nodes BEFORE user-specific handlers in CallOption.
 // Note: This function is not thread-safe and should only be called during process initialization.
-func AppendGlobalHandlers(handlers []Handler) {
+func AppendGlobalHandlers(handlers ...Handler) {
 	callbacks.GlobalHandlers = append(callbacks.GlobalHandlers, handlers...)
 }
 

--- a/callbacks/interface.go
+++ b/callbacks/interface.go
@@ -52,7 +52,7 @@ type Handler = callbacks.Handler
 // InitCallbackHandlers sets the global callback handlers.
 // It should be called BEFORE any callback handler by user.
 // It's useful when you want to inject some basic callbacks to all nodes.
-// Deprecated: Use AppendGlobalHandlers instead. This function overwrites all existing global handlers.
+// Deprecated: Use AppendGlobalHandlers instead.
 func InitCallbackHandlers(handlers []Handler) {
 	callbacks.GlobalHandlers = handlers
 }

--- a/callbacks/interface_test.go
+++ b/callbacks/interface_test.go
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2025 CloudWeGo Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package callbacks
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/cloudwego/eino/internal/callbacks"
+)
+
+func TestAppendGlobalHandlers(t *testing.T) {
+	// Clear global handlers before test
+	callbacks.GlobalHandlers = nil
+
+	// Create test handlers
+	handler1 := NewHandlerBuilder().Build()
+	handler2 := NewHandlerBuilder().Build()
+
+	// Test appending first handler
+	AppendGlobalHandlers(handler1)
+	assert.Equal(t, 1, len(callbacks.GlobalHandlers))
+	assert.Contains(t, callbacks.GlobalHandlers, handler1)
+
+	// Test appending second handler
+	AppendGlobalHandlers(handler2)
+	assert.Equal(t, 2, len(callbacks.GlobalHandlers))
+	assert.Contains(t, callbacks.GlobalHandlers, handler1)
+	assert.Contains(t, callbacks.GlobalHandlers, handler2)
+
+	// Test appending nil handler
+	AppendGlobalHandlers([]Handler{}...)
+	assert.Equal(t, 2, len(callbacks.GlobalHandlers))
+}

--- a/callbacks/interface_test.go
+++ b/callbacks/interface_test.go
@@ -17,6 +17,7 @@
 package callbacks
 
 import (
+	"context"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -29,8 +30,14 @@ func TestAppendGlobalHandlers(t *testing.T) {
 	callbacks.GlobalHandlers = nil
 
 	// Create test handlers
-	handler1 := NewHandlerBuilder().Build()
-	handler2 := NewHandlerBuilder().Build()
+	handler1 := NewHandlerBuilder().
+		OnStartFn(func(ctx context.Context, info *RunInfo, input CallbackInput) context.Context {
+			return ctx
+		}).Build()
+	handler2 := NewHandlerBuilder().
+		OnEndFn(func(ctx context.Context, info *RunInfo, output CallbackOutput) context.Context {
+			return ctx
+		}).Build()
 
 	// Test appending first handler
 	AppendGlobalHandlers(handler1)

--- a/schema/message.go
+++ b/schema/message.go
@@ -313,8 +313,6 @@ type messagesPlaceholder struct {
 //	)
 //	msgs, err := chatTemplate.Format(ctx, params)
 func MessagesPlaceholder(key string, optional bool) MessagesTemplate {
-	a := "https://bytedance.larkoffice.com/docx/KjjSdayZ8o1Ru8xkV03cRL27nbf"
-	_ = a
 	return &messagesPlaceholder{
 		key:      key,
 		optional: optional,

--- a/schema/message.go
+++ b/schema/message.go
@@ -313,6 +313,8 @@ type messagesPlaceholder struct {
 //	)
 //	msgs, err := chatTemplate.Format(ctx, params)
 func MessagesPlaceholder(key string, optional bool) MessagesTemplate {
+	a := "https://bytedance.larkoffice.com/docx/KjjSdayZ8o1Ru8xkV03cRL27nbf"
+	_ = a
 	return &messagesPlaceholder{
 		key:      key,
 		optional: optional,


### PR DESCRIPTION
InitCallbackHandlers always overrides the existing GlobalHandlers, which makes it difficult to inject separate Callback Handlers for different scenarios. Therefore, the AppendGlobalHandlers method has been added.