### PR TITLE
fix: resolve edge handlers on successor ready, not on predecessor done

### DIFF
--- a/compose/dag.go
+++ b/compose/dag.go
@@ -125,7 +125,8 @@ func (ch *dagChannel) reportSkip(keys []string) bool {
 	return allSkipped
 }
 
-func (ch *dagChannel) get(isStream bool) (any, bool, error) {
+func (ch *dagChannel) get(isStream bool, name string, edgeHandler *edgeHandlerManager) (
+	any, bool, error) {
 	if ch.Skipped {
 		return nil, false, nil
 	}
@@ -159,7 +160,11 @@ func (ch *dagChannel) get(isStream bool) (any, bool, error) {
 	names := make([]string, len(ch.Values))
 	i := 0
 	for k, value := range ch.Values {
-		valueList[i] = value
+		resolvedV, err := edgeHandler.handle(k, name, value, isStream)
+		if err != nil {
+			return nil, false, err
+		}
+		valueList[i] = resolvedV
 		names[i] = k
 		i++
 	}

--- a/compose/pregel.go
+++ b/compose/pregel.go
@@ -52,7 +52,8 @@ func (ch *pregelChannel) reportValues(ins map[string]any) error {
 	return nil
 }
 
-func (ch *pregelChannel) get(_ bool) (any, bool, error) {
+func (ch *pregelChannel) get(isStream bool, name string, edgeHandler *edgeHandlerManager) (
+	any, bool, error) {
 	if len(ch.Values) == 0 {
 		return nil, false, nil
 	}
@@ -61,7 +62,11 @@ func (ch *pregelChannel) get(_ bool) (any, bool, error) {
 	names := make([]string, len(ch.Values))
 	i := 0
 	for k, v := range ch.Values {
-		values[i] = v
+		resolvedV, err := edgeHandler.handle(k, name, v, isStream)
+		if err != nil {
+			return nil, false, err
+		}
+		values[i] = resolvedV
 		names[i] = k
 		i++
 	}


### PR DESCRIPTION
#### What type of PR is this?

fix an issue when a workflow node A 'indirectly maps' to another node B across branch, the field mapping on edge is eagerly resolved as soon as node A returns, which bypasses the branch control and may cause unexpected behavior.