### PR TITLE
feat(adk): align filesystem backend  FileInfo.Path field behavior with Python glob and ls command

### DIFF
--- a/adk/filesystem/backend.go
+++ b/adk/filesystem/backend.go
@@ -25,7 +25,7 @@ import (
 
 // FileInfo represents basic file metadata information.
 type FileInfo struct {
-	// Path is the absolute path of the file or directory.
+	// Path is the path of the file or directory, which can be a filename, relative path, or absolute path.
 	Path string
 
 	// IsDir indicates whether the entry is a directory.

--- a/adk/handler.go
+++ b/adk/handler.go
@@ -161,8 +161,28 @@ type ChatModelAgentMiddleware interface {
 	//   - CallID: The unique identifier for this specific tool call
 	WrapStreamableToolCall(ctx context.Context, endpoint StreamableToolCallEndpoint, tCtx *ToolContext) (StreamableToolCallEndpoint, error)
 
+	// WrapEnhancedInvokableToolCall wraps an enhanced tool's synchronous execution with custom behavior.
+	// Return the input endpoint unchanged and nil error if no wrapping is needed.
+	//
+	// This method is only called for tools that implement EnhancedInvokableTool.
+	// If a tool only implements EnhancedStreamableTool, this method will not be called for that tool.
+	//
+	// This method is called at request time when the tool is about to be executed.
+	// The tCtx parameter provides metadata about the tool:
+	//   - Name: The name of the tool being wrapped
+	//   - CallID: The unique identifier for this specific tool call
 	WrapEnhancedInvokableToolCall(ctx context.Context, endpoint EnhancedInvokableToolCallEndpoint, tCtx *ToolContext) (EnhancedInvokableToolCallEndpoint, error)
 
+	// WrapEnhancedStreamableToolCall wraps an enhanced tool's streaming execution with custom behavior.
+	// Return the input endpoint unchanged and nil error if no wrapping is needed.
+	//
+	// This method is only called for tools that implement EnhancedStreamableTool.
+	// If a tool only implements EnhancedInvokableTool, this method will not be called for that tool.
+	//
+	// This method is called at request time when the tool is about to be executed.
+	// The tCtx parameter provides metadata about the tool:
+	//   - Name: The name of the tool being wrapped
+	//   - CallID: The unique identifier for this specific tool call
 	WrapEnhancedStreamableToolCall(ctx context.Context, endpoint EnhancedStreamableToolCallEndpoint, tCtx *ToolContext) (EnhancedStreamableToolCallEndpoint, error)
 
 	// WrapModel wraps a chat model with custom behavior.

--- a/adk/middlewares/filesystem/filesystem_test.go
+++ b/adk/middlewares/filesystem/filesystem_test.go
@@ -84,17 +84,17 @@ func TestLsTool(t *testing.T) {
 		{
 			name:     "list root",
 			input:    `{"path": "/"}`,
-			expected: []string{"/file1.txt", "/file2.go", "/dir1", "/dir2"},
+			expected: []string{"file1.txt", "file2.go", "dir1", "dir2"},
 		},
 		{
 			name:     "list empty path (defaults to root)",
 			input:    `{"path": ""}`,
-			expected: []string{"/file1.txt", "/file2.go", "/dir1", "/dir2"},
+			expected: []string{"file1.txt", "file2.go", "dir1", "dir2"},
 		},
 		{
 			name:     "list dir1",
 			input:    `{"path": "/dir1"}`,
-			expected: []string{"/dir1/file3.txt", "/dir1/file4.py"},
+			expected: []string{"file3.txt", "file4.py"},
 		},
 	}
 
@@ -328,27 +328,34 @@ func TestGlobTool(t *testing.T) {
 		{
 			name:     "match all .txt files in root",
 			input:    `{"pattern": "*.txt", "path": "/"}`,
-			expected: []string{"/file1.txt"},
+			expected: []string{"file1.txt"},
 		},
 		{
 			name:     "match all .go files in root",
 			input:    `{"pattern": "*.go", "path": "/"}`,
-			expected: []string{"/file2.go"},
+			expected: []string{"file2.go"},
 		},
 		{
 			name:     "match all .txt files in dir1",
 			input:    `{"pattern": "*.txt", "path": "/dir1"}`,
-			expected: []string{"/dir1/file3.txt"},
+			expected: []string{"file3.txt"},
 		},
 		{
 			name:     "match all .py files in dir1",
 			input:    `{"pattern": "*.py", "path": "/dir1"}`,
-			expected: []string{"/dir1/file4.py"},
+			expected: []string{"file4.py"},
 		},
+
 		{
 			name:     "empty path defaults to root",
 			input:    `{"pattern": "*.go", "path": ""}`,
-			expected: []string{"/file2.go"},
+			expected: []string{"file2.go"},
+		},
+
+		{
+			name:     "match all .txt files in dir1 in root dir",
+			input:    `{"pattern": "/dir1/*.txt", "path": "/"}`,
+			expected: []string{"/dir1/file3.txt"},
 		},
 	}
 

--- a/adk/middlewares/reduction/reduction.go
+++ b/adk/middlewares/reduction/reduction.go
@@ -248,7 +248,7 @@ func (t *toolReductionMiddleware) WrapInvokableToolCall(_ context.Context, endpo
 		detail := &ToolDetail{
 			ToolContext: tCtx,
 			ToolArgument: &schema.ToolArgument{
-				TextArgument: argumentsInJSON,
+				Text: argumentsInJSON,
 			},
 			ToolResult: &schema.ToolResult{
 				Parts: []schema.ToolOutputPart{
@@ -299,7 +299,7 @@ func (t *toolReductionMiddleware) WrapStreamableToolCall(_ context.Context, endp
 		detail := &ToolDetail{
 			ToolContext: tCtx,
 			ToolArgument: &schema.ToolArgument{
-				TextArgument: argumentsInJSON,
+				Text: argumentsInJSON,
 			},
 			ToolResult: &schema.ToolResult{
 				Parts: []schema.ToolOutputPart{
@@ -428,7 +428,7 @@ func (t *toolReductionMiddleware) BeforeModelRewriteState(ctx context.Context, s
 						CallID: toolCall.ID,
 					},
 					ToolArgument: &schema.ToolArgument{
-						TextArgument: toolCall.Function.Arguments,
+						Text: toolCall.Function.Arguments,
 					},
 					ToolResult: toolResult,
 				}
@@ -450,7 +450,7 @@ func (t *toolReductionMiddleware) BeforeModelRewriteState(ctx context.Context, s
 					}
 				}
 
-				tcMsg.ToolCalls[tcIndex].Function.Arguments = td.ToolArgument.TextArgument
+				tcMsg.ToolCalls[tcIndex].Function.Arguments = td.ToolArgument.Text
 				if fromContent {
 					if len(td.ToolResult.Parts) > 0 {
 						resultMsg.Content = td.ToolResult.Parts[0].Text

--- a/adk/middlewares/reduction/reduction_test.go
+++ b/adk/middlewares/reduction/reduction_test.go
@@ -259,7 +259,7 @@ func TestReductionMiddlewareClear(t *testing.T) {
 		backend := filesystem.NewInMemoryBackend()
 		handler := func(ctx context.Context, detail *ToolDetail) (*OffloadInfo, error) {
 			arguments := make(map[string]string)
-			if err := json.Unmarshal([]byte(detail.ToolArgument.TextArgument), &arguments); err != nil {
+			if err := json.Unmarshal([]byte(detail.ToolArgument.Text), &arguments); err != nil {
 				return nil, err
 			}
 			offloadContent := &OffloadContent{
@@ -271,7 +271,7 @@ func TestReductionMiddlewareClear(t *testing.T) {
 			for k := range arguments {
 				replacedArguments[k] = "argument offloaded"
 			}
-			detail.ToolArgument.TextArgument = toJson(replacedArguments)
+			detail.ToolArgument.Text = toJson(replacedArguments)
 			detail.ToolResult.Parts[0].Text = "result offloaded, retrieve it from " + filePath
 			return &OffloadInfo{
 				NeedClear:      true,
@@ -364,7 +364,7 @@ func TestDefaultOffloadHandler(t *testing.T) {
 			Name:   "mock_name",
 			CallID: "mock_call_id_12345",
 		},
-		ToolArgument: &schema.ToolArgument{TextArgument: "anything"},
+		ToolArgument: &schema.ToolArgument{Text: "anything"},
 		ToolResult:   &schema.ToolResult{Parts: []schema.ToolOutputPart{{Type: schema.ToolPartTypeText, Text: "hello"}}},
 	}
 

--- a/adk/wrappers.go
+++ b/adk/wrappers.go
@@ -187,7 +187,7 @@ func handlersToToolMiddlewares(handlers []handlerInfo) []compose.ToolMiddleware 
 							output, err := next(ctx, &compose.ToolInput{
 								Name:        input.Name,
 								CallID:      input.CallID,
-								Arguments:   toolArgument.TextArgument,
+								Arguments:   toolArgument.Text,
 								CallOptions: opts,
 							})
 							if err != nil {
@@ -200,7 +200,7 @@ func handlersToToolMiddlewares(handlers []handlerInfo) []compose.ToolMiddleware 
 					if err != nil {
 						return nil, err
 					}
-					result, err := wrappedEndpoint(ctx, &schema.ToolArgument{TextArgument: input.Arguments}, input.CallOptions...)
+					result, err := wrappedEndpoint(ctx, &schema.ToolArgument{Text: input.Arguments}, input.CallOptions...)
 					if err != nil {
 						return nil, err
 					}
@@ -223,7 +223,7 @@ func handlersToToolMiddlewares(handlers []handlerInfo) []compose.ToolMiddleware 
 							output, err := next(ctx, &compose.ToolInput{
 								Name:        input.Name,
 								CallID:      input.CallID,
-								Arguments:   toolArgument.TextArgument,
+								Arguments:   toolArgument.Text,
 								CallOptions: opts,
 							})
 							if err != nil {
@@ -236,7 +236,7 @@ func handlersToToolMiddlewares(handlers []handlerInfo) []compose.ToolMiddleware 
 					if err != nil {
 						return nil, err
 					}
-					result, err := wrappedEndpoint(ctx, &schema.ToolArgument{TextArgument: input.Arguments}, input.CallOptions...)
+					result, err := wrappedEndpoint(ctx, &schema.ToolArgument{Text: input.Arguments}, input.CallOptions...)
 					if err != nil {
 						return nil, err
 					}

--- a/adk/wrappers_test.go
+++ b/adk/wrappers_test.go
@@ -510,7 +510,7 @@ func TestBaseChatModelAgentMiddlewareEnhancedDefaults(t *testing.T) {
 
 		wrapped, wrapErr := base.WrapEnhancedInvokableToolCall(context.Background(), endpoint, &ToolContext{Name: "test", CallID: "1"})
 		assert.NoError(t, wrapErr)
-		_, err := wrapped(context.Background(), &schema.ToolArgument{TextArgument: "{}"})
+		_, err := wrapped(context.Background(), &schema.ToolArgument{Text: "{}"})
 
 		assert.NoError(t, err)
 		assert.True(t, called)
@@ -527,7 +527,7 @@ func TestBaseChatModelAgentMiddlewareEnhancedDefaults(t *testing.T) {
 
 		wrapped, wrapErr := base.WrapEnhancedStreamableToolCall(context.Background(), endpoint, &ToolContext{Name: "test", CallID: "1"})
 		assert.NoError(t, wrapErr)
-		_, err := wrapped(context.Background(), &schema.ToolArgument{TextArgument: "{}"})
+		_, err := wrapped(context.Background(), &schema.ToolArgument{Text: "{}"})
 
 		assert.NoError(t, err)
 		assert.True(t, called)
@@ -543,7 +543,7 @@ func TestEnhancedToolArgumentsPropagation(t *testing.T) {
 					BaseChatModelAgentMiddleware: &BaseChatModelAgentMiddleware{},
 					wrapEnhancedInvokableFn: func(_ context.Context, endpoint EnhancedInvokableToolCallEndpoint, _ *ToolContext) EnhancedInvokableToolCallEndpoint {
 						return func(ctx context.Context, toolArgument *schema.ToolArgument, opts ...tool.Option) (*schema.ToolResult, error) {
-							capturedArgs = toolArgument.TextArgument
+							capturedArgs = toolArgument.Text
 							return endpoint(ctx, toolArgument, opts...)
 						}
 					},

--- a/components/tool/callback_extra.go
+++ b/components/tool/callback_extra.go
@@ -48,7 +48,7 @@ func ConvCallbackInput(src callbacks.CallbackInput) *CallbackInput {
 	case string:
 		return &CallbackInput{ArgumentsInJSON: t}
 	case *schema.ToolArgument:
-		return &CallbackInput{ArgumentsInJSON: t.TextArgument}
+		return &CallbackInput{ArgumentsInJSON: t.Text}
 	default:
 		return nil
 	}

--- a/components/tool/utils/invokable_func.go
+++ b/components/tool/utils/invokable_func.go
@@ -263,7 +263,7 @@ func (e *enhancedInvokableTool[T]) InvokableRun(ctx context.Context, toolArgumen
 
 	if e.um != nil {
 		var val any
-		val, err = e.um(ctx, toolArgument.TextArgument)
+		val, err = e.um(ctx, toolArgument.Text)
 		if err != nil {
 			return nil, fmt.Errorf("[EnhancedLocalFunc] failed to unmarshal arguments, toolName=%s, err=%w", e.getToolName(), err)
 		}
@@ -275,7 +275,7 @@ func (e *enhancedInvokableTool[T]) InvokableRun(ctx context.Context, toolArgumen
 	} else {
 		inst = generic.NewInstance[T]()
 
-		err = sonic.UnmarshalString(toolArgument.TextArgument, &inst)
+		err = sonic.UnmarshalString(toolArgument.Text, &inst)
 		if err != nil {
 			return nil, fmt.Errorf("[EnhancedLocalFunc] failed to unmarshal arguments in json, toolName=%s, err=%w", e.getToolName(), err)
 		}

--- a/compose/tool_node.go
+++ b/compose/tool_node.go
@@ -401,7 +401,7 @@ func wrapEnhancedInvokableToolCall(eiTool tool.EnhancedInvokableTool, middleware
 		eiTool = &enhancedInvokableToolWithCallback{eiTool: eiTool}
 	}
 	return middleware(func(ctx context.Context, input *ToolInput) (*EnhancedInvokableToolOutput, error) {
-		result, err := eiTool.InvokableRun(ctx, &schema.ToolArgument{TextArgument: input.Arguments}, input.CallOptions...)
+		result, err := eiTool.InvokableRun(ctx, &schema.ToolArgument{Text: input.Arguments}, input.CallOptions...)
 		if err != nil {
 			return nil, err
 		}
@@ -420,7 +420,7 @@ func wrapEnhancedStreamableToolCall(est tool.EnhancedStreamableTool, middlewares
 		est = &enhancedStreamableToolWithCallback{est: est}
 	}
 	return middleware(func(ctx context.Context, input *ToolInput) (*EnhancedStreamableToolOutput, error) {
-		result, err := est.StreamableRun(ctx, &schema.ToolArgument{TextArgument: input.Arguments}, input.CallOptions...)
+		result, err := est.StreamableRun(ctx, &schema.ToolArgument{Text: input.Arguments}, input.CallOptions...)
 		if err != nil {
 			return nil, err
 		}

--- a/compose/tool_node_test.go
+++ b/compose/tool_node_test.go
@@ -1058,7 +1058,7 @@ func TestEnhancedToolNode(t *testing.T) {
 		fn: func(ctx context.Context, input *schema.ToolArgument) (*schema.ToolResult, error) {
 			return &schema.ToolResult{
 				Parts: []schema.ToolOutputPart{
-					{Type: schema.ToolPartTypeText, Text: "invokable result: " + input.TextArgument},
+					{Type: schema.ToolPartTypeText, Text: "invokable result: " + input.Text},
 				},
 			}, nil
 		},
@@ -1071,7 +1071,7 @@ func TestEnhancedToolNode(t *testing.T) {
 		},
 		fn: func(ctx context.Context, input *schema.ToolArgument) (*schema.StreamReader[*schema.ToolResult], error) {
 			results := []*schema.ToolResult{
-				{Parts: []schema.ToolOutputPart{{Type: schema.ToolPartTypeText, Text: "stream part 1: " + input.TextArgument}}},
+				{Parts: []schema.ToolOutputPart{{Type: schema.ToolPartTypeText, Text: "stream part 1: " + input.Text}}},
 				{Parts: []schema.ToolOutputPart{{Type: schema.ToolPartTypeText, Text: " stream part 2"}}},
 			}
 			return schema.StreamReaderFromArray(results), nil
@@ -1147,7 +1147,7 @@ func TestEnhancedToolConversion(t *testing.T) {
 		fn: func(ctx context.Context, input *schema.ToolArgument) (*schema.ToolResult, error) {
 			return &schema.ToolResult{
 				Parts: []schema.ToolOutputPart{
-					{Type: schema.ToolPartTypeText, Text: "enhanced: " + input.TextArgument},
+					{Type: schema.ToolPartTypeText, Text: "enhanced: " + input.Text},
 				},
 			}, nil
 		},

--- a/go.mod
+++ b/go.mod
@@ -17,6 +17,7 @@ require (
 
 require (
 	github.com/bahlo/generic-list-go v0.2.0 // indirect
+	github.com/bmatcuk/doublestar/v4 v4.10.0 // indirect
 	github.com/buger/jsonparser v1.1.1 // indirect
 	github.com/bytedance/gopkg v0.1.3 // indirect
 	github.com/bytedance/sonic/loader v0.3.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -2,6 +2,8 @@ github.com/airbrake/gobrake v3.6.1+incompatible/go.mod h1:wM4gu3Cn0W0K7GUuVWnlXZ
 github.com/bahlo/generic-list-go v0.2.0 h1:5sz/EEAK+ls5wF+NeqDpk5+iNdMDXrh3z3nPnH1Wvgk=
 github.com/bahlo/generic-list-go v0.2.0/go.mod h1:2KvAjgMlE5NNynlg/5iLrrCCZ2+5xWbdbCW3pNTGyYg=
 github.com/bitly/go-simplejson v0.5.0/go.mod h1:cXHtHw4XUPsvGaxgjIAn8PhEWG9NfngEKAMDJEczWVA=
+github.com/bmatcuk/doublestar/v4 v4.10.0 h1:zU9WiOla1YA122oLM6i4EXvGW62DvKZVxIe6TYWexEs=
+github.com/bmatcuk/doublestar/v4 v4.10.0/go.mod h1:xBQ8jztBU6kakFMg+8WGxn0c6z1fTSPVIjEY1Wr7jzc=
 github.com/bmizerany/assert v0.0.0-20160611221934-b7ed37b82869/go.mod h1:Ekp36dRnpXw/yCqJaO+ZrUyxD+3VXMFFr56k5XYrpB4=
 github.com/buger/jsonparser v1.1.1 h1:2PnMjfWD7wBILjqQbt530v576A/cAbQvEW9gGIpYMUs=
 github.com/buger/jsonparser v1.1.1/go.mod h1:6RYKKt7H4d4+iWqouImQ9R2FZql3VbhNgx27UK13J/0=

--- a/schema/message.go
+++ b/schema/message.go
@@ -328,8 +328,8 @@ type ToolOutputPart struct {
 // ToolArgument contains the input information for a tool call.
 // It is used to pass tool call arguments to enhanced tools.
 type ToolArgument struct {
-	// TextArgument contains the arguments for the tool call in JSON format.
-	TextArgument string
+	// Text contains the arguments for the tool call in JSON format.
+	Text string `json:"text,omitempty"`
 }
 
 // ToolResult represents the structured multimodal output from a tool execution.


### PR DESCRIPTION
Enhanced the filesystem backend to align Path field behavior with Python glob patterns and standard ls command output.

Key Changes:

1. Updated FileInfo.Path field documentation:
   - Changed from "absolute path only" to support filename, relative path, or absolute path
   - Clarified that Path value depends on the command context (Ls vs Glob)

2. Modified LsInfo implementation:
   - Returns only filename/directory name instead of full path
   - Uses filepath.Base() for file entries
   - Uses parts[0] for immediate children in directory listings
   - Behavior now matches standard ls command output

3. Enhanced GlobInfo with Python glob compatibility:
   - Added matchGlob() and matchGlobParts() functions for recursive pattern matching
   - Implemented ** (double star) support for recursive directory traversal
   - Added absolute pattern detection (patterns starting with /)
   - Absolute patterns return absolute paths; relative patterns return relative paths
   - Supports ** in any position: beginning, middle, or end of pattern

4. Comprehensive test coverage:
   - Added TestInMemoryBackend_LsInfo_PathIsFilename: validates Ls returns filenames only
   - Added TestInMemoryBackend_GlobInfo_RelativePath: tests relative/absolute pattern behavior
   - Added TestInMemoryBackend_GlobInfo_RecursivePattern: validates ** recursive matching
   - Updated existing tests to match new Path field behavior

Technical Implementation:
   - Recursive matching algorithm handles ** by trying all possible directory depths
   - Pattern matching splits paths by "/" and matches segment by segment
   - Absolute patterns (starting with /) bypass basePath filtering and return full paths
   - Relative patterns respect basePath and return paths relative to it

Impact:
   - Ls command now returns clean filenames like standard Unix ls
   - Glob patterns behave identically to Python glob.glob() with recursive=True
   - Supports complex patterns like "**/*.go", "src/**/*.go", and "/absolute/path/**/*.go"