### PR TITLE
feat(schema): Make ToJSONSchema output deterministic

### DIFF
--- a/schema/tool.go
+++ b/schema/tool.go
@@ -17,6 +17,8 @@
 package schema
 
 import (
+	"sort"
+
 	"github.com/eino-contrib/jsonschema"
 	orderedmap "github.com/wk8/go-ordered-map/v2"
 )
@@ -126,7 +128,13 @@ func (p *ParamsOneOf) ToJSONSchema() (*jsonschema.Schema, error) {
 			Required:   make([]string, 0, len(p.params)),
 		}
 
+		keys := make([]string, 0, len(p.params))
 		for k := range p.params {
+			keys = append(keys, k)
+		}
+		sort.Strings(keys)
+
+		for _, k := range keys {
 			v := p.params[k]
 			sc.Properties.Set(k, paramInfoToJSONSchema(v))
 			if v.Required {
@@ -160,7 +168,14 @@ func paramInfoToJSONSchema(paramInfo *ParameterInfo) *jsonschema.Schema {
 	if len(paramInfo.SubParams) > 0 {
 		required := make([]string, 0, len(paramInfo.SubParams))
 		js.Properties = orderedmap.New[string, *jsonschema.Schema]()
-		for k, v := range paramInfo.SubParams {
+		keys := make([]string, 0, len(paramInfo.SubParams))
+		for k := range paramInfo.SubParams {
+			keys = append(keys, k)
+		}
+		sort.Strings(keys)
+
+		for _, k := range keys {
+			v := paramInfo.SubParams[k]
 			item := paramInfoToJSONSchema(v)
 			js.Properties.Set(k, item)
 			if v.Required {

--- a/schema/tool_test.go
+++ b/schema/tool_test.go
@@ -17,10 +17,12 @@
 package schema
 
 import (
+	"encoding/json"
 	"testing"
 
 	"github.com/eino-contrib/jsonschema"
 	"github.com/smartystreets/goconvey/convey"
+	"github.com/stretchr/testify/assert"
 )
 
 func TestParamsOneOfToJSONSchema(t *testing.T) {
@@ -81,5 +83,53 @@ func TestParamsOneOfToJSONSchema(t *testing.T) {
 			converted, err = oneOf.ToJSONSchema()
 			convey.So(err, convey.ShouldBeNil)
 		})
+
+		convey.Convey("user provides map[string]ParameterInfo, converts to json schema in order", func() {
+			params := &ParamsOneOf{
+				params: map[string]*ParameterInfo{
+					"c": {
+						Type: "string",
+					},
+					"a": {
+						Type: "object",
+						SubParams: map[string]*ParameterInfo{
+							"z": {
+								Type: "number",
+							},
+							"y": {
+								Type: "string",
+							},
+						},
+					},
+					"b": {
+						Type: "array",
+						ElemInfo: &ParameterInfo{
+							Type: "object",
+							SubParams: map[string]*ParameterInfo{
+								"p": {
+									Type: "integer",
+								},
+								"o": {
+									Type: "boolean",
+								},
+							},
+						},
+					},
+				},
+			}
+
+			schema1, err := params.ToJSONSchema()
+			assert.NoError(t, err)
+			json1, err := json.Marshal(schema1)
+			assert.NoError(t, err)
+
+			schema2, err := params.ToJSONSchema()
+			assert.NoError(t, err)
+			json2, err := json.Marshal(schema2)
+			assert.NoError(t, err)
+
+			assert.Equal(t, string(json1), string(json2))
+		})
+
 	})
 }


### PR DESCRIPTION
feat(schema): Make ToJSONSchema output deterministic

This commit ensures that the ToJSONSchema function produces a deterministic output for a given input.

Previously, when converting a ParamsOneOf struct containing a map[string]*ParameterInfo to a jsonschema.Schema , the iteration order of the map keys was not guaranteed. This resulted in the Properties of the generated schema having an inconsistent order across multiple calls. The same problem existed for nested objects in SubParams . This non-deterministic behavior could lead to cache misses in downstream systems that rely on a stable JSON representation of the schema.

To resolve this, the keys of the params and SubParams maps are now explicitly collected and sorted alphabetically before generating the schema. This guarantees that the order of properties in the resulting jsonschema.Schema is always consistent.

Additionally, a new unit test, TestToJSONSchemaDeterministic , has been added to verify this behavior. The test repeatedly calls ToJSONSchema on a complex, nested parameter structure and asserts that the marshaled JSON output is identical each time, confirming the deterministic nature of the function.