### PR TITLE
fix(adk): abort loop agent on sub-agent error

### DIFF
--- a/adk/workflow.go
+++ b/adk/workflow.go
@@ -350,6 +350,11 @@ func (a *workflowAgent) runLoop(ctx context.Context, generator *AsyncGenerator[*
 					break
 				}
 
+				if event.Err != nil {
+					generator.Send(event)
+					return nil
+				}
+
 				if lastActionEvent != nil {
 					generator.Send(lastActionEvent)
 					lastActionEvent = nil


### PR DESCRIPTION
## Problem

`NewLoopAgent` does not abort its loop when a sub-agent emits an `AgentEvent` with an error. Instead, it continues to the next iteration. This is inconsistent with `NewSequentialAgent` behavior and leads to unexpected execution continuation despite errors.

**Expected**: When a sub-agent returns an error event, the loop should abort immediately.
**Actual**: The loop ignores the error and continues iterating.

## Solution

Add error check in `runLoop` (lines 366-369) to detect `event.Err != nil` and abort execution:

```go
if event.Err != nil {
    generator.Send(event)
    return nil
}
```

This mirrors the existing error handling in `runSequential` (lines 216-220).

## Key Insight

The `runSequential` method already had proper error handling, but `runLoop` was missing it. Both workflow types should behave consistently - when a sub-agent encounters an error, the parent workflow should propagate that error and stop execution.

## Test Coverage

Added 4 test cases:
- `TestSequentialAgentWithError`: Verifies sequential agent aborts on first sub-agent error
- `TestLoopAgentWithError`: Verifies loop agent aborts on first iteration error  
- `TestLoopAgentWithErrorAfterSuccessfulIterations`: Verifies loop runs 2 iterations successfully, then aborts on 3rd iteration error
- `TestSequentialAgentWithMultipleSubAgentsError`: Verifies sequential agent runs first sub-agent, aborts on second, never runs third

---

## 问题

`NewLoopAgent` 在子 Agent 返回错误事件时不会中止循环，而是继续下一次迭代。这与 `NewSequentialAgent` 的行为不一致，导致即使发生错误也会继续执行。

**期望行为**：当子 Agent 返回错误事件时，循环应该立即中止。
**实际行为**：循环忽略错误并继续迭代。

## 解决方案

在 `runLoop` 中添加错误检查（第 366-369 行），检测 `event.Err != nil` 并中止执行：

```go
if event.Err != nil {
    generator.Send(event)
    return nil
}
```

这与 `runSequential` 中现有的错误处理逻辑（第 216-220 行）保持一致。

## 关键洞察

`runSequential` 方法已经有了正确的错误处理，但 `runLoop` 缺失了这部分。两种工作流类型应该保持一致的行为 - 当子 Agent 遇到错误时，父工作流应该传播该错误并停止执行。

## 测试覆盖

新增 4 个测试用例：
- `TestSequentialAgentWithError`：验证顺序 Agent 在第一个子 Agent 错误时中止
- `TestLoopAgentWithError`：验证循环 Agent 在第一次迭代错误时中止
- `TestLoopAgentWithErrorAfterSuccessfulIterations`：验证循环成功运行 2 次迭代后，在第 3 次迭代错误时中止
- `TestSequentialAgentWithMultipleSubAgentsError`：验证顺序 Agent 运行第一个子 Agent 后，在第二个出错时中止，不运行第三个
