### PR TITLE
 feat: Improve type safety in StreamReaderWithConvert

### DIFF
--- a/schema/stream.go
+++ b/schema/stream.go
@@ -553,7 +553,12 @@ func newStreamReaderWithConvert[T any](origin iStreamReader, convert func(any) (
 //	fmt.Println(s) // Output: val_1
 func StreamReaderWithConvert[T, D any](sr *StreamReader[T], convert func(T) (D, error)) *StreamReader[D] {
 	c := func(a any) (D, error) {
-		return convert(a.(T)) // nolint: byted_interface_check_golintx
+		v, ok := a.(T)
+		if !ok {
+			var d D
+			return d, fmt.Errorf("failed to convert type %T to %T", a, d)
+		}
+		return convert(v)
 	}
 
 	return newStreamReaderWithConvert(sr, c)


### PR DESCRIPTION
This change enhances the robustness of the StreamReaderWithConvert function in
  schema/stream.go. It introduces a type assertion check when converting from any
   to the target type T.

  Previously, if an unexpected type was passed, the a.(T) assertion could lead
  to a runtime panic. By adding an explicit ok check, the function now
  gracefully handles type mismatches by returning a descriptive error,
  preventing potential crashes and making the code more resilient to future
  changes or unexpected inputs. This improvement does not alter the existing
  functionality for valid type conversions.