### PR TITLE
fix(adk): return modified message from AfterChatModel #717

### DIFF
--- a/adk/chatmodel_retry_test.go
+++ b/adk/chatmodel_retry_test.go
@@ -175,92 +175,148 @@ func (m *streamErrorModel) WithTools(tools []*schema.ToolInfo) (model.ToolCallin
 }
 
 func TestChatModelAgentRetry_StreamError(t *testing.T) {
-	tests := []struct {
-		name     string
-		withTool bool
-	}{
-		{"NoTools", false},
-		{"WithTools", true},
-	}
+	t.Run("WithTools", func(t *testing.T) {
+		ctx := context.Background()
 
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			ctx := context.Background()
+		m := &streamErrorModel{
+			failAtChunk: 2,
+			maxFailures: 2,
+			returnTool:  false,
+		}
 
-			m := &streamErrorModel{
-				failAtChunk: 2,
-				maxFailures: 2,
-				returnTool:  false,
-			}
-
-			config := &ChatModelAgentConfig{
-				Name:        "RetryTestAgent",
-				Description: "Test agent for retry functionality",
-				Instruction: "You are a helpful assistant.",
-				Model:       m,
-				ModelRetryConfig: &ModelRetryConfig{
-					MaxRetries:  3,
-					IsRetryAble: func(ctx context.Context, err error) bool { return errors.Is(err, errRetryAble) },
+		config := &ChatModelAgentConfig{
+			Name:        "RetryTestAgent",
+			Description: "Test agent for retry functionality",
+			Instruction: "You are a helpful assistant.",
+			Model:       m,
+			ModelRetryConfig: &ModelRetryConfig{
+				MaxRetries:  3,
+				IsRetryAble: func(ctx context.Context, err error) bool { return errors.Is(err, errRetryAble) },
+			},
+			ToolsConfig: ToolsConfig{
+				ToolsNodeConfig: compose.ToolsNodeConfig{
+					Tools: []tool.BaseTool{&fakeToolForTest{tarCount: 0}},
 				},
+			},
+		}
+
+		agent, err := NewChatModelAgent(ctx, config)
+		assert.NoError(t, err)
+
+		input := &AgentInput{
+			Messages:        []Message{schema.UserMessage("Hello")},
+			EnableStreaming: true,
+		}
+		iterator := agent.Run(ctx, input)
+
+		var events []*AgentEvent
+		for {
+			event, ok := iterator.Next()
+			if !ok {
+				break
 			}
+			events = append(events, event)
+		}
 
-			if tt.withTool {
-				config.ToolsConfig = ToolsConfig{
-					ToolsNodeConfig: compose.ToolsNodeConfig{
-						Tools: []tool.BaseTool{&fakeToolForTest{tarCount: 0}},
-					},
-				}
-			}
+		assert.Equal(t, 3, len(events))
 
-			agent, err := NewChatModelAgent(ctx, config)
-			assert.NoError(t, err)
-
-			input := &AgentInput{
-				Messages:        []Message{schema.UserMessage("Hello")},
-				EnableStreaming: true,
-			}
-			iterator := agent.Run(ctx, input)
-
-			var events []*AgentEvent
-			for {
-				event, ok := iterator.Next()
-				if !ok {
-					break
-				}
-				events = append(events, event)
-			}
-
-			assert.Equal(t, 3, len(events))
-
-			var streamErrEventCount int
-			var errs []error
-			for i, event := range events {
-				if event.Output != nil && event.Output.MessageOutput != nil && event.Output.MessageOutput.IsStreaming {
-					sr := event.Output.MessageOutput.MessageStream
-					for {
-						msg, err := sr.Recv()
-						if err == io.EOF {
-							break
-						}
-						if err != nil {
-							streamErrEventCount++
-							errs = append(errs, err)
-							t.Logf("event %d: err: %v", i, err)
-							break
-						}
-						t.Logf("event %d: %v", i, msg.Content)
+		var streamErrEventCount int
+		var errs []error
+		for i, event := range events {
+			if event.Output != nil && event.Output.MessageOutput != nil && event.Output.MessageOutput.IsStreaming {
+				sr := event.Output.MessageOutput.MessageStream
+				for {
+					msg, err := sr.Recv()
+					if err == io.EOF {
+						break
 					}
+					if err != nil {
+						streamErrEventCount++
+						errs = append(errs, err)
+						t.Logf("event %d: err: %v", i, err)
+						break
+					}
+					t.Logf("event %d: %v", i, msg.Content)
 				}
 			}
+		}
 
-			assert.Equal(t, 2, streamErrEventCount)
-			assert.Equal(t, 2, len(errs))
-			var willRetryErr *WillRetryError
-			assert.True(t, errors.As(errs[0], &willRetryErr))
-			assert.True(t, errors.As(errs[1], &willRetryErr))
-			assert.Equal(t, int32(3), atomic.LoadInt32(&m.callCount))
-		})
-	}
+		assert.Equal(t, 2, streamErrEventCount)
+		assert.Equal(t, 2, len(errs))
+		var willRetryErr *WillRetryError
+		assert.True(t, errors.As(errs[0], &willRetryErr))
+		assert.True(t, errors.As(errs[1], &willRetryErr))
+		assert.Equal(t, int32(3), atomic.LoadInt32(&m.callCount))
+	})
+
+	t.Run("NoTools", func(t *testing.T) {
+		ctx := context.Background()
+
+		m := &streamErrorModel{
+			failAtChunk: 2,
+			maxFailures: 2,
+			returnTool:  false,
+		}
+
+		config := &ChatModelAgentConfig{
+			Name:        "RetryTestAgent",
+			Description: "Test agent for retry functionality",
+			Instruction: "You are a helpful assistant.",
+			Model:       m,
+			ModelRetryConfig: &ModelRetryConfig{
+				MaxRetries:  3,
+				IsRetryAble: func(ctx context.Context, err error) bool { return errors.Is(err, errRetryAble) },
+			},
+		}
+
+		agent, err := NewChatModelAgent(ctx, config)
+		assert.NoError(t, err)
+
+		input := &AgentInput{
+			Messages:        []Message{schema.UserMessage("Hello")},
+			EnableStreaming: true,
+		}
+		iterator := agent.Run(ctx, input)
+
+		var events []*AgentEvent
+		for {
+			event, ok := iterator.Next()
+			if !ok {
+				break
+			}
+			events = append(events, event)
+		}
+
+		assert.Equal(t, 3, len(events))
+
+		var streamErrEventCount int
+		var errs []error
+		for i, event := range events {
+			if event.Output != nil && event.Output.MessageOutput != nil && event.Output.MessageOutput.IsStreaming {
+				sr := event.Output.MessageOutput.MessageStream
+				for {
+					msg, err := sr.Recv()
+					if err == io.EOF {
+						break
+					}
+					if err != nil {
+						streamErrEventCount++
+						errs = append(errs, err)
+						t.Logf("event %d: err: %v", i, err)
+						break
+					}
+					t.Logf("event %d: %v", i, msg.Content)
+				}
+			}
+		}
+
+		assert.Equal(t, 2, streamErrEventCount)
+		assert.Equal(t, 2, len(errs))
+		var willRetryErr *WillRetryError
+		assert.True(t, errors.As(errs[0], &willRetryErr))
+		assert.True(t, errors.As(errs[1], &willRetryErr))
+		assert.Equal(t, int32(3), atomic.LoadInt32(&m.callCount))
+	})
 }
 
 func TestChatModelAgentRetry_WithTools_DirectError_Generate(t *testing.T) {

--- a/adk/react.go
+++ b/adk/react.go
@@ -297,7 +297,7 @@ func newReact(ctx context.Context, config *reactConfig) (reactGraph, error) {
 			}
 		}
 		st.Messages = s.Messages
-		return input, nil
+		return st.Messages[len(st.Messages)-1], nil
 	}
 	_ = g.AddChatModelNode(chatModel_, chatModel,
 		compose.WithStatePreHandler(modelPreHandle), compose.WithStatePostHandler(modelPostHandle), compose.WithNodeName(chatModel_))


### PR DESCRIPTION
## Summary

Enable `AfterChatModel` middleware modifications to affect the ReAct Agent processing flow, while keeping AgentEvent consistent with ChatModel's original output.

## Problem

In ReAct Agent scenario, when `AfterChatModel` callback modifies `state.Messages` (e.g., adding/removing ToolCalls), it should affect the subsequent processing flow (like whether to call tools), but the AgentEvent should still reflect the original ChatModel output.

## Solution

### NoTools Scenario (chatmodel.go)
- AgentEvent is sent via callback with original ChatModel output
- `StatePostHandler` returns `st.Messages[len(st.Messages)-1]` (the potentially modified message)

### ReAct Scenario (react.go)
- `StatePostHandler` returns `st.Messages[len(st.Messages)-1]` (the potentially modified message)
- This affects subsequent flow - e.g., if AfterChatModel removes ToolCalls, the tool node won't be called
- AgentEvent is still sent via callback with original ChatModel output
- If user wants to emit custom events for modifications, they can call `SendEvent` method

## Changes

### react.go
- Changed `modelPostHandle` return value from `input` to `st.Messages[len(st.Messages)-1]`
- This ensures AfterChatModel modifications affect subsequent nodes (tools, etc.)

### chatmodel.go  
- `StatePostHandler` returns original `in` (no change to output)
- Restored callback-based event emission for NoTools scenario

### chatmodel_test.go
Added test cases:
- `AfterChatModel_NoTools_ModifyDoesNotAffectEvent`: Verifies NoTools scenario returns original ChatModel output
- `AfterChatModel_ReAct_ModifyAffectsFlow`: Verifies removing ToolCalls in AfterChatModel stops tool execution
- `AfterChatModel_ReAct_AppendToolCall_AffectsFlow`: Verifies adding ToolCalls in AfterChatModel triggers tool execution

## Testing

All tests pass:
```
go test ./adk/...
ok      github.com/cloudwego/eino/adk
ok      github.com/cloudwego/eino/adk/filesystem
ok      github.com/cloudwego/eino/adk/middlewares/filesystem
ok      github.com/cloudwego/eino/adk/middlewares/reduction
ok      github.com/cloudwego/eino/adk/middlewares/skill
ok      github.com/cloudwego/eino/adk/prebuilt
ok      github.com/cloudwego/eino/adk/prebuilt/deep
ok      github.com/cloudwego/eino/adk/prebuilt/planexecute
ok      github.com/cloudwego/eino/adk/prebuilt/supervisor
```