### PR TITLE
feat(adk): add Handlers field to deep.Config for ChatModelAgentMiddleware support

### DIFF
--- a/adk/prebuilt/deep/deep.go
+++ b/adk/prebuilt/deep/deep.go
@@ -67,6 +67,16 @@ type Config struct {
 
 	Middlewares []adk.AgentMiddleware
 
+	// Handlers configures interface-based handlers for extending agent behavior.
+	// Unlike Middlewares (struct-based), Handlers allow users to:
+	//   - Add custom methods to their handler implementations
+	//   - Return modified context from handler methods
+	//   - Centralize configuration in struct fields instead of closures
+	//
+	// Handlers are processed after Middlewares, in registration order.
+	// See adk.ChatModelAgentMiddleware documentation for when to use Handlers vs Middlewares.
+	Handlers []adk.ChatModelAgentMiddleware
+
 	ModelRetryConfig *adk.ModelRetryConfig
 
 	// OutputKey stores the agent's response in the session.
@@ -115,6 +125,7 @@ func New(ctx context.Context, cfg *Config) (adk.ResumableAgent, error) {
 		ToolsConfig:   cfg.ToolsConfig,
 		MaxIterations: cfg.MaxIteration,
 		Middlewares:   append(middlewares, cfg.Middlewares...),
+		Handlers:      cfg.Handlers,
 
 		GenModelInput:    genModelInput,
 		ModelRetryConfig: cfg.ModelRetryConfig,


### PR DESCRIPTION
## Summary

| Problem | Solution |
|---------|----------|
| DeepAgent's `Config` lacks `Handlers` field, preventing users from using `ChatModelAgentMiddleware` for advanced agent customization | Add `Handlers` field to `deep.Config` and pass it to `adk.NewChatModelAgent` |

## Key Insight

The `ChatModelAgentConfig` already supports `Handlers` for interface-based agent behavior extension. The `deep.Config` should expose the same capability to allow users to:
- Add custom methods to their handler implementations
- Return modified context from handler methods
- Centralize configuration in struct fields instead of closures

This change maintains consistency between `ChatModelAgentConfig` and `deep.Config`.

## Changes

- Added `Handlers []adk.ChatModelAgentMiddleware` field to `deep.Config`
- Passed `cfg.Handlers` to `adk.NewChatModelAgent` in the `New` function
- Added documentation for the new field

---

## 摘要

| 问题 | 解决方案 |
|------|----------|
| DeepAgent 的 `Config` 缺少 `Handlers` 字段，导致用户无法使用 `ChatModelAgentMiddleware` 进行高级 Agent 定制 | 在 `deep.Config` 中添加 `Handlers` 字段，并将其传递给 `adk.NewChatModelAgent` |

## 关键洞察

`ChatModelAgentConfig` 已经支持 `Handlers` 用于基于接口的 Agent 行为扩展。`deep.Config` 应该暴露相同的能力，允许用户：
- 为 handler 实现添加自定义方法
- 从 handler 方法返回修改后的 context
- 在结构体字段中集中配置，而不是使用闭包

此更改保持了 `ChatModelAgentConfig` 和 `deep.Config` 之间的一致性。

## 变更

- 在 `deep.Config` 中添加了 `Handlers []adk.ChatModelAgentMiddleware` 字段
- 在 `New` 函数中将 `cfg.Handlers` 传递给 `adk.NewChatModelAgent`
- 为新字段添加了文档注释