### PR TITLE
feat(compose): enable nested graphs to access parent graph state

### DIFF
--- a/compose/graph.go
+++ b/compose/graph.go
@@ -806,8 +806,14 @@ func (g *graph) compile(ctx context.Context, opt *graphCompileOptions) (*composa
 
 	if g.stateGenerator != nil {
 		r.runCtx = func(ctx context.Context) context.Context {
+			var parent *internalState
+			if p, ok := ctx.Value(stateKey{}).(*internalState); ok {
+				parent = p
+			}
+
 			return context.WithValue(ctx, stateKey{}, &internalState{
-				state: g.stateGenerator(ctx),
+				state:  g.stateGenerator(ctx),
+				parent: parent,
 			})
 		}
 	}

--- a/compose/graph_run.go
+++ b/compose/graph_run.go
@@ -395,7 +395,14 @@ func (r *runner) restoreFromCheckPoint(
 			cp.State = data
 		}
 
-		ctx = context.WithValue(ctx, stateKey{}, &internalState{state: cp.State})
+		var parent *internalState
+		if prev := ctx.Value(stateKey{}); prev != nil {
+			if p, ok := prev.(*internalState); ok {
+				parent = p
+			}
+		}
+
+		ctx = context.WithValue(ctx, stateKey{}, &internalState{state: cp.State, parent: parent})
 	}
 
 	nextTasks, err := r.restoreTasks(ctx, cp.Inputs, cp.SkipPreHandler, cp.RerunNodes, isStream, optMap) // should restore after set state to context


### PR DESCRIPTION
# Enable Nested Graphs to Access Parent Graph State

## Summary

Enable nested graphs to access parent graph state through a state chaining mechanism, supporting both direct nesting ([AddGraphNode](file:///Users/bytedance/github/eino/compose/graph.go#403-410)) and lambda-nested scenarios.

## Motivation

Previously, nodes within nested graphs could not access state from parent graphs, limiting expressiveness in complex nested scenarios. This PR resolves that limitation while maintaining backward compatibility and concurrency safety.

## Implementation

### State Chaining Mechanism

Introduced a `parent` pointer in [internalState](file:///Users/bytedance/github/eino/compose/state.go#34-39) to form a chain of states:

```go
type internalState struct {
    state  any
    mu     sync.Mutex
    parent *internalState  // Points to parent graph's state
}
```

### Key Changes

**1. State Lookup ([compose/state.go](file:///Users/bytedance/github/eino/compose/state.go))**
- Modified [getState()](file:///Users/bytedance/github/eino/compose/state.go#144-165) to traverse the `parent` chain upward when searching for a specific state type
- Follows lexical scoping: inner states of the same type shadow outer states
- Returns the appropriate mutex for the matched state level

**2. State Linking ([compose/graph.go](file:///Users/bytedance/github/eino/compose/graph.go))**  
- Updated `runCtx` to capture existing state from context and set it as parent when initializing nested graph state
- Ensures state chain is established during graph execution

**3. Resume Support ([compose/graph_run.go](file:///Users/bytedance/github/eino/compose/graph_run.go))**
- Modified [restoreFromCheckPoint](file:///Users/bytedance/github/eino/compose/graph_run.go#368-414) to correctly link parent state when resuming from checkpoint
- Ensures state chain integrity across interrupt/resume cycles

## API Changes

**None** - This change is fully backward compatible. Existing code using [ProcessState](file:///Users/bytedance/github/eino/compose/state.go#114-143) and `GetState` works without modification.

## Usage

Nested graph nodes can now directly access parent state:

```go
// In a nested graph node
innerNode := func(ctx context.Context, input string) (string, error) {
    // Access parent graph's state
    err := ProcessState(ctx, func(ctx context.Context, s *ParentState) error {
        s.Counter++
        return nil
    })
    return input, nil
}
```

### Supported Scenarios

1. **Direct Nesting** - via [AddGraphNode](file:///Users/bytedance/github/eino/compose/graph.go#403-410)
2. **Lambda Nesting** - graph invoked from within a Lambda node
3. **Interrupt/Resume** - state chain correctly restored from checkpoint

### State Shadowing

When inner and outer graphs define the same state type, lexical scoping applies:
- Inner state shadows outer state
- [ProcessState](file:///Users/bytedance/github/eino/compose/state.go#114-143) will access the nearest (innermost) matching state

## Concurrency Safety

✅ Each [internalState](file:///Users/bytedance/github/eino/compose/state.go#34-39) has its own mutex  
✅ [ProcessState](file:///Users/bytedance/github/eino/compose/state.go#114-143) locks the correct mutex regardless of state level (current or parent)  
✅ Validated with race detector tests

## Testing

Added comprehensive test suite in [compose/state_test.go](file:///Users/bytedance/github/eino/compose/state_test.go):

- [TestNestedGraphStateAccess](file:///Users/bytedance/github/eino/compose/state_test.go#350-400) - Basic state access across nested graphs
- [TestNestedGraphStateShadowing](file:///Users/bytedance/github/eino/compose/state_test.go#401-445) - Lexical scoping verification
- [TestNestedGraphStateAfterResume](file:///Users/bytedance/github/eino/compose/state_test.go#446-511) - State access after checkpoint resume
- [TestLambdaNestedGraphStateAccess](file:///Users/bytedance/github/eino/compose/state_test.go#512-577) - Lambda-nested graph state access
- [TestLambdaNestedGraphStateAfterResume](file:///Users/bytedance/github/eino/compose/state_test.go#578-683) - Lambda-nested resume scenario
- [TestNestedGraphStateConcurrency](file:///Users/bytedance/github/eino/compose/state_test.go#684-764) - Concurrent access validation (with `-race`)

All tests pass, including race detector validation.

## Breaking Changes

None. The change is fully backward compatible.

## Checklist

- [x] Implementation complete
- [x] Tests added and passing
- [x] Race detector validation passed
- [x] Documentation updated (Chinese feature description included)
- [x] No API changes required
- [x] Backward compatible