### PR TITLE
feat: Add video message part type support for Alibaba Cloud vision models

### DIFF
--- a/schema/message.go
+++ b/schema/message.go
@@ -221,9 +221,21 @@ type ChatMessageFileURL struct {
 	Extra map[string]any `json:"extra,omitempty"`
 }
 
+// ChatMessageVideo is used to represent a video part with multiple frames in a chat message.
+// This supports the custom video format with an array of base64-encoded frames.
+type ChatMessageVideo struct {
+	// Video is an array of base64-encoded video frames, typically in data URI format.
+	Video []string `json:"video,omitempty"`
+
+	// MIMEType is the mime type of the video frames, eg. "image/jpeg", "image/png".
+	MIMEType string `json:"mime_type,omitempty"`
+	// Extra is used to store extra information for the video.
+	Extra map[string]any `json:"extra,omitempty"`
+}
+
 // ChatMessagePart is the part in a chat message.
 type ChatMessagePart struct {
-	// Type is the type of the part, eg. "text", "image_url", "audio_url", "video_url", "file_url".
+	// Type is the type of the part, eg. "text", "image_url", "audio_url", "video_url", "file_url", "video".
 	Type ChatMessagePartType `json:"type,omitempty"`
 
 	// Text is the text of the part, it's used when Type is "text".
@@ -237,6 +249,8 @@ type ChatMessagePart struct {
 	VideoURL *ChatMessageVideoURL `json:"video_url,omitempty"`
 	// FileURL is the file url of the part, it's used when Type is "file_url".
 	FileURL *ChatMessageFileURL `json:"file_url,omitempty"`
+	// Video is the video frames of the part, it's used when Type is "video".
+	Video *ChatMessageVideo `json:"video,omitempty"`
 }
 
 // LogProbs is the top-level structure containing the log probability information.


### PR DESCRIPTION
## Summary
This PR adds support for a new `video` message part type in the eino schema to enable direct video frame transmission compatible with Alibaba Cloud's vision model services.

## Background
Alibaba Cloud's Model Studio vision models support video content processing through a specific format that requires video frames to be sent as an array of base64-encoded images. This enhancement enables eino framework to work seamlessly with Alibaba Cloud's multimodal capabilities.

Reference: https://help.aliyun.com/zh/model-studio/vision#80dbf6ca8fh6s

## Changes
- Added `ChatMessagePartTypeVideo = "video"` constant for video message parts
- Added `ChatMessageVideo` struct to handle video frames with base64-encoded data
- Updated `ChatMessagePart` struct to include `Video *ChatMessageVideo` field
- Updated message concatenation logic to handle video fields

## API Changes
### New Types
```go
// ChatMessagePartTypeVideo represents video content with multiple frames
const ChatMessagePartTypeVideo ChatMessagePartType = "video"

// ChatMessageVideo handles video frames in base64 format for Alibaba Cloud compatibility
type ChatMessageVideo struct {
    Video    []string          `json:"video,omitempty"`    // Array of base64-encoded frames
    MIMEType string            `json:"mime_type,omitempty"` // Frame format (e.g., "image/jpeg")
    Extra    map[string]any    `json:"extra,omitempty"`     // Additional metadata
}