### PR TITLE
fix(adk): add nil checks for execContext in ChatModelAgent Run and Resume

### DIFF
--- a/adk/chatmodel_test.go
+++ b/adk/chatmodel_test.go
@@ -1296,3 +1296,84 @@ func testToolOption(value string) tool.Option {
 		o.value = value
 	})
 }
+
+type errorTool struct {
+	infoErr error
+}
+
+func (e *errorTool) Info(_ context.Context) (*schema.ToolInfo, error) {
+	return nil, e.infoErr
+}
+
+func (e *errorTool) InvokableRun(_ context.Context, _ string, _ ...tool.Option) (string, error) {
+	return "", nil
+}
+
+func TestChatModelAgent_PrepareExecContextError(t *testing.T) {
+	t.Run("Run_WithToolInfoError_ReturnsError", func(t *testing.T) {
+		ctx := context.Background()
+
+		ctrl := gomock.NewController(t)
+		cm := mockModel.NewMockToolCallingChatModel(ctrl)
+
+		expectedErr := errors.New("tool info error")
+		errTool := &errorTool{infoErr: expectedErr}
+
+		agent, err := NewChatModelAgent(ctx, &ChatModelAgentConfig{
+			Name:        "TestAgent",
+			Description: "Test agent",
+			Model:       cm,
+			ToolsConfig: ToolsConfig{
+				ToolsNodeConfig: compose.ToolsNodeConfig{
+					Tools: []tool.BaseTool{errTool},
+				},
+			},
+		})
+		assert.NoError(t, err)
+
+		iter := agent.Run(ctx, &AgentInput{Messages: []Message{schema.UserMessage("test")}})
+
+		event, ok := iter.Next()
+		assert.True(t, ok)
+		assert.NotNil(t, event.Err)
+		assert.Contains(t, event.Err.Error(), "tool info error")
+
+		_, ok = iter.Next()
+		assert.False(t, ok)
+	})
+
+	t.Run("Resume_WithToolInfoError_ReturnsError", func(t *testing.T) {
+		ctx := context.Background()
+
+		ctrl := gomock.NewController(t)
+		cm := mockModel.NewMockToolCallingChatModel(ctrl)
+
+		expectedErr := errors.New("tool info error for resume")
+		errTool := &errorTool{infoErr: expectedErr}
+
+		agent, err := NewChatModelAgent(ctx, &ChatModelAgentConfig{
+			Name:        "TestAgent",
+			Description: "Test agent",
+			Model:       cm,
+			ToolsConfig: ToolsConfig{
+				ToolsNodeConfig: compose.ToolsNodeConfig{
+					Tools: []tool.BaseTool{errTool},
+				},
+			},
+		})
+		assert.NoError(t, err)
+
+		iter := agent.Resume(ctx, &ResumeInfo{
+			InterruptState:  []byte("dummy"),
+			EnableStreaming: false,
+		})
+
+		event, ok := iter.Next()
+		assert.True(t, ok)
+		assert.NotNil(t, event.Err)
+		assert.Contains(t, event.Err.Error(), "tool info error for resume")
+
+		_, ok = iter.Next()
+		assert.False(t, ok)
+	})
+}


### PR DESCRIPTION
## Summary

| Problem | Solution |
|---------|----------|
| Potential nil pointer dereference when `prepareExecContext` fails | Add nil checks for `execContext` in `getRunFunc`, `Run`, and `Resume` methods |

## Key Insight

When `prepareExecContext()` fails (e.g., when a tool's `Info()` method returns an error), `a.exeCtx` remains `nil` while `a.run` is set to `errFunc(err)`. The original code assumed `bc` (execContext) would always be non-nil after `getRunFunc()` returned, leading to potential nil pointer dereferences when accessing `bc.toolInfos`, `bc.instruction`, etc.

The fix adds defensive nil checks at three locations:
1. **`getRunFunc()`**: Early return when `bc` is nil
2. **`Run()`**: Guard `bc` field access with nil check
3. **`Resume()`**: Guard `bc` field access with nil check

This ensures the error is properly propagated through the event iterator instead of causing a panic.

## Testing

Added `TestChatModelAgent_PrepareExecContextError` with two sub-tests:
- `Run_WithToolInfoError_ReturnsError`: Verifies `Run()` properly returns error
- `Resume_WithToolInfoError_ReturnsError`: Verifies `Resume()` properly returns error

---

## 摘要

| 问题 | 解决方案 |
|------|----------|
| `prepareExecContext` 失败时可能出现空指针解引用 | 在 `getRunFunc`、`Run` 和 `Resume` 方法中添加 nil 检查 |

## 关键洞察

当 `prepareExecContext()` 失败时（例如，当工具的 `Info()` 方法返回错误时），`a.exeCtx` 保持为 `nil`，而 `a.run` 被设置为 `errFunc(err)`。原始代码假设 `getRunFunc()` 返回后 `bc`（execContext）始终非空，导致访问 `bc.toolInfos`、`bc.instruction` 等字段时可能出现空指针解引用。

修复在三个位置添加了防御性 nil 检查：
1. **`getRunFunc()`**：当 `bc` 为 nil 时提前返回
2. **`Run()`**：使用 nil 检查保护 `bc` 字段访问
3. **`Resume()`**：使用 nil 检查保护 `bc` 字段访问

这确保错误通过事件迭代器正确传播，而不是导致 panic。

## 测试

添加了 `TestChatModelAgent_PrepareExecContextError` 测试，包含两个子测试：
- `Run_WithToolInfoError_ReturnsError`：验证 `Run()` 正确返回错误
- `Resume_WithToolInfoError_ReturnsError`：验证 `Resume()` 正确返回错误