### PR TITLE
fix: avoid sonic runtime path in core packages for Go 1.24 compatibility

### DIFF
--- a/adk/agent_tool.go
+++ b/adk/agent_tool.go
@@ -19,10 +19,9 @@ package adk
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
-
-	"github.com/bytedance/sonic"
 
 	"github.com/cloudwego/eino/components/tool"
 	"github.com/cloudwego/eino/compose"
@@ -142,7 +141,7 @@ func (at *agentTool) InvokableRun(ctx context.Context, argumentsInJSON string, o
 				}
 
 				req := &request{}
-				err = sonic.UnmarshalString(argumentsInJSON, req)
+				err = json.Unmarshal([]byte(argumentsInJSON), req)
 				if err != nil {
 					return "", err
 				}

--- a/adk/chatmodel.go
+++ b/adk/chatmodel.go
@@ -20,6 +20,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/gob"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"math"
@@ -27,8 +28,6 @@ import (
 	"strings"
 	"sync"
 	"sync/atomic"
-
-	"github.com/bytedance/sonic"
 
 	"github.com/cloudwego/eino/callbacks"
 	"github.com/cloudwego/eino/components/model"
@@ -383,7 +382,7 @@ func (et ExitTool) InvokableRun(ctx context.Context, argumentsInJSON string, _ .
 	}
 
 	params := &exitParams{}
-	err := sonic.UnmarshalString(argumentsInJSON, params)
+	err := json.Unmarshal([]byte(argumentsInJSON), params)
 	if err != nil {
 		return "", err
 	}
@@ -412,7 +411,7 @@ func (tta transferToAgent) InvokableRun(ctx context.Context, argumentsInJSON str
 	}
 
 	params := &transferParams{}
-	err := sonic.UnmarshalString(argumentsInJSON, params)
+	err := json.Unmarshal([]byte(argumentsInJSON), params)
 	if err != nil {
 		return "", err
 	}

--- a/adk/prebuilt/deep/deep.go
+++ b/adk/prebuilt/deep/deep.go
@@ -19,9 +19,8 @@ package deep
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
-
-	"github.com/bytedance/sonic"
 
 	"github.com/cloudwego/eino/adk"
 	"github.com/cloudwego/eino/components/model"
@@ -158,10 +157,11 @@ type writeTodosArguments struct {
 func newWriteTodos() (adk.AgentMiddleware, error) {
 	t, err := utils.InferTool("write_todos", writeTodosToolDescription, func(ctx context.Context, input writeTodosArguments) (output string, err error) {
 		adk.AddSessionValue(ctx, SessionKeyTodos, input.Todos)
-		todos, err := sonic.MarshalString(input.Todos)
+		todosBytes, err := json.Marshal(input.Todos)
 		if err != nil {
 			return "", err
 		}
+		todos := string(todosBytes)
 		return fmt.Sprintf("Updated todo list to %s", todos), nil
 	})
 	if err != nil {

--- a/adk/prebuilt/deep/task_tool.go
+++ b/adk/prebuilt/deep/task_tool.go
@@ -20,10 +20,8 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"strings"
-
-	"github.com/bytedance/sonic"
 	"github.com/slongfield/pyfmt"
+	"strings"
 
 	"github.com/cloudwego/eino/adk"
 	"github.com/cloudwego/eino/components/model"
@@ -151,12 +149,13 @@ func (t *taskTool) InvokableRun(ctx context.Context, argumentsInJSON string, opt
 		return "", fmt.Errorf("subagent type %s not found", input.SubagentType)
 	}
 
-	params, err := sonic.MarshalString(map[string]string{
+	paramsBytes, err := json.Marshal(map[string]string{
 		"request": input.Description,
 	})
 	if err != nil {
 		return "", err
 	}
+	params := string(paramsBytes)
 
 	return a.InvokableRun(ctx, params, opts...)
 }

--- a/adk/prebuilt/planexecute/plan_execute.go
+++ b/adk/prebuilt/planexecute/plan_execute.go
@@ -24,8 +24,6 @@ import (
 	"runtime/debug"
 	"strings"
 
-	"github.com/bytedance/sonic"
-
 	"github.com/cloudwego/eino/adk"
 	"github.com/cloudwego/eino/components/model"
 	"github.com/cloudwego/eino/components/prompt"
@@ -90,12 +88,12 @@ func (p *defaultPlan) FirstStep() string {
 
 func (p *defaultPlan) MarshalJSON() ([]byte, error) {
 	type planTyp defaultPlan
-	return sonic.Marshal((*planTyp)(p))
+	return json.Marshal((*planTyp)(p))
 }
 
 func (p *defaultPlan) UnmarshalJSON(bytes []byte) error {
 	type planTyp defaultPlan
-	return sonic.Unmarshal(bytes, (*planTyp)(p))
+	return json.Unmarshal(bytes, (*planTyp)(p))
 }
 
 // Response represents the final response to the user.

--- a/components/tool/utils/common.go
+++ b/components/tool/utils/common.go
@@ -17,12 +17,16 @@
 package utils
 
 import (
-	"github.com/bytedance/sonic"
+	"encoding/json"
 )
 
 func marshalString(resp any) (string, error) {
 	if rs, ok := resp.(string); ok {
 		return rs, nil
 	}
-	return sonic.MarshalString(resp)
+	b, err := json.Marshal(resp)
+	if err != nil {
+		return "", err
+	}
+	return string(b), nil
 }

--- a/components/tool/utils/invokable_func.go
+++ b/components/tool/utils/invokable_func.go
@@ -18,11 +18,10 @@ package utils
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
-	"strings"
-
-	"github.com/bytedance/sonic"
 	"github.com/eino-contrib/jsonschema"
+	"strings"
 
 	"github.com/cloudwego/eino/components/tool"
 	"github.com/cloudwego/eino/internal/generic"
@@ -173,7 +172,7 @@ func (i *invokableTool[T, D]) InvokableRun(ctx context.Context, arguments string
 	} else {
 		inst = generic.NewInstance[T]()
 
-		err = sonic.UnmarshalString(arguments, &inst)
+		err = json.Unmarshal([]byte(arguments), &inst)
 		if err != nil {
 			return "", fmt.Errorf("[LocalFunc] failed to unmarshal arguments in json, toolName=%s, err=%w", i.getToolName(), err)
 		}
@@ -275,7 +274,7 @@ func (e *enhancedInvokableTool[T]) InvokableRun(ctx context.Context, toolArgumen
 	} else {
 		inst = generic.NewInstance[T]()
 
-		err = sonic.UnmarshalString(toolArgument.Text, &inst)
+		err = json.Unmarshal([]byte(toolArgument.Text), &inst)
 		if err != nil {
 			return nil, fmt.Errorf("[EnhancedLocalFunc] failed to unmarshal arguments in json, toolName=%s, err=%w", e.getToolName(), err)
 		}

--- a/components/tool/utils/streamable_func.go
+++ b/components/tool/utils/streamable_func.go
@@ -18,9 +18,8 @@ package utils
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
-
-	"github.com/bytedance/sonic"
 
 	"github.com/cloudwego/eino/components/tool"
 	"github.com/cloudwego/eino/internal/generic"
@@ -112,7 +111,7 @@ func (s *streamableTool[T, D]) StreamableRun(ctx context.Context, argumentsInJSO
 
 		inst = generic.NewInstance[T]()
 
-		err = sonic.UnmarshalString(argumentsInJSON, &inst)
+		err = json.Unmarshal([]byte(argumentsInJSON), &inst)
 		if err != nil {
 			return nil, fmt.Errorf("[LocalStreamFunc] failed to unmarshal arguments in json, toolName=%s, err=%w", s.getToolName(), err)
 		}
@@ -233,7 +232,7 @@ func (s *enhancedStreamableTool[T]) StreamableRun(ctx context.Context, toolArgum
 	} else {
 		inst = generic.NewInstance[T]()
 
-		err = sonic.UnmarshalString(toolArgument.Text, &inst)
+		err = json.Unmarshal([]byte(toolArgument.Text), &inst)
 		if err != nil {
 			return nil, fmt.Errorf("[EnhancedLocalStreamFunc] failed to unmarshal arguments in json, toolName=%s, err=%w", s.getToolName(), err)
 		}


### PR DESCRIPTION
## Summary
This PR replaces runtime JSON usage of github.com/bytedance/sonic with Go standard library encoding/json in core runtime packages.

## Why
On Go 1.24, users can hit linker errors similar to:
link: github.com/bytedance/sonic/loader: invalid reference to runtime.lastmoduledatap
when running basic Eino examples.

Using encoding/json in runtime paths avoids this incompatibility and keeps behavior consistent.

## Changed
- dk: chatmodel.go, gent_tool.go
- components/tool/utils: common.go, invokable_func.go, streamable_func.go
- schema: message_parser.go (replace GetFromString path extraction with stdlib traversal)
- internal/serialization: serialization.go
- dk/prebuilt: deep/deep.go, deep/task_tool.go, planexecute/plan_execute.go

## Validation
- go build ./adk ./adk/prebuilt/deep ./adk/prebuilt/planexecute ./components/tool/utils ./schema ./internal/serialization passes on Go 1.24.

## Notes
- Test files still reference sonic in some places; this PR focuses on runtime code paths used by end users.