### PR TITLE
feat: support no input for nodes at request time

### DIFF
--- a/compose/graph_manager.go
+++ b/compose/graph_manager.go
@@ -70,14 +70,8 @@ func (p *preNodeHandlerManager) handle(nodeKey string, value any, isStream bool)
 		return value, nil
 	}
 	if isStream {
-		var newValue streamReader
-		if value == nil {
-			newValue = (streamReader)(nil)
-		} else {
-			newValue = value.(streamReader)
-		}
 		for _, v := range p.h[nodeKey] {
-			value = v.transform(newValue)
+			value = v.transform(value.(streamReader))
 		}
 	} else {
 		for _, v := range p.h[nodeKey] {

--- a/compose/graph_run.go
+++ b/compose/graph_run.go
@@ -111,6 +111,9 @@ func runnableInvoke(ctx context.Context, r *composableRunnable, input any, opts 
 }
 
 func runnableTransform(ctx context.Context, r *composableRunnable, input any, opts ...any) (any, error) {
+	if input == nil {
+		return r.t(ctx, (streamReader)(nil), opts...)
+	}
 	return r.t(ctx, input.(streamReader), opts...)
 }
 

--- a/compose/workflow.go
+++ b/compose/workflow.go
@@ -440,36 +440,6 @@ func (wf *Workflow[I, O]) compile(ctx context.Context, options *graphCompileOpti
 				wf.g.handlerPreNode[n.key] = append([]handlerPair{pair}, wf.g.handlerPreNode[n.key]...)
 			}
 		}
-
-		if len(n.mappedFieldPath) == 0 { // absolutely no input data
-			inputType := n.g.nodes[n.key].inputType()
-			if inputType != reflect.TypeOf(map[string]any{}) { // only support such case when input is map[string]any{}
-				return nil, fmt.Errorf("node %s has no input data, but its input type is not map[string]any", n.key)
-			}
-
-			pair := handlerPair{
-				invoke: func(in any) (any, error) {
-					if in == nil {
-						return map[string]any{}, nil
-					}
-					return in, nil
-				},
-				transform: func(in streamReader) streamReader {
-					if in == nil {
-						sr, sw := schema.Pipe[map[string]any](1)
-						sw.Send(map[string]any{}, nil)
-						sw.Close()
-						return packStreamReader(sr)
-					}
-					return in
-				},
-			}
-			if _, ok := wf.g.handlerPreNode[n.key]; !ok {
-				wf.g.handlerPreNode[n.key] = []handlerPair{pair}
-			} else {
-				wf.g.handlerPreNode[n.key] = append([]handlerPair{pair}, wf.g.handlerPreNode[n.key]...)
-			}
-		}
 	}
 
 	// TODO: check indirect edges are legal

--- a/compose/workflow_test.go
+++ b/compose/workflow_test.go
@@ -849,6 +849,29 @@ func TestBranch(t *testing.T) {
 		assert.NoError(t, err)
 		assert.Equal(t, map[string]any{START: "world"}, out)
 	})
+
+	t.Run("empty input for node after branch", func(t *testing.T) {
+		wf := NewWorkflow[map[string]any, map[string]any]()
+		wf.AddLambdaNode("start_1", InvokableLambda(func(ctx context.Context, input map[string]any) (map[string]any, error) {
+			return map[string]any{}, nil
+		})).AddInput("start")
+		wf.AddLambdaNode("branch_1", InvokableLambda(func(ctx context.Context, input map[string]any) (map[string]any, error) {
+			return map[string]any{}, nil
+		}))
+		wf.AddPassthroughNode("my_branch").AddInput("start_1")
+		wf.AddBranch("my_branch", NewGraphBranch(func(ctx context.Context, input map[string]any) (string, error) {
+			return END, nil
+		}, map[string]bool{
+			"branch_1": true,
+			END:        true,
+		}))
+		wf.End().AddInput("branch_1")
+		runner, err := wf.Compile(context.Background())
+		assert.NoError(t, err)
+		resp, err := runner.Invoke(context.Background(), map[string]any{})
+		assert.NoError(t, err)
+		assert.Equal(t, resp, (map[string]any)(nil))
+	})
 }
 
 type goodInterface interface {


### PR DESCRIPTION
#### What type of PR is this?

Support no input for nodes at request time.

Two scenarios for no input:
1. a workflow node that have no inputs, only dependencies
2. a workflow node controlled by a branch, and the selection of the branch cause the node to have no input
