### PR TITLE
feat: support multiple intents in host multi-agent

### DIFF
--- a/flow/agent/multiagent/host/callback.go
+++ b/flow/agent/multiagent/host/callback.go
@@ -50,14 +50,13 @@ func ConvertCallbackHandlers(handlers ...MultiAgentCallback) callbacks.Handler {
 			return ctx
 		}
 
-		agentName := msg.ToolCalls[0].Function.Name
-		argument := msg.ToolCalls[0].Function.Arguments
-
 		for _, cb := range handlers {
-			ctx = cb.OnHandOff(ctx, &HandOffInfo{
-				ToAgentName: agentName,
-				Argument:    argument,
-			})
+			for _, toolCall := range msg.ToolCalls {
+				ctx = cb.OnHandOff(ctx, &HandOffInfo{
+					ToAgentName: toolCall.Function.Name,
+					Argument:    toolCall.Function.Arguments,
+				})
+			}
 		}
 
 		return ctx
@@ -98,10 +97,12 @@ func ConvertCallbackHandlers(handlers ...MultiAgentCallback) callbacks.Handler {
 		}
 
 		for _, cb := range handlers {
-			ctx = cb.OnHandOff(ctx, &HandOffInfo{
-				ToAgentName: msg.ToolCalls[0].Function.Name,
-				Argument:    msg.ToolCalls[0].Function.Arguments,
-			})
+			for _, toolCall := range msg.ToolCalls {
+				ctx = cb.OnHandOff(ctx, &HandOffInfo{
+					ToAgentName: toolCall.Function.Name,
+					Argument:    toolCall.Function.Arguments,
+				})
+			}
 		}
 
 		return ctx

--- a/flow/agent/multiagent/host/types.go
+++ b/flow/agent/multiagent/host/types.go
@@ -90,6 +90,11 @@ type MultiAgentConfig struct {
 	// Note: The default implementation does not work well with Claude, which typically outputs tool calls after text content.
 	// Note: If your ChatModel doesn't output tool calls first, you can try adding prompts to constrain the model from generating extra text during the tool call.
 	StreamToolCallChecker func(ctx context.Context, modelOutput *schema.StreamReader[*schema.Message]) (bool, error)
+
+	// Summarizer is the summarizer agent that will summarize the outputs of all the chosen specialist agents.
+	// Only when the Host agent picks multiple Specialist will this be called.
+	// If you do not provide a summarizer, a default summarizer that simply concatenates all the output messages into one message will be used.
+	Summarizer *Summarizer
 }
 
 func (conf *MultiAgentConfig) validate() error {
@@ -160,6 +165,11 @@ type Specialist struct {
 
 	Invokable  compose.Invoke[[]*schema.Message, *schema.Message, agent.AgentOption]
 	Streamable compose.Stream[[]*schema.Message, *schema.Message, agent.AgentOption]
+}
+
+type Summarizer struct {
+	ChatModel    model.BaseChatModel
+	SystemPrompt string
 }
 
 func firstChunkStreamToolCallChecker(_ context.Context, sr *schema.StreamReader[*schema.Message]) (bool, error) {


### PR DESCRIPTION
#### What type of PR is this?
feat: host multi-agent now supports recognizing multiple intents at the same time.

1. Previously, host multi-agent can only pick one specialist per run. Recognizing multiple intents would result in error.
2. Now, if the host picks more than one specialist at the same time, all the chosen specialists will be executed in parallel.
3. If so, a Summarizer node will summarize these specialists' output messages into a single message.
4. Optionally, host multi-agent can accept a Summarizer configuration, which is a BaseChatModel with a system prompt.
5. If no Summarizer specified by the user, a default Summarizer that simply concatenates all the message contents will be used.