### PR TITLE
refactor(adk): add error returns to wrap methods and ModelContext to AfterModelRewriteState

### DIFF
--- a/adk/middlewares/dynamictool/toolsearch/toolsearch.go
+++ b/adk/middlewares/dynamictool/toolsearch/toolsearch.go
@@ -87,8 +87,8 @@ func (m *middleware) BeforeAgent(ctx context.Context, runCtx *adk.ChatModelAgent
 	return ctx, &nRunCtx, nil
 }
 
-func (m *middleware) WrapModel(_ context.Context, cm model.BaseChatModel, mc *adk.ModelContext) model.BaseChatModel {
-	return &wrapper{allTools: mc.Tools, cm: cm, dynamicTools: m.dynamicTools}
+func (m *middleware) WrapModel(_ context.Context, cm model.BaseChatModel, mc *adk.ModelContext) (model.BaseChatModel, error) {
+	return &wrapper{allTools: mc.Tools, cm: cm, dynamicTools: m.dynamicTools}, nil
 }
 
 type wrapper struct {

--- a/adk/wrappers_test.go
+++ b/adk/wrappers_test.go
@@ -36,18 +36,18 @@ type testEnhancedToolWrapperHandler struct {
 	wrapEnhancedStreamableFn func(context.Context, EnhancedStreamableToolCallEndpoint, *ToolContext) EnhancedStreamableToolCallEndpoint
 }
 
-func (h *testEnhancedToolWrapperHandler) WrapEnhancedInvokableToolCall(ctx context.Context, endpoint EnhancedInvokableToolCallEndpoint, tCtx *ToolContext) EnhancedInvokableToolCallEndpoint {
+func (h *testEnhancedToolWrapperHandler) WrapEnhancedInvokableToolCall(ctx context.Context, endpoint EnhancedInvokableToolCallEndpoint, tCtx *ToolContext) (EnhancedInvokableToolCallEndpoint, error) {
 	if h.wrapEnhancedInvokableFn != nil {
-		return h.wrapEnhancedInvokableFn(ctx, endpoint, tCtx)
+		return h.wrapEnhancedInvokableFn(ctx, endpoint, tCtx), nil
 	}
-	return endpoint
+	return endpoint, nil
 }
 
-func (h *testEnhancedToolWrapperHandler) WrapEnhancedStreamableToolCall(ctx context.Context, endpoint EnhancedStreamableToolCallEndpoint, tCtx *ToolContext) EnhancedStreamableToolCallEndpoint {
+func (h *testEnhancedToolWrapperHandler) WrapEnhancedStreamableToolCall(ctx context.Context, endpoint EnhancedStreamableToolCallEndpoint, tCtx *ToolContext) (EnhancedStreamableToolCallEndpoint, error) {
 	if h.wrapEnhancedStreamableFn != nil {
-		return h.wrapEnhancedStreamableFn(ctx, endpoint, tCtx)
+		return h.wrapEnhancedStreamableFn(ctx, endpoint, tCtx), nil
 	}
-	return endpoint
+	return endpoint, nil
 }
 
 func newTestEnhancedInvokableToolCallWrapper(beforeFn, afterFn func()) func(context.Context, EnhancedInvokableToolCallEndpoint, *ToolContext) EnhancedInvokableToolCallEndpoint {
@@ -508,7 +508,8 @@ func TestBaseChatModelAgentMiddlewareEnhancedDefaults(t *testing.T) {
 			return &schema.ToolResult{}, nil
 		}
 
-		wrapped := base.WrapEnhancedInvokableToolCall(context.Background(), endpoint, &ToolContext{Name: "test", CallID: "1"})
+		wrapped, wrapErr := base.WrapEnhancedInvokableToolCall(context.Background(), endpoint, &ToolContext{Name: "test", CallID: "1"})
+		assert.NoError(t, wrapErr)
 		_, err := wrapped(context.Background(), &schema.ToolArgument{TextArgument: "{}"})
 
 		assert.NoError(t, err)
@@ -524,7 +525,8 @@ func TestBaseChatModelAgentMiddlewareEnhancedDefaults(t *testing.T) {
 			return schema.StreamReaderFromArray([]*schema.ToolResult{}), nil
 		}
 
-		wrapped := base.WrapEnhancedStreamableToolCall(context.Background(), endpoint, &ToolContext{Name: "test", CallID: "1"})
+		wrapped, wrapErr := base.WrapEnhancedStreamableToolCall(context.Background(), endpoint, &ToolContext{Name: "test", CallID: "1"})
+		assert.NoError(t, wrapErr)
 		_, err := wrapped(context.Background(), &schema.ToolArgument{TextArgument: "{}"})
 
 		assert.NoError(t, err)


### PR DESCRIPTION
## Summary

| Problem | Solution |
|---------|----------|
| Wrap methods in ChatModelAgentMiddleware cannot report errors during wrapping | Add error as second return value to all wrap methods |
| AfterModelRewriteState lacks access to ModelContext | Add ModelContext parameter to match BeforeModelRewriteState signature |

## Key Changes

### 1. Error Returns for Wrap Methods

All wrap methods in `ChatModelAgentMiddleware` interface now return `(endpoint/model, error)` instead of just the endpoint/model:

- `WrapModel` → `(model.BaseChatModel, error)`
- `WrapInvokableToolCall` → `(InvokableToolCallEndpoint, error)`
- `WrapStreamableToolCall` → `(StreamableToolCallEndpoint, error)`
- `WrapEnhancedInvokableToolCall` → `(EnhancedInvokableToolCallEndpoint, error)`
- `WrapEnhancedStreamableToolCall` → `(EnhancedStreamableToolCallEndpoint, error)`

**Key Insight**: This allows middleware implementations to fail gracefully during the wrapping phase (e.g., when validating configuration or initializing resources), rather than deferring errors to runtime.

### 2. ModelContext for AfterModelRewriteState

`AfterModelRewriteState` now accepts `*ModelContext` as a parameter, matching the signature of `BeforeModelRewriteState`:

```go
// Before
AfterModelRewriteState(ctx context.Context, state *ChatModelAgentState) (context.Context, *ChatModelAgentState, error)

// After
AfterModelRewriteState(ctx context.Context, state *ChatModelAgentState, mc *ModelContext) (context.Context, *ChatModelAgentState, error)
```

**Key Insight**: This provides symmetry between before/after hooks and allows AfterModelRewriteState to access the tool configuration that was sent to the model.

## Files Changed

- `adk/handler.go` - Interface and default implementation updates
- `adk/wrappers.go` - Call site updates with error handling
- `adk/handler_test.go` - Test implementation updates
- `adk/wrappers_test.go` - Test implementation updates
- `adk/middlewares/dynamictool/toolsearch/toolsearch.go` - Middleware implementation update

---

## 概要

| 问题 | 解决方案 |
|------|----------|
| ChatModelAgentMiddleware 中的 Wrap 方法无法在包装阶段报告错误 | 为所有 wrap 方法添加 error 作为第二个返回值 |
| AfterModelRewriteState 无法访问 ModelContext | 添加 ModelContext 参数以匹配 BeforeModelRewriteState 的签名 |

## 主要变更

### 1. Wrap 方法添加错误返回

`ChatModelAgentMiddleware` 接口中的所有 wrap 方法现在返回 `(endpoint/model, error)` 而不是仅返回 endpoint/model：

- `WrapModel` → `(model.BaseChatModel, error)`
- `WrapInvokableToolCall` → `(InvokableToolCallEndpoint, error)`
- `WrapStreamableToolCall` → `(StreamableToolCallEndpoint, error)`
- `WrapEnhancedInvokableToolCall` → `(EnhancedInvokableToolCallEndpoint, error)`
- `WrapEnhancedStreamableToolCall` → `(EnhancedStreamableToolCallEndpoint, error)`

**关键洞察**：这允许中间件实现在包装阶段优雅地失败（例如，在验证配置或初始化资源时），而不是将错误推迟到运行时。

### 2. AfterModelRewriteState 添加 ModelContext

`AfterModelRewriteState` 现在接受 `*ModelContext` 作为参数，与 `BeforeModelRewriteState` 的签名匹配。

**关键洞察**：这在 before/after 钩子之间提供了对称性，并允许 AfterModelRewriteState 访问发送给模型的工具配置。