### PR TITLE
docs: rewrite README with focus on ADK, simplify style

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,9 +17,10 @@ English | [中文](README.zh_CN.md)
 **Eino['aino]** is an LLM application development framework in Golang. It draws from LangChain, Google ADK, and other open-source frameworks, and is designed to follow Golang conventions.
 
 Eino provides:
-- **Components**: reusable building blocks like `ChatModel`, `Tool`, `Retriever`, and `ChatTemplate`.
+- **[Components](https://github.com/cloudwego/eino-ext)**: reusable building blocks like `ChatModel`, `Tool`, `Retriever`, and `ChatTemplate`, with official implementations for OpenAI, Ollama, and more.
 - **Agent Development Kit (ADK)**: build AI agents with tool use, multi-agent coordination, context management, interrupt/resume for human-in-the-loop, and ready-to-use agent patterns.
 - **Composition**: connect components into graphs and workflows that can run standalone or be exposed as tools for agents.
+- **[Examples](https://github.com/cloudwego/eino-examples)**: working code for common patterns and real-world use cases.
 
 ![](.github/static/img/eino/eino_concept.jpeg)
 
@@ -130,62 +131,29 @@ This lets you build domain-specific pipelines with exact control, then let agent
 
 # Key Features
 
-## Components
+## Component Ecosystem
 
-- **Component abstractions** with multiple **implementations** ready to use
-    - Abstractions include ChatModel, Tool, ChatTemplate, Retriever, Document Loader, Lambda, etc.
-    - Each component type has its own interface: defined Input & Output types, Option types, and streaming paradigms
-    - Implementations are transparent when orchestrating components
+Eino defines component abstractions (ChatModel, Tool, Retriever, Embedding, etc.) with official implementations for OpenAI, Claude, Gemini, Ark, Ollama, Elasticsearch, and more.
 
-- Implementations can be nested and capture complex business logic
-    - ReAct Agent, MultiQueryRetriever, Host MultiAgent, etc. consist of multiple components and non-trivial logic
-    - They remain transparent from the outside. A MultiQueryRetriever can be used anywhere that accepts a Retriever
-
-## Agent Development Kit (ADK)
-
-The **ADK** package provides abstractions for building AI agents:
-
-- **ChatModelAgent**: A ReAct-style agent that handles tool calling, conversation state, and the reasoning loop
-- **Multi-Agent with Context Engineering**: Hierarchical agent systems where conversation history is managed across agent transfers and agent-as-tool invocations
-- **Workflow Agents**: Compose agents using `SequentialAgent`, `ParallelAgent`, and `LoopAgent`
-- **Human-in-the-Loop**: `Interrupt` and `Resume` mechanisms with checkpoint persistence
-- **Prebuilt Patterns**: Deep Agent (task orchestration), Supervisor (hierarchical coordination), and Plan-Execute-Replan
-- **Agent Middlewares**: Extensible middleware system for adding tools and managing context
-
-## Orchestration
-
-**Graph orchestration** provides fine-grained control over data flow from Retriever / Document Loaders / ChatTemplate to ChatModel, then to Tools and final output.
-
-- Component instances are graph nodes; edges are data flow channels
-- Features:
-  - Type checking, stream processing, concurrency management, aspect injection, and option assignment
-  - Runtime branching, global state read/write, field-level data mapping via workflow
-
-## Aspects (Callbacks)
-
-**Aspects** handle cross-cutting concerns: logging, tracing, and metrics. They can be applied to components, orchestrated graphs, or ADK agents.
-
-- Five aspect types: OnStart, OnEnd, OnError, OnStartWithStreamInput, OnEndWithStreamOutput
-- Custom callback handlers can be added at runtime via options
+→ [eino-ext](https://github.com/cloudwego/eino-ext)
 
 ## Stream Processing
 
-ChatModel outputs message chunks in real time. Eino handles streaming throughout orchestration:
+Eino automatically handles streaming throughout orchestration: concatenating, boxing, merging, and copying streams as data flows between nodes. Components only implement the streaming paradigms that make sense for them; the framework handles the rest.
 
-- **Concatenates** stream chunks for downstream nodes that accept non-stream input (e.g., ToolsNode)
-- **Boxes** non-stream into stream when needed during graph execution
-- **Merges** multiple streams when they converge into a single node
-- **Copies** streams when they fan out to different nodes or callback handlers
-- **Branch** and **state handlers** are stream-aware
+→ [docs](https://www.cloudwego.io/docs/eino/core_modules/chain_and_graph_orchestration/stream_programming_essentials/)
 
-A compiled Graph supports 4 streaming paradigms:
+## Callback Aspects
 
-| Streaming Paradigm | Explanation                                                                 |
-| ------------------ | --------------------------------------------------------------------------- |
-| Invoke             | Accepts non-stream type I and returns non-stream type O                     |
-| Stream             | Accepts non-stream type I and returns stream type StreamReader[O]           |
-| Collect            | Accepts stream type StreamReader[I] and returns non-stream type O           |
-| Transform          | Accepts stream type StreamReader[I] and returns stream type StreamReader[O] |
+Inject logging, tracing, and metrics at fixed points (OnStart, OnEnd, OnError, OnStartWithStreamInput, OnEndWithStreamOutput) across components, graphs, and agents.
+
+→ [docs](https://www.cloudwego.io/docs/eino/core_modules/chain_and_graph_orchestration/callback_manual/)
+
+## Interrupt/Resume
+
+Any agent or tool can pause execution for human input and resume from checkpoint. The framework handles state persistence and routing.
+
+→ [docs](https://www.cloudwego.io/docs/eino/core_modules/eino_adk/agent_hitl/) · [examples](https://github.com/cloudwego/eino-examples/tree/main/adk/human-in-the-loop)
 
 # Framework Structure
 


### PR DESCRIPTION
## Summary

| Problem | Solution |
|---------|----------|
| README was verbose with marketing language | Rewrote in down-to-earth, matter-of-fact style |
| Quick Start section showed low-level orchestration details | Restructured around ChatModelAgent, DeepAgent, and Composition |
| Key Features section was too long | Simplified to 4 key capabilities with links |
| Missing links to examples and docs | Added links to eino-ext, eino-examples, and cloudwego docs |

## Key Changes

### Overview Section
- Simplified introduction, removed marketing phrases
- Added 4 clear bullet points: Components, ADK, Composition, Examples
- Each item now links to relevant repo (eino-ext, eino-examples)

### Quick Start Section (completely rewritten)
- **ChatModelAgent**: Shows how simple it is to get started
- **DeepAgent**: Shows power of task orchestration for complex problems
- **Composition**: Shows how to build precise workflows and expose them as tools for agents
- Each section has links to examples and documentation

### Key Features Section (simplified from ~60 lines to ~25 lines)
- **Component Ecosystem**: abstractions + official implementations
- **Stream Processing**: automatic handling in orchestration
- **Callback Aspects**: inject logging/tracing/metrics
- **Interrupt/Resume**: pause for human input, resume from checkpoint

### Style Changes
- Removed adjectives without substance
- Chinese README rewritten to sound native, not translated
- Consistent link formatting throughout

## Key Insight

The README now tells a clear story: start simple with ChatModelAgent, scale up with DeepAgent for complex tasks, use Composition when you need precise control.

---

## 概要

| 问题 | 解决方案 |
|------|----------|
| README 冗长，充斥营销用语 | 改写为朴实、务实的风格 |
| 快速上手展示底层编排细节 | 围绕 ChatModelAgent、DeepAgent、编排重构 |
| 主要特性部分过长 | 精简为 4 个关键能力并附链接 |
| 缺少示例和文档链接 | 添加 eino-ext、eino-examples、cloudwego 文档链接 |

## 主要改动

### 简介部分
- 精简介绍，去掉营销用语
- 4 个清晰要点：组件、ADK、编排、示例
- 每项链接到相关仓库

### 快速上手部分（完全重写）
- **ChatModelAgent**：展示上手有多简单
- **DeepAgent**：展示复杂任务的编排能力
- **编排**：展示如何构建精确工作流并作为工具给智能体用

### 主要特性部分（从约 60 行精简到约 25 行）
- **组件生态**：抽象 + 官方实现
- **流式处理**：编排中自动处理
- **回调切面**：注入日志/追踪/指标
- **中断/恢复**：暂停等待人工输入，从检查点恢复

### 风格改动
- 去掉空洞形容词
- 中文 README 改写为原生中文风格
- 全文链接格式统一