### PR TITLE
fix: default stream tool call checker skips empty chunks at the front

### DIFF
--- a/flow/agent/multiagent/host/types.go
+++ b/flow/agent/multiagent/host/types.go
@@ -161,14 +161,20 @@ type Specialist struct {
 func firstChunkStreamToolCallChecker(_ context.Context, sr *schema.StreamReader[*schema.Message]) (bool, error) {
 	defer sr.Close()
 
-	msg, err := sr.Recv()
-	if err != nil {
-		return false, err
-	}
+	for {
+		msg, err := sr.Recv()
+		if err != nil {
+			return false, err
+		}
 
-	if len(msg.ToolCalls) == 0 {
+		if len(msg.ToolCalls) > 0 {
+			return true, nil
+		}
+
+		if len(msg.Content) == 0 { // skip empty chunks at the front
+			continue
+		}
+
 		return false, nil
 	}
-
-	return true, nil
 }

--- a/flow/agent/react/react.go
+++ b/flow/agent/react/react.go
@@ -99,16 +99,22 @@ func NewPersonaModifier(persona string) MessageModifier {
 func firstChunkStreamToolCallChecker(_ context.Context, sr *schema.StreamReader[*schema.Message]) (bool, error) {
 	defer sr.Close()
 
-	msg, err := sr.Recv()
-	if err != nil {
-		return false, err
-	}
+	for {
+		msg, err := sr.Recv()
+		if err != nil {
+			return false, err
+		}
 
-	if len(msg.ToolCalls) == 0 {
+		if len(msg.ToolCalls) > 0 {
+			return true, nil
+		}
+
+		if len(msg.Content) == 0 { // skip empty chunks at the front
+			continue
+		}
+
 		return false, nil
 	}
-
-	return true, nil
 }
 
 // Agent is the ReAct agent.


### PR DESCRIPTION
#### What type of PR is this?

There are ChatModels that emits message trunks with empty content and empty tool calls first, then emits message chunks with non-empty tool calls.

When given message Stream like this, the default StreamToolCallChecker will not be able to tell the Stream contains tool call, because the first chunk would not contain tool call.

This PR fix this by modifying the behavior of default StreamToolCallChecker by skipping message chunks containing empty Content at the front.