### PR TITLE
fix: add to start and end node list even if the branch skips data

### DIFF
--- a/compose/graph.go
+++ b/compose/graph.go
@@ -497,6 +497,14 @@ func (g *graph) addBranch(startNode string, branch *GraphBranch, skipData bool) 
 			}
 		}
 	} else {
+		for endNode := range branch.endNodes {
+			if startNode == START {
+				g.startNodes = append(g.startNodes, endNode)
+			}
+			if endNode == END {
+				g.endNodes = append(g.endNodes, startNode)
+			}
+		}
 		branch.noDataFlow = true
 	}
 


### PR DESCRIPTION
workflow branch will skip data passing to successor nodes. Previously, these kind of branches won't add the branch 'from node' and 'end nodes' to graph's start node and end node list, which does not make sense