### PR TITLE
refactor(adk): exit action can be consumed, limiting its scope

### DIFF
--- a/adk/agent_tool_test.go
+++ b/adk/agent_tool_test.go
@@ -52,7 +52,7 @@ func (a *mockAgentForTool) Run(_ context.Context, _ *AgentInput, _ ...AgentRunOp
 			generator.Send(event)
 
 			// If the event has an Exit action, stop sending events
-			if event.Action != nil && event.Action.Exit {
+			if event.Action != nil && event.Action.NeedExit() {
 				break
 			}
 		}

--- a/adk/chatmodel_test.go
+++ b/adk/chatmodel_test.go
@@ -334,7 +334,7 @@ func TestExitTool(t *testing.T) {
 
 	// Verify the action is Exit
 	assert.NotNil(t, event2.Action)
-	assert.True(t, event2.Action.Exit)
+	assert.True(t, event2.Action.NeedExit())
 
 	// Verify the final result
 	assert.Equal(t, "This is the final result", event2.Output.MessageOutput.Message.Content)

--- a/adk/flow.go
+++ b/adk/flow.go
@@ -428,7 +428,7 @@ func (a *flowAgent) run(
 			appendInterruptRunCtx(ctx, runCtx)
 			return
 		}
-		if lastAction.Exit {
+		if lastAction.NeedExit() { // do not consume the exit action, let the parent do it
 			return
 		}
 

--- a/adk/prebuilt/planexecute/plan_execute.go
+++ b/adk/prebuilt/planexecute/plan_execute.go
@@ -883,9 +883,10 @@ func New(ctx context.Context, cfg *Config) (adk.Agent, error) {
 		maxIterations = 10
 	}
 	loop, err := adk.NewLoopAgent(ctx, &adk.LoopAgentConfig{
-		Name:          "execute_replan",
-		SubAgents:     []adk.Agent{cfg.Executor, cfg.Replanner},
-		MaxIterations: maxIterations,
+		Name:                 "execute_replan",
+		SubAgents:            []adk.Agent{cfg.Executor, cfg.Replanner},
+		MaxIterations:        maxIterations,
+		ConsumeSubAgentExits: true,
 	})
 	if err != nil {
 		return nil, err

--- a/adk/prebuilt/planexecute/plan_execute_test.go
+++ b/adk/prebuilt/planexecute/plan_execute_test.go
@@ -511,7 +511,7 @@ func TestReplannerRunWithRespond(t *testing.T) {
 	event, ok = iterator.Next()
 	assert.True(t, ok)
 	assert.NotNil(t, event.Action)
-	assert.True(t, event.Action.Exit)
+	assert.True(t, event.Action.NeedExit())
 
 	_, ok = iterator.Next()
 	assert.False(t, ok)

--- a/adk/runner.go
+++ b/adk/runner.go
@@ -195,6 +195,10 @@ func (r *Runner) handleIter(ctx context.Context, aIter *AsyncIterator[*AgentEven
 			interruptedInfo = nil
 		}
 
+		if event.Action != nil && event.Action.NeedExit() {
+			event.Action.ConsumeExit() // consume the exit action, keep the exit signal within our own scope
+		}
+
 		gen.Send(event)
 	}
 

--- a/adk/runner_test.go
+++ b/adk/runner_test.go
@@ -59,7 +59,7 @@ func (a *mockRunnerAgent) Run(_ context.Context, input *AgentInput, _ ...AgentRu
 			generator.Send(event)
 
 			// If the event has an Exit action, stop sending events
-			if event.Action != nil && event.Action.Exit {
+			if event.Action != nil && event.Action.NeedExit() {
 				break
 			}
 		}


### PR DESCRIPTION
## `refactor(adk): Make ExitAction consumable to limit its scope`

### Description

#### Motivation and Rationale

The existing `Exit` action in the ADK framework has a global and absolute effect. When any agent emits an `Exit`, it unconditionally terminates the entire execution stack. This rigid behavior is undesirable for building complex, resilient workflows where finer control is needed.

The core principle behind this change is that **an individual agent should not have the capacity to unilaterally terminate the entire execution stack.** An agent's responsibility should be to signal its intent to complete its own task. It is then up to the containing workflow or other 'container' to interpret that signal and decide on the appropriate course of action—either by consuming the exit and terminate only current layer, or by propagating it to terminate the broader process.

This refactoring moves the framework from a model of global termination to one of **scoped, hierarchical control**, enabling more sophisticated agent interactions and completion handling.

#### Implementation Details

To achieve this, the following changes were made:

1.  **New `ExitAction` Struct**:
    *   The simple `Exit bool` field in `AgentAction` has been deprecated in favor of a new `ExitAction *ExitAction` field.
    *   The `ExitAction` struct contains a `Consumed bool` flag, which allows the framework to track whether an exit signal has been handled.

2.  **`AgentAction` Helper Methods**:
    *   To encapsulate the new logic, two helper methods have been added to `AgentAction`:
        *   `NeedExit() bool`: This is the new primary method for checking if an action requires termination. It correctly returns `false` if the exit has already been consumed.
        *   `ConsumeExit()`: This method marks an `ExitAction` as consumed, preventing it from causing further termination up the execution stack.

3.  **`ConsumeSubAgentExits` Configuration**:
    *   A new boolean flag, `ConsumeSubAgentExits`, has been added to `SequentialAgentConfig`, `LoopAgentConfig`, and `ParallelAgentConfig`.
    *   When set to `true`, the respective workflow agent will use `ConsumeExit()` on any `ExitAction` it receives from its children. This effectively limits the exit's scope, allowing the parent workflow to continue its own execution.

4.  **Updated Workflow Logic**:
    *   The core execution methods (`runSequential`, `runLoop`, and `runParallel`) have been updated to use the new `NeedExit()` and `ConsumeExit()` helpers, correctly implementing the consumption logic based on the `ConsumeSubAgentExits` flag.

#### Backward Compatibility

These changes are **fully backward-compatible**. The default value for `ConsumeSubAgentExits` is `false`. If this flag is not set, all agents will behave exactly as they did before, with the `ExitAction` propagating up the stack and terminating the entire run. The deprecated `Exit` field is also preserved to ensure existing code continues to function without modification.

### 标题：`refactor(adk): 使 ExitAction 可被消费以限制其作用范围`

### 描述

#### 动机与基本原理

ADK 框架中现有的 `Exit` 动作具有全局性和绝对性的效果。当任何 agent 发出 `Exit` 时，它会无条件地终止整个执行堆栈。对于构建需要更精细控制的复杂、有弹性的工作流来说，这种僵化的行为是不可取的。

此更改背后的核心原则是，**单个 agent 不应有能力单方面终止整个执行。** agent 的职责应该是发出信号，表明其完成自身任务的意图。然后，由其所属的工作流或其他“容器”来解释该信号，并决定适当的行动方案——要么消费该退出信号并仅终止当前层，要么传播它以终止更广泛的进程。

本次重构将框架从全局终止模型转变为**有范围的、分层的控制模型**，从而实现了更复杂的 agent 交互和完成处理。

#### 实现细节

为实现这一目标，进行了以下更改：

*   **新的 `ExitAction` 结构体:**
    *   `AgentAction` 中简单的 `Exit bool` 字段已被弃用，取而代之的是一个新的 `ExitAction *ExitAction` 字段。
    *   `ExitAction` 结构体包含一个 `Consumed bool` 标志，允许框架跟踪退出信号是否已被处理。

*   **`AgentAction` 辅助方法:**
    *   为了封装新逻辑，向 `AgentAction` 添加了两个辅助方法：
        *   `NeedExit() bool`: 这是用于检查动作是否需要终止的主要新方法。如果退出已被消费，它会正确地返回 `false`。
        *   `ConsumeExit()`: 此方法将 `ExitAction` 标记为已消费，从而防止其在执行堆栈中进一步向上传播终止信号。

*   **`ConsumeSubAgentExits` 配置:**
    *   一个新的布尔标志 `ConsumeSubAgentExits` 已被添加到 `SequentialAgentConfig`、`LoopAgentConfig` 和 `ParallelAgentConfig` 中。
    *   当设置为 `true` 时，相应的工作流 agent 将对其从子 agent 收到的任何 `ExitAction` 调用 `ConsumeExit()`。这有效地限制了退出的范围，允许父工作流继续其自身的执行。

*   **更新的工作流逻辑:**
    *   核心执行方法（`runSequential`、`runLoop` 和 `runParallel`）已更新，以使用新的 `NeedExit()` 和 `ConsumeExit()` 辅助方法，从而根据 `ConsumeSubAgentExits` 标志正确实现消费逻辑。

#### 向后兼容性

这些更改是**完全向后兼容的**。`ConsumeSubAgentExits` 的默认值为 `false`。如果未设置此标志，所有 agent 的行为将与以前完全相同，`ExitAction` 将在堆栈中向上传播并终止整个运行。已弃用的 `Exit` 字段也被保留，以确保现有代码可以继续正常工作而无需修改。
        
        