### PR TITLE
feat: agentic model support stop option

### DIFF
--- a/components/model/option.go
+++ b/components/model/option.go
@@ -30,6 +30,8 @@ type Options struct {
 	Tools []*schema.ToolInfo
 	// MaxTokens is the max number of tokens, if reached the max tokens, the model will stop generating, and mostly return a finish reason of "length".
 	MaxTokens *int
+	// Stop is the stop words for the model, which controls the stopping condition of the model.
+	Stop []string
 
 	// Options only available for chat model.
 
@@ -38,8 +40,6 @@ type Options struct {
 	// AllowedToolNames specifies a list of tool names that the model is allowed to call.
 	// This allows for constraining the model to a specific subset of the available tools.
 	AllowedToolNames []string
-	// Stop is the stop words for the model, which controls the stopping condition of the model.
-	Stop []string
 
 	// Options only available for agentic model.
 
@@ -64,7 +64,6 @@ func WithTemperature(temperature float32) Option {
 }
 
 // WithMaxTokens is the option to set the max tokens for the model.
-// Only available for ChatModel.
 func WithMaxTokens(maxTokens int) Option {
 	return Option{
 		apply: func(opts *Options) {
@@ -92,7 +91,6 @@ func WithTopP(topP float32) Option {
 }
 
 // WithStop is the option to set the stop words for the model.
-// Only available for ChatModel.
 func WithStop(stop []string) Option {
 	return Option{
 		apply: func(opts *Options) {


### PR DESCRIPTION
#### What type of PR is this?
<!--
Add one of the following kinds:

build: Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)
ci: Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
docs: Documentation only changes
feat: A new feature
optimize: A new optimization
fix: A bug fix
perf: A code change that improves performance
refactor: A code change that neither fixes a bug nor adds a feature
style: Changes that do not affect the meaning of the code (white space, formatting, missing semi-colons, etc)
test: Adding missing tests or correcting existing tests
chore: Changes to the build process or auxiliary tools and libraries such as documentation generation
-->

#### Check the PR title.
<!--
The description of the title will be attached in Release Notes, 
so please describe it from user-oriented, what this PR does / why we need it.
Please check your PR title with the below requirements:
-->
- [ ] This PR title match the format: \<type\>(optional scope): \<description\>
- [ ] The description of this PR title is user-oriented and clear enough for others to understand.
- [ ] Attach the PR updating the user documentation if the current PR requires user awareness at the usage level. [User docs repo](https://github.com/cloudwego/cloudwego.github.io)


#### (Optional) Translate the PR title into Chinese.


#### (Optional) More detailed description for this PR(en: English/zh: Chinese).
<!--
Provide more detailed info for review(e.g., it's recommended to provide perf data if this is a perf type PR).
-->
en:
zh(optional): 


#### (Optional) Which issue(s) this PR fixes:
<!--
Automatically closes linked issue when PR is merged.
Eg: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

#### (optional) The PR that updates user documentation:
<!--
If the current PR requires user awareness at the usage level, please submit a PR to update user docs. [User docs repo](https://github.com/cloudwego/cloudwego.github.io)
-->
