### PR TITLE
feat(adk): define BreakLoopAction

### DIFF
--- a/adk/interface.go
+++ b/adk/interface.go
@@ -146,6 +146,8 @@ type AgentAction struct {
 
 	TransferToAgent *TransferToAgentAction
 
+	BreakLoop *BreakLoopAction
+
 	CustomizedAction any
 }
 

--- a/adk/prebuilt/planexecute/plan_execute.go
+++ b/adk/prebuilt/planexecute/plan_execute.go
@@ -739,7 +739,7 @@ func (r *replanner) Run(ctx context.Context, input *adk.AgentInput, _ ...adk.Age
 			s.Close()
 
 			if isResponse {
-				action := adk.NewExitAction()
+				action := adk.NewBreakLoopAction(r.Name(ctx))
 				generator.Send(&adk.AgentEvent{Action: action})
 				return
 			}

--- a/adk/workflow_test.go
+++ b/adk/workflow_test.go
@@ -374,24 +374,22 @@ func TestLoopAgent(t *testing.T) {
 	}
 }
 
-// TestLoopAgentWithExit tests the loop workflow agent with an exit action
-func TestLoopAgentWithExit(t *testing.T) {
+// TestLoopAgentWithBreakLoop tests the loop workflow agent with an break loop action
+func TestLoopAgentWithBreakLoop(t *testing.T) {
 	ctx := context.Background()
 
-	// Create a mock agent that will exit after the first iteration
+	// Create a mock agent that will break the loop after the first iteration
 	agent := newMockAgent("LoopAgent", "Loop agent", []*AgentEvent{
 		{
 			AgentName: "LoopAgent",
 			Output: &AgentOutput{
 				MessageOutput: &MessageVariant{
 					IsStreaming: false,
-					Message:     schema.AssistantMessage("Loop iteration with exit", nil),
+					Message:     schema.AssistantMessage("Loop iteration with break loop", nil),
 					Role:        schema.Assistant,
 				},
 			},
-			Action: &AgentAction{
-				Exit: true,
-			},
+			Action: NewBreakLoopAction("LoopAgent"),
 		},
 	})
 
@@ -427,7 +425,7 @@ func TestLoopAgentWithExit(t *testing.T) {
 		events = append(events, event)
 	}
 
-	// Should have only 1 event due to exit action
+	// Should have only 1 event due to break loop action
 	assert.Equal(t, 1, len(events))
 
 	// Verify the event
@@ -436,11 +434,14 @@ func TestLoopAgentWithExit(t *testing.T) {
 	assert.NotNil(t, event.Output)
 	assert.NotNil(t, event.Output.MessageOutput)
 	assert.NotNil(t, event.Action)
-	assert.True(t, event.Action.Exit)
+	assert.NotNil(t, event.Action.BreakLoop)
+	assert.True(t, event.Action.BreakLoop.Done)
+	assert.Equal(t, "LoopAgent", event.Action.BreakLoop.From)
+	assert.Equal(t, 0, event.Action.BreakLoop.CurrentIterations)
 
 	msg := event.Output.MessageOutput.Message
 	assert.NotNil(t, msg)
-	assert.Equal(t, "Loop iteration with exit", msg.Content)
+	assert.Equal(t, "Loop iteration with break loop", msg.Content)
 }
 
 // Add these test functions to the existing workflow_test.go file


### PR DESCRIPTION
### Title: `feat(adk): Define BreakLoopAction for Programmatic Loop Termination`

### Description

#### Motivation and Rationale

Currently, the only way to prematurely exit a `LoopAgent` is by using the global `EXIT` action. However, `EXIT` is designed to be an unconditional, cascading termination signal that shuts down the entire execution stack. This behavior is too aggressive for scenarios where a developer simply wants to programmatically break out of a loop and allow the parent workflow to continue.

For example, an agent within a loop might be processing a list of items and encounter a specific condition (e.g., finding the desired item, or hitting an API rate limit) that requires it to stop the loop, but not to terminate the entire application.

This PR introduces a new, narrowly-scoped agent action, `BreakLoopAction`, to solve this specific problem.

#### Implementation Details

1.  **New `BreakLoopAction` Struct**:
    *   A new `BreakLoopAction` struct has been added to `adk/workflow.go`.
    *   This action is intended **for programmatic use only**. It is not exposed to LLMs (e.g., via a tool), which preserves the simple, unambiguous `EXIT` semantic for model-driven terminations.

2.  **Targeted Logic**:
    *   The core logic is handled by a new internal function, `breakLoopIfNeeded`, which checks for the presence of a `BreakLoopAction`.
    *   This check is placed within `(*workflowAgent).runSequential`, which is the underlying execution engine for the `LoopAgent`. When the action is detected, `runSequential` returns an `exit=true` signal to its caller.
    *   The `(*workflowAgent).runLoop` method interprets this signal, terminates its iteration, and returns control to its parent, without propagating the exit signal any further.

3.  **Preservation of `EXIT`**:
    *   The semantics of the existing `EXIT` action remain entirely unchanged. It continues to function as a global, unconditional termination signal.
    *   This design choice ensures full backward compatibility and avoids introducing complexity for developers already familiar with the framework.

#### How This Solves the Problem

This approach provides a clean, safe, and explicit mechanism for developers to control loop execution flow from within a sub-agent.

*   **It's safe:** The change is minimal and isolated, with no risk of unintended side effects in other parts of the framework.
*   **It's clear:** The action's name, `BreakLoopAction`, is unambiguous and its purpose is immediately understandable.
*   **It maintains separation of concerns:** It avoids burdening the `ChatModelAgent` or the LLM with the need to understand different scopes of termination, correctly keeping this control flow logic in the hands of the developer.
 


### 标题：`feat(adk): 定义 BreakLoopAction 以实现程序化循环终止`

### 描述

#### 动机与基本原理

目前，提前退出 `LoopAgent` 的唯一方法是使用全局的 `EXIT` 动作。然而，`EXIT` 被设计为一个无条件的、级联的终止信号，它会关闭整个执行堆栈。对于开发者希望以编程方式跳出循环，并允许父工作流继续执行的场景，这种行为过于“激烈”。

例如，一个在循环中处理项目列表的 agent 可能会遇到一个特定条件（比如，找到了所需项目，或达到了 API 速率限制），这要求它停止循环，而不是终止整个应用程序。

此 PR 引入了一个新的、作用范围明确的 agent 动作——`BreakLoopAction`，以解决这一特定问题。

#### 实现细节

1.  **新的 `BreakLoopAction` 结构体**:
    *   在 `adk/workflow.go` 中添加了一个新的 `BreakLoopAction` 结构体。
    *   此动作**仅供程序化使用**。它不会通过工具等方式暴露给大语言模型（LLM），这为模型驱动的终止保留了简单、明确的 `EXIT` 语义。

2.  **目标明确的逻辑**:
    *   核心逻辑由一个新的内部函数 `breakLoopIfNeeded` 处理，该函数检查是否存在 `BreakLoopAction`。
    *   这个检查被放置在 `(*workflowAgent).runSequential` 中，后者是 `LoopAgent` 的底层执行引擎。当检测到该动作时，`runSequential` 会向其调用者返回一个 `exit=true` 的信号。
    *   `(*workflowAgent).runLoop` 方法会解释这个信号，终止其迭代，并将控制权交还给其父级，而不会再向上层传播退出信号。

3.  **保留 `EXIT` 的语义**:
    *   现有 `EXIT` 动作的语义完全保持不变。它继续作为全局的、无条件的终止信号。
    *   这种设计选择确保了完全的向后兼容性，并避免了给已经熟悉该框架的开发者带来困惑。

#### 如何解决问题

该方法为开发人员提供了一种清晰、安全且明确的机制，用于从子 agent 内部控制循环的执行流程。

*   **安全：** 更改是最小且隔离的，在框架的其他部分没有意外副作用的风险。
*   **清晰：** 动作的名称 `BreakLoopAction` 含义明确，其目的可以立即被理解。
*   **保持关注点分离：** 它避免了让 `ChatModelAgent` 或 LLM 承担理解不同终止范围的负担，正确地将此控制流逻辑保留在开发人员手中。
        