### PR TITLE
feat(adk): Add NodeName injection to ADK RunInfo for enhanced callback tracing

### DIFF
--- a/adk/react.go
+++ b/adk/react.go
@@ -165,7 +165,7 @@ func newReact(ctx context.Context, config *reactConfig) (reactGraph, error) {
 		return st.Messages, nil
 	}
 	_ = g.AddChatModelNode(chatModel_, chatModel,
-		compose.WithStatePreHandler(modelPreHandle), compose.WithNodeName(chatModel_))
+		compose.WithStatePreHandler(modelPreHandle), compose.WithNodeName(config.agentName))
 
 	toolPreHandle := func(ctx context.Context, input Message, st *State) (Message, error) {
 		if input != nil {

--- a/adk/runctx.go
+++ b/adk/runctx.go
@@ -274,3 +274,12 @@ func getSession(ctx context.Context) *runSession {
 
 	return nil
 }
+
+// GetRunSteps retrieves the current run steps from the context.
+func GetRunSteps(ctx context.Context) ([]RunStep, bool) {
+	runCtx := getRunCtx(ctx)
+	if runCtx == nil {
+		return nil, false
+	}
+	return runCtx.RunPath, true
+}


### PR DESCRIPTION
#### What type of PR is this?
<!--
Add one of the following kinds:

build: Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)
ci: Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
docs: Documentation only changes
feat: A new feature
optimize: A new optimization
fix: A bug fix
perf: A code change that improves performance
refactor: A code change that neither fixes a bug nor adds a feature
style: Changes that do not affect the meaning of the code (white space, formatting, missing semi-colons, etc)
test: Adding missing tests or correcting existing tests
chore: Changes to the build process or auxiliary tools and libraries such as documentation generation
-->

This PR enhances the observability of ADK by injecting the NodeName property into the RunInfo of ChatModel-type components during prebuild. Previously, the callback system lacked sufficient context for detailed tracing, making it difficult to track component execution flows effectively.

By injecting RunInfo and exposing RunSteps information, the collection system in the Callback can obtain more data, thereby aligning with the user experience of the early Graph design in eino.

#### Check the PR title.
<!--
The description of the title will be attached in Release Notes, 
so please describe it from user-oriented, what this PR does / why we need it.
Please check your PR title with the below requirements:
-->
- [x] This PR title match the format: \<type\>(optional scope): \<description\>
- [x] The description of this PR title is user-oriented and clear enough for others to understand.
- [x] Attach the PR updating the user documentation if the current PR requires user awareness at the usage level. [User docs repo](https://github.com/cloudwego/cloudwego.github.io)

#### More detailed description for this PR.

在早期使用基础 Graph 设计时，Eino能够提供清晰的节点名称（NodeName）等追踪信息，为系统的可观测性提供了有力支持。然而，在迁移至 ADK 框架后，我们发现其 Callback 回调机制在信息暴露上存在不足，特别是缺乏对组件节点名称的注入。这导致在记录执行轨迹（Trace）时，无法准确关联回调事件与特定的智能体，使得调试和性能分析变得困难，与早期 Graph 提供的体验产生了差距。

针对这一问题，本 PR 在 prebuild 包含的常用智能体范式中，主动向其运行信息（RunInfo）中注入其所在的智能体名称（AgentName）属性。同时，对外暴露 RunSteps 信息，Callback 可以通过 `GetRunSteps` 方法从上下文中获取执行路径信息。为 Trace 提供了更有力的支撑。