### PR TITLE
docs: prioritize ADK in README feature highlights

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,8 +18,8 @@ English | [中文](README.zh_CN.md)
 
 What Eino provides are:
 - a carefully curated list of **component** abstractions and implementations that can be easily reused and combined to build LLM applications
-- a powerful **composition** framework that does the heavy lifting of strong type checking, stream processing, concurrency management, aspect injection, option assignment, etc. for the user.
 - an **Agent Development Kit (ADK)** that provides high-level abstractions for building AI agents with multi-agent orchestration, human-in-the-loop interrupts, and prebuilt agent patterns.
+- a powerful **composition** framework that does the heavy lifting of strong type checking, stream processing, concurrency management, aspect injection, option assignment, etc. for the user.
 - a set of meticulously designed **API** that obsesses on simplicity and clarity.
 - an ever-growing collection of best practices in the form of bundled **flows** and **examples**.
 - a useful set of tools that covers the entire development cycle, from visualized development and debugging to online tracing and evaluation.
@@ -286,18 +286,9 @@ agent, _ := adk.NewChatModelAgent(ctx, &adk.ChatModelAgentConfig{
     - ReAct Agent, MultiQueryRetriever, Host MultiAgent, etc. They consist of multiple components and non-trivial business logic.
     - They are still transparent from the outside. A MultiQueryRetriever can be used anywhere that accepts a Retriever.
 
-## Powerful Orchestration
-
-- Data flows from Retriever / Document Loaders / ChatTemplate to ChatModel, then flows to Tools and parsed as Final Answer. This directed, controlled flow of data through multiple components can be implemented through **graph orchestration**.
-- Component instances are graph nodes, and edges are data flow channels.
-- Graph orchestration is powerful and flexible enough to implement complex business logic:
-  - type checking, stream processing, concurrency management, aspect injection and option assignment are handled by the framework.
-  - branch out execution at runtime, read and write global state, or do field level data mapping using workflow(currently in alpha stage).
-  - **Aspects (Callbacks)** handle cross-cutting concerns such as logging, tracing, and metrics. Five aspects are supported: OnStart, OnEnd, OnError, OnStartWithStreamInput, OnEndWithStreamOutput. Custom callback handlers can be added during graph run via options.
-
 ## Agent Development Kit (ADK)
 
-While graph orchestration gives you fine-grained control, the **ADK** package provides higher-level abstractions optimized for building AI agents:
+The **ADK** package provides high-level abstractions optimized for building AI agents:
 
 - **ChatModelAgent**: A ReAct-style agent that handles tool calling, conversation state, and the reasoning loop automatically.
 - **Multi-Agent with Context Engineering**: Build hierarchical agent systems where conversation history is automatically managed across agent transfers and agent-as-tool invocations, enabling seamless context sharing between specialized agents.
@@ -305,6 +296,22 @@ While graph orchestration gives you fine-grained control, the **ADK** package pr
 - **Human-in-the-Loop**: `Interrupt` and `Resume` mechanisms with checkpoint persistence for workflows requiring human approval or input.
 - **Prebuilt Patterns**: Ready-to-use implementations including Deep Agent (task orchestration), Supervisor (hierarchical coordination), and Plan-Execute-Replan.
 - **Agent Middlewares**: Extensible middleware system for adding tools (filesystem operations) and managing context (token reduction).
+
+## Powerful Orchestration
+
+For fine-grained control, Eino provides **graph orchestration** where data flows from Retriever / Document Loaders / ChatTemplate to ChatModel, then flows to Tools and parsed as Final Answer.
+
+- Component instances are graph nodes, and edges are data flow channels.
+- Graph orchestration is powerful and flexible enough to implement complex business logic:
+  - type checking, stream processing, concurrency management, aspect injection and option assignment are handled by the framework.
+  - branch out execution at runtime, read and write global state, or do field level data mapping using workflow.
+
+## Aspects (Callbacks)
+
+**Aspects** handle cross-cutting concerns such as logging, tracing, and metrics. They can be applied to components directly, orchestrated graphs, or ADK agents.
+
+- Five aspect types are supported: OnStart, OnEnd, OnError, OnStartWithStreamInput, OnEndWithStreamOutput.
+- Custom callback handlers can be added at runtime via options.
 
 ## Complete Stream Processing
 

--- a/README.zh_CN.md
+++ b/README.zh_CN.md
@@ -18,8 +18,8 @@
 
 Eino 提供的价值如下：
 - 精心整理的一系列 **组件（component）** 抽象与实现，可轻松复用与组合，用于构建 LLM 应用。
-- 强大的 **编排（orchestration）** 框架，为用户承担繁重的类型检查、流式处理、并发管理、切面注入、选项赋值等工作。
 - **智能体开发套件（ADK）**，提供构建 AI 智能体的高级抽象，支持多智能体编排、人机协作中断机制以及预置的智能体模式。
+- 强大的 **编排（orchestration）** 框架，为用户承担繁重的类型检查、流式处理、并发管理、切面注入、选项赋值等工作。
 - 一套精心设计、注重简洁明了的 **API**。
 - 以集成 **流程（flow）** 和 **示例（example）** 形式不断扩充的最佳实践集合。
 - 一套实用 **工具（DevOps tools）**，涵盖从可视化开发与调试到在线追踪与评估的整个开发生命周期。
@@ -285,18 +285,9 @@ agent, _ := adk.NewChatModelAgent(ctx, &adk.ChatModelAgentConfig{
     - ReAct Agent、MultiQueryRetriever、Host MultiAgent 等。它们由多个组件和复杂的业务逻辑构成。
     - 从外部看，它们的实现细节依然透明。例如在任何接受 Retriever 的地方，都可以使用 MultiQueryRetriever。
 
-## 强大的编排 (Graph/Chain/Workflow)
-
-- 数据从 Retriever / Document Loader / ChatTemplate 流向 ChatModel，接着流向 Tool ，并被解析为最终答案。这种通过多个组件的有向、可控的数据流，可以通过**图编排**来实现。
-- 组件实例是图的 **节点（Node）** ，而 **边（Edge）** 则是数据流通道。
-- 图编排功能强大且足够灵活，能够实现复杂的业务逻辑：
-    - **类型检查、流处理、并发管理、切面注入和选项分配**都由框架处理。
-    - 在运行时进行**分支（Branch）**执行、读写全局**状态（State）**，或者使用工作流进行字段级别的数据映射。
-    - **切面（Callbacks）** 处理日志记录、追踪、指标统计等横切关注点。支持五种切面：OnStart、OnEnd、OnError、OnStartWithStreamInput、OnEndWithStreamOutput。可通过 Option 在图运行时添加自定义回调处理程序。
-
 ## 智能体开发套件（ADK）
 
-图编排提供细粒度控制，而 **ADK** 包则提供了针对构建 AI 智能体优化的更高级抽象：
+**ADK** 包提供了针对构建 AI 智能体优化的高级抽象：
 
 - **ChatModelAgent**：ReAct 风格的智能体，自动处理工具调用、对话状态和推理循环。
 - **多智能体与上下文工程**：构建层级化智能体系统，对话历史在智能体转移和智能体作为工具调用时自动管理，实现专业智能体间的无缝上下文共享。
@@ -304,6 +295,22 @@ agent, _ := adk.NewChatModelAgent(ctx, &adk.ChatModelAgentConfig{
 - **人机协作**：`Interrupt` 和 `Resume` 机制，支持检查点持久化，适用于需要人工审批或输入的工作流。
 - **预置模式**：开箱即用的实现，包括 Deep Agent（任务编排）、Supervisor（层级协调）和 Plan-Execute-Replan。
 - **智能体中间件**：可扩展的中间件系统，用于添加工具（文件系统操作）和管理上下文（token 缩减）。
+
+## 强大的编排 (Graph/Chain/Workflow)
+
+如需细粒度控制，Eino 提供**图编排**能力，数据从 Retriever / Document Loader / ChatTemplate 流向 ChatModel，接着流向 Tool ，并被解析为最终答案。
+
+- 组件实例是图的 **节点（Node）** ，而 **边（Edge）** 则是数据流通道。
+- 图编排功能强大且足够灵活，能够实现复杂的业务逻辑：
+    - **类型检查、流处理、并发管理、切面注入和选项分配**都由框架处理。
+    - 在运行时进行**分支（Branch）**执行、读写全局**状态（State）**，或者使用工作流进行字段级别的数据映射。
+
+## 切面（Callbacks）
+
+**切面**处理日志记录、追踪、指标统计等横切关注点。切面可以直接应用于组件、编排图或 ADK 智能体。
+
+- 支持五种切面类型：OnStart、OnEnd、OnError、OnStartWithStreamInput、OnEndWithStreamOutput。
+- 可通过 Option 在运行时添加自定义回调处理程序。
 
 ## 完整的流式处理能力
 


### PR DESCRIPTION
## Summary

This PR reorders the README documentation to put the **Agent Development Kit (ADK)** in a more prominent position, reflecting its importance as a primary feature of Eino.

## Changes

| Location | Change |
|----------|--------|
| What Eino provides list | Moved ADK to 2nd position (after components, before composition) |
| Key Features section | Moved ADK section above Orchestration section |

## Rationale

The ADK package provides high-level abstractions that most users will interact with first when building AI agents. By positioning it before the lower-level composition/orchestration framework, new users can more easily discover the recommended starting point for agent development.

## Files Changed

- README.md - English version
- README.zh_CN.md - Chinese version

---

## 概要

本 PR 调整了 README 文档的顺序，将 **智能体开发套件（ADK）** 放在更显眼的位置，以体现其作为 Eino 主要特性的重要性。

## 变更

| 位置 | 变更内容 |
|------|----------|
| Eino 提供的价值 列表 | 将 ADK 移至第 2 位（组件之后，编排之前） |
| 关键特性 章节 | 将 ADK 章节移至编排章节之前 |

## 原因

ADK 包提供了大多数用户在构建 AI 智能体时首先会接触的高级抽象。将其放在较低级别的编排框架之前，可以让新用户更容易发现智能体开发的推荐起点。
