### PR TITLE
fix(adk): change ReturnDirectly type from map[string]struct{} to map[string]bool

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -45,9 +45,9 @@ output/*
 # Specs files (internal documentation)
 **/specs/
 
+# Reports (generated analysis files)
+reports/
+
 .DS_Store
 *.log
 CLAUDE.md
-
-# Specs directories
-*/specs

--- a/adk/chatmodel_test.go
+++ b/adk/chatmodel_test.go
@@ -457,8 +457,8 @@ func TestParallelReturnDirectlyToolCall(t *testing.T) {
 					&myTool{name: "tool3", desc: "tool3", waitTime: 100 * time.Millisecond},
 				},
 			},
-			ReturnDirectly: map[string]struct{}{
-				"tool1": {},
+			ReturnDirectly: map[string]bool{
+				"tool1": true,
 			},
 		},
 	})

--- a/adk/handler.go
+++ b/adk/handler.go
@@ -73,7 +73,7 @@ type ChatModelAgentContext struct {
 	// ReturnDirectly is the set of tool names currently configured to cause the Agent to return directly.
 	// This is based on the return directly map configured for the agent, plus any modifications
 	// by previous BeforeAgent handlers.
-	ReturnDirectly map[string]struct{}
+	ReturnDirectly map[string]bool
 }
 
 // ChatModelAgentMiddleware defines the interface for customizing ChatModelAgent behavior.

--- a/adk/handler_test.go
+++ b/adk/handler_test.go
@@ -71,7 +71,7 @@ func (h *testToolsHandler) BeforeAgent(ctx context.Context, runCtx *ChatModelAge
 
 type testToolsFuncHandler struct {
 	*BaseChatModelAgentMiddleware
-	fn func(ctx context.Context, tools []tool.BaseTool, returnDirectly map[string]struct{}) (context.Context, []tool.BaseTool, map[string]struct{}, error)
+	fn func(ctx context.Context, tools []tool.BaseTool, returnDirectly map[string]bool) (context.Context, []tool.BaseTool, map[string]bool, error)
 }
 
 func (h *testToolsFuncHandler) BeforeAgent(ctx context.Context, runCtx *ChatModelAgentContext) (context.Context, *ChatModelAgentContext, error) {
@@ -344,7 +344,7 @@ func TestToolsHandlerCombinations(t *testing.T) {
 				},
 			},
 			Handlers: []ChatModelAgentMiddleware{
-				&testToolsFuncHandler{fn: func(ctx context.Context, tools []tool.BaseTool, returnDirectly map[string]struct{}) (context.Context, []tool.BaseTool, map[string]struct{}, error) {
+				&testToolsFuncHandler{fn: func(ctx context.Context, tools []tool.BaseTool, returnDirectly map[string]bool) (context.Context, []tool.BaseTool, map[string]bool, error) {
 					filtered := make([]tool.BaseTool, 0)
 					for _, t := range tools {
 						info, _ := t.Info(ctx)
@@ -394,11 +394,11 @@ func TestToolsHandlerCombinations(t *testing.T) {
 				},
 			},
 			Handlers: []ChatModelAgentMiddleware{
-				&testToolsFuncHandler{fn: func(ctx context.Context, tools []tool.BaseTool, returnDirectly map[string]struct{}) (context.Context, []tool.BaseTool, map[string]struct{}, error) {
+				&testToolsFuncHandler{fn: func(ctx context.Context, tools []tool.BaseTool, returnDirectly map[string]bool) (context.Context, []tool.BaseTool, map[string]bool, error) {
 					for _, t := range tools {
 						info, _ := t.Info(ctx)
 						if info.Name == "tool1" {
-							returnDirectly[info.Name] = struct{}{}
+							returnDirectly[info.Name] = true
 						}
 					}
 					return ctx, tools, returnDirectly, nil

--- a/adk/interrupt_test.go
+++ b/adk/interrupt_test.go
@@ -1932,8 +1932,8 @@ func TestReturnDirectlyEventSentAfterResume(t *testing.T) {
 					&interruptingTool{name: interruptingToolName},
 				},
 			},
-			ReturnDirectly: map[string]struct{}{
-				returnDirectlyToolName: {},
+			ReturnDirectly: map[string]bool{
+				returnDirectlyToolName: true,
 			},
 		},
 		Handlers: []ChatModelAgentMiddleware{

--- a/adk/react.go
+++ b/adk/react.go
@@ -280,7 +280,7 @@ type reactConfig struct {
 	toolsConfig      *compose.ToolsNodeConfig
 	modelWrapperConf *modelWrapperConfig
 
-	toolsReturnDirectly map[string]struct{}
+	toolsReturnDirectly map[string]bool
 
 	agentName string
 

--- a/adk/react_test.go
+++ b/adk/react_test.go
@@ -102,7 +102,7 @@ func TestReact(t *testing.T) {
 			toolsConfig: &compose.ToolsNodeConfig{
 				Tools: []tool.BaseTool{fakeTool},
 			},
-			toolsReturnDirectly: map[string]struct{}{},
+			toolsReturnDirectly: map[string]bool{},
 		}
 
 		graph, err := newReact(ctx, config)
@@ -169,7 +169,7 @@ func TestReact(t *testing.T) {
 			toolsConfig: &compose.ToolsNodeConfig{
 				Tools: []tool.BaseTool{fakeTool},
 			},
-			toolsReturnDirectly: map[string]struct{}{info.Name: {}},
+			toolsReturnDirectly: map[string]bool{info.Name: true},
 		}
 
 		graph, err := newReact(ctx, config)
@@ -261,7 +261,7 @@ func TestReact(t *testing.T) {
 			toolsConfig: &compose.ToolsNodeConfig{
 				Tools: []tool.BaseTool{fakeTool, fakeStreamTool},
 			},
-			toolsReturnDirectly: map[string]struct{}{},
+			toolsReturnDirectly: map[string]bool{},
 		}
 
 		graph, err := newReact(ctx, config)
@@ -371,7 +371,7 @@ func TestReact(t *testing.T) {
 			toolsConfig: &compose.ToolsNodeConfig{
 				Tools: []tool.BaseTool{fakeTool, fakeStreamTool},
 			},
-			toolsReturnDirectly: map[string]struct{}{streamInfo.Name: {}},
+			toolsReturnDirectly: map[string]bool{streamInfo.Name: true},
 		}
 
 		graph, err := newReact(ctx, config)
@@ -459,7 +459,7 @@ func TestReact(t *testing.T) {
 			toolsConfig: &compose.ToolsNodeConfig{
 				Tools: []tool.BaseTool{fakeTool},
 			},
-			toolsReturnDirectly: map[string]struct{}{},
+			toolsReturnDirectly: map[string]bool{},
 			maxIterations:       6,
 		}
 
@@ -489,7 +489,7 @@ func TestReact(t *testing.T) {
 			toolsConfig: &compose.ToolsNodeConfig{
 				Tools: []tool.BaseTool{fakeTool},
 			},
-			toolsReturnDirectly: map[string]struct{}{},
+			toolsReturnDirectly: map[string]bool{},
 			maxIterations:       5,
 		}
 


### PR DESCRIPTION
## Summary

| Problem | Solution |
|---------|----------|
| `ReturnDirectly` type `map[string]struct{}` is less intuitive and harder to use | Changed to `map[string]bool` for better usability |

## Key Changes

This PR changes the `ReturnDirectly` field type from `map[string]struct{}` to `map[string]bool` across the ADK package.

### Files Modified

- **adk/chatmodel.go**: Updated `ToolsConfig.ReturnDirectly`, `chatModelAgentExecCtx.runtimeReturnDirectly`, `execContext.returnDirectly`, and related function signatures
- **adk/handler.go**: Updated `ChatModelAgentContext.ReturnDirectly`
- **adk/react.go**: Updated `reactConfig.toolsReturnDirectly`
- **Test files**: Updated all test usages to use `map[string]bool{"toolName": true}` syntax

### Key Insight

The change from `map[string]struct{}` to `map[string]bool` improves API usability:

**Before:**
```go
ReturnDirectly: map[string]struct{}{
    "tool1": {},
}
```

**After:**
```go
ReturnDirectly: map[string]bool{
    "tool1": true,
}
```

The `map[string]bool` type is more intuitive and self-documenting - the value explicitly indicates whether the tool should trigger immediate return.

---

## 摘要

| 问题 | 解决方案 |
|------|----------|
| `ReturnDirectly` 类型 `map[string]struct{}` 不够直观且难以使用 | 改为 `map[string]bool` 以提高可用性 |

## 主要更改

本 PR 将 ADK 包中的 `ReturnDirectly` 字段类型从 `map[string]struct{}` 改为 `map[string]bool`。

### 修改的文件

- **adk/chatmodel.go**: 更新了 `ToolsConfig.ReturnDirectly`、`chatModelAgentExecCtx.runtimeReturnDirectly`、`execContext.returnDirectly` 及相关函数签名
- **adk/handler.go**: 更新了 `ChatModelAgentContext.ReturnDirectly`
- **adk/react.go**: 更新了 `reactConfig.toolsReturnDirectly`
- **测试文件**: 更新所有测试用例使用 `map[string]bool{"toolName": true}` 语法

### 关键洞察

从 `map[string]struct{}` 改为 `map[string]bool` 提高了 API 可用性：

**之前:**
```go
ReturnDirectly: map[string]struct{}{
    "tool1": {},
}
```

**之后:**
```go
ReturnDirectly: map[string]bool{
    "tool1": true,
}
```

`map[string]bool` 类型更加直观且具有自文档性 - 值明确表示该工具是否应触发立即返回。