### PR TITLE
feat: modify trigger mode comment

### DIFF
--- a/compose/graph_compile_options.go
+++ b/compose/graph_compile_options.go
@@ -65,8 +65,9 @@ func WithGraphName(graphName string) GraphCompileOption {
 	}
 }
 
-// WithNodeTriggerMode sets node trigger mode for the graph.
-// Different node trigger mode will affect graph execution order and result for specific graphs, such as those with parallel branches having different length of nodes.
+// WithNodeTriggerMode sets the trigger mode for nodes in the graph.
+// The trigger mode determines when a node is triggered during graph execution, ref: https://www.cloudwego.io/docs/eino/core_modules/chain_and_graph_orchestration/orchestration_design_principles/#internal-mechanism
+// AnyPredecessor by default.
 func WithNodeTriggerMode(triggerMode NodeTriggerMode) GraphCompileOption {
 	return func(o *graphCompileOptions) {
 		o.nodeTriggerMode = triggerMode

--- a/compose/types.go
+++ b/compose/types.go
@@ -38,9 +38,8 @@ const (
 type NodeTriggerMode string
 
 const (
-	// AnyPredecessor means that the current node will be triggered as long as any of its predecessor nodes has finished running.
-	// Note that actual implementation organizes node execution in batches.
-	// In this context, 'any predecessor finishes' would means the other nodes of the same batch need to be finished too.
+	// AnyPredecessor means that the node will be triggered when any of its predecessors is included in the previous completed super step.
+	// Ref:https://www.cloudwego.io/docs/eino/core_modules/chain_and_graph_orchestration/orchestration_design_principles/#runtime-engine
 	AnyPredecessor NodeTriggerMode = "any_predecessor"
 	// AllPredecessor means that the current node will only be triggered when all of its predecessor nodes have finished running.
 	AllPredecessor NodeTriggerMode = "all_predecessor"


### PR DESCRIPTION
#### What type of PR is this?
<!--
Add one of the following kinds:

build: Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)
ci: Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
docs: Documentation only changes
feat: A new feature
optimize: A new optimization
fix: A bug fix
perf: A code change that improves performance
refactor: A code change that neither fixes a bug nor adds a feature
style: Changes that do not affect the meaning of the code (white space, formatting, missing semi-colons, etc)
test: Adding missing tests or correcting existing tests
chore: Changes to the build process or auxiliary tools and libraries such as documentation generation
-->

#### Check the PR title.
<!--
The description of the title will be attached in Release Notes, 
so please describe it from user-oriented, what this PR does / why we need it.
Please check your PR title with the below requirements:
-->
- [ ] This PR title match the format: \<type\>(optional scope): \<description\>
- [ ] The description of this PR title is user-oriented and clear enough for others to understand.
- [ ] Attach the PR updating the user documentation if the current PR requires user awareness at the usage level. [User docs repo](https://github.com/cloudwego/cloudwego.github.io)


#### (Optional) Translate the PR title into Chinese.


#### (Optional) More detailed description for this PR(en: English/zh: Chinese).
<!--
Provide more detailed info for review(e.g., it's recommended to provide perf data if this is a perf type PR).
-->
en:
zh(optional): 


#### (Optional) Which issue(s) this PR fixes:
<!--
Automatically closes linked issue when PR is merged.
Eg: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

#### (optional) The PR that updates user documentation:
<!--
If the current PR requires user awareness at the usage level, please submit a PR to update user docs. [User docs repo](https://github.com/cloudwego/cloudwego.github.io)
-->
