### PR TITLE
Fix/07

### DIFF
--- a/adk/interrupt_test.go
+++ b/adk/interrupt_test.go
@@ -126,9 +126,8 @@ func TestSimpleInterrupt(t *testing.T) {
 	_, ok = iter.Next()
 	assert.False(t, ok)
 
-	iter, err := runner.ResumeWithParams(ctx, ResumeParams{
-		CheckPointID: "1",
-		Targets:      map[string]any{
+	iter, err := runner.ResumeWithParams(ctx, "1", ResumeParams{
+		Targets: map[string]any{
 			interruptEvent.Action.Interrupted.InterruptContexts[0].ID: nil,
 		},
 	})
@@ -215,9 +214,8 @@ func TestMultiAgentInterrupt(t *testing.T) {
 	_, ok = iter.Next()
 	assert.False(t, ok)
 
-	iter, err = runner.ResumeWithParams(ctx, ResumeParams{
-		CheckPointID: "1",
-		Targets:      map[string]any{
+	iter, err = runner.ResumeWithParams(ctx, "1", ResumeParams{
+		Targets: map[string]any{
 			interruptID: "resume data",
 		},
 	})
@@ -455,9 +453,8 @@ func TestWorkflowInterrupt(t *testing.T) {
 		events = []*AgentEvent{}
 
 		// Resume after sa1 interrupt
-		iter, err = runner.ResumeWithParams(ctx, ResumeParams{
-			CheckPointID: "sequential-1",
-			Targets:      map[string]any{
+		iter, err = runner.ResumeWithParams(ctx, "sequential-1", ResumeParams{
+			Targets: map[string]any{
 				interruptID1: "resume sa1",
 			},
 		})
@@ -479,9 +476,8 @@ func TestWorkflowInterrupt(t *testing.T) {
 		events = []*AgentEvent{}
 
 		// Resume after sa2 interrupt
-		iter, err = runner.ResumeWithParams(ctx, ResumeParams{
-			CheckPointID: "sequential-1",
-			Targets:      map[string]any{
+		iter, err = runner.ResumeWithParams(ctx, "sequential-1", ResumeParams{
+			Targets: map[string]any{
 				interruptID2: "resume sa2",
 			},
 		})
@@ -573,9 +569,8 @@ func TestWorkflowInterrupt(t *testing.T) {
 		events = []*AgentEvent{}
 
 		// Resume after sa1 interrupt
-		iter, err = runner.ResumeWithParams(ctx, ResumeParams{
-			CheckPointID: "loop-1",
-			Targets:      map[string]any{
+		iter, err = runner.ResumeWithParams(ctx, "loop-1", ResumeParams{
+			Targets: map[string]any{
 				loopInterruptID1: "resume sa1",
 			},
 		})
@@ -641,9 +636,8 @@ func TestWorkflowInterrupt(t *testing.T) {
 		events = []*AgentEvent{}
 
 		// Resume after sa2 interrupt
-		iter, err = runner.ResumeWithParams(ctx, ResumeParams{
-			CheckPointID: "loop-1",
-			Targets:      map[string]any{
+		iter, err = runner.ResumeWithParams(ctx, "loop-1", ResumeParams{
+			Targets: map[string]any{
 				loopInterruptID2: "resume sa2",
 			},
 		})
@@ -787,9 +781,8 @@ func TestWorkflowInterrupt(t *testing.T) {
 		events = []*AgentEvent{}
 
 		// Resume after third interrupt
-		iter, err = runner.ResumeWithParams(ctx, ResumeParams{
-			CheckPointID: "loop-1",
-			Targets:      map[string]any{
+		iter, err = runner.ResumeWithParams(ctx, "loop-1", ResumeParams{
+			Targets: map[string]any{
 				loopInterruptID3: "resume sa1",
 			},
 		})
@@ -809,9 +802,8 @@ func TestWorkflowInterrupt(t *testing.T) {
 		events = []*AgentEvent{}
 
 		// Resume after fourth interrupt
-		iter, err = runner.ResumeWithParams(ctx, ResumeParams{
-			CheckPointID: "loop-1",
-			Targets:      map[string]any{
+		iter, err = runner.ResumeWithParams(ctx, "loop-1", ResumeParams{
+			Targets: map[string]any{
 				loopInterruptID4: "resume sa2",
 			},
 		})
@@ -951,9 +943,8 @@ func TestWorkflowInterrupt(t *testing.T) {
 		assert.NotEmpty(t, parallelInterruptID1)
 		assert.NotEmpty(t, parallelInterruptID2)
 
-		iter, err = runner.ResumeWithParams(ctx, ResumeParams{
-			CheckPointID: "1",
-			Targets:      map[string]any{
+		iter, err = runner.ResumeWithParams(ctx, "1", ResumeParams{
+			Targets: map[string]any{
 				parallelInterruptID1: "resume sa1",
 				parallelInterruptID2: "resume sa2",
 			},
@@ -1032,9 +1023,8 @@ func TestChatModelInterrupt(t *testing.T) {
 	event, ok = iter.Next()
 	assert.False(t, ok)
 
-	iter, err = runner.ResumeWithParams(ctx, ResumeParams{
-		CheckPointID: "1",
-		Targets:      map[string]any{
+	iter, err = runner.ResumeWithParams(ctx, "1", ResumeParams{
+		Targets: map[string]any{
 			chatModelAgentID: &ChatModelAgentResumeData{
 				HistoryModifier: func(ctx context.Context, history []Message) []Message {
 					history[2].Content = "new user message"
@@ -1158,9 +1148,8 @@ func TestChatModelAgentToolInterrupt(t *testing.T) {
 	event, ok = iter.Next()
 	assert.False(t, ok)
 
-	iter, err = runner.ResumeWithParams(ctx, ResumeParams{
-		CheckPointID: "1",
-		Targets:      map[string]any{
+	iter, err = runner.ResumeWithParams(ctx, "1", ResumeParams{
+		Targets: map[string]any{
 			toolInterruptID: "resume sa",
 		},
 	})
@@ -1408,9 +1397,8 @@ func TestCyclicalAgentInterrupt(t *testing.T) {
 	assert.NotEmpty(t, interruptCtx.ID)
 
 	// Resume the execution
-	iter, err = runner.ResumeWithParams(ctx, ResumeParams{
-		CheckPointID: "cyclical-1",
-		Targets:      map[string]any{
+	iter, err = runner.ResumeWithParams(ctx, "cyclical-1", ResumeParams{
+		Targets: map[string]any{
 			interruptCtx.ID: "resume C",
 		},
 	})
@@ -1528,9 +1516,8 @@ func TestChatModelParallelToolInterruptAndResume(t *testing.T) {
 	assert.NotEmpty(t, toolBInterruptID)
 
 	// 2. Resume, targeting only toolA. toolB should re-interrupt.
-	iter, err = runner.ResumeWithParams(ctx, ResumeParams{
-		CheckPointID: "parallel-tool-test-1",
-		Targets:      map[string]any{
+	iter, err = runner.ResumeWithParams(ctx, "parallel-tool-test-1", ResumeParams{
+		Targets: map[string]any{
 			toolAInterruptID: "toolA resumed",
 		},
 	})
@@ -1556,9 +1543,8 @@ func TestChatModelParallelToolInterruptAndResume(t *testing.T) {
 	toolBReInterruptID := rootCause.ID
 
 	// 3. Resume the re-interrupted toolB. The agent should then call the tools again.
-	iter, err = runner.ResumeWithParams(ctx, ResumeParams{
-		CheckPointID: "parallel-tool-test-1",
-		Targets:      map[string]any{
+	iter, err = runner.ResumeWithParams(ctx, "parallel-tool-test-1", ResumeParams{
+		Targets: map[string]any{
 			toolBReInterruptID: "toolB resumed",
 		},
 	})
@@ -1690,9 +1676,8 @@ func TestNestedChatModelAgentWithAgentTool(t *testing.T) {
 
 	// Now resume the interrupt
 	interruptID := interruptCtx.ID
-	iter, err = runner.ResumeWithParams(ctx, ResumeParams{
-		CheckPointID: "nested-agent-test-1",
-		Targets:      map[string]any{
+	iter, err = runner.ResumeWithParams(ctx, "nested-agent-test-1", ResumeParams{
+		Targets: map[string]any{
 			interruptID: "resume inner tool",
 		},
 	})

--- a/adk/workflow_test.go
+++ b/adk/workflow_test.go
@@ -715,9 +715,8 @@ func TestParallelWorkflowResumeWithEvents(t *testing.T) {
 		assert.NotEmpty(t, parallelInterruptID1)
 		assert.NotEmpty(t, parallelInterruptID2)
 
-		iter, err = runner.ResumeWithParams(ctx, ResumeParams{
-			CheckPointID: "1",
-			Targets:      map[string]any{
+		iter, err = runner.ResumeWithParams(ctx, "1", ResumeParams{
+			Targets: map[string]any{
 				parallelInterruptID1: "resume sa1",
 				parallelInterruptID2: "resume sa2",
 			},
@@ -991,9 +990,8 @@ func TestNestedParallelWorkflow(t *testing.T) {
 		}
 	}
 
-	iter, err = runner.ResumeWithParams(ctx, ResumeParams{
-		CheckPointID: "nested-parallel-test",
-		Targets:      map[string]any{
+	iter, err = runner.ResumeWithParams(ctx, "nested-parallel-test", ResumeParams{
+		Targets: map[string]any{
 			innerInterruptID1: "resume inner1",
 			innerInterruptID2: "resume inner2",
 		},


### PR DESCRIPTION
1. change `TargetedResume` method signature to `ResumeWithParams`
2. make sure to have saved checkpoint before emitting interrupt event to end-user