### PR TITLE
fix(adk): session now only store events with output

### DIFF
--- a/adk/flow.go
+++ b/adk/flow.go
@@ -387,12 +387,16 @@ func (a *flowAgent) run(
 
 		event.AgentName = a.Name(ctx)
 		event.RunPath = runCtx.RunPath
-		// copy the event so that the copied event's stream is exclusive for any potential consumer
-		// copy before adding to session because once added to session it's stream could be consumed by genAgentInput at any time
-		copied := copyAgentEvent(event)
-		setAutomaticClose(copied)
-		setAutomaticClose(event)
-		runCtx.Session.addEvent(copied)
+		if event.Action == nil || event.Action.Interrupted == nil {
+			// copy the event so that the copied event's stream is exclusive for any potential consumer
+			// copy before adding to session because once added to session it's stream could be consumed by genAgentInput at any time
+			// interrupt action are not added to session, because ALL information contained in it
+			// is either presented to end-user, or made available to agents through other means
+			copied := copyAgentEvent(event)
+			setAutomaticClose(copied)
+			setAutomaticClose(event)
+			runCtx.Session.addEvent(copied)
+		}
 		lastAction = event.Action
 		generator.Send(event)
 	}


### PR DESCRIPTION
Currently events without output are also stored in session, such as Interrupt Event emitted by ChatModelAgent, which contains State ( inside of which are ever-growing list of messages). 

This is useless now because events without output can never get into an agent's actual input. 

This also introduces a potential problem of growing session storage cost since multiple interrupt events with large State might accumulate in session.