### PR TITLE
fix: implement IsCallbacksEnabled and GetType for cancelableChatModel

### DIFF
--- a/adk/cancel_wrapper.go
+++ b/adk/cancel_wrapper.go
@@ -19,11 +19,14 @@ package adk
 import (
 	"context"
 	"io"
+	"reflect"
 	"runtime/debug"
 	"time"
 
+	"github.com/cloudwego/eino/components"
 	"github.com/cloudwego/eino/components/model"
 	"github.com/cloudwego/eino/compose"
+	"github.com/cloudwego/eino/internal/generic"
 	"github.com/cloudwego/eino/internal/safe"
 	"github.com/cloudwego/eino/schema"
 )
@@ -116,6 +119,18 @@ func (c *cancelableChatModel) Stream(ctx context.Context, input []*schema.Messag
 		return nil, compose.Interrupt(ctx, "cancelled externally")
 	}
 	return res.result, res.err
+}
+
+func (c *cancelableChatModel) IsCallbacksEnabled() bool {
+	return components.IsCallbacksEnabled(c.inner)
+}
+
+func (c *cancelableChatModel) GetType() string {
+	if name, ok := components.GetType(c.inner); ok {
+		return name
+	}
+
+	return generic.ParseTypeName(reflect.ValueOf(c.inner))
 }
 
 func cancelableToolInvokable(cs *cancelSig, endpoint compose.InvokableToolEndpoint) compose.InvokableToolEndpoint {


### PR DESCRIPTION
## Summary

This PR adds two interface methods to `cancelableChatModel` to properly propagate callback and type information from the wrapped inner model.

## Changes

- Add `IsCallbacksEnabled() bool` method to delegate callback status check to the inner model
- Add `GetType() string` method to return the type name of the inner model

## Why

The `cancelableChatModel` wraps a `model.ChatModel` to add cancellation support. However, without these methods, the wrapper would lose the ability to report:
1. Whether callbacks are enabled on the underlying model
2. The actual type name of the inner model for logging/debugging purposes

This ensures proper functionality when using the cancelable wrapper with the component callback system and type introspection.

## Testing

The implementation delegates to existing utility functions (`components.IsCallbacksEnabled`, `components.GetType`, `generic.ParseTypeName`) which are already tested.