### PR TITLE
fix: supports direct streaming output from host while using host multi-agent callback

### DIFF
--- a/flow/agent/multiagent/host/types.go
+++ b/flow/agent/multiagent/host/types.go
@@ -94,6 +94,7 @@ type MultiAgentConfig struct {
 	// Summarizer is the summarizer agent that will summarize the outputs of all the chosen specialist agents.
 	// Only when the Host agent picks multiple Specialist will this be called.
 	// If you do not provide a summarizer, a default summarizer that simply concatenates all the output messages into one message will be used.
+	// Note: the default summarizer do not support streaming.
 	Summarizer *Summarizer
 }
 


### PR DESCRIPTION
#### What type of PR is this?

Previously, in the scenario where Host Multi-Agent streamed answers directly from the Host, using the OnHandOff callback simultaneously would cause the loss of streaming effects, resulting in the direct output of the Host's full answer in one message chunk. This PR fixes this issue.