### PR TITLE
feat: add deprecated GetState

### DIFF
--- a/compose/state.go
+++ b/compose/state.go
@@ -110,6 +110,25 @@ func streamConvertPostHandler[O, S any](handler StreamStatePostHandler[O, S]) *c
 	return runnableLambda[O, O](nil, nil, nil, rf, false)
 }
 
+// GetState gets the state from the context.
+// Notice: The returned state isn't concurrency-safe that may cause data race in graph execution.
+// Deprecated: use ProcessState instead.
+func GetState[S any](ctx context.Context) (S, error) {
+	state := ctx.Value(stateKey{})
+
+	iState := state.(*internalState)
+	iState.mu.Lock()
+	defer iState.mu.Unlock()
+	cState, ok := iState.state.(S)
+	if !ok {
+		var s S
+		return s, fmt.Errorf("unexpected state type. expected: %v, got: %v",
+			generic.TypeOf[S](), reflect.TypeOf(iState.state))
+	}
+
+	return cState, nil
+}
+
 // ProcessState processes the state from the context in a concurrency-safe way.
 // This is the recommended way to access and modify state in custom nodes.
 // The provided function handler will be executed with exclusive access to the state (protected by mutex).


### PR DESCRIPTION
#### What type of PR is this?
<!--
Add one of the following kinds:

build: Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)
ci: Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
docs: Documentation only changes
feat: A new feature
optimize: A new optimization
fix: A bug fix
perf: A code change that improves performance
refactor: A code change that neither fixes a bug nor adds a feature
style: Changes that do not affect the meaning of the code (white space, formatting, missing semi-colons, etc)
test: Adding missing tests or correcting existing tests
chore: Changes to the build process or auxiliary tools and libraries such as documentation generation
-->

#### Check the PR title.
<!--
The description of the title will be attached in Release Notes, 
so please describe it from user-oriented, what this PR does / why we need it.
Please check your PR title with the below requirements:
-->
- [ ] This PR title match the format: \<type\>(optional scope): \<description\>
- [ ] The description of this PR title is user-oriented and clear enough for others to understand.
- [ ] Attach the PR updating the user documentation if the current PR requires user awareness at the usage level. [User docs repo](https://github.com/cloudwego/cloudwego.github.io)


#### (Optional) Translate the PR title into Chinese.


#### (Optional) More detailed description for this PR(en: English/zh: Chinese).
<!--
Provide more detailed info for review(e.g., it's recommended to provide perf data if this is a perf type PR).
-->
en:
zh(optional): 


#### (Optional) Which issue(s) this PR fixes:
<!--
Automatically closes linked issue when PR is merged.
Eg: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

#### (optional) The PR that updates user documentation:
<!--
If the current PR requires user awareness at the usage level, please submit a PR to update user docs. [User docs repo](https://github.com/cloudwego/cloudwego.github.io)
-->
