### PR TITLE
opt(adk): return error from AddSessionValue instead of silent failure

### DIFF
--- a/adk/agent_tool_test.go
+++ b/adk/agent_tool_test.go
@@ -100,7 +100,7 @@ func TestAgentTool_SharedParentSessionValues(t *testing.T) {
 
 	input := &AgentInput{Messages: []Message{schema.UserMessage("q")}}
 	ctx, _ = initRunCtx(ctx, "outer", input)
-	AddSessionValue(ctx, "parent_key", "parent_val")
+	assert.NoError(t, AddSessionValue(ctx, "parent_key", "parent_val"))
 	parentSession := getRunCtx(ctx).Session
 
 	_, err := innerTool.InvokableRun(ctx, `{"request":"hello"}`)
@@ -151,7 +151,7 @@ func (a *sessionValuesAgent) Run(ctx context.Context, _ *AgentInput, _ ...AgentR
 		a.capturedSession = rc.Session
 	}
 	a.seenParentValue, _ = GetSessionValue(ctx, "parent_key")
-	AddSessionValue(ctx, "child_key", "child_val")
+	_ = AddSessionValue(ctx, "child_key", "child_val")
 
 	it, gen := NewAsyncIteratorPair[*AgentEvent]()
 	gen.Send(&AgentEvent{

--- a/adk/chatmodel.go
+++ b/adk/chatmodel.go
@@ -676,8 +676,7 @@ func genNoToolsCallbacks(generator *AsyncGenerator[*AgentEvent], modelRetryConfi
 
 func setOutputToSession(ctx context.Context, msg Message, msgStream MessageStream, outputKey string) error {
 	if msg != nil {
-		AddSessionValue(ctx, outputKey, msg.Content)
-		return nil
+		return AddSessionValue(ctx, outputKey, msg.Content)
 	}
 
 	concatenated, err := schema.ConcatMessageStream(msgStream)
@@ -685,8 +684,7 @@ func setOutputToSession(ctx context.Context, msg Message, msgStream MessageStrea
 		return err
 	}
 
-	AddSessionValue(ctx, outputKey, concatenated.Content)
-	return nil
+	return AddSessionValue(ctx, outputKey, concatenated.Content)
 }
 
 func errFunc(err error) runFunc {

--- a/adk/prebuilt/deep/deep.go
+++ b/adk/prebuilt/deep/deep.go
@@ -138,7 +138,9 @@ type writeTodosArguments struct {
 
 func newWriteTodos() (adk.AgentMiddleware, error) {
 	t, err := utils.InferTool("write_todos", writeTodosToolDescription, func(ctx context.Context, input writeTodosArguments) (output string, err error) {
-		adk.AddSessionValue(ctx, SessionKeyTodos, input.Todos)
+		if err = adk.AddSessionValue(ctx, SessionKeyTodos, input.Todos); err != nil {
+			return "", err
+		}
 		todos, err := sonic.MarshalString(input.Todos)
 		if err != nil {
 			return "", err

--- a/adk/prebuilt/deep/deep_test.go
+++ b/adk/prebuilt/deep/deep_test.go
@@ -41,9 +41,9 @@ func TestWriteTodos(t *testing.T) {
 	todos := `[{"content":"content1","status":"pending"},{"content":"content2","status":"pending"}]`
 	args := fmt.Sprintf(`{"todos": %s}`, todos)
 
-	result, err := wt.InvokableRun(context.Background(), args)
-	assert.NoError(t, err)
-	assert.Equal(t, fmt.Sprintf("Updated todo list to %s", todos), result)
+	// Without a session, AddSessionValue should return ErrSessionNotInitialized
+	_, err = wt.InvokableRun(context.Background(), args)
+	assert.ErrorIs(t, err, adk.ErrSessionNotInitialized)
 }
 
 func TestDeepSubAgentSharesSessionValues(t *testing.T) {

--- a/adk/prebuilt/planexecute/plan_execute.go
+++ b/adk/prebuilt/planexecute/plan_execute.go
@@ -326,7 +326,7 @@ func (p *planner) Run(ctx context.Context, input *adk.AgentInput,
 
 	iterator, generator := adk.NewAsyncIteratorPair[*adk.AgentEvent]()
 
-	adk.AddSessionValue(ctx, UserInputSessionKey, input.Messages)
+	_ = adk.AddSessionValue(ctx, UserInputSessionKey, input.Messages)
 
 	go func() {
 		defer func() {
@@ -400,7 +400,7 @@ func (p *planner) Run(ctx context.Context, input *adk.AgentInput,
 						return nil, fmt.Errorf("unmarshal plan error: %w", err)
 					}
 
-					adk.AddSessionValue(ctx, PlanSessionKey, plan)
+					_ = adk.AddSessionValue(ctx, PlanSessionKey, plan)
 
 					return plan, nil
 				}),
@@ -666,7 +666,7 @@ func (r *replanner) genInput(ctx context.Context) ([]adk.Message, error) {
 		Step:   step,
 		Result: executedStep_,
 	})
-	adk.AddSessionValue(ctx, ExecutedStepsSessionKey, executedSteps_)
+	_ = adk.AddSessionValue(ctx, ExecutedStepsSessionKey, executedSteps_)
 
 	userInput, ok := adk.GetSessionValue(ctx, UserInputSessionKey)
 	if !ok {
@@ -757,7 +757,7 @@ func (r *replanner) Run(ctx context.Context, input *adk.AgentInput, _ ...adk.Age
 						return nil, fmt.Errorf("unmarshal plan error: %w", err)
 					}
 
-					adk.AddSessionValue(ctx, PlanSessionKey, plan)
+					_ = adk.AddSessionValue(ctx, PlanSessionKey, plan)
 
 					return plan, nil
 				}),

--- a/adk/prebuilt/planexecute/plan_execute_test.go
+++ b/adk/prebuilt/planexecute/plan_execute_test.go
@@ -255,7 +255,7 @@ func TestExecutorRun(t *testing.T) {
 
 	// Store a plan in the session
 	plan := &defaultPlan{Steps: []string{"Step 1", "Step 2", "Step 3"}}
-	adk.AddSessionValue(ctx, PlanSessionKey, plan)
+	_ = adk.AddSessionValue(ctx, PlanSessionKey, plan)
 
 	// Set up expectations for the mock model
 	// The model should return the last user message as its response
@@ -610,8 +610,8 @@ func TestPlanExecuteAgentWithReplan(t *testing.T) {
 			iterator, generator := adk.NewAsyncIteratorPair[*adk.AgentEvent]()
 
 			// Set the plan in the session
-			adk.AddSessionValue(ctx, PlanSessionKey, originalPlan)
-			adk.AddSessionValue(ctx, UserInputSessionKey, userInput)
+			_ = adk.AddSessionValue(ctx, PlanSessionKey, originalPlan)
+			_ = adk.AddSessionValue(ctx, UserInputSessionKey, userInput)
 
 			// Send a message event
 			planJSON, _ := sonic.MarshalString(originalPlan)
@@ -635,10 +635,10 @@ func TestPlanExecuteAgentWithReplan(t *testing.T) {
 			// Check if this is the first replanning (original plan has 3 steps)
 			if len(currentPlan.Steps) == 3 {
 				msg = schema.AssistantMessage(originalExecuteResult, nil)
-				adk.AddSessionValue(ctx, ExecutedStepSessionKey, originalExecuteResult)
+				_ = adk.AddSessionValue(ctx, ExecutedStepSessionKey, originalExecuteResult)
 			} else {
 				msg = schema.AssistantMessage(updatedExecuteResult, nil)
-				adk.AddSessionValue(ctx, ExecutedStepSessionKey, updatedExecuteResult)
+				_ = adk.AddSessionValue(ctx, ExecutedStepSessionKey, updatedExecuteResult)
 			}
 			event := adk.EventFromMessage(msg, nil, schema.Assistant, "")
 			generator.Send(event)
@@ -667,8 +667,8 @@ func TestPlanExecuteAgentWithReplan(t *testing.T) {
 				generator.Send(event)
 
 				// Set the updated plan & execute result in the session
-				adk.AddSessionValue(ctx, PlanSessionKey, updatedPlan)
-				adk.AddSessionValue(ctx, ExecutedStepsSessionKey, []ExecutedStep{{
+				_ = adk.AddSessionValue(ctx, PlanSessionKey, updatedPlan)
+				_ = adk.AddSessionValue(ctx, ExecutedStepsSessionKey, []ExecutedStep{{
 					Step:   currentPlan.Steps[0],
 					Result: originalExecuteResult,
 				}})
@@ -835,8 +835,8 @@ func TestPlanExecuteAgentInterruptResume(t *testing.T) {
 		func(ctx context.Context, input *adk.AgentInput, opts ...adk.AgentRunOption) *adk.AsyncIterator[*adk.AgentEvent] {
 			iterator, generator := adk.NewAsyncIteratorPair[*adk.AgentEvent]()
 
-			adk.AddSessionValue(ctx, PlanSessionKey, plan)
-			adk.AddSessionValue(ctx, UserInputSessionKey, userInput)
+			_ = adk.AddSessionValue(ctx, PlanSessionKey, plan)
+			_ = adk.AddSessionValue(ctx, UserInputSessionKey, userInput)
 
 			planJSON, _ := sonic.MarshalString(plan)
 			msg := schema.AssistantMessage(planJSON, nil)

--- a/adk/runctx.go
+++ b/adk/runctx.go
@@ -20,6 +20,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/gob"
+	"errors"
 	"fmt"
 	"sort"
 	"sync"
@@ -27,6 +28,9 @@ import (
 
 	"github.com/cloudwego/eino/schema"
 )
+
+// ErrSessionNotInitialized is returned when session is not available in the context.
+var ErrSessionNotInitialized = errors.New("session not initialized")
 
 // runSession CheckpointSchema: persisted via serialization.RunCtx (gob).
 type runSession struct {
@@ -99,23 +103,27 @@ func GetSessionValues(ctx context.Context) map[string]any {
 }
 
 // AddSessionValue sets a single session key-value pair for the current run.
-func AddSessionValue(ctx context.Context, key string, value any) {
+// Returns ErrSessionNotInitialized if called before Runner.Run() has initialized the session.
+func AddSessionValue(ctx context.Context, key string, value any) error {
 	session := getSession(ctx)
 	if session == nil {
-		return
+		return ErrSessionNotInitialized
 	}
 
 	session.addValue(key, value)
+	return nil
 }
 
 // AddSessionValues sets multiple session key-value pairs for the current run.
-func AddSessionValues(ctx context.Context, kvs map[string]any) {
+// Returns ErrSessionNotInitialized if called before Runner.Run() has initialized the session.
+func AddSessionValues(ctx context.Context, kvs map[string]any) error {
 	session := getSession(ctx)
 	if session == nil {
-		return
+		return ErrSessionNotInitialized
 	}
 
 	session.addValues(kvs)
+	return nil
 }
 
 // GetSessionValue retrieves a session value by key and reports whether it exists.

--- a/adk/runctx_test.go
+++ b/adk/runctx_test.go
@@ -42,7 +42,7 @@ func TestSessionValues(t *testing.T) {
 			"key2": 42,
 			"key3": true,
 		}
-		AddSessionValues(ctx, values)
+		assert.NoError(t, AddSessionValues(ctx, values))
 
 		// Get all values from the session
 		retrievedValues := GetSessionValues(ctx)
@@ -62,7 +62,10 @@ func TestSessionValues(t *testing.T) {
 		values := map[string]any{
 			"key1": "value1",
 		}
-		AddSessionValues(ctx, values)
+		err := AddSessionValues(ctx, values)
+
+		// Should return error
+		assert.ErrorIs(t, err, ErrSessionNotInitialized)
 
 		// Get values should return empty map
 		retrievedValues := GetSessionValues(ctx)
@@ -88,7 +91,7 @@ func TestSessionValues(t *testing.T) {
 		ctx = setRunCtx(ctx, runCtx)
 
 		// Add nil values map
-		AddSessionValues(ctx, nil)
+		assert.NoError(t, AddSessionValues(ctx, nil))
 
 		// Get values should still be empty
 		retrievedValues := GetSessionValues(ctx)
@@ -105,7 +108,7 @@ func TestSessionValues(t *testing.T) {
 		ctx = setRunCtx(ctx, runCtx)
 
 		// Add empty values map
-		AddSessionValues(ctx, map[string]any{})
+		assert.NoError(t, AddSessionValues(ctx, map[string]any{}))
 
 		// Get values should be empty
 		retrievedValues := GetSessionValues(ctx)
@@ -131,7 +134,7 @@ func TestSessionValues(t *testing.T) {
 			"map":    map[string]int{"x": 1, "y": 2},
 			"struct": struct{ Name string }{Name: "test"},
 		}
-		AddSessionValues(ctx, values)
+		assert.NoError(t, AddSessionValues(ctx, values))
 
 		// Get all values from the session
 		retrievedValues := GetSessionValues(ctx)
@@ -161,14 +164,14 @@ func TestSessionValues(t *testing.T) {
 			"key1": "initial1",
 			"key2": "initial2",
 		}
-		AddSessionValues(ctx, initialValues)
+		assert.NoError(t, AddSessionValues(ctx, initialValues))
 
 		// Add values that overwrite some keys
 		overwriteValues := map[string]any{
 			"key1": "overwritten1",
 			"key3": "new3",
 		}
-		AddSessionValues(ctx, overwriteValues)
+		assert.NoError(t, AddSessionValues(ctx, overwriteValues))
 
 		// Get all values from the session
 		retrievedValues := GetSessionValues(ctx)
@@ -193,7 +196,7 @@ func TestSessionValues(t *testing.T) {
 		initialValues := map[string]any{
 			"counter": 0,
 		}
-		AddSessionValues(ctx, initialValues)
+		assert.NoError(t, AddSessionValues(ctx, initialValues))
 
 		// Simulate concurrent access
 		done := make(chan bool)
@@ -204,7 +207,7 @@ func TestSessionValues(t *testing.T) {
 				values := map[string]any{
 					"goroutine1": i,
 				}
-				AddSessionValues(ctx, values)
+				_ = AddSessionValues(ctx, values)
 			}
 			done <- true
 		}()
@@ -215,7 +218,7 @@ func TestSessionValues(t *testing.T) {
 				values := map[string]any{
 					"goroutine2": i,
 				}
-				AddSessionValues(ctx, values)
+				_ = AddSessionValues(ctx, values)
 			}
 			done <- true
 		}()
@@ -245,7 +248,7 @@ func TestSessionValues(t *testing.T) {
 			"key1": "value1",
 			"key2": 42,
 		}
-		AddSessionValues(ctx, values)
+		assert.NoError(t, AddSessionValues(ctx, values))
 
 		// Get individual values
 		value1, exists1 := GetSessionValue(ctx, "key1")
@@ -273,8 +276,8 @@ func TestSessionValues(t *testing.T) {
 		ctx = setRunCtx(ctx, runCtx)
 
 		// Add individual values
-		AddSessionValue(ctx, "key1", "value1")
-		AddSessionValue(ctx, "key2", 42)
+		assert.NoError(t, AddSessionValue(ctx, "key1", "value1"))
+		assert.NoError(t, AddSessionValue(ctx, "key2", 42))
 
 		// Get all values
 		retrievedValues := GetSessionValues(ctx)
@@ -290,7 +293,10 @@ func TestSessionValues(t *testing.T) {
 		ctx := context.Background()
 
 		// Add individual value to a context without a run session
-		AddSessionValue(ctx, "key1", "value1")
+		err := AddSessionValue(ctx, "key1", "value1")
+
+		// Should return error
+		assert.ErrorIs(t, err, ErrSessionNotInitialized)
 
 		// Get individual value should return false
 		value, exists := GetSessionValue(ctx, "key1")
@@ -322,7 +328,7 @@ func TestSessionValues(t *testing.T) {
 		values := map[string]any{
 			"integration_key": "integration_value",
 		}
-		AddSessionValues(ctx, values)
+		assert.NoError(t, AddSessionValues(ctx, values))
 
 		// Get values from the session
 		retrievedValues := GetSessionValues(ctx)

--- a/adk/runner.go
+++ b/adk/runner.go
@@ -84,7 +84,7 @@ func (r *Runner) Run(ctx context.Context, messages []Message,
 
 	ctx = ctxWithNewRunCtx(ctx, input, o.sharedParentSession)
 
-	AddSessionValues(ctx, o.sessionValues)
+	_ = AddSessionValues(ctx, o.sessionValues)
 
 	iter := fa.Run(ctx, input, opts...)
 	if r.store == nil {
@@ -167,7 +167,7 @@ func (r *Runner) resume(ctx context.Context, checkPointID string, resumeData map
 
 	ctx = setRunCtx(ctx, runCtx)
 
-	AddSessionValues(ctx, o.sessionValues)
+	_ = AddSessionValues(ctx, o.sessionValues)
 
 	if len(resumeData) > 0 {
 		ctx = core.BatchResumeWithData(ctx, resumeData)


### PR DESCRIPTION
 ## 问题

 runner.Run() 之后才会init session之前 session 不存在时静默返回无法得知写入失败难以调试。比如 TestWriteTodos 这个测试原来静默失败后函数继续执行返回字符串，测试只验证了返回值格式没验证 todos 是否真的写入了session
Get方法也是可能可以类似 adk-go 如果没有key也会return error 他们Set err都是nil大概率接口保留
https://github.com/google/adk-go/blob/main/session/database/session.go

## 改动

- AddSessionValue 和 AddSessionValues 现在返回 error
- 新增 ErrSessionNotInitialized error var
break了api但是感觉return err更合理一些
