### PR TITLE
fix(adk): restore HasReturnDirectly field for backward compatibility

### DIFF
--- a/adk/react.go
+++ b/adk/react.go
@@ -43,6 +43,7 @@ type State struct {
 
 	// Internal fields below - do not access directly.
 	// Kept exported for backward compatibility with existing checkpoints.
+	HasReturnDirectly        bool
 	ReturnDirectlyToolCallID string
 	ToolGenActions           map[string]*AgentAction
 	AgentName                string
@@ -120,6 +121,8 @@ func (s *State) setReturnDirectlyToolCallID(id string) {
 		s.internals = make(map[string]any)
 	}
 	s.internals[stateKeyReturnDirectlyToolCallID] = id
+	s.ReturnDirectlyToolCallID = id
+	s.HasReturnDirectly = id != ""
 }
 
 func (s *State) getToolGenActions() map[string]*AgentAction {
@@ -184,6 +187,7 @@ func (s *State) decrementRemainingIterations() {
 
 type stateSerialization struct {
 	Messages                 []Message
+	HasReturnDirectly        bool
 	ReturnDirectlyToolCallID string
 	ToolGenActions           map[string]*AgentAction
 	AgentName                string
@@ -199,6 +203,7 @@ func (s *State) GobEncode() ([]byte, error) {
 	}
 	ss := &stateSerialization{
 		Messages:                 s.Messages,
+		HasReturnDirectly:        s.HasReturnDirectly,
 		ReturnDirectlyToolCallID: s.getReturnDirectlyToolCallID(),
 		ToolGenActions:           s.getToolGenActions(),
 		AgentName:                s.AgentName,
@@ -226,6 +231,7 @@ func (s *State) GobDecode(b []byte) error {
 	}
 
 	s.AgentName = ss.AgentName
+	s.HasReturnDirectly = ss.HasReturnDirectly
 
 	if ss.ReturnDirectlyToolCallID != "" {
 		s.setReturnDirectlyToolCallID(ss.ReturnDirectlyToolCallID)


### PR DESCRIPTION
## Summary

| Problem | Solution |
|---------|----------|
| State.HasReturnDirectly field was removed in alpha/08, breaking backward compatibility for external users who depend on this field | Restore the field and ensure it's properly written when ReturnDirectlyToolCallID is set |

## Key Insight

The alpha/08 branch refactored internal state management to use an internals map instead of exported fields. However, the HasReturnDirectly field was directly removed without considering external users who might depend on reading this field via compose.ProcessState.

The fix ensures both the internal internals map and the exported HasReturnDirectly field are synchronized when setReturnDirectlyToolCallID is called, maintaining full backward compatibility.

## Changes

1. Add HasReturnDirectly field back to State struct - Restore the exported bool field for backward compatibility
2. Update setReturnDirectlyToolCallID method - Also set the exported ReturnDirectlyToolCallID and HasReturnDirectly fields when setting the internal state
3. Update serialization - Include HasReturnDirectly in stateSerialization struct and GobEncode/GobDecode methods

---

## 概要

| 问题 | 解决方案 |
|------|----------|
| State.HasReturnDirectly 字段在 alpha/08 中被移除，导致依赖该字段的外部用户代码不兼容 | 恢复该字段，并确保在设置 ReturnDirectlyToolCallID 时正确写入 |

## 关键洞察

alpha/08 分支重构了内部状态管理，使用 internals map 替代导出字段。但是，HasReturnDirectly 字段被直接移除，没有考虑到可能通过 compose.ProcessState 读取此字段的外部用户。

修复方案确保当调用 setReturnDirectlyToolCallID 时，内部 internals map 和导出的 HasReturnDirectly 字段同步更新，保持完全的向后兼容性。