### PR TITLE
fix: dynamic field mapping can map from nil to acceptable types

### DIFF
--- a/compose/field_mapping.go
+++ b/compose/field_mapping.go
@@ -708,6 +708,14 @@ func validateFieldMapping(predecessorType reflect.Type, successorType reflect.Ty
 		if predecessorIntermediateInterface {
 			checker := func(a any) (any, error) {
 				trueInType := reflect.TypeOf(a)
+				if trueInType == nil {
+					switch successorFieldType.Kind() {
+					case reflect.Map, reflect.Slice, reflect.Ptr, reflect.Interface:
+						return a, nil
+					default:
+						return nil, fmt.Errorf("runtime check failed for mapping %s, field[%v]-[%v] is absolutely not assignable", mapping, trueInType, successorFieldType)
+					}
+				}
 				if !trueInType.AssignableTo(successorFieldType) {
 					return nil, fmt.Errorf("runtime check failed for mapping %s, field[%v]-[%v] is absolutely not assignable", mapping, trueInType, successorFieldType)
 				}


### PR DESCRIPTION
#### What type of PR is this?
fix: when field mapping from an interface type, we have deferred type checking at request time. Then at request time, the real value could potentially be 'nil', which does not have type information, so the request time check will fail. 

Now if we encounter nil, we will check if it can be assigned to the target type.