### PR TITLE
feat(compose): remove GetState & use eager execution by default in graph with all predecessor

### DIFF
--- a/compose/graph.go
+++ b/compose/graph.go
@@ -656,14 +656,11 @@ func (g *graph) compile(ctx context.Context, opt *graphCompileOptions) (*composa
 
 	// get eager type
 	eager := false
-	if opt != nil {
-		eager = opt.eager
-	}
-	if runType == runTypePregel && eager {
-		return nil, errors.New("eager mode is not allowed when trigger mode is AnyPredecessor")
-	}
-	if isWorkflow(g.cmp) {
+	if isWorkflow(g.cmp) || runType == runTypeDAG {
 		eager = true
+	}
+	if opt != nil && opt.eagerDisabled {
+		eager = false
 	}
 
 	if len(g.startNodes) == 0 {

--- a/compose/graph_compile_options.go
+++ b/compose/graph_compile_options.go
@@ -30,7 +30,7 @@ type graphCompileOptions struct {
 	interruptBeforeNodes []string
 	interruptAfterNodes  []string
 
-	eager bool
+	eagerDisabled bool
 
 	mergeConfigs map[string]FanInMergeConfig
 }
@@ -73,9 +73,21 @@ func WithGraphName(graphName string) GraphCompileOption {
 // without waiting for the completion of a super step, ref: https://www.cloudwego.io/docs/eino/core_modules/chain_and_graph_orchestration/orchestration_design_principles/#runtime-engine
 // Note: Eager mode is not allowed when the graph's trigger mode is set to AnyPredecessor.
 // Workflow uses eager mode by default.
+// Deprecated: Eager execution is automatically enabled by default when a node's trigger mode is set to AllPredecessor.
+// If you were using this option previously, it can be safely removed without changing behavior.
 func WithEagerExecution() GraphCompileOption {
 	return func(o *graphCompileOptions) {
-		o.eager = true
+		return
+	}
+}
+
+// WithEagerExecutionDisabled disables the eager execution mode for the graph.
+// By default, eager execution is enabled for Workflow and Graph with the AllPredecessor trigger mode.
+// After using this option, nodes will wait for the completion of a super step instead of execute immediately once they are ready to run.
+// ref: https://www.cloudwego.io/docs/eino/core_modules/chain_and_graph_orchestration/orchestration_design_principles/#runtime-engine
+func WithEagerExecutionDisabled() GraphCompileOption {
+	return func(o *graphCompileOptions) {
+		o.eagerDisabled = true
 	}
 }
 

--- a/compose/state.go
+++ b/compose/state.go
@@ -110,25 +110,6 @@ func streamConvertPostHandler[O, S any](handler StreamStatePostHandler[O, S]) *c
 	return runnableLambda[O, O](nil, nil, nil, rf, false)
 }
 
-// GetState gets the state from the context.
-// Notice: The returned state isn't concurrency-safe that may cause data race in graph execution.
-// Deprecated: use ProcessState instead.
-func GetState[S any](ctx context.Context) (S, error) {
-	state := ctx.Value(stateKey{})
-
-	iState := state.(*internalState)
-	iState.mu.Lock()
-	defer iState.mu.Unlock()
-	cState, ok := iState.state.(S)
-	if !ok {
-		var s S
-		return s, fmt.Errorf("unexpected state type. expected: %v, got: %v",
-			generic.TypeOf[S](), reflect.TypeOf(iState.state))
-	}
-
-	return cState, nil
-}
-
 // ProcessState processes the state from the context in a concurrency-safe way.
 // This is the recommended way to access and modify state in custom nodes.
 // The provided function handler will be executed with exclusive access to the state (protected by mutex).


### PR DESCRIPTION
#### What type of PR is this?
<!--
Add one of the following kinds:

build: Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)
ci: Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
docs: Documentation only changes
feat: A new feature
optimize: A new optimization
fix: A bug fix
perf: A code change that improves performance
refactor: A code change that neither fixes a bug nor adds a feature
style: Changes that do not affect the meaning of the code (white space, formatting, missing semi-colons, etc)
test: Adding missing tests or correcting existing tests
chore: Changes to the build process or auxiliary tools and libraries such as documentation generation
-->

#### Check the PR title.
<!--
The description of the title will be attached in Release Notes, 
so please describe it from user-oriented, what this PR does / why we need it.
Please check your PR title with the below requirements:
-->
- [ ] This PR title match the format: \<type\>(optional scope): \<description\>
- [ ] The description of this PR title is user-oriented and clear enough for others to understand.
- [ ] Attach the PR updating the user documentation if the current PR requires user awareness at the usage level. [User docs repo](https://github.com/cloudwego/cloudwego.github.io)


#### (Optional) Translate the PR title into Chinese.


#### (Optional) More detailed description for this PR(en: English/zh: Chinese).
<!--
Provide more detailed info for review(e.g., it's recommended to provide perf data if this is a perf type PR).
-->
en:
zh(optional): 


#### (Optional) Which issue(s) this PR fixes:
<!--
Automatically closes linked issue when PR is merged.
Eg: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

#### (optional) The PR that updates user documentation:
<!--
If the current PR requires user awareness at the usage level, please submit a PR to update user docs. [User docs repo](https://github.com/cloudwego/cloudwego.github.io)
-->
