### PR TITLE
fix(adk): return the last message after afterChatModel callbacks

### DIFF
--- a/adk/chatmodel.go
+++ b/adk/chatmodel.go
@@ -763,7 +763,7 @@ func (a *ChatModelAgent) buildRunFunc(ctx context.Context) runFunc {
 								}
 							}
 							if len(state.Messages) == 0 {
-								return nil, errors.New("messages is empty after afterChatModel callbacks")
+								return nil, errors.New("messages is empty after AfterChatModel")
 							}
 							return state.Messages[len(state.Messages)-1], nil
 						}),

--- a/adk/react.go
+++ b/adk/react.go
@@ -215,7 +215,7 @@ func newReact(ctx context.Context, config *reactConfig) (reactGraph, error) {
 		}
 		st.Messages = s.Messages
 		if len(st.Messages) == 0 {
-			return nil, errors.New("messages is empty after afterChatModel callbacks")
+			return nil, errors.New("messages is empty after AfterChatModel")
 		}
 		return st.Messages[len(st.Messages)-1], nil
 	}


### PR DESCRIPTION
## Summary

Fix the return value in `modelPostHandle` function to return the last message from `st.Messages` instead of the original `input`.

## Problem

The `modelPostHandle` was returning the original `input` message, but the `afterChatModel` callbacks may modify `s.Messages`. This caused the subsequent nodes to receive the unmodified input instead of the processed message.

## Solution

Changed the return statement from:
```go
return input, nil
```
to:
```go
return st.Messages[len(st.Messages)-1], nil
```

This ensures that any modifications made by `afterChatModel` callbacks are properly propagated to subsequent nodes in the graph.