### PR TITLE
feat: directly print primitive type for tool output

### DIFF
--- a/components/tool/utils/invokable_func.go
+++ b/components/tool/utils/invokable_func.go
@@ -165,7 +165,7 @@ func (i *invokableTool[T, D]) InvokableRun(ctx context.Context, arguments string
 			return "", fmt.Errorf("[LocalFunc] failed to marshal output, toolName=%s, err=%w", i.getToolName(), err)
 		}
 	} else {
-		output, err = sonic.MarshalString(resp)
+		output, err = defaultMarshalOutput(ctx, resp)
 		if err != nil {
 			return "", fmt.Errorf("[LocalFunc] failed to marshal output in json, toolName=%s, err=%w", i.getToolName(), err)
 		}
@@ -184,6 +184,17 @@ func (i *invokableTool[T, D]) getToolName() string {
 	}
 
 	return i.info.Name
+}
+
+func defaultMarshalOutput(ctx context.Context, output any) (string, error) {
+	switch v := output.(type) {
+	case string:
+		return v, nil
+	case int64, uint64, int32, uint32, int16, uint16, int8, uint8, int, uint, float64, float32, bool:
+		return fmt.Sprint(v), nil
+	default:
+		return sonic.MarshalString(output)
+	}
 }
 
 // snakeToCamel converts a snake_case string to CamelCase.

--- a/components/tool/utils/streamable_func.go
+++ b/components/tool/utils/streamable_func.go
@@ -132,7 +132,7 @@ func (s *streamableTool[T, D]) StreamableRun(ctx context.Context, argumentsInJSO
 				return "", fmt.Errorf("[LocalStreamFunc] failed to marshal output, toolName=%s, err=%w", s.getToolName(), e)
 			}
 		} else {
-			out, e = sonic.MarshalString(d)
+			out, e = defaultMarshalOutput(ctx, d)
 			if e != nil {
 				return "", fmt.Errorf("[LocalStreamFunc] failed to marshal output in json, toolName=%s, err=%w", s.getToolName(), e)
 			}


### PR DESCRIPTION
#### What type of PR is this?

directly print primitive type for tool output
don't need to use json.Marshal for primitive type

#### Check the PR title.

#### (Optional) Translate the PR title into Chinese.


#### (Optional) More detailed description for this PR(en: English/zh: Chinese).
en:
zh(optional): 

#### (Optional) Which issue(s) this PR fixes:

#### (optional) The PR that updates user documentation:
