### PR TITLE
fix(compose): unique graph successors

### DIFF
--- a/compose/graph.go
+++ b/compose/graph.go
@@ -865,7 +865,20 @@ func getSuccessors(c *chanCall) []string {
 			ret = append(ret, node)
 		}
 	}
-	return ret
+	return uniqueSlice(ret)
+}
+
+func uniqueSlice(s []string) []string {
+	seen := make(map[string]struct{}, len(s))
+	cur := 0
+	for i := range s {
+		if _, ok := seen[s[i]]; !ok {
+			seen[s[i]] = struct{}{}
+			s[cur] = s[i]
+			cur++
+		}
+	}
+	return s[:cur]
 }
 
 type subGraphCompileCallback struct {

--- a/compose/graph_test.go
+++ b/compose/graph_test.go
@@ -2064,3 +2064,8 @@ func (t *testGraphStateCallbackHandler) OnStartWithStreamInput(ctx context.Conte
 func (t *testGraphStateCallbackHandler) OnEndWithStreamOutput(ctx context.Context, info *callbacks.RunInfo, output *schema.StreamReader[callbacks.CallbackOutput]) context.Context {
 	return ctx
 }
+
+func TestUniqueSlice(t *testing.T) {
+	assert.Equal(t, []string{"a", "b", "c"}, uniqueSlice([]string{"a", "b", "a", "c", "b"}))
+	assert.Equal(t, []string{}, uniqueSlice([]string{}))
+}


### PR DESCRIPTION
#### What type of PR is this?
<!--
Add one of the following kinds:

build: Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)
ci: Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
docs: Documentation only changes
feat: A new feature
optimize: A new optimization
fix: A bug fix
perf: A code change that improves performance
refactor: A code change that neither fixes a bug nor adds a feature
style: Changes that do not affect the meaning of the code (white space, formatting, missing semi-colons, etc)
test: Adding missing tests or correcting existing tests
chore: Changes to the build process or auxiliary tools and libraries such as documentation generation
-->

#### Check the PR title.
<!--
The description of the title will be attached in Release Notes, 
so please describe it from user-oriented, what this PR does / why we need it.
Please check your PR title with the below requirements:
-->
- [ ] This PR title match the format: \<type\>(optional scope): \<description\>
- [ ] The description of this PR title is user-oriented and clear enough for others to understand.
- [ ] Attach the PR updating the user documentation if the current PR requires user awareness at the usage level. [User docs repo](https://github.com/cloudwego/cloudwego.github.io)


#### (Optional) Translate the PR title into Chinese.


#### (Optional) More detailed description for this PR(en: English/zh: Chinese).
<!--
Provide more detailed info for review(e.g., it's recommended to provide perf data if this is a perf type PR).
-->
en:
zh(optional): 


#### (Optional) Which issue(s) this PR fixes:
<!--
Automatically closes linked issue when PR is merged.
Eg: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

#### (optional) The PR that updates user documentation:
<!--
If the current PR requires user awareness at the usage level, please submit a PR to update user docs. [User docs repo](https://github.com/cloudwego/cloudwego.github.io)
-->
