### PR TITLE
fix(adk): key ToolGenActions by ToolCallID

### DIFF
--- a/adk/chatmodel.go
+++ b/adk/chatmodel.go
@@ -470,6 +470,9 @@ func (h *cbHandler) onToolEndWithStreamOutput(ctx context.Context,
 	out := schema.StreamReaderWithConvert(output, cvt)
 	event := EventFromMessage(nil, out, schema.Tool, runInfo.Name)
 
+	action := popToolGenAction(ctx, runInfo.Name)
+	event.Action = action
+
 	returnDirectlyID, hasReturnDirectly := getReturnDirectlyToolCallID(ctx)
 	if hasReturnDirectly && returnDirectlyID == toolCallID {
 		// return-directly tool event will be sent on the end of tools node to ensure this event must be the last tool event.

--- a/adk/react.go
+++ b/adk/react.go
@@ -41,19 +41,51 @@ type State struct {
 	RemainingIterations int
 }
 
+// SendToolGenAction attaches an AgentAction to the next tool event emitted for the
+// current tool execution.
+//
+// Where/when to use:
+//   - Invoke within a tool's Run (Invokable/Streamable) implementation to include
+//     an action alongside that tool's output event.
+//   - The action is scoped by the current tool call context: if a ToolCallID is
+//     available, it is used as the key to support concurrent calls of the same
+//     tool with different parameters; otherwise, the provided toolName is used.
+//   - The stored action is ephemeral and will be popped and attached to the tool
+//     event when the tool finishes (including streaming completion).
+//
+// Limitation:
+//   - This function is intended for use within ChatModelAgent runs only. It relies
+//     on ChatModelAgent's internal State to store and pop actions, which is not
+//     available in other agent types.
 func SendToolGenAction(ctx context.Context, toolName string, action *AgentAction) error {
+	key := toolName
+	toolCallID := compose.GetToolCallID(ctx)
+	if len(toolCallID) > 0 {
+		key = toolCallID
+	}
+
 	return compose.ProcessState(ctx, func(ctx context.Context, st *State) error {
-		st.ToolGenActions[toolName] = action
+		st.ToolGenActions[key] = action
 
 		return nil
 	})
 }
 
 func popToolGenAction(ctx context.Context, toolName string) *AgentAction {
+	toolCallID := compose.GetToolCallID(ctx)
+
 	var action *AgentAction
 	err := compose.ProcessState(ctx, func(ctx context.Context, st *State) error {
-		action = st.ToolGenActions[toolName]
-		if action != nil {
+		if len(toolCallID) > 0 {
+			if a := st.ToolGenActions[toolCallID]; a != nil {
+				action = a
+				delete(st.ToolGenActions, toolCallID)
+				return nil
+			}
+		}
+
+		if a := st.ToolGenActions[toolName]; a != nil {
+			action = a
 			delete(st.ToolGenActions, toolName)
 		}
 


### PR DESCRIPTION
- Problem: Actions keyed only by toolName in State.ToolGenActions caused mis-association under concurrent calls of the same tool with different parameters.
- Solution: Use ToolCallID as the primary key when present; fall back to toolName to load legacy entries from persisted checkpoints. Ensure (*cbHandler).onToolEndWithStreamOutput pops and attaches actions.
- Backward Compatibility: popToolGenAction first attempts ToolCallID , then falls back to toolName . This preserves behavior when resuming from older checkpoints without migration.
- Tests: Added concise tests validating concurrent same-tool actions for both invokable and streamable paths, plus a legacy fallback case for stream tools.
- Docs: Clarified that SendToolGenAction is intended for ChatModelAgent only, described scoping by ToolCallID , and noted ephemeral action lifecycle.