### PR TITLE
feat(schema): The Format function supports the UserInputMultiContent field

### DIFF
--- a/schema/message.go
+++ b/schema/message.go
@@ -602,24 +602,24 @@ func (m *Message) Format(_ context.Context, vs map[string]any, formatType Format
 	copied := *m
 	copied.Content = c
 
-	copied.MultiContent, err = formatMultiContent(m.MultiContent, vs, formatType)
-	if err != nil {
-		return nil, err
+	if len(m.MultiContent) > 0 {
+		copied.MultiContent, err = formatMultiContent(m.MultiContent, vs, formatType)
+		if err != nil {
+			return nil, err
+		}
 	}
 
-	copied.UserInputMultiContent, err = formatUserInputMultiContent(m.UserInputMultiContent, vs, formatType)
-	if err != nil {
-		return nil, err
+	if len(m.UserInputMultiContent) > 0 {
+		copied.UserInputMultiContent, err = formatUserInputMultiContent(m.UserInputMultiContent, vs, formatType)
+		if err != nil {
+			return nil, err
+		}
 	}
 
 	return []*Message{&copied}, nil
 }
 
 func formatMultiContent(multiContent []ChatMessagePart, vs map[string]any, formatType FormatType) ([]ChatMessagePart, error) {
-	if len(multiContent) == 0 {
-		return multiContent, nil
-	}
-
 	copiedMC := make([]ChatMessagePart, len(multiContent))
 	copy(copiedMC, multiContent)
 
@@ -628,7 +628,7 @@ func formatMultiContent(multiContent []ChatMessagePart, vs map[string]any, forma
 		case ChatMessagePartTypeText:
 			nmc, err := formatContent(mc.Text, vs, formatType)
 			if err != nil {
-				return copiedMC, err
+				return nil, err
 			}
 			copiedMC[i].Text = nmc
 		case ChatMessagePartTypeImageURL:
@@ -637,7 +637,7 @@ func formatMultiContent(multiContent []ChatMessagePart, vs map[string]any, forma
 			}
 			url, err := formatContent(mc.ImageURL.URL, vs, formatType)
 			if err != nil {
-				return copiedMC, err
+				return nil, err
 			}
 			copiedMC[i].ImageURL.URL = url
 		case ChatMessagePartTypeAudioURL:
@@ -646,7 +646,7 @@ func formatMultiContent(multiContent []ChatMessagePart, vs map[string]any, forma
 			}
 			url, err := formatContent(mc.AudioURL.URL, vs, formatType)
 			if err != nil {
-				return copiedMC, err
+				return nil, err
 			}
 			copiedMC[i].AudioURL.URL = url
 		case ChatMessagePartTypeVideoURL:
@@ -655,7 +655,7 @@ func formatMultiContent(multiContent []ChatMessagePart, vs map[string]any, forma
 			}
 			url, err := formatContent(mc.VideoURL.URL, vs, formatType)
 			if err != nil {
-				return copiedMC, err
+				return nil, err
 			}
 			copiedMC[i].VideoURL.URL = url
 		case ChatMessagePartTypeFileURL:
@@ -664,7 +664,7 @@ func formatMultiContent(multiContent []ChatMessagePart, vs map[string]any, forma
 			}
 			url, err := formatContent(mc.FileURL.URL, vs, formatType)
 			if err != nil {
-				return copiedMC, err
+				return nil, err
 			}
 			copiedMC[i].FileURL.URL = url
 		}
@@ -674,10 +674,6 @@ func formatMultiContent(multiContent []ChatMessagePart, vs map[string]any, forma
 }
 
 func formatUserInputMultiContent(userInputMultiContent []MessageInputPart, vs map[string]any, formatType FormatType) ([]MessageInputPart, error) {
-	if len(userInputMultiContent) == 0 {
-		return userInputMultiContent, nil
-	}
-
 	copiedUIMC := make([]MessageInputPart, len(userInputMultiContent))
 	copy(copiedUIMC, userInputMultiContent)
 
@@ -686,7 +682,7 @@ func formatUserInputMultiContent(userInputMultiContent []MessageInputPart, vs ma
 		case ChatMessagePartTypeText:
 			text, err := formatContent(uimc.Text, vs, formatType)
 			if err != nil {
-				return copiedUIMC, err
+				return nil, err
 			}
 			copiedUIMC[i].Text = text
 		case ChatMessagePartTypeImageURL:
@@ -696,14 +692,14 @@ func formatUserInputMultiContent(userInputMultiContent []MessageInputPart, vs ma
 			if uimc.Image.URL != nil && *uimc.Image.URL != "" {
 				url, err := formatContent(*uimc.Image.URL, vs, formatType)
 				if err != nil {
-					return copiedUIMC, err
+					return nil, err
 				}
 				copiedUIMC[i].Image.URL = &url
 			}
 			if uimc.Image.Base64Data != nil && *uimc.Image.Base64Data != "" {
 				base64data, err := formatContent(*uimc.Image.Base64Data, vs, formatType)
 				if err != nil {
-					return copiedUIMC, err
+					return nil, err
 				}
 				copiedUIMC[i].Image.Base64Data = &base64data
 			}
@@ -714,14 +710,14 @@ func formatUserInputMultiContent(userInputMultiContent []MessageInputPart, vs ma
 			if uimc.Audio.URL != nil && *uimc.Audio.URL != "" {
 				url, err := formatContent(*uimc.Audio.URL, vs, formatType)
 				if err != nil {
-					return copiedUIMC, err
+					return nil, err
 				}
 				copiedUIMC[i].Audio.URL = &url
 			}
 			if uimc.Audio.Base64Data != nil && *uimc.Audio.Base64Data != "" {
 				base64data, err := formatContent(*uimc.Audio.Base64Data, vs, formatType)
 				if err != nil {
-					return copiedUIMC, err
+					return nil, err
 				}
 				copiedUIMC[i].Audio.Base64Data = &base64data
 			}
@@ -732,14 +728,14 @@ func formatUserInputMultiContent(userInputMultiContent []MessageInputPart, vs ma
 			if uimc.Video.URL != nil && *uimc.Video.URL != "" {
 				url, err := formatContent(*uimc.Video.URL, vs, formatType)
 				if err != nil {
-					return copiedUIMC, err
+					return nil, err
 				}
 				copiedUIMC[i].Video.URL = &url
 			}
 			if uimc.Video.Base64Data != nil && *uimc.Video.Base64Data != "" {
 				base64data, err := formatContent(*uimc.Video.Base64Data, vs, formatType)
 				if err != nil {
-					return copiedUIMC, err
+					return nil, err
 				}
 				copiedUIMC[i].Video.Base64Data = &base64data
 			}
@@ -750,14 +746,14 @@ func formatUserInputMultiContent(userInputMultiContent []MessageInputPart, vs ma
 			if uimc.File.URL != nil && *uimc.File.URL != "" {
 				url, err := formatContent(*uimc.File.URL, vs, formatType)
 				if err != nil {
-					return copiedUIMC, err
+					return nil, err
 				}
 				copiedUIMC[i].File.URL = &url
 			}
 			if uimc.File.Base64Data != nil && *uimc.File.Base64Data != "" {
 				base64data, err := formatContent(*uimc.File.Base64Data, vs, formatType)
 				if err != nil {
-					return copiedUIMC, err
+					return nil, err
 				}
 				copiedUIMC[i].File.Base64Data = &base64data
 			}

--- a/schema/message_test.go
+++ b/schema/message_test.go
@@ -908,7 +908,7 @@ func TestFormatMultiContent(t *testing.T) {
 	t.Run("empty input", func(t *testing.T) {
 		out, err := formatMultiContent(nil, vs, FString)
 		assert.NoError(t, err)
-		assert.Nil(t, out)
+		assert.Equal(t, []ChatMessagePart{}, out)
 	})
 
 	t.Run("render text and urls with FString", func(t *testing.T) {
@@ -966,7 +966,7 @@ func TestFormatUserInputMultiContent(t *testing.T) {
 	t.Run("empty input", func(t *testing.T) {
 		out, err := formatUserInputMultiContent(nil, vs, FString)
 		assert.NoError(t, err)
-		assert.Nil(t, out)
+		assert.Equal(t, []MessageInputPart{}, out)
 	})
 
 	t.Run("render text and both URL/Base64 for each type", func(t *testing.T) {


### PR DESCRIPTION
#### What type of PR is this?
<!--
Add one of the following kinds:

build: Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)
ci: Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
docs: Documentation only changes
feat: A new feature
optimize: A new optimization
fix: A bug fix
perf: A code change that improves performance
refactor: A code change that neither fixes a bug nor adds a feature
style: Changes that do not affect the meaning of the code (white space, formatting, missing semi-colons, etc)
test: Adding missing tests or correcting existing tests
chore: Changes to the build process or auxiliary tools and libraries such as documentation generation
-->
feat(schema): The Format function supports the UserInputMultiContent field

#### Check the PR title.
<!--
The description of the title will be attached in Release Notes, 
so please describe it from user-oriented, what this PR does / why we need it.
Please check your PR title with the below requirements:
-->
- [x] This PR title match the format: \<type\>(optional scope): \<description\>
- [x] The description of this PR title is user-oriented and clear enough for others to understand.
- [x] Attach the PR updating the user documentation if the current PR requires user awareness at the usage . [User docs repo](https://github.com/cloudwego/cloudwego.github.io)


#### (Optional) Translate the PR title into Chinese.
Format函数增加对UserInputMultiContent字段的支持

#### (Optional) More detailed description for this PR(en: English/zh: Chinese).
<!--
Provide more detailed  for review(e.g., it's recommended to provide perf data if this is a perf type PR).
-->
en: The `MultiContent` field will no longer be supported; the new multimodal field `UserInputMultiContent` needs to be handled during `Message.Format`. This PR adds handling for the `Text` field and the multimodal fields `URL` and `Base64Data`.
zh(optional): `MultiContent`字段将不再持续支持，新的多模态字段`UserInputMultiContent`在`Message.Format`的时候需要被处理。这个PR中增加了新字段文本类型`Text`字段和多模态类型`URL`、`Base64Data`字段的处理


#### (Optional) Which issue(s) this PR fixes:
<!--
Automatically closes linked issue when PR is merged.
Eg: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

#### (optional) The PR that updates user documentation:
<!--
If the current PR requires user awareness at the usage , please submit a PR to update user docs. [User docs repo](https://github.com/cloudwego/cloudwego.github.io)
-->
