### PR TITLE
fix(flow_react): use correct context to call `toolCallChecker`

### DIFF
--- a/flow/agent/react/react.go
+++ b/flow/agent/react/react.go
@@ -263,7 +263,7 @@ func NewAgent(ctx context.Context, config *AgentConfig) (_ *Agent, err error) {
 		return nil, err
 	}
 
-	modelPostBranchCondition := func(_ context.Context, sr *schema.StreamReader[*schema.Message]) (endNode string, err error) {
+	modelPostBranchCondition := func(ctx context.Context, sr *schema.StreamReader[*schema.Message]) (endNode string, err error) {
 		if isToolCall, err := toolCallChecker(ctx, sr); err != nil {
 			return "", err
 		} else if isToolCall {


### PR DESCRIPTION
#### What type of PR is this?

fix: A bug fix

#### Check the PR title.

- [x] This PR title match the format: \<type\>(optional scope): \<description\>
- [x] The description of this PR title is user-oriented and clear enough for others to understand.
- [x] Attach the PR updating the user documentation if the current PR requires user awareness at the usage level. [User docs repo](https://github.com/cloudwego/cloudwego.github.io)


#### (Optional) Translate the PR title into Chinese.

使用正确的 context 调用 `toolCallChecker`

#### (Optional) More detailed description for this PR(en: English/zh: Chinese).

en:

The ignored ctx parameter leads to the actual use of NewAgent ctx parameter when calling toolCallChecker.

The default toolCallChecker works well with that, because it does not use ctx.

When a custom toolCallChecker is specified, this issue is exposed.

zh(optional):

忽略的 ctx 参数导致调用 toolCallChecker 时实际使用的是 NewAgent 的 ctx 参数。

默认的 toolCallChecker 能正常工作，因为它并没有使用 ctx。

但当自定义 toolCallChecker 时，暴露了该问题。


#### (Optional) Which issue(s) this PR fixes:

None.

#### (optional) The PR that updates user documentation:

None.