### PR TITLE
feat: add ToolCallName to schema.Message

### DIFF
--- a/compose/tool_node.go
+++ b/compose/tool_node.go
@@ -391,7 +391,7 @@ func (tn *ToolsNode) Invoke(ctx context.Context, input *schema.Message,
 			rerunExtra.ExecutedTools[tasks[i].callID] = tasks[i].output
 		}
 		if !rerun {
-			output[i] = schema.ToolMessage(tasks[i].output, tasks[i].callID)
+			output[i] = schema.ToolMessage(tasks[i].output, tasks[i].callID, schema.WithToolName(tasks[i].name))
 		}
 	}
 	if rerun {
@@ -469,9 +469,10 @@ func (tn *ToolsNode) Stream(ctx context.Context, input *schema.Message,
 	for i := 0; i < n; i++ {
 		index := i
 		callID := tasks[i].callID
+		callName := tasks[i].name
 		convert := func(s string) ([]*schema.Message, error) {
 			ret := make([]*schema.Message, n)
-			ret[index] = schema.ToolMessage(s, callID)
+			ret[index] = schema.ToolMessage(s, callID, schema.WithToolName(callName))
 
 			return ret, nil
 		}

--- a/compose/tool_node_test.go
+++ b/compose/tool_node_test.go
@@ -629,11 +629,13 @@ func TestUnknownTool(t *testing.T) {
 			Role:       schema.Tool,
 			Content:    "unknown",
 			ToolCallID: "1",
+			ToolName:   "unknown1",
 		},
 		{
 			Role:       schema.Tool,
 			Content:    "unknown",
 			ToolCallID: "2",
+			ToolName:   "unknown2",
 		},
 	}
 


### PR DESCRIPTION
#### What type of PR is this?
<!--
Add one of the following kinds:

build: Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)
ci: Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
docs: Documentation only changes
feat: A new feature
optimize: A new optimization
fix: A bug fix
perf: A code change that improves performance
refactor: A code change that neither fixes a bug nor adds a feature
style: Changes that do not affect the meaning of the code (white space, formatting, missing semi-colons, etc)
test: Adding missing tests or correcting existing tests
chore: Changes to the build process or auxiliary tools and libraries such as documentation generation
-->

#### Check the PR title.
<!--
The description of the title will be attached in Release Notes, 
so please describe it from user-oriented, what this PR does / why we need it.
Please check your PR title with the below requirements:
-->
- [ ] This PR title match the format: \<type\>(optional scope): \<description\>
- [ ] The description of this PR title is user-oriented and clear enough for others to understand.
- [ ] Attach the PR updating the user documentation if the current PR requires user awareness at the usage level. [User docs repo](https://github.com/cloudwego/cloudwego.github.io)


#### (Optional) Translate the PR title into Chinese.


#### (Optional) More detailed description for this PR(en: English/zh: Chinese).
<!--
Provide more detailed info for review(e.g., it's recommended to provide perf data if this is a perf type PR).
-->
en:
zh(optional): 


#### (Optional) Which issue(s) this PR fixes:
<!--
Automatically closes linked issue when PR is merged.
Eg: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

#### (optional) The PR that updates user documentation:
<!--
If the current PR requires user awareness at the usage level, please submit a PR to update user docs. [User docs repo](https://github.com/cloudwego/cloudwego.github.io)
-->
