### PR TITLE
feat: add return directly message validity checker for react agent

### DIFF
--- a/flow/agent/react/react.go
+++ b/flow/agent/react/react.go
@@ -62,6 +62,7 @@ type AgentConfig struct {
 
 	// Tools that will make agent return directly when the tool is called.
 	// When multiple tools are called and more than one tool is in the return directly list, only the first one will be returned.
+	// When ToolMsgValidityChecker is not nil, only the first valid tool message will be returned.
 	ToolReturnDirectly     map[string]struct{}
 	ToolMsgValidityChecker func(msg *schema.Message) bool
 
@@ -218,7 +219,7 @@ func NewAgent(ctx context.Context, config *AgentConfig) (_ *Agent, err error) {
 		return nil, err
 	}
 
-	returnDirectlyToolCallID := make(map[string]bool)
+	returnDirectlyToolCallID := make(map[string]bool) // tool call ids of tools that should return directly
 	toolsNodePreHandle := func(ctx context.Context, input *schema.Message, state *state) (*schema.Message, error) {
 		if input == nil {
 			return state.Messages[len(state.Messages)-1], nil // used for rerun interrupt resume

--- a/flow/agent/react/react.go
+++ b/flow/agent/react/react.go
@@ -219,7 +219,7 @@ func NewAgent(ctx context.Context, config *AgentConfig) (_ *Agent, err error) {
 		return nil, err
 	}
 
-	returnDirectlyToolCallID := make(map[string]bool) // tool call ids of tools that should return directly
+	returnDirectlyToolCallID := make(map[string]bool) // tool call ids of tools that are set in ToolReturnDirectly
 	toolsNodePreHandle := func(ctx context.Context, input *schema.Message, state *state) (*schema.Message, error) {
 		if input == nil {
 			return state.Messages[len(state.Messages)-1], nil // used for rerun interrupt resume

--- a/flow/agent/react/react.go
+++ b/flow/agent/react/react.go
@@ -342,8 +342,8 @@ func genToolInfos(ctx context.Context, config compose.ToolsNodeConfig) ([]*schem
 	return toolInfos, nil
 }
 
-func getReturnDirectlyToolCallID(input []*schema.Message, toolReturnDirectly map[string]bool, msgChecker func(msg *schema.Message) bool) string {
-	if len(toolReturnDirectly) == 0 {
+func getReturnDirectlyToolCallID(input []*schema.Message, returnDirectlyToolCallID map[string]bool, msgChecker func(msg *schema.Message) bool) string {
+	if len(returnDirectlyToolCallID) == 0 {
 		return ""
 	}
 	if msgChecker == nil {
@@ -354,7 +354,7 @@ func getReturnDirectlyToolCallID(input []*schema.Message, toolReturnDirectly map
 
 	for _, msg := range input {
 		if msg.Role == schema.Tool {
-			if toolReturnDirectly[msg.ToolCallID] && msgChecker(msg) {
+			if returnDirectlyToolCallID[msg.ToolCallID] && msgChecker(msg) {
 				return msg.ToolCallID
 			}
 		}

--- a/flow/agent/react/react.go
+++ b/flow/agent/react/react.go
@@ -354,8 +354,7 @@ func getReturnDirectlyToolCallID(input []*schema.Message, toolReturnDirectly map
 
 	for _, msg := range input {
 		if msg.Role == schema.Tool {
-			_, has := toolReturnDirectly[msg.ToolCallID]
-			if has && msgVilidityChecker(msg) {
+			if toolReturnDirectly[msg.ToolCallID] && msgVilidityChecker(msg) {
 				return msg.ToolCallID
 			}
 		}


### PR DESCRIPTION
#### What type of PR is this?
<!--
Add one of the following kinds:

build: Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)
ci: Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
docs: Documentation only changes

optimize: A new optimization
fix: A bug fix
perf: A code change that improves performance
refactor: A code change that neither fixes a bug nor adds a feature
style: Changes that do not affect the meaning of the code (white space, formatting, missing semi-colons, etc)
test: Adding missing tests or correcting existing tests
chore: Changes to the build process or auxiliary tools and libraries such as documentation generation
-->
feat: add return directly message validity checker for react agent

#### Check the PR title.
<!--
The description of the title will be attached in Release Notes, 
so please describe it from user-oriented, what this PR does / why we need it.
Please check your PR title with the below requirements:
-->
- [x] This PR title match the format: \<type\>(optional scope): \<description\>
- [ ] The description of this PR title is user-oriented and clear enough for others to understand.
- [ ] Attach the PR updating the user documentation if the current PR requires user awareness at the usage level. [User docs repo](https://github.com/cloudwego/cloudwego.github.io)


#### (Optional) Translate the PR title into Chinese.
feat(react): 添加工具消息有效性检查器以更好地控制工具返回

#### (Optional) More detailed description for this PR(en: English/zh: Chinese).
<!--
Provide more detailed info for review(e.g., it's recommended to provide perf data if this is a perf type PR).
-->
en:
This PR enhances the ReAct agent's tool return mechanism by adding a ToolMsgValidityChecker function to the AgentConfig.
Key changes:
Added ToolMsgValidityChecker func(msg *schema.Message) bool field to AgentConfig
Modified the tool return logic to only return the first valid tool message when multiple tools are configured to return directly
Refactored getReturnDirectlyToolCallID function to work with tool messages instead of tool calls and incorporate validity checking
Updated the tool node handling logic to use post-handler for determining return-directly tool call IDs
Benefits:
Provides fine-grained control over which tool messages should trigger direct returns
Enables validation of tool execution results before deciding to return directly
Maintains backward compatibility (checker is optional and defaults to accepting all messages)

zh(optional):
此PR通过向AgentConfig添加ToolMsgValidityChecker函数来增强ReAct代理的工具返回机制。
主要变更：
在AgentConfig中添加了ToolMsgValidityChecker func(msg *schema.Message) bool字段
修改了工具返回逻辑，当配置多个工具直接返回时，只返回第一个有效的工具消息
重构了getReturnDirectlyToolCallID函数，使其处理工具消息而非工具调用，并集成有效性检查
更新了工具节点处理逻辑，使用后置处理器确定直接返回的工具调用ID
优势：
提供对哪些工具消息应触发直接返回的细粒度控制
支持在决定直接返回前验证工具执行结果
保持向后兼容性（检查器是可选的，默认接受所有消息）

#### (Optional) Which issue(s) this PR fixes:
<!--
Automatically closes linked issue when PR is merged.
Eg: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

#### (optional) The PR that updates user documentation:
<!--
If the current PR requires user awareness at the usage level, please submit a PR to update user docs. [User docs repo](https://github.com/cloudwego/cloudwego.github.io)
-->
