### PR TITLE
feat(adk): support config OutputKey to store final answer to SessionValues

### DIFF
--- a/adk/prebuilt/deep/deep.go
+++ b/adk/prebuilt/deep/deep.go
@@ -66,6 +66,10 @@ type Config struct {
 	Middlewares []adk.AgentMiddleware
 
 	ModelRetryConfig *adk.ModelRetryConfig
+
+	// OutputKey stores the agent's response in the session.
+	// Optional. When set, stores output via AddSessionValue(ctx, outputKey, msg.Content).
+	OutputKey string
 }
 
 // New creates a new Deep agent instance with the provided configuration.
@@ -111,6 +115,7 @@ func New(ctx context.Context, cfg *Config) (adk.ResumableAgent, error) {
 		Middlewares:   append(middlewares, cfg.Middlewares...),
 
 		ModelRetryConfig: cfg.ModelRetryConfig,
+		OutputKey:        cfg.OutputKey,
 	})
 }
 


### PR DESCRIPTION
#### What type of PR is this?

feat: A new feature

#### Check the PR title.

- [x] This PR title match the format: \<type\>(optional scope): \<description\>
- [x] The description of this PR title is user-oriented and clear enough for others to understand.
- [ ] Attach the PR updating the user documentation if the current PR requires user awareness at the usage level.

#### (Optional) Translate the PR title into Chinese.

feat(adk): 在 DeepAgent 配置中暴露 OutputKey 以支持顺序工作流

#### (Optional) More detailed description for this PR(en: English/zh: Chinese).

en:

This PR exposes the `OutputKey` configuration option from `ChatModelAgent` to `DeepAgent`, enabling users to store the agent's final response in the session.

**Background:**

When chaining `DeepAgent` with other agents (e.g., `ChatModelAgent`) in a Sequential Workflow, there was no way to pass the output from `DeepAgent` to downstream agents via session values.

**Changes:**

- Added `OutputKey` field to `deep.Config` struct
- Passed `OutputKey` to the underlying `ChatModelAgentConfig` during agent creation
- Added comprehensive unit tests covering:
  - Non-streaming mode: verifies output is stored in session
  - Streaming mode: verifies concatenated stream content is stored in session
  - Empty OutputKey: verifies no session value is set when OutputKey is not configured

**Usage Example:**

```go
deepAgent, _ := deep.New(ctx, &deep.Config{
    Name:      "deep_agent",
    ChatModel: chatModel,
    OutputKey: "deep_agent_output", // Output will be stored in session
})

// Downstream agents can access via: adk.GetSessionValue(ctx, "deep_agent_output")
```

zh(optional):

本 PR 将 `ChatModelAgent` 的 `OutputKey` 配置项暴露到 `DeepAgent`，使用户能够将 agent 的最终响应存储到 session 中，便于在 Sequential Workflow 中串联多个 agent 时传递数据。

#### (Optional) Which issue(s) this PR fixes:

N/A

#### (optional) The PR that updates user documentation:

N/A