### PR TITLE
fix: deep copy callback handlers when AppendHandlers

### DIFF
--- a/compose/utils.go
+++ b/compose/utils.go
@@ -167,6 +167,10 @@ func initGraphCallbacks(ctx context.Context, info *nodeInfo, meta *executorMeta,
 		}
 	}
 
+	if len(cbs) == 0 {
+		return icb.ReuseHandlers(ctx, ri)
+	}
+
 	return icb.AppendHandlers(ctx, ri, cbs...)
 }
 
@@ -193,6 +197,10 @@ func initNodeCallbacks(ctx context.Context, key string, info *nodeInfo, meta *ex
 				}
 			}
 		}
+	}
+
+	if len(cbs) == 0 {
+		return icb.ReuseHandlers(ctx, ri)
 	}
 
 	return icb.AppendHandlers(ctx, ri, cbs...)

--- a/internal/callbacks/inject.go
+++ b/internal/callbacks/inject.go
@@ -60,7 +60,10 @@ func AppendHandlers(ctx context.Context, info *RunInfo, handlers ...Handler) con
 	if !ok {
 		return InitCallbacks(ctx, info, handlers...)
 	}
-	return InitCallbacks(ctx, info, append(cbm.handlers, handlers...)...)
+	nh := make([]Handler, len(cbm.handlers)+len(handlers))
+	copy(nh[:len(cbm.handlers)], cbm.handlers)
+	copy(nh[len(cbm.handlers):], handlers)
+	return InitCallbacks(ctx, info, nh...)
 }
 
 type Handle[T any] func(context.Context, T, *RunInfo, []Handler) (context.Context, T)


### PR DESCRIPTION
deep copy callback handlers when AppendHandlers, to avoid lost updates when two concurrent child processes appending to the same Context.