### PR TITLE
fix: unexpected setting ResponseMeta of the first element in slice af…

### DIFF
--- a/schema/message.go
+++ b/schema/message.go
@@ -671,8 +671,10 @@ func ConcatMessages(msgs []*Message) (*Message, error) {
 		}
 
 		if msg.ResponseMeta != nil && ret.ResponseMeta == nil {
-			ret.ResponseMeta = msg.ResponseMeta
-		} else if msg.ResponseMeta != nil && ret.ResponseMeta != nil {
+			ret.ResponseMeta = &ResponseMeta{}
+		}
+
+		if msg.ResponseMeta != nil && ret.ResponseMeta != nil {
 			// keep the last FinishReason with a valid value.
 			if msg.ResponseMeta.FinishReason != "" {
 				ret.ResponseMeta.FinishReason = msg.ResponseMeta.FinishReason

--- a/schema/message_test.go
+++ b/schema/message_test.go
@@ -402,6 +402,37 @@ func TestConcatMessage(t *testing.T) {
 		assert.Equal(t, msgs[0].ResponseMeta.LogProbs.Content[1], msg.ResponseMeta.LogProbs.Content[1])
 		assert.Equal(t, msgs[1].ResponseMeta.LogProbs.Content[0], msg.ResponseMeta.LogProbs.Content[2])
 	})
+
+	t.Run("fix unexpected setting ResponseMeta of the first element in slice after ConcatMessages", func(t *testing.T) {
+		msgs := []*Message{
+			{
+				Role:    Assistant,
+				Content: "🚀",
+				//ResponseMeta: &ResponseMeta{},
+			},
+			{
+				Role:         "",
+				Content:      "❤️",
+				ResponseMeta: &ResponseMeta{},
+			},
+			{
+				Role: "",
+				ResponseMeta: &ResponseMeta{
+					FinishReason: "stop",
+					Usage: &TokenUsage{
+						PromptTokens:     7,
+						CompletionTokens: 3,
+						TotalTokens:      10,
+					},
+				},
+			},
+		}
+
+		msg, err := ConcatMessages(msgs)
+		assert.NoError(t, err)
+		assert.Equal(t, msgs[2].ResponseMeta, msg.ResponseMeta)
+		assert.Nil(t, msgs[0].ResponseMeta)
+	})
 }
 
 func TestConcatToolCalls(t *testing.T) {


### PR DESCRIPTION
…ter ConcatMessages

#### What type of PR is this?
<!--
Add one of the following kinds:

build: Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)
ci: Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
docs: Documentation only changes
feat: A new feature
optimize: A new optimization
fix: A bug fix
perf: A code change that improves performance
refactor: A code change that neither fixes a bug nor adds a feature
style: Changes that do not affect the meaning of the code (white space, formatting, missing semi-colons, etc)
test: Adding missing tests or correcting existing tests
chore: Changes to the build process or auxiliary tools and libraries such as documentation generation
-->
fix

#### Check the PR title.
<!--
The description of the title will be attached in Release Notes, 
so please describe it from user-oriented, what this PR does / why we need it.
Please check your PR title with the below requirements:
-->
- [x] This PR title match the format: \<type\>(optional scope): \<description\>
- [x] The description of this PR title is user-oriented and clear enough for others to understand.
- [ ] Attach the PR updating the user documentation if the current PR requires user awareness at the usage level. [User docs repo](https://github.com/cloudwego/cloudwego.github.io)


#### (Optional) Translate the PR title into Chinese.
修复了在 ConcatMessages 后 slice 中首个元素的 ResponseMeta 被设置的问题

#### (Optional) More detailed description for this PR(en: English/zh: Chinese).
<!--
Provide more detailed info for review(e.g., it's recommended to provide perf data if this is a perf type PR).
-->
en:
zh(optional): 


#### (Optional) Which issue(s) this PR fixes:
<!--
Automatically closes linked issue when PR is merged.
Eg: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

#### (optional) The PR that updates user documentation:
<!--
If the current PR requires user awareness at the usage level, please submit a PR to update user docs. [User docs repo](https://github.com/cloudwego/cloudwego.github.io)
-->
