### PR TITLE
fix: deep copy callback handlers when AppendHandlers; init global cal…

### DIFF
--- a/callbacks/aspect_inject.go
+++ b/callbacks/aspect_inject.go
@@ -96,11 +96,13 @@ func OnError(ctx context.Context, err error) context.Context {
 
 // EnsureRunInfo ensures the RunInfo in context matches the given type and component.
 // If the current callback manager doesn't match or doesn't exist, it creates a new one while preserving existing handlers.
+// Will initialize Global callback handlers if none exist in the ctx before.
 func EnsureRunInfo(ctx context.Context, typ string, comp components.Component) context.Context {
 	return callbacks.EnsureRunInfo(ctx, typ, comp)
 }
 
 // ReuseHandlers initializes a new context with the provided RunInfo, while using the same handlers already exist.
+// Will initialize Global callback handlers if none exist in the ctx before.
 func ReuseHandlers(ctx context.Context, info *RunInfo) context.Context {
 	return callbacks.ReuseHandlers(ctx, info)
 }

--- a/compose/utils.go
+++ b/compose/utils.go
@@ -167,6 +167,10 @@ func initGraphCallbacks(ctx context.Context, info *nodeInfo, meta *executorMeta,
 		}
 	}
 
+	if len(cbs) == 0 {
+		return icb.ReuseHandlers(ctx, ri)
+	}
+
 	return icb.AppendHandlers(ctx, ri, cbs...)
 }
 
@@ -193,6 +197,10 @@ func initNodeCallbacks(ctx context.Context, key string, info *nodeInfo, meta *ex
 				}
 			}
 		}
+	}
+
+	if len(cbs) == 0 {
+		return icb.ReuseHandlers(ctx, ri)
 	}
 
 	return icb.AppendHandlers(ctx, ri, cbs...)


### PR DESCRIPTION
…lback handlers when ReuseHandlers or EnsureRunInfo

#### What type of PR is this?
this PR contains several fixes for callback utility functions:
1. Deep copy callback handlers when AppendHandlers, to avoid lost updates when two concurrent child processes appending to the same Context.
2. When using ReuseHandlers or EnsureRunInfo, if the original Context was not initialized with global callback handlers at all, create a new Context with global callback handlers.