### PR TITLE
fix: golint

### DIFF
--- a/components/prompt/callback_extra.go
+++ b/components/prompt/callback_extra.go
@@ -34,6 +34,7 @@ type AgenticCallbackOutput struct {
 	Extra     map[string]any
 }
 
+// ConvAgenticCallbackInput converts the callback input to the agentic callback input.
 func ConvAgenticCallbackInput(src callbacks.CallbackInput) *AgenticCallbackInput {
 	switch t := src.(type) {
 	case *AgenticCallbackInput:
@@ -47,6 +48,7 @@ func ConvAgenticCallbackInput(src callbacks.CallbackInput) *AgenticCallbackInput
 	}
 }
 
+// ConvAgenticCallbackOutput converts the callback output to the agentic callback output.
 func ConvAgenticCallbackOutput(src callbacks.CallbackOutput) *AgenticCallbackOutput {
 	switch t := src.(type) {
 	case *AgenticCallbackOutput:

--- a/schema/agentic_message.go
+++ b/schema/agentic_message.go
@@ -23,13 +23,12 @@ import (
 	"sort"
 	"strings"
 
-	"github.com/cloudwego/eino/schema/claude"
-	"github.com/cloudwego/eino/schema/gemini"
+	"github.com/eino-contrib/jsonschema"
 
 	"github.com/cloudwego/eino/internal"
+	"github.com/cloudwego/eino/schema/claude"
+	"github.com/cloudwego/eino/schema/gemini"
 	"github.com/cloudwego/eino/schema/openai"
-
-	"github.com/eino-contrib/jsonschema"
 )
 
 type ContentBlockType string
@@ -848,7 +847,8 @@ func concatAgenticResponseMeta(metas []*AgenticResponseMeta) (ret *AgenticRespon
 	}
 
 	if extensions.IsValid() && !extensions.IsZero() {
-		extension, err := internal.ConcatSliceValue(extensions)
+		var extension reflect.Value
+		extension, err = internal.ConcatSliceValue(extensions)
 		if err != nil {
 			return nil, fmt.Errorf("failed to concat extensions: %w", err)
 		}

--- a/schema/claude/consts.go
+++ b/schema/claude/consts.go
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 
+// Package claude defines constants for claude.
 package claude
 
 type TextCitationType string

--- a/schema/gemini/extension.go
+++ b/schema/gemini/extension.go
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 
+// Package gemini defines the extension for gemini.
 package gemini
 
 import (
@@ -42,7 +43,7 @@ type GroundingChunk struct {
 	Web *GroundingChunkWeb `json:"web,omitempty"`
 }
 
-// Chunk from the web.
+// GroundingChunkWeb is the chunk from the web.
 type GroundingChunkWeb struct {
 	// Domain of the (original) URI. This field is not supported in Gemini API.
 	Domain string `json:"domain,omitempty"`
@@ -79,7 +80,7 @@ type Segment struct {
 	Text string `json:"text,omitempty"`
 }
 
-// Google search entry point.
+// SearchEntryPoint is the Google search entry point.
 type SearchEntryPoint struct {
 	// Optional. Web content snippet that can be embedded in a web page or an app webview.
 	RenderedContent string `json:"rendered_content,omitempty"`

--- a/schema/openai/consts.go
+++ b/schema/openai/consts.go
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 
+// Package openai defines constants for openai.
 package openai
 
 type TextAnnotationType string

--- a/schema/openai/extension.go
+++ b/schema/openai/extension.go
@@ -112,6 +112,7 @@ type TextAnnotationFilePath struct {
 	Index int `json:"index,omitempty"`
 }
 
+// ConcatAssistantGenTextExtensions concatenates multiple AssistantGenTextExtension chunks into a single one.
 func ConcatAssistantGenTextExtensions(chunks []*AssistantGenTextExtension) (*AssistantGenTextExtension, error) {
 	if len(chunks) == 0 {
 		return nil, fmt.Errorf("no assistant generated text extension found")
@@ -166,6 +167,7 @@ func ConcatAssistantGenTextExtensions(chunks []*AssistantGenTextExtension) (*Ass
 	return ret, nil
 }
 
+// ConcatResponseMetaExtensions concatenates multiple ResponseMetaExtension chunks into a single one.
 func ConcatResponseMetaExtensions(chunks []*ResponseMetaExtension) (*ResponseMetaExtension, error) {
 	if len(chunks) == 0 {
 		return nil, fmt.Errorf("no response meta extension found")


### PR DESCRIPTION
#### What type of PR is this?
<!--
Add one of the following kinds:

build: Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)
ci: Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
docs: Documentation only changes
feat: A new feature
optimize: A new optimization
fix: A bug fix
perf: A code change that improves performance
refactor: A code change that neither fixes a bug nor adds a feature
style: Changes that do not affect the meaning of the code (white space, formatting, missing semi-colons, etc)
test: Adding missing tests or correcting existing tests
chore: Changes to the build process or auxiliary tools and libraries such as documentation generation
-->

#### Check the PR title.
<!--
The description of the title will be attached in Release Notes, 
so please describe it from user-oriented, what this PR does / why we need it.
Please check your PR title with the below requirements:
-->
- [ ] This PR title match the format: \<type\>(optional scope): \<description\>
- [ ] The description of this PR title is user-oriented and clear enough for others to understand.
- [ ] Attach the PR updating the user documentation if the current PR requires user awareness at the usage level. [User docs repo](https://github.com/cloudwego/cloudwego.github.io)


#### (Optional) Translate the PR title into Chinese.


#### (Optional) More detailed description for this PR(en: English/zh: Chinese).
<!--
Provide more detailed info for review(e.g., it's recommended to provide perf data if this is a perf type PR).
-->
en:
zh(optional): 


#### (Optional) Which issue(s) this PR fixes:
<!--
Automatically closes linked issue when PR is merged.
Eg: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

#### (optional) The PR that updates user documentation:
<!--
If the current PR requires user awareness at the usage level, please submit a PR to update user docs. [User docs repo](https://github.com/cloudwego/cloudwego.github.io)
-->
