### PR TITLE
feat: Add Unwrap method to compose internalError

### DIFF
--- a/compose/error.go
+++ b/compose/error.go
@@ -132,3 +132,7 @@ func (i *internalError) Error() string {
 	sb.WriteString("")
 	return sb.String()
 }
+
+func (i *internalError) Unwrap() error {
+	return i.origError
+}


### PR DESCRIPTION
#### What type of PR is this?
This PR adds the `Unwrap() error` method to the `internalError` struct in the `compose` package to support Go's error unwrapping mechanism (`errors.Unwrap` and `errors.Is`). It also adds a test case to verify proper handling of `context.Canceled` errors.
