### PR TITLE
feat: introduce lanes for session event visibility of parallel executions

### DIFF
--- a/adk/interrupt_test.go
+++ b/adk/interrupt_test.go
@@ -47,10 +47,10 @@ func TestSaveAgentEventWrapper(t *testing.T) {
 			},
 			RunPath: []RunStep{
 				{
-					"a1",
+					agentName: "a1",
 				},
 				{
-					"a2",
+					agentName: "a2",
 				},
 			},
 		},
@@ -307,7 +307,7 @@ func TestWorkflowInterrupt(t *testing.T) {
 
 	firstInterruptEvent := &AgentEvent{
 		AgentName: "sa1",
-		RunPath:   []RunStep{{"sequential"}, {"sa1"}},
+		RunPath:   []RunStep{{agentName: "sequential"}, {agentName: "sa1"}},
 		Action: &AgentAction{
 			Interrupted: &InterruptInfo{
 				Data: &WorkflowInterruptInfo{
@@ -353,7 +353,7 @@ func TestWorkflowInterrupt(t *testing.T) {
 	_ = firstInterruptEvent
 	secondInterruptEvent := &AgentEvent{
 		AgentName: "sa2",
-		RunPath:   []RunStep{{"sequential"}, {"sa1"}, {"sa2"}},
+		RunPath:   []RunStep{{agentName: "sequential"}, {agentName: "sa1"}, {agentName: "sa2"}},
 		Action: &AgentAction{
 			Interrupted: &InterruptInfo{
 				Data: &WorkflowInterruptInfo{
@@ -399,7 +399,7 @@ func TestWorkflowInterrupt(t *testing.T) {
 	messageEvents := []*AgentEvent{
 		{
 			AgentName: "sa3",
-			RunPath:   []RunStep{{"sequential"}, {"sa1"}, {"sa2"}, {"sa3"}},
+			RunPath:   []RunStep{{agentName: "sequential"}, {agentName: "sa1"}, {agentName: "sa2"}, {agentName: "sa3"}},
 			Output: &AgentOutput{
 				MessageOutput: &MessageVariant{
 					Message: schema.UserMessage("sa3 completed"),
@@ -408,7 +408,7 @@ func TestWorkflowInterrupt(t *testing.T) {
 		},
 		{
 			AgentName: "sa4",
-			RunPath:   []RunStep{{"sequential"}, {"sa1"}, {"sa2"}, {"sa3"}, {"sa4"}},
+			RunPath:   []RunStep{{agentName: "sequential"}, {agentName: "sa1"}, {agentName: "sa2"}, {agentName: "sa3"}, {agentName: "sa4"}},
 			Output: &AgentOutput{
 				MessageOutput: &MessageVariant{
 					Message: schema.UserMessage("sa4 completed"),
@@ -510,7 +510,7 @@ func TestWorkflowInterrupt(t *testing.T) {
 
 		loopFirstInterruptEvent := &AgentEvent{
 			AgentName: "sa1",
-			RunPath:   []RunStep{{"loop"}, {"sa1"}},
+			RunPath:   []RunStep{{agentName: "loop"}, {agentName: "sa1"}},
 			Action: &AgentAction{
 				Interrupted: &InterruptInfo{
 					Data: &WorkflowInterruptInfo{
@@ -575,7 +575,7 @@ func TestWorkflowInterrupt(t *testing.T) {
 
 		loopSecondInterruptEvent := &AgentEvent{
 			AgentName: "sa2",
-			RunPath:   []RunStep{{"loop"}, {"sa1"}, {"sa2"}},
+			RunPath:   []RunStep{{agentName: "loop"}, {agentName: "sa1"}, {agentName: "sa2"}},
 			Action: &AgentAction{
 				Interrupted: &InterruptInfo{
 					Data: &WorkflowInterruptInfo{
@@ -640,7 +640,7 @@ func TestWorkflowInterrupt(t *testing.T) {
 
 		loopThirdInterruptEvent := &AgentEvent{
 			AgentName: "sa1",
-			RunPath:   []RunStep{{"loop"}, {"sa1"}, {"sa2"}, {"sa3"}, {"sa4"}, {"sa1"}},
+			RunPath:   []RunStep{{agentName: "loop"}, {agentName: "sa1"}, {agentName: "sa2"}, {agentName: "sa3"}, {agentName: "sa4"}, {agentName: "sa1"}},
 			Action: &AgentAction{
 				Interrupted: &InterruptInfo{
 					Data: &WorkflowInterruptInfo{
@@ -686,7 +686,7 @@ func TestWorkflowInterrupt(t *testing.T) {
 
 		loopFourthInterruptEvent := &AgentEvent{
 			AgentName: "sa2",
-			RunPath:   []RunStep{{"loop"}, {"sa1"}, {"sa2"}, {"sa3"}, {"sa4"}, {"sa1"}, {"sa2"}},
+			RunPath:   []RunStep{{agentName: "loop"}, {agentName: "sa1"}, {agentName: "sa2"}, {agentName: "sa3"}, {agentName: "sa4"}, {agentName: "sa1"}, {agentName: "sa2"}},
 			Action: &AgentAction{
 				Interrupted: &InterruptInfo{
 					Data: &WorkflowInterruptInfo{
@@ -733,7 +733,7 @@ func TestWorkflowInterrupt(t *testing.T) {
 		loopMessageEvents := []*AgentEvent{
 			{
 				AgentName: "sa3",
-				RunPath:   []RunStep{{"loop"}, {"sa1"}, {"sa2"}, {"sa3"}},
+				RunPath:   []RunStep{{agentName: "loop"}, {agentName: "sa1"}, {agentName: "sa2"}, {agentName: "sa3"}},
 				Output: &AgentOutput{
 					MessageOutput: &MessageVariant{
 						Message: schema.UserMessage("sa3 completed"),
@@ -742,7 +742,7 @@ func TestWorkflowInterrupt(t *testing.T) {
 			},
 			{
 				AgentName: "sa4",
-				RunPath:   []RunStep{{"loop"}, {"sa1"}, {"sa2"}, {"sa3"}, {"sa4"}},
+				RunPath:   []RunStep{{agentName: "loop"}, {agentName: "sa1"}, {agentName: "sa2"}, {agentName: "sa3"}, {agentName: "sa4"}},
 				Output: &AgentOutput{
 					MessageOutput: &MessageVariant{
 						Message: schema.UserMessage("sa4 completed"),
@@ -802,7 +802,7 @@ func TestWorkflowInterrupt(t *testing.T) {
 		loopFinalMessageEvents := []*AgentEvent{
 			{
 				AgentName: "sa3",
-				RunPath:   []RunStep{{"loop"}, {"sa1"}, {"sa2"}, {"sa3"}, {"sa4"}, {"sa1"}, {"sa2"}, {"sa3"}},
+				RunPath:   []RunStep{{agentName: "loop"}, {agentName: "sa1"}, {agentName: "sa2"}, {agentName: "sa3"}, {agentName: "sa4"}, {agentName: "sa1"}, {agentName: "sa2"}, {agentName: "sa3"}},
 				Output: &AgentOutput{
 					MessageOutput: &MessageVariant{
 						Message: schema.UserMessage("sa3 completed"),
@@ -811,7 +811,7 @@ func TestWorkflowInterrupt(t *testing.T) {
 			},
 			{
 				AgentName: "sa4",
-				RunPath:   []RunStep{{"loop"}, {"sa1"}, {"sa2"}, {"sa3"}, {"sa4"}, {"sa1"}, {"sa2"}, {"sa3"}, {"sa4"}},
+				RunPath:   []RunStep{{agentName: "loop"}, {agentName: "sa1"}, {agentName: "sa2"}, {agentName: "sa3"}, {agentName: "sa4"}, {agentName: "sa1"}, {agentName: "sa2"}, {agentName: "sa3"}, {agentName: "sa4"}},
 				Output: &AgentOutput{
 					MessageOutput: &MessageVariant{
 						Message: schema.UserMessage("sa4 completed"),
@@ -862,7 +862,7 @@ func TestWorkflowInterrupt(t *testing.T) {
 		parallelMessageEvents := []*AgentEvent{
 			{
 				AgentName: "sa4",
-				RunPath:   []RunStep{{"parallel agent"}, {"sa4"}},
+				RunPath:   []RunStep{{agentName: "parallel agent"}, {agentName: "sa4", lanes: []string{"sa4"}}},
 				Output: &AgentOutput{
 					MessageOutput: &MessageVariant{
 						Message: schema.UserMessage("sa4 completed"),
@@ -871,7 +871,7 @@ func TestWorkflowInterrupt(t *testing.T) {
 			},
 			{
 				AgentName: "sa3",
-				RunPath:   []RunStep{{"parallel agent"}, {"sa3"}},
+				RunPath:   []RunStep{{agentName: "parallel agent"}, {agentName: "sa3", lanes: []string{"sa3"}}},
 				Output: &AgentOutput{
 					MessageOutput: &MessageVariant{
 						Message: schema.UserMessage("sa3 completed"),
@@ -885,7 +885,7 @@ func TestWorkflowInterrupt(t *testing.T) {
 
 		assert.NotNil(t, interruptEvent)
 		assert.Equal(t, "parallel agent", interruptEvent.AgentName)
-		assert.Equal(t, []RunStep{{"parallel agent"}}, interruptEvent.RunPath)
+		assert.Equal(t, []RunStep{{agentName: "parallel agent"}}, interruptEvent.RunPath)
 		assert.NotNil(t, interruptEvent.Action.Interrupted)
 		wii, ok := interruptEvent.Action.Interrupted.Data.(*WorkflowInterruptInfo)
 		assert.True(t, ok)


### PR DESCRIPTION
### **Pull Request Description**

**Title:** `feat(adk): Introduce 'lanes' for Parallel Execution Visibility`

**Description:**

#### **Summary**

This PR introduces a new visibility model to correctly handle event visibility for agents in complex workflows, particularly for agents that precede or succeed parallel executions. The previous model was either too restrictive (preventing successors from seeing parallel events) or too simple (preventing parallel agents from seeing their predecessors).

This change resolves these issues by introducing the concept of **"lanes"** for parallel execution paths and implementing a robust, symmetric visibility rule.

#### **What has changed**

1.  **`adk.RunStep` Enhancement**: The `RunStep` struct has been enhanced with a new field: `lanes []string`.
    *   This slice tracks the hierarchical path of parallel executions.
    *   Each string in the slice is a "lane identifier," corresponding to the unique name of the agent that initiated that parallel path.
    *   This allows us to trace nested parallel executions (e.g., `lanes: ["ParentParallel", "ChildParallel"]`).

2.  **New Symmetric Visibility Logic**: The `belongToRunPath` function has been rewritten to use a single, powerful rule: **an agent can see an event if the `lanes` of one is a prefix of the `lanes` of the other.** This symmetric check correctly handles all critical scenarios:
    *   **Predecessor Visibility**: An agent sees events from its sequential predecessors.
        *   *Example (`A -> Par(B)`)*: `B` sees `A`'s events because `A.lanes` (`[]`) is a prefix of `B.lanes` (`["B"]`).
    *   **Successor Visibility**: An agent sees events from parallel predecessors it follows.
        *   *Example (`Par(B) -> C`)*: `C` sees `B`'s events because `C.lanes` (`[]`) is a prefix of `B.lanes` (`["B"]`).
    *   **Isolation**: Agents in different parallel lanes are isolated from each other.
        *   *Example (`Par(B, C)`)*: `B` does not see `C`'s events because `["B"]` is not a prefix of `["C"]`, and vice-versa.

3.  **Context Propagation**: The `runParallel` orchestrator now correctly creates and propagates the `lanes` information to its children via `context.Context`, ensuring each parallel agent runs in its designated lane. A comment has been added to clarify the necessity of a defensive copy to prevent data races.
        