### PR TITLE
fix: concatMessageArray empty slice handling

### DIFF
--- a/schema/message.go
+++ b/schema/message.go
@@ -42,6 +42,10 @@ func init() {
 }
 
 func concatMessageArray(mas [][]*Message) ([]*Message, error) {
+	if len(mas) == 0 {
+		return nil, fmt.Errorf("empty message array")
+	}
+
 	arrayLen := len(mas[0])
 
 	ret := make([]*Message, arrayLen)

--- a/schema/message_test.go
+++ b/schema/message_test.go
@@ -742,3 +742,8 @@ func TestConcatToolCalls(t *testing.T) {
 		assert.EqualValues(t, expectedToolCall, tc)
 	})
 }
+
+func TestConcatMessageArrayEmpty(t *testing.T) {
+	_, err := concatMessageArray([][]*Message{})
+	assert.Error(t, err)
+}


### PR DESCRIPTION
- avoid panic when concatenating empty message arrays
- add unit test for empty slice

**find by codex 😏**