### PR TITLE
fix(adk): loop workflow agent should break when BreakLoopAction is detected mid-stream

### DIFF
--- a/adk/workflow_test.go
+++ b/adk/workflow_test.go
@@ -1144,3 +1144,72 @@ func TestLoopAgentWithError(t *testing.T) {
 	assert.Contains(t, errorEvent.Err.Error(), "error on iteration 3")
 	assert.Equal(t, 3, iterationCount, "loop should stop at iteration 3")
 }
+
+func TestLoopAgentWithBreakLoopFollowedByMoreEvents(t *testing.T) {
+	ctx := context.Background()
+
+	agent := newMockAgent("SubAgent", "Sub agent", []*AgentEvent{
+		{
+			AgentName: "SubAgent",
+			Output: &AgentOutput{
+				MessageOutput: &MessageVariant{
+					IsStreaming: false,
+					Message:     schema.ToolMessage("tool result", "call_123"),
+					Role:        schema.Tool,
+				},
+			},
+			Action: NewBreakLoopAction("SubAgent"),
+		},
+		{
+			AgentName: "SubAgent",
+			Output: &AgentOutput{
+				MessageOutput: &MessageVariant{
+					IsStreaming: false,
+					Message:     schema.AssistantMessage("Final response after tool", nil),
+					Role:        schema.Assistant,
+				},
+			},
+		},
+	})
+
+	loopAgent, err := NewLoopAgent(ctx, &LoopAgentConfig{
+		Name:          "LoopTestAgent",
+		Description:   "Test loop agent",
+		SubAgents:     []Agent{agent},
+		MaxIterations: 3,
+	})
+	assert.NoError(t, err)
+	assert.NotNil(t, loopAgent)
+
+	input := &AgentInput{
+		Messages: []Message{
+			schema.UserMessage("Test input"),
+		},
+	}
+	ctx, _ = initRunCtx(ctx, loopAgent.Name(ctx), input)
+
+	iterator := loopAgent.Run(ctx, input)
+	assert.NotNil(t, iterator)
+
+	var events []*AgentEvent
+	for {
+		event, ok := iterator.Next()
+		if !ok {
+			break
+		}
+		events = append(events, event)
+	}
+
+	assert.Equal(t, 2, len(events), "should have 2 events (tool event with BreakLoop + final response) and loop should break")
+
+	assert.NotNil(t, events[0].Action, "first event should have an action")
+	assert.NotNil(t, events[0].Action.BreakLoop, "first event should have BreakLoop action")
+	assert.True(t, events[0].Action.BreakLoop.Done, "BreakLoop should be marked as Done")
+	assert.Equal(t, "SubAgent", events[0].Action.BreakLoop.From)
+	assert.Equal(t, 0, events[0].Action.BreakLoop.CurrentIterations)
+	assert.Equal(t, schema.Tool, events[0].Output.MessageOutput.Role, "first event should be tool message")
+
+	assert.Nil(t, events[1].Action, "second event should not have an action")
+	assert.Equal(t, schema.Assistant, events[1].Output.MessageOutput.Role, "second event should be assistant message")
+	assert.Equal(t, "Final response after tool", events[1].Output.MessageOutput.Message.Content)
+}


### PR DESCRIPTION
## Summary

| What | Why |
|------|-----|
| Fix loop workflow agent not breaking when `BreakLoopAction` is emitted mid-stream | A tool inside `ChatModelAgent` calling `SendToolGenAction` with `BreakLoopAction` followed by more events would not break the loop |

## Key Insight

When a tool emits a `BreakLoopAction` via `SendToolGenAction`, the action is attached to the tool event. However, the `ChatModelAgent` may emit more events after the tool completes (e.g., the model's final response). 

Previously, the loop workflow agent only checked for `BreakLoopAction` on the **last event** from the sub-agent. If the `BreakLoopAction` was on an earlier event, it would be forwarded without being processed, and the loop would continue iterating.

The fix tracks `BreakLoopAction` events as they are forwarded, marks them as `Done` immediately (to prevent parent loop agents from accidentally breaking), and breaks the loop after processing all events from the sub-agent.

## Changes

- Track `BreakLoopAction` events in `runLoop` as they are forwarded
- Mark `BreakLoop.Done = true` immediately when detected (before forwarding)
- Break the loop after sub-agent completes if a `BreakLoopAction` was detected
- Remove redundant `doBreakLoopIfNeeded` method
- Add test `TestLoopAgentWithBreakLoopFollowedByMoreEvents`

---

## 概述

| 改动 | 原因 |
|------|-----|
| 修复 loop workflow agent 在 `BreakLoopAction` 中途发出时无法中断循环的问题 | `ChatModelAgent` 中的工具调用 `SendToolGenAction` 发送 `BreakLoopAction` 后如果还有后续事件，循环不会中断 |

## 关键洞察

当工具通过 `SendToolGenAction` 发出 `BreakLoopAction` 时，该动作会附加到工具事件上。然而，`ChatModelAgent` 可能在工具完成后继续发出更多事件（如模型的最终响应）。

之前，loop workflow agent 只在子代理的**最后一个事件**上检查 `BreakLoopAction`。如果 `BreakLoopAction` 在较早的事件上，它会被转发而不被处理，循环会继续迭代。

修复方案是在转发事件时跟踪 `BreakLoopAction` 事件，立即将其标记为 `Done`（防止父级 loop agent 意外中断），并在子代理处理完所有事件后中断循环。

## 改动内容

- 在 `runLoop` 中转发事件时跟踪 `BreakLoopAction` 事件
- 检测到时立即标记 `BreakLoop.Done = true`（转发前）
- 如果检测到 `BreakLoopAction`，在子代理完成后中断循环
- 移除冗余的 `doBreakLoopIfNeeded` 方法
- 添加测试 `TestLoopAgentWithBreakLoopFollowedByMoreEvents`
