### PR TITLE
feat: add custom tool name support for filesystem middleware tools

### DIFF
--- a/adk/middlewares/filesystem/filesystem.go
+++ b/adk/middlewares/filesystem/filesystem.go
@@ -78,6 +78,28 @@ type Config struct {
 	// optional, ToolsSystemPrompt by default
 	CustomSystemPrompt *string
 
+	// CustomLsToolName overrides the ls tool name used in tool registration
+	// optional, ToolNameLs by default
+	CustomLsToolName *string
+	// CustomReadFileToolName overrides the read_file tool name
+	// optional, ToolNameReadFile by default
+	CustomReadFileToolName *string
+	// CustomWriteFileToolName overrides the write_file tool name
+	// optional, ToolNameWriteFile by default
+	CustomWriteFileToolName *string
+	// CustomEditFileToolName overrides the edit_file tool name
+	// optional, ToolNameEditFile by default
+	CustomEditFileToolName *string
+	// CustomGlobToolName overrides the glob tool name
+	// optional, ToolNameGlob by default
+	CustomGlobToolName *string
+	// CustomGrepToolName overrides the grep tool name
+	// optional, ToolNameGrep by default
+	CustomGrepToolName *string
+	// CustomExecuteToolName overrides the execute tool name
+	// optional, ToolNameExecute by default
+	CustomExecuteToolName *string
+
 	// CustomLsToolDesc overrides the ls tool description used in tool registration
 	// optional, ListFilesToolDesc by default
 	CustomLsToolDesc *string
@@ -130,6 +152,13 @@ func NewMiddleware(ctx context.Context, config *Config) (adk.AgentMiddleware, er
 		Shell:                   config.Shell,
 		StreamingShell:          config.StreamingShell,
 		CustomSystemPrompt:      config.CustomSystemPrompt,
+		CustomLsToolName:        config.CustomLsToolName,
+		CustomReadFileToolName:  config.CustomReadFileToolName,
+		CustomWriteFileToolName: config.CustomWriteFileToolName,
+		CustomEditFileToolName:  config.CustomEditFileToolName,
+		CustomGlobToolName:      config.CustomGlobToolName,
+		CustomGrepToolName:      config.CustomGrepToolName,
+		CustomExecuteToolName:   config.CustomExecuteToolName,
 		CustomLsToolDesc:        config.CustomLsToolDesc,
 		CustomReadFileToolDesc:  config.CustomReadFileToolDesc,
 		CustomGrepToolDesc:      config.CustomGrepToolDesc,
@@ -194,6 +223,28 @@ type MiddlewareConfig struct {
 	// CustomSystemPrompt overrides the default ToolsSystemPrompt appended to agent instruction
 	// optional, ToolsSystemPrompt by default
 	CustomSystemPrompt *string
+
+	// CustomLsToolName overrides the ls tool name used in tool registration
+	// optional, ToolNameLs by default
+	CustomLsToolName *string
+	// CustomReadFileToolName overrides the read_file tool name
+	// optional, ToolNameReadFile by default
+	CustomReadFileToolName *string
+	// CustomWriteFileToolName overrides the write_file tool name
+	// optional, ToolNameWriteFile by default
+	CustomWriteFileToolName *string
+	// CustomEditFileToolName overrides the edit_file tool name
+	// optional, ToolNameEditFile by default
+	CustomEditFileToolName *string
+	// CustomGlobToolName overrides the glob tool name
+	// optional, ToolNameGlob by default
+	CustomGlobToolName *string
+	// CustomGrepToolName overrides the grep tool name
+	// optional, ToolNameGrep by default
+	CustomGrepToolName *string
+	// CustomExecuteToolName overrides the execute tool name
+	// optional, ToolNameExecute by default
+	CustomExecuteToolName *string
 
 	// CustomLsToolDesc overrides the ls tool description used in tool registration
 	// optional, ListFilesToolDesc by default
@@ -310,14 +361,14 @@ func getFilesystemTools(_ context.Context, validatedConfig *MiddlewareConfig) ([
 
 	if validatedConfig.StreamingShell != nil {
 		var executeTool tool.BaseTool
-		executeTool, err = newStreamingExecuteTool(validatedConfig.StreamingShell, validatedConfig.CustomExecuteToolDesc)
+		executeTool, err = newStreamingExecuteTool(validatedConfig.StreamingShell, validatedConfig.CustomExecuteToolName, validatedConfig.CustomExecuteToolDesc)
 		if err != nil {
 			return nil, err
 		}
 		tools = append(tools, executeTool)
 	} else if validatedConfig.Shell != nil {
 		var executeTool tool.BaseTool
-		executeTool, err = newExecuteTool(validatedConfig.Shell, validatedConfig.CustomExecuteToolDesc)
+		executeTool, err = newExecuteTool(validatedConfig.Shell, validatedConfig.CustomExecuteToolName, validatedConfig.CustomExecuteToolDesc)
 		if err != nil {
 			return nil, err
 		}
@@ -328,37 +379,37 @@ func getFilesystemTools(_ context.Context, validatedConfig *MiddlewareConfig) ([
 		return tools, nil
 	}
 
-	lsTool, err := newLsTool(validatedConfig.Backend, validatedConfig.CustomLsToolDesc)
+	lsTool, err := newLsTool(validatedConfig.Backend, validatedConfig.CustomLsToolName, validatedConfig.CustomLsToolDesc)
 	if err != nil {
 		return nil, err
 	}
 	tools = append(tools, lsTool)
 
-	readTool, err := newReadFileTool(validatedConfig.Backend, validatedConfig.CustomReadFileToolDesc)
+	readTool, err := newReadFileTool(validatedConfig.Backend, validatedConfig.CustomReadFileToolName, validatedConfig.CustomReadFileToolDesc)
 	if err != nil {
 		return nil, err
 	}
 	tools = append(tools, readTool)
 
-	writeTool, err := newWriteFileTool(validatedConfig.Backend, validatedConfig.CustomWriteFileToolDesc)
+	writeTool, err := newWriteFileTool(validatedConfig.Backend, validatedConfig.CustomWriteFileToolName, validatedConfig.CustomWriteFileToolDesc)
 	if err != nil {
 		return nil, err
 	}
 	tools = append(tools, writeTool)
 
-	editTool, err := newEditFileTool(validatedConfig.Backend, validatedConfig.CustomEditToolDesc)
+	editTool, err := newEditFileTool(validatedConfig.Backend, validatedConfig.CustomEditFileToolName, validatedConfig.CustomEditToolDesc)
 	if err != nil {
 		return nil, err
 	}
 	tools = append(tools, editTool)
 
-	globTool, err := newGlobTool(validatedConfig.Backend, validatedConfig.CustomGlobToolDesc)
+	globTool, err := newGlobTool(validatedConfig.Backend, validatedConfig.CustomGlobToolName, validatedConfig.CustomGlobToolDesc)
 	if err != nil {
 		return nil, err
 	}
 	tools = append(tools, globTool)
 
-	grepTool, err := newGrepTool(validatedConfig.Backend, validatedConfig.CustomGrepToolDesc)
+	grepTool, err := newGrepTool(validatedConfig.Backend, validatedConfig.CustomGrepToolName, validatedConfig.CustomGrepToolDesc)
 	if err != nil {
 		return nil, err
 	}
@@ -371,12 +422,13 @@ type lsArgs struct {
 	Path string `json:"path"`
 }
 
-func newLsTool(fs filesystem.Backend, desc *string) (tool.BaseTool, error) {
+func newLsTool(fs filesystem.Backend, name *string, desc *string) (tool.BaseTool, error) {
+	toolName := selectToolName(name, ToolNameLs)
 	d, err := selectToolDesc(desc, ListFilesToolDesc, ListFilesToolDescChinese)
 	if err != nil {
 		return nil, err
 	}
-	return utils.InferTool(ToolNameLs, d, func(ctx context.Context, input lsArgs) (string, error) {
+	return utils.InferTool(toolName, d, func(ctx context.Context, input lsArgs) (string, error) {
 		infos, err := fs.LsInfo(ctx, &filesystem.LsInfoRequest{Path: input.Path})
 		if err != nil {
 			return "", err
@@ -400,12 +452,13 @@ type readFileArgs struct {
 	Limit int `json:"limit" jsonschema:"description=The number of lines to read. Only provide if the file is too large to read at once."`
 }
 
-func newReadFileTool(fs filesystem.Backend, desc *string) (tool.BaseTool, error) {
+func newReadFileTool(fs filesystem.Backend, name *string, desc *string) (tool.BaseTool, error) {
+	toolName := selectToolName(name, ToolNameReadFile)
 	d, err := selectToolDesc(desc, ReadFileToolDesc, ReadFileToolDescChinese)
 	if err != nil {
 		return nil, err
 	}
-	return utils.InferTool(ToolNameReadFile, d, func(ctx context.Context, input readFileArgs) (string, error) {
+	return utils.InferTool(toolName, d, func(ctx context.Context, input readFileArgs) (string, error) {
 		return fs.Read(ctx, &filesystem.ReadRequest{
 			FilePath: input.FilePath,
 			Offset:   input.Offset,
@@ -422,12 +475,13 @@ type writeFileArgs struct {
 	Content string `json:"content" jsonschema:"description=The content to write to the file"`
 }
 
-func newWriteFileTool(fs filesystem.Backend, desc *string) (tool.BaseTool, error) {
+func newWriteFileTool(fs filesystem.Backend, name *string, desc *string) (tool.BaseTool, error) {
+	toolName := selectToolName(name, ToolNameWriteFile)
 	d, err := selectToolDesc(desc, WriteFileToolDesc, WriteFileToolDescChinese)
 	if err != nil {
 		return nil, err
 	}
-	return utils.InferTool(ToolNameWriteFile, d, func(ctx context.Context, input writeFileArgs) (string, error) {
+	return utils.InferTool(toolName, d, func(ctx context.Context, input writeFileArgs) (string, error) {
 		err := fs.Write(ctx, &filesystem.WriteRequest{
 			FilePath: input.FilePath,
 			Content:  input.Content,
@@ -453,12 +507,13 @@ type editFileArgs struct {
 	ReplaceAll bool `json:"replace_all" jsonschema:"description=Replace all occurrences of old_string (default false),default=false"`
 }
 
-func newEditFileTool(fs filesystem.Backend, desc *string) (tool.BaseTool, error) {
+func newEditFileTool(fs filesystem.Backend, name *string, desc *string) (tool.BaseTool, error) {
+	toolName := selectToolName(name, ToolNameEditFile)
 	d, err := selectToolDesc(desc, EditFileToolDesc, EditFileToolDescChinese)
 	if err != nil {
 		return nil, err
 	}
-	return utils.InferTool(ToolNameEditFile, d, func(ctx context.Context, input editFileArgs) (string, error) {
+	return utils.InferTool(toolName, d, func(ctx context.Context, input editFileArgs) (string, error) {
 		err := fs.Edit(ctx, &filesystem.EditRequest{
 			FilePath:   input.FilePath,
 			OldString:  input.OldString,
@@ -480,12 +535,13 @@ type globArgs struct {
 	Path string `json:"path" jsonschema:"description=The directory to search in. If not specified\\, the current working directory will be used. IMPORTANT: Omit this field to use the default directory. DO NOT enter 'undefined' or 'null' - simply omit it for the default behavior. Must be a valid directory path if provided."`
 }
 
-func newGlobTool(fs filesystem.Backend, desc *string) (tool.BaseTool, error) {
+func newGlobTool(fs filesystem.Backend, name *string, desc *string) (tool.BaseTool, error) {
+	toolName := selectToolName(name, ToolNameGlob)
 	d, err := selectToolDesc(desc, GlobToolDesc, GlobToolDescChinese)
 	if err != nil {
 		return nil, err
 	}
-	return utils.InferTool(ToolNameGlob, d, func(ctx context.Context, input globArgs) (string, error) {
+	return utils.InferTool(toolName, d, func(ctx context.Context, input globArgs) (string, error) {
 		infos, err := fs.GlobInfo(ctx, &filesystem.GlobInfoRequest{
 			Pattern: input.Pattern,
 			Path:    input.Path,
@@ -555,12 +611,13 @@ type grepArgs struct {
 	Multiline *bool `json:"multiline,omitempty" jsonschema:"description=Enable multiline mode where . matches newlines and patterns can span lines (rg -U --multiline-dotall). Default: false."`
 }
 
-func newGrepTool(fs filesystem.Backend, desc *string) (tool.BaseTool, error) {
+func newGrepTool(fs filesystem.Backend, name *string, desc *string) (tool.BaseTool, error) {
+	toolName := selectToolName(name, ToolNameGrep)
 	d, err := selectToolDesc(desc, GrepToolDesc, GrepToolDescChinese)
 	if err != nil {
 		return nil, err
 	}
-	return utils.InferTool(ToolNameGrep, d, func(ctx context.Context, input grepArgs) (string, error) {
+	return utils.InferTool(toolName, d, func(ctx context.Context, input grepArgs) (string, error) {
 		// Extract string parameters
 		path := valueOrDefault(input.Path, "")
 		glob := valueOrDefault(input.Glob, "")
@@ -623,12 +680,13 @@ type executeArgs struct {
 	Command string `json:"command"`
 }
 
-func newExecuteTool(sb filesystem.Shell, desc *string) (tool.BaseTool, error) {
+func newExecuteTool(sb filesystem.Shell, name *string, desc *string) (tool.BaseTool, error) {
+	toolName := selectToolName(name, ToolNameExecute)
 	d, err := selectToolDesc(desc, ExecuteToolDesc, ExecuteToolDescChinese)
 	if err != nil {
 		return nil, err
 	}
-	return utils.InferTool(ToolNameExecute, d, func(ctx context.Context, input executeArgs) (string, error) {
+	return utils.InferTool(toolName, d, func(ctx context.Context, input executeArgs) (string, error) {
 		result, err := sb.Execute(ctx, &filesystem.ExecuteRequest{
 			Command: input.Command,
 		})
@@ -640,12 +698,13 @@ func newExecuteTool(sb filesystem.Shell, desc *string) (tool.BaseTool, error) {
 	})
 }
 
-func newStreamingExecuteTool(sb filesystem.StreamingShell, desc *string) (tool.BaseTool, error) {
+func newStreamingExecuteTool(sb filesystem.StreamingShell, name *string, desc *string) (tool.BaseTool, error) {
+	toolName := selectToolName(name, ToolNameExecute)
 	d, err := selectToolDesc(desc, ExecuteToolDesc, ExecuteToolDescChinese)
 	if err != nil {
 		return nil, err
 	}
-	return utils.InferStreamTool(ToolNameExecute, d, func(ctx context.Context, input executeArgs) (*schema.StreamReader[string], error) {
+	return utils.InferStreamTool(toolName, d, func(ctx context.Context, input executeArgs) (*schema.StreamReader[string], error) {
 		result, err := sb.ExecuteStreaming(ctx, &filesystem.ExecuteRequest{
 			Command: input.Command,
 		})
@@ -809,4 +868,12 @@ func selectToolDesc(customDesc *string, defaultEnglish, defaultChinese string) (
 		English: defaultEnglish,
 		Chinese: defaultChinese,
 	}), nil
+}
+
+// selectToolName returns the custom tool name if provided, otherwise returns the default name.
+func selectToolName(customName *string, defaultName string) string {
+	if customName != nil {
+		return *customName
+	}
+	return defaultName
 }

--- a/adk/middlewares/filesystem/filesystem_test.go
+++ b/adk/middlewares/filesystem/filesystem_test.go
@@ -70,7 +70,7 @@ func invokeTool(_ *testing.T, bt tool.BaseTool, input string) (string, error) {
 
 func TestLsTool(t *testing.T) {
 	backend := setupTestBackend()
-	lsTool, err := newLsTool(backend, nil)
+	lsTool, err := newLsTool(backend, nil, nil)
 	if err != nil {
 		t.Fatalf("Failed to create ls tool: %v", err)
 	}
@@ -115,7 +115,7 @@ func TestLsTool(t *testing.T) {
 
 func TestReadFileTool(t *testing.T) {
 	backend := setupTestBackend()
-	readTool, err := newReadFileTool(backend, nil)
+	readTool, err := newReadFileTool(backend, nil, nil)
 	if err != nil {
 		t.Fatalf("Failed to create read_file tool: %v", err)
 	}
@@ -174,7 +174,7 @@ func TestReadFileTool(t *testing.T) {
 
 func TestWriteFileTool(t *testing.T) {
 	backend := setupTestBackend()
-	writeTool, err := newWriteFileTool(backend, nil)
+	writeTool, err := newWriteFileTool(backend, nil, nil)
 	if err != nil {
 		t.Fatalf("Failed to create write_file tool: %v", err)
 	}
@@ -233,7 +233,7 @@ func TestWriteFileTool(t *testing.T) {
 
 func TestEditFileTool(t *testing.T) {
 	backend := setupTestBackend()
-	editTool, err := newEditFileTool(backend, nil)
+	editTool, err := newEditFileTool(backend, nil, nil)
 	if err != nil {
 		t.Fatalf("Failed to create edit_file tool: %v", err)
 	}
@@ -314,7 +314,7 @@ func TestEditFileTool(t *testing.T) {
 
 func TestGlobTool(t *testing.T) {
 	backend := setupTestBackend()
-	globTool, err := newGlobTool(backend, nil)
+	globTool, err := newGlobTool(backend, nil, nil)
 	if err != nil {
 		t.Fatalf("Failed to create glob tool: %v", err)
 	}
@@ -376,7 +376,7 @@ func TestGlobTool(t *testing.T) {
 
 func TestGrepTool(t *testing.T) {
 	backend := setupTestBackend()
-	grepTool, err := newGrepTool(backend, nil)
+	grepTool, err := newGrepTool(backend, nil, nil)
 	if err != nil {
 		t.Fatalf("Failed to create grep tool: %v", err)
 	}
@@ -500,7 +500,7 @@ func TestExecuteTool(t *testing.T) {
 			executeTool, err := newExecuteTool(&mockShellBackend{
 				Backend: backend,
 				resp:    tt.resp,
-			}, nil)
+			}, nil, nil)
 			assert.NoError(t, err)
 
 			result, err := invokeTool(t, executeTool, tt.input)
@@ -720,7 +720,7 @@ func TestGrepToolWithSortingAndPagination(t *testing.T) {
 		Content:  "match6\nmatch7\nmatch8",
 	})
 
-	grepTool, err := newGrepTool(backend, nil)
+	grepTool, err := newGrepTool(backend, nil, nil)
 	assert.NoError(t, err)
 
 	t.Run("files sorted by basename", func(t *testing.T) {
@@ -835,5 +835,165 @@ func TestApplyPagination(t *testing.T) {
 		items := []string{"a", "b", "c", "d", "e"}
 		result := applyPagination(items, 1, 0)
 		assert.Equal(t, []string{"b", "c", "d", "e"}, result)
+	})
+}
+
+func TestCustomToolNames(t *testing.T) {
+	backend := setupTestBackend()
+	ctx := context.Background()
+
+	t.Run("custom tool names applied to individual tools", func(t *testing.T) {
+		customLsName := "list_files"
+		customReadName := "read"
+		customWriteName := "write"
+		customEditName := "edit"
+		customGlobName := "find_files"
+		customGrepName := "search"
+
+		lsTool, err := newLsTool(backend, &customLsName, nil)
+		assert.NoError(t, err)
+		info, _ := lsTool.Info(ctx)
+		assert.Equal(t, "list_files", info.Name)
+
+		readTool, err := newReadFileTool(backend, &customReadName, nil)
+		assert.NoError(t, err)
+		info, _ = readTool.Info(ctx)
+		assert.Equal(t, "read", info.Name)
+
+		writeTool, err := newWriteFileTool(backend, &customWriteName, nil)
+		assert.NoError(t, err)
+		info, _ = writeTool.Info(ctx)
+		assert.Equal(t, "write", info.Name)
+
+		editTool, err := newEditFileTool(backend, &customEditName, nil)
+		assert.NoError(t, err)
+		info, _ = editTool.Info(ctx)
+		assert.Equal(t, "edit", info.Name)
+
+		globTool, err := newGlobTool(backend, &customGlobName, nil)
+		assert.NoError(t, err)
+		info, _ = globTool.Info(ctx)
+		assert.Equal(t, "find_files", info.Name)
+
+		grepTool, err := newGrepTool(backend, &customGrepName, nil)
+		assert.NoError(t, err)
+		info, _ = grepTool.Info(ctx)
+		assert.Equal(t, "search", info.Name)
+	})
+
+	t.Run("default tool names when custom names not provided", func(t *testing.T) {
+		lsTool, err := newLsTool(backend, nil, nil)
+		assert.NoError(t, err)
+		info, _ := lsTool.Info(ctx)
+		assert.Equal(t, ToolNameLs, info.Name)
+
+		readTool, err := newReadFileTool(backend, nil, nil)
+		assert.NoError(t, err)
+		info, _ = readTool.Info(ctx)
+		assert.Equal(t, ToolNameReadFile, info.Name)
+
+		writeTool, err := newWriteFileTool(backend, nil, nil)
+		assert.NoError(t, err)
+		info, _ = writeTool.Info(ctx)
+		assert.Equal(t, ToolNameWriteFile, info.Name)
+
+		editTool, err := newEditFileTool(backend, nil, nil)
+		assert.NoError(t, err)
+		info, _ = editTool.Info(ctx)
+		assert.Equal(t, ToolNameEditFile, info.Name)
+
+		globTool, err := newGlobTool(backend, nil, nil)
+		assert.NoError(t, err)
+		info, _ = globTool.Info(ctx)
+		assert.Equal(t, ToolNameGlob, info.Name)
+
+		grepTool, err := newGrepTool(backend, nil, nil)
+		assert.NoError(t, err)
+		info, _ = grepTool.Info(ctx)
+		assert.Equal(t, ToolNameGrep, info.Name)
+	})
+
+	t.Run("custom execute tool name", func(t *testing.T) {
+		customExecuteName := "run_command"
+		shellBackend := &mockShellBackend{
+			Backend: backend,
+			resp:    &filesystem.ExecuteResponse{Output: "ok"},
+		}
+
+		executeTool, err := newExecuteTool(shellBackend, &customExecuteName, nil)
+		assert.NoError(t, err)
+		info, _ := executeTool.Info(ctx)
+		assert.Equal(t, "run_command", info.Name)
+	})
+
+	t.Run("custom tool names in getFilesystemTools", func(t *testing.T) {
+		customLsName := "list_files"
+		customReadName := "read"
+		customWriteName := "write"
+		customEditName := "edit"
+		customGlobName := "find_files"
+		customGrepName := "search"
+
+		tools, err := getFilesystemTools(ctx, &MiddlewareConfig{
+			Backend:                 backend,
+			CustomLsToolName:        &customLsName,
+			CustomReadFileToolName:  &customReadName,
+			CustomWriteFileToolName: &customWriteName,
+			CustomEditFileToolName:  &customEditName,
+			CustomGlobToolName:      &customGlobName,
+			CustomGrepToolName:      &customGrepName,
+		})
+		assert.NoError(t, err)
+		assert.Len(t, tools, 6)
+
+		toolNames := make(map[string]bool)
+		for _, to := range tools {
+			info, _ := to.Info(ctx)
+			toolNames[info.Name] = true
+		}
+
+		assert.True(t, toolNames["list_files"])
+		assert.True(t, toolNames["read"])
+		assert.True(t, toolNames["write"])
+		assert.True(t, toolNames["edit"])
+		assert.True(t, toolNames["find_files"])
+		assert.True(t, toolNames["search"])
+	})
+
+	t.Run("custom tool names in middleware", func(t *testing.T) {
+		customLsName := "list_files"
+		customReadName := "read"
+
+		m, err := New(ctx, &MiddlewareConfig{
+			Backend:                backend,
+			CustomLsToolName:       &customLsName,
+			CustomReadFileToolName: &customReadName,
+		})
+		assert.NoError(t, err)
+
+		fm, ok := m.(*filesystemMiddleware)
+		assert.True(t, ok)
+
+		toolNames := make(map[string]bool)
+		for _, to := range fm.additionalTools {
+			info, _ := to.Info(ctx)
+			toolNames[info.Name] = true
+		}
+
+		assert.True(t, toolNames["list_files"])
+		assert.True(t, toolNames["read"])
+	})
+}
+
+func TestSelectToolName(t *testing.T) {
+	t.Run("returns custom name when provided", func(t *testing.T) {
+		customName := "custom_tool"
+		result := selectToolName(&customName, "default_tool")
+		assert.Equal(t, "custom_tool", result)
+	})
+
+	t.Run("returns default name when custom name is nil", func(t *testing.T) {
+		result := selectToolName(nil, "default_tool")
+		assert.Equal(t, "default_tool", result)
 	})
 }


### PR DESCRIPTION
Added the ability to customize tool names for all filesystem middleware tools, allowing users to override default tool names with their own naming conventions.

Main changes:
- Added CustomXXXToolName fields to Config and MiddlewareConfig structs for all 7 tools (ls, read_file, write_file, edit_file, glob, grep, execute)
- Implemented selectToolName() helper function to handle custom name selection with fallback to defaults
- Updated all tool creation functions (newLsTool, newReadFileTool, newWriteFileTool, newEditFileTool, newGlobTool, newGrepTool, newExecuteTool, newStreamingExecuteTool) to accept name parameter
- Modified getFilesystemTools() to pass custom tool names to each tool creation function
- Updated NewMiddleware() to forward custom tool name configurations

Implementation details:
- Custom tool names are optional pointer fields, maintaining backward compatibility
- When CustomXXXToolName is nil, default constants from ToolNameXXX are used
- selectToolName() provides centralized logic for name resolution
- All 7 filesystem tools now support name customization: ls, read_file, write_file, edit_file, glob, grep, and execute

Benefits:
- Enables alignment with organization-specific naming conventions
- Allows shorter or more intuitive names for specific use cases
- Prevents naming conflicts with other tools in the system
- Maintains full backward compatibility with existing code

