### PR TITLE
feat(adk): add ChatModelAgentMiddleware constructors for filesystem and reduction packages

### DIFF
--- a/adk/middlewares/filesystem/filesystem_test.go
+++ b/adk/middlewares/filesystem/filesystem_test.go
@@ -23,8 +23,10 @@ import (
 
 	"github.com/stretchr/testify/assert"
 
+	"github.com/cloudwego/eino/adk"
 	"github.com/cloudwego/eino/adk/filesystem"
 	"github.com/cloudwego/eino/components/tool"
+	"github.com/cloudwego/eino/schema"
 )
 
 // setupTestBackend creates a test backend with some initial files
@@ -635,5 +637,260 @@ func TestGetFilesystemTools(t *testing.T) {
 				assert.Equal(t, customReadDesc, info.Desc)
 			}
 		}
+	})
+}
+
+func TestNewChatModelAgentMiddleware(t *testing.T) {
+	ctx := context.Background()
+	backend := setupTestBackend()
+
+	t.Run("nil config returns error", func(t *testing.T) {
+		_, err := NewChatModelAgentMiddleware(ctx, nil)
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "config should not be nil")
+	})
+
+	t.Run("nil backend returns error", func(t *testing.T) {
+		_, err := NewChatModelAgentMiddleware(ctx, &Config{Backend: nil})
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "backend should not be nil")
+	})
+
+	t.Run("valid config with default settings", func(t *testing.T) {
+		m, err := NewChatModelAgentMiddleware(ctx, &Config{Backend: backend})
+		assert.NoError(t, err)
+		assert.NotNil(t, m)
+
+		fm, ok := m.(*filesystemMiddleware)
+		assert.True(t, ok)
+		assert.Contains(t, fm.additionalInstruction, ToolsSystemPrompt)
+		assert.Len(t, fm.additionalTools, 6)
+		assert.NotNil(t, fm.offloading)
+	})
+
+	t.Run("custom system prompt", func(t *testing.T) {
+		customPrompt := "Custom system prompt"
+		m, err := NewChatModelAgentMiddleware(ctx, &Config{
+			Backend:            backend,
+			CustomSystemPrompt: &customPrompt,
+		})
+		assert.NoError(t, err)
+
+		fm, ok := m.(*filesystemMiddleware)
+		assert.True(t, ok)
+		assert.Equal(t, customPrompt, fm.additionalInstruction)
+	})
+
+	t.Run("disable large tool result offloading", func(t *testing.T) {
+		m, err := NewChatModelAgentMiddleware(ctx, &Config{
+			Backend:                          backend,
+			WithoutLargeToolResultOffloading: true,
+		})
+		assert.NoError(t, err)
+
+		fm, ok := m.(*filesystemMiddleware)
+		assert.True(t, ok)
+		assert.Nil(t, fm.offloading)
+	})
+
+	t.Run("ShellBackend adds execute tool", func(t *testing.T) {
+		shellBackend := &mockShellBackend{
+			Backend: backend,
+			resp:    &filesystem.ExecuteResponse{Output: "ok"},
+		}
+		m, err := NewChatModelAgentMiddleware(ctx, &Config{Backend: shellBackend})
+		assert.NoError(t, err)
+
+		fm, ok := m.(*filesystemMiddleware)
+		assert.True(t, ok)
+		assert.Len(t, fm.additionalTools, 7)
+	})
+}
+
+func TestFilesystemMiddleware_BeforeAgent(t *testing.T) {
+	ctx := context.Background()
+	backend := setupTestBackend()
+
+	t.Run("adds instruction and tools to context", func(t *testing.T) {
+		m, err := NewChatModelAgentMiddleware(ctx, &Config{Backend: backend})
+		assert.NoError(t, err)
+
+		runCtx := &adk.ChatModelAgentContext{
+			Instruction: "Original instruction",
+			Tools:       nil,
+		}
+
+		newCtx, newRunCtx, err := m.BeforeAgent(ctx, runCtx)
+		assert.NoError(t, err)
+		assert.NotNil(t, newCtx)
+		assert.NotNil(t, newRunCtx)
+		assert.Contains(t, newRunCtx.Instruction, "Original instruction")
+		assert.Contains(t, newRunCtx.Instruction, ToolsSystemPrompt)
+		assert.Len(t, newRunCtx.Tools, 6)
+	})
+
+	t.Run("nil runCtx returns nil", func(t *testing.T) {
+		m, err := NewChatModelAgentMiddleware(ctx, &Config{Backend: backend})
+		assert.NoError(t, err)
+
+		newCtx, newRunCtx, err := m.BeforeAgent(ctx, nil)
+		assert.NoError(t, err)
+		assert.NotNil(t, newCtx)
+		assert.Nil(t, newRunCtx)
+	})
+}
+
+func TestFilesystemMiddleware_WrapInvokableToolCall(t *testing.T) {
+	ctx := context.Background()
+	backend := setupTestBackend()
+
+	t.Run("small result passes through unchanged", func(t *testing.T) {
+		m, err := NewChatModelAgentMiddleware(ctx, &Config{Backend: backend})
+		assert.NoError(t, err)
+
+		endpoint := func(ctx context.Context, args string, opts ...tool.Option) (string, error) {
+			return "small result", nil
+		}
+
+		tCtx := &adk.ToolContext{Name: "test_tool", CallID: "call-1"}
+		wrapped, err := m.WrapInvokableToolCall(ctx, endpoint, tCtx)
+		assert.NoError(t, err)
+
+		result, err := wrapped(ctx, "{}")
+		assert.NoError(t, err)
+		assert.Equal(t, "small result", result)
+	})
+
+	t.Run("large result is offloaded", func(t *testing.T) {
+		m, err := NewChatModelAgentMiddleware(ctx, &Config{
+			Backend:                             backend,
+			LargeToolResultOffloadingTokenLimit: 10,
+		})
+		assert.NoError(t, err)
+
+		largeResult := strings.Repeat("x", 100)
+		endpoint := func(ctx context.Context, args string, opts ...tool.Option) (string, error) {
+			return largeResult, nil
+		}
+
+		tCtx := &adk.ToolContext{Name: "test_tool", CallID: "call-large"}
+		wrapped, err := m.WrapInvokableToolCall(ctx, endpoint, tCtx)
+		assert.NoError(t, err)
+
+		result, err := wrapped(ctx, "{}")
+		assert.NoError(t, err)
+		assert.Contains(t, result, "Tool result too large")
+		assert.Contains(t, result, "/large_tool_result/call-large")
+	})
+
+	t.Run("offloading disabled returns endpoint unchanged", func(t *testing.T) {
+		m, err := NewChatModelAgentMiddleware(ctx, &Config{
+			Backend:                          backend,
+			WithoutLargeToolResultOffloading: true,
+		})
+		assert.NoError(t, err)
+
+		endpoint := func(ctx context.Context, args string, opts ...tool.Option) (string, error) {
+			return "result", nil
+		}
+
+		tCtx := &adk.ToolContext{Name: "test_tool", CallID: "call-1"}
+		wrapped, err := m.WrapInvokableToolCall(ctx, endpoint, tCtx)
+		assert.NoError(t, err)
+
+		result, err := wrapped(ctx, "{}")
+		assert.NoError(t, err)
+		assert.Equal(t, "result", result)
+	})
+}
+
+func TestFilesystemMiddleware_WrapStreamableToolCall(t *testing.T) {
+	ctx := context.Background()
+	backend := setupTestBackend()
+
+	t.Run("small result passes through unchanged", func(t *testing.T) {
+		m, err := NewChatModelAgentMiddleware(ctx, &Config{Backend: backend})
+		assert.NoError(t, err)
+
+		endpoint := func(ctx context.Context, args string, opts ...tool.Option) (*schema.StreamReader[string], error) {
+			return schema.StreamReaderFromArray([]string{"small", " result"}), nil
+		}
+
+		tCtx := &adk.ToolContext{Name: "test_tool", CallID: "call-1"}
+		wrapped, err := m.WrapStreamableToolCall(ctx, endpoint, tCtx)
+		assert.NoError(t, err)
+
+		sr, err := wrapped(ctx, "{}")
+		assert.NoError(t, err)
+
+		var result strings.Builder
+		for {
+			chunk, err := sr.Recv()
+			if err != nil {
+				break
+			}
+			result.WriteString(chunk)
+		}
+		assert.Equal(t, "small result", result.String())
+	})
+
+	t.Run("large result is offloaded", func(t *testing.T) {
+		m, err := NewChatModelAgentMiddleware(ctx, &Config{
+			Backend:                             backend,
+			LargeToolResultOffloadingTokenLimit: 10,
+		})
+		assert.NoError(t, err)
+
+		largeResult := strings.Repeat("x", 100)
+		endpoint := func(ctx context.Context, args string, opts ...tool.Option) (*schema.StreamReader[string], error) {
+			return schema.StreamReaderFromArray([]string{largeResult}), nil
+		}
+
+		tCtx := &adk.ToolContext{Name: "test_tool", CallID: "call-stream-large"}
+		wrapped, err := m.WrapStreamableToolCall(ctx, endpoint, tCtx)
+		assert.NoError(t, err)
+
+		sr, err := wrapped(ctx, "{}")
+		assert.NoError(t, err)
+
+		var result strings.Builder
+		for {
+			chunk, err := sr.Recv()
+			if err != nil {
+				break
+			}
+			result.WriteString(chunk)
+		}
+		assert.Contains(t, result.String(), "Tool result too large")
+		assert.Contains(t, result.String(), "/large_tool_result/call-stream-large")
+	})
+
+	t.Run("offloading disabled returns endpoint unchanged", func(t *testing.T) {
+		m, err := NewChatModelAgentMiddleware(ctx, &Config{
+			Backend:                          backend,
+			WithoutLargeToolResultOffloading: true,
+		})
+		assert.NoError(t, err)
+
+		endpoint := func(ctx context.Context, args string, opts ...tool.Option) (*schema.StreamReader[string], error) {
+			return schema.StreamReaderFromArray([]string{"result"}), nil
+		}
+
+		tCtx := &adk.ToolContext{Name: "test_tool", CallID: "call-1"}
+		wrapped, err := m.WrapStreamableToolCall(ctx, endpoint, tCtx)
+		assert.NoError(t, err)
+
+		sr, err := wrapped(ctx, "{}")
+		assert.NoError(t, err)
+
+		var result strings.Builder
+		for {
+			chunk, err := sr.Recv()
+			if err != nil {
+				break
+			}
+			result.WriteString(chunk)
+		}
+		assert.Equal(t, "result", result.String())
 	})
 }

--- a/adk/middlewares/reduction/clear_tool_result_test.go
+++ b/adk/middlewares/reduction/clear_tool_result_test.go
@@ -25,6 +25,8 @@ import (
 	"github.com/stretchr/testify/assert"
 
 	"github.com/cloudwego/eino/adk"
+	"github.com/cloudwego/eino/adk/filesystem"
+	"github.com/cloudwego/eino/components/tool"
 	"github.com/cloudwego/eino/schema"
 )
 
@@ -299,4 +301,218 @@ func Test_newClearToolResult(t *testing.T) {
 		assert.NoError(t, err)
 		assert.Equal(t, "short result", state.Messages[1].Content)
 	})
+}
+
+func TestNewChatModelAgentMiddleware(t *testing.T) {
+	ctx := context.Background()
+
+	t.Run("valid config with default settings", func(t *testing.T) {
+		backend := &clearToolResultMockBackend{}
+		m, err := NewChatModelAgentMiddleware(ctx, &ToolResultConfig{
+			Backend: backend,
+		})
+		assert.NoError(t, err)
+		assert.NotNil(t, m)
+
+		tm, ok := m.(*toolResultMiddleware)
+		assert.True(t, ok)
+		assert.NotNil(t, tm.clearConfig)
+		assert.NotNil(t, tm.offloading)
+		assert.Equal(t, 20000, tm.clearConfig.ToolResultTokenThreshold)
+		assert.Equal(t, 40000, tm.clearConfig.KeepRecentTokens)
+		assert.Equal(t, "[Old tool result content cleared]", tm.clearConfig.ClearToolResultPlaceholder)
+		assert.Equal(t, 20000, tm.offloading.tokenLimit)
+		assert.Equal(t, "read_file", tm.offloading.toolName)
+	})
+
+	t.Run("custom config values", func(t *testing.T) {
+		backend := &clearToolResultMockBackend{}
+		m, err := NewChatModelAgentMiddleware(ctx, &ToolResultConfig{
+			Backend:                    backend,
+			ClearingTokenThreshold:     5000,
+			KeepRecentTokens:           10000,
+			ClearToolResultPlaceholder: "[Custom placeholder]",
+			OffloadingTokenLimit:       8000,
+			ReadFileToolName:           "custom_read",
+		})
+		assert.NoError(t, err)
+
+		tm, ok := m.(*toolResultMiddleware)
+		assert.True(t, ok)
+		assert.Equal(t, 5000, tm.clearConfig.ToolResultTokenThreshold)
+		assert.Equal(t, 10000, tm.clearConfig.KeepRecentTokens)
+		assert.Equal(t, "[Custom placeholder]", tm.clearConfig.ClearToolResultPlaceholder)
+		assert.Equal(t, 8000, tm.offloading.tokenLimit)
+		assert.Equal(t, "custom_read", tm.offloading.toolName)
+	})
+}
+
+func TestToolResultMiddleware_BeforeModelRewriteState(t *testing.T) {
+	ctx := context.Background()
+	backend := &clearToolResultMockBackend{}
+
+	t.Run("clears old tool results when threshold exceeded", func(t *testing.T) {
+		m, err := NewChatModelAgentMiddleware(ctx, &ToolResultConfig{
+			Backend:                backend,
+			ClearingTokenThreshold: 20,
+			KeepRecentTokens:       10,
+		})
+		assert.NoError(t, err)
+
+		state := &adk.ChatModelAgentState{
+			Messages: []adk.Message{
+				schema.UserMessage("msg1"),
+				schema.ToolMessage(strings.Repeat("a", 40), "call-1", schema.WithToolName("tool1")),
+				schema.UserMessage("msg2"),
+				schema.ToolMessage(strings.Repeat("b", 40), "call-2", schema.WithToolName("tool2")),
+				schema.UserMessage("msg3"),
+				schema.ToolMessage(strings.Repeat("c", 40), "call-3", schema.WithToolName("tool3")),
+			},
+		}
+
+		newCtx, newState, err := m.BeforeModelRewriteState(ctx, state, &adk.ModelContext{})
+		assert.NoError(t, err)
+		assert.NotNil(t, newCtx)
+		assert.NotNil(t, newState)
+		assert.Equal(t, "[Old tool result content cleared]", newState.Messages[1].Content)
+		assert.Equal(t, "[Old tool result content cleared]", newState.Messages[3].Content)
+		assert.Equal(t, strings.Repeat("c", 40), newState.Messages[5].Content)
+	})
+
+	t.Run("no clearing when under threshold", func(t *testing.T) {
+		m, err := NewChatModelAgentMiddleware(ctx, &ToolResultConfig{
+			Backend:                backend,
+			ClearingTokenThreshold: 100000,
+			KeepRecentTokens:       100000,
+		})
+		assert.NoError(t, err)
+
+		state := &adk.ChatModelAgentState{
+			Messages: []adk.Message{
+				schema.UserMessage("msg1"),
+				schema.ToolMessage("short result", "call-1", schema.WithToolName("tool1")),
+			},
+		}
+
+		newCtx, newState, err := m.BeforeModelRewriteState(ctx, state, &adk.ModelContext{})
+		assert.NoError(t, err)
+		assert.NotNil(t, newCtx)
+		assert.Equal(t, "short result", newState.Messages[1].Content)
+	})
+}
+
+func TestToolResultMiddleware_WrapInvokableToolCall(t *testing.T) {
+	ctx := context.Background()
+	backend := &clearToolResultMockBackend{}
+
+	t.Run("small result passes through unchanged", func(t *testing.T) {
+		m, err := NewChatModelAgentMiddleware(ctx, &ToolResultConfig{
+			Backend: backend,
+		})
+		assert.NoError(t, err)
+
+		endpoint := func(ctx context.Context, args string, opts ...tool.Option) (string, error) {
+			return "small result", nil
+		}
+
+		tCtx := &adk.ToolContext{Name: "test_tool", CallID: "call-1"}
+		wrapped, err := m.WrapInvokableToolCall(ctx, endpoint, tCtx)
+		assert.NoError(t, err)
+
+		result, err := wrapped(ctx, "{}")
+		assert.NoError(t, err)
+		assert.Equal(t, "small result", result)
+	})
+
+	t.Run("large result is offloaded", func(t *testing.T) {
+		m, err := NewChatModelAgentMiddleware(ctx, &ToolResultConfig{
+			Backend:              backend,
+			OffloadingTokenLimit: 5,
+		})
+		assert.NoError(t, err)
+
+		largeResult := strings.Repeat("x", 100)
+		endpoint := func(ctx context.Context, args string, opts ...tool.Option) (string, error) {
+			return largeResult, nil
+		}
+
+		tCtx := &adk.ToolContext{Name: "test_tool", CallID: "call-large"}
+		wrapped, err := m.WrapInvokableToolCall(ctx, endpoint, tCtx)
+		assert.NoError(t, err)
+
+		result, err := wrapped(ctx, "{}")
+		assert.NoError(t, err)
+		assert.Contains(t, result, "Tool result too large")
+		assert.Contains(t, result, "/large_tool_result/call-large")
+	})
+}
+
+func TestToolResultMiddleware_WrapStreamableToolCall(t *testing.T) {
+	ctx := context.Background()
+	backend := &clearToolResultMockBackend{}
+
+	t.Run("small result passes through unchanged", func(t *testing.T) {
+		m, err := NewChatModelAgentMiddleware(ctx, &ToolResultConfig{
+			Backend: backend,
+		})
+		assert.NoError(t, err)
+
+		endpoint := func(ctx context.Context, args string, opts ...tool.Option) (*schema.StreamReader[string], error) {
+			return schema.StreamReaderFromArray([]string{"small", " result"}), nil
+		}
+
+		tCtx := &adk.ToolContext{Name: "test_tool", CallID: "call-1"}
+		wrapped, err := m.WrapStreamableToolCall(ctx, endpoint, tCtx)
+		assert.NoError(t, err)
+
+		sr, err := wrapped(ctx, "{}")
+		assert.NoError(t, err)
+
+		var result strings.Builder
+		for {
+			chunk, err := sr.Recv()
+			if err != nil {
+				break
+			}
+			result.WriteString(chunk)
+		}
+		assert.Equal(t, "small result", result.String())
+	})
+
+	t.Run("large result is offloaded", func(t *testing.T) {
+		m, err := NewChatModelAgentMiddleware(ctx, &ToolResultConfig{
+			Backend:              backend,
+			OffloadingTokenLimit: 5,
+		})
+		assert.NoError(t, err)
+
+		largeResult := strings.Repeat("x", 100)
+		endpoint := func(ctx context.Context, args string, opts ...tool.Option) (*schema.StreamReader[string], error) {
+			return schema.StreamReaderFromArray([]string{largeResult}), nil
+		}
+
+		tCtx := &adk.ToolContext{Name: "test_tool", CallID: "call-stream-large"}
+		wrapped, err := m.WrapStreamableToolCall(ctx, endpoint, tCtx)
+		assert.NoError(t, err)
+
+		sr, err := wrapped(ctx, "{}")
+		assert.NoError(t, err)
+
+		var result strings.Builder
+		for {
+			chunk, err := sr.Recv()
+			if err != nil {
+				break
+			}
+			result.WriteString(chunk)
+		}
+		assert.Contains(t, result.String(), "Tool result too large")
+		assert.Contains(t, result.String(), "/large_tool_result/call-stream-large")
+	})
+}
+
+type clearToolResultMockBackend struct{}
+
+func (m *clearToolResultMockBackend) Write(ctx context.Context, req *filesystem.WriteRequest) error {
+	return nil
 }


### PR DESCRIPTION
## Summary

| Problem | Solution |
|---------|----------|
| Existing `NewMiddleware` and `NewToolResultMiddleware` return `AgentMiddleware` struct which has limited extensibility | Added new `NewChatModelAgentMiddleware` constructors that return `ChatModelAgentMiddleware` interface |

## Key Insight

The `ChatModelAgentMiddleware` interface provides better context propagation through wrapper methods (`WrapInvokableToolCall`, `WrapStreamableToolCall`) compared to the struct-based `AgentMiddleware`. The new constructors enable:

1. **Better context propagation** - Wrapper methods can pass modified context to the next wrapper in the chain
2. **More flexible extension points** - Interface-based design allows users to implement custom handlers
3. **Consistent API** - Both packages now follow the same pattern as `adk.ChatModelAgentMiddleware`

## Changes

### Filesystem Package
- Added `NewChatModelAgentMiddleware` with `BeforeAgent`, `WrapInvokableToolCall`, `WrapStreamableToolCall`
- Marked `NewMiddleware` as deprecated

### Reduction Package  
- Added `NewChatModelAgentMiddleware` with `BeforeModelRewriteState`, `WrapInvokableToolCall`, `WrapStreamableToolCall`
- Marked `NewToolResultMiddleware` as deprecated

---

## 概要

| 问题 | 解决方案 |
|------|----------|
| 现有的 `NewMiddleware` 和 `NewToolResultMiddleware` 返回 `AgentMiddleware` 结构体，扩展性有限 | 添加新的 `NewChatModelAgentMiddleware` 构造函数，返回 `ChatModelAgentMiddleware` 接口 |

## 关键洞察

`ChatModelAgentMiddleware` 接口通过包装方法（`WrapInvokableToolCall`、`WrapStreamableToolCall`）提供了比基于结构体的 `AgentMiddleware` 更好的上下文传播能力。新构造函数实现了：

1. **更好的上下文传播** - 包装方法可以将修改后的上下文传递给链中的下一个包装器
2. **更灵活的扩展点** - 基于接口的设计允许用户实现自定义处理器
3. **一致的 API** - 两个包现在都遵循与 `adk.ChatModelAgentMiddleware` 相同的模式

## 变更

### Filesystem 包
- 添加了 `NewChatModelAgentMiddleware`，包含 `BeforeAgent`、`WrapInvokableToolCall`、`WrapStreamableToolCall`
- 将 `NewMiddleware` 标记为已弃用

### Reduction 包
- 添加了 `NewChatModelAgentMiddleware`，包含 `BeforeModelRewriteState`、`WrapInvokableToolCall`、`WrapStreamableToolCall`
- 将 `NewToolResultMiddleware` 标记为已弃用