### PR TITLE
fix(adk): improve instruction formatting error handling

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -45,3 +45,6 @@ output/*
 .DS_Store
 *.log
 CLAUDE.md
+
+# Specs directories
+*/specs

--- a/adk/chatmodel.go
+++ b/adk/chatmodel.go
@@ -125,7 +125,10 @@ func defaultGenModelInput(ctx context.Context, instruction string, input *AgentI
 			ct := prompt.FromMessages(schema.FString, sp)
 			ms, err := ct.Format(ctx, vs)
 			if err != nil {
-				return nil, err
+				return nil, fmt.Errorf("defaultGenModelInput: failed to format instruction using FString template. "+
+					"This formatting is triggered automatically when SessionValues are present. "+
+					"If your instruction contains literal curly braces (e.g., JSON), provide a custom GenModelInput that uses another format. If you are using "+
+					"SessionValues for purposes other than instruction formatting, provide a custom GenModelInput that does no formatting at all: %w", err)
 			}
 
 			sp = ms[0]


### PR DESCRIPTION
# Instruction 格式化问题修复

## 问题

`defaultGenModelInput` 在 SessionValues 存在时会静默应用 FString 格式化，导致包含 JSON 的 Instruction 解析失败。

**具体场景**：

```go
// 用户的 Instruction 包含 JSON 示例
instruction := `Output in this format: {"name": "value"}`

// 用户使用 SessionValues 存储状态（非格式化用途）
r.Run(ctx, msgs, adk.WithSessionValues(map[string]any{"user_id": "123"}))
```

**期望**：Instruction 原样传递给模型
**实际**：FString 尝试解析 `{name}` 和 `{value}` 作为变量，失败并报错

**问题根源**：

```go
// chatmodel.go: defaultGenModelInput
vs := GetSessionValues(ctx)
if len(vs) > 0 {
    ct := prompt.FromMessages(schema.FString, sp)
    ms, err := ct.Format(ctx, vs)  // 静默触发格式化
    if err != nil {
        return nil, err  // 原错误信息不清晰
    }
}
```

这个设计假设 SessionValues 的唯一用途是 Instruction 格式化，但实际上用户可能：
- 用 SessionValues 存储运行时状态
- Instruction 中的花括号是字面量（如 JSON 示例）

**DeepAgent 的额外问题**：

DeepAgent 封装了 `ChatModelAgent`，但没有暴露 `GenModelInput` 配置，导致用户无法绕过默认行为。同样，`Handlers` 配置也未暴露，用户无法通过 `BeforeAgent` 自定义格式化逻辑。

## 解决方案

### 1. 改进错误信息

在 [defaultGenModelInput](file:///Users/bytedance/github/eino/adk/chatmodel.go#L93-L120) 中，将原本的通用错误信息改为详细说明：

```go
return nil, fmt.Errorf("defaultGenModelInput: failed to format instruction using FString template. "+
    "This formatting is triggered automatically when SessionValues are present. "+
    "If your instruction contains literal curly braces (e.g., JSON), or you are using "+
    "SessionValues for purposes other than instruction formatting, provide a custom GenModelInput "+
    "to bypass this default behavior: %w", err)
```

**关键洞察**：错误信息应该解释"为什么会发生"和"如何解决"，而不仅仅是"发生了什么"。

### 2. DeepAgent 新增 DisableDefaultInstructionFormatting 配置

在 [Config](file:///Users/bytedance/github/eino/adk/prebuilt/deep/deep.go#L39-L93) 中新增配置项：

```go
// DisableDefaultInstructionFormatting disables the default FString template formatting on the Instruction.
//
// By default, when SessionValues are present, the Instruction is formatted using FString
// (e.g., "{name}" is replaced with the value of "name" from SessionValues).
//
// Set to true if:
//   - Your Instruction contains curly braces that should be literal (e.g., JSON examples)
//   - You are using SessionValues for purposes other than instruction formatting
//   - You want to handle instruction formatting yourself via a BeforeAgent handler
DisableDefaultInstructionFormatting bool
```

实现方式：提供一个不做格式化的 [genModelInputWithoutFormatting](file:///Users/bytedance/github/eino/adk/prebuilt/deep/deep.go#L148-L155)：

```go
func genModelInputWithoutFormatting(_ context.Context, instruction string, input *adk.AgentInput) ([]adk.Message, error) {
    msgs := make([]adk.Message, 0, len(input.Messages)+1)
    if instruction != "" {
        msgs = append(msgs, schema.SystemMessage(instruction))
    }
    msgs = append(msgs, input.Messages...)
    return msgs, nil
}
```

### 3. DeepAgent 新增 Handlers 配置

在 [Config](file:///Users/bytedance/github/eino/adk/prebuilt/deep/deep.go#L68-L76) 中暴露 Handlers：

```go
// Handlers configures interface-based handlers for extending agent behavior.
// Unlike Middlewares (struct-based), Handlers allow users to:
//   - Add custom methods to their handler implementations
//   - Return modified context from handler methods
//   - Centralize configuration in struct fields instead of closures
Handlers []adk.HandlerMiddleware
```

这允许用户通过 `BeforeAgent` 实现自定义格式化逻辑。

## 决策记录

### 考虑过的方案：添加 InstructionFormatType 配置

```go
type Config struct {
    InstructionFormatType schema.FormatType  // FString, GoTemplate, None
}
```

**拒绝原因**：
1. 与自定义 `GenModelInput` 功能重叠
2. 如果用户同时设置 `InstructionFormatType` 和 `GenModelInput`，行为不明确
3. 增加 API 复杂度，但只解决一个特定问题

**最终选择**：`DisableDefaultInstructionFormatting` 是一个简单的开关，语义明确：
- `false`（默认）：使用默认的 FString 格式化
- `true`：禁用默认格式化，Instruction 原样传递

### 为什么同时暴露 Handlers

`DisableDefaultInstructionFormatting` 只能禁用格式化，但用户可能需要自定义格式化逻辑（如使用 Go template 或其他模板引擎）。通过暴露 `Handlers`，用户可以在 `BeforeAgent` 中实现任意格式化：

```go
handler := &customHandler{
    fn: func(ctx context.Context, runCtx *adk.AgentContext) (context.Context, *adk.AgentContext, error) {
        vs := adk.GetSessionValues(ctx)
        if user, ok := vs["user"].(string); ok {
            runCtx.Instruction = strings.ReplaceAll(runCtx.Instruction, "{{ user }}", user)
        }
        return ctx, runCtx, nil
    },
}

agent, _ := deep.New(ctx, &deep.Config{
    DisableDefaultInstructionFormatting: true,
    Handlers: []adk.HandlerMiddleware{handler},
})
```

## 总结

| 问题 | 解决方案 |
|------|----------|
| 错误信息不清晰 | 详细说明触发原因和解决方法 |
| DeepAgent 无法禁用默认格式化 | 新增 `DisableDefaultInstructionFormatting` 配置 |
| DeepAgent 无法自定义格式化 | 暴露 `Handlers` 配置，支持 `BeforeAgent` 自定义逻辑 |

solves: https://github.com/cloudwego/eino/issues/685
solves: https://github.com/cloudwego/eino/issues/677
