### PR TITLE
fix(flow): host multi-agent OnHandOff correctly captures streaming to…

### DIFF
--- a/flow/agent/multiagent/host/compose_test.go
+++ b/flow/agent/multiagent/host/compose_test.go
@@ -477,7 +477,6 @@ func TestHostMultiAgent(t *testing.T) {
 				{
 					Index: generic.PtrOf(1),
 					Function: schema.FunctionCall{
-						Name:      specialist2.Name,
 						Arguments: ` is also good"}`,
 					},
 				},


### PR DESCRIPTION
…ol arguments

#### What type of PR is this?
          
# Fix: Host Multi-Agent OnHandOff Correctly Captures Streaming Output

## Problem

The host multi-agent system's `OnHandOff` callback was not properly capturing tool call arguments in streaming scenarios.

## Solution

Use Eino's canonical ConcatMessageStream ability to properly concatenate streaming chunks into whole Message, so that ALL tool call arguments are properly captured.

fixes https://github.com/cloudwego/eino/issues/426