### PR TITLE
refactor: modify type of ToolChoice in model.CallbackInput

### DIFF
--- a/components/model/callback_extra.go
+++ b/components/model/callback_extra.go
@@ -59,8 +59,7 @@ type CallbackInput struct {
 	// Tools is the tools to be used in the model.
 	Tools []*schema.ToolInfo
 	// ToolChoice is the tool choice, which controls the tool to be used in the model.
-	// Deprecated: ToolChoice is no longer supported and should not be set.
-	ToolChoice any // string / *schema.ToolInfo
+	ToolChoice *schema.ToolChoice
 	// Config is the config for the model.
 	Config *Config
 	// Extra is the extra information for the callback.


### PR DESCRIPTION
#### What type of PR is this?
<!--
Add one of the following kinds:

build: Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)
ci: Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
docs: Documentation only changes
feat: A new feature
optimize: A new optimization
fix: A bug fix
perf: A code change that improves performance
refactor: A code change that neither fixes a bug nor adds a feature
style: Changes that do not affect the meaning of the code (white space, formatting, missing semi-colons, etc)
test: Adding missing tests or correcting existing tests
chore: Changes to the build process or auxiliary tools and libraries such as documentation generation
-->
refactor: Change CallbackInput.ToolChoice type from any to *schema.ToolChoice (break change)

#### Check the PR title.
<!--
The description of the title will be attached in Release Notes, 
so please describe it from user-oriented, what this PR does / why we need it.
Please check your PR title with the below requirements:
-->
- [x] This PR title match the format: \<type\>(optional scope): \<description\>
- [x] The description of this PR title is user-oriented and clear enough for others to understand.
- [ ] Attach the PR updating the user documentation if the current PR requires user awareness at the usage level. [User docs repo](https://github.com/cloudwego/cloudwego.github.io)


#### (Optional) Translate the PR title into Chinese.
refactor：将 model.CallbackInput 中的 ToolChoice 字段类型从 any 改为 *schema.ToolChoice（break change）

#### (Optional) More detailed description for this PR(en: English/zh: Chinese).
<!--
Provide more detailed info for review(e.g., it's recommended to provide perf data if this is a perf type PR).
-->
en:
This PR changes the type of the ToolChoice field in model.CallbackInput from `any` to `*schema.ToolChoice`. 
Although this is a breaking change, the field has been deprecated for over six months, so this update is acceptable.

zh(optional): 
本次提交将 model.CallbackInput 中的 ToolChoice 字段类型由 `any` 修改为 `*schema.ToolChoice`。
该变更属于 break change，升级不兼容，但该字段已被废弃超过半年，认为修改是可接受的。

#### (Optional) Which issue(s) this PR fixes:
<!--
Automatically closes linked issue when PR is merged.
Eg: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

#### (optional) The PR that updates user documentation:
<!--
If the current PR requires user awareness at the usage level, please submit a PR to update user docs. [User docs repo](https://github.com/cloudwego/cloudwego.github.io)
-->
