### PR TITLE
fix(adk): prevent duplicate callback invocations in workflow agents

### DIFF
--- a/adk/call_option.go
+++ b/adk/call_option.go
@@ -44,7 +44,7 @@ func getCommonOptions(base *options, opts ...AgentRunOption) *options {
 		base = &options{}
 	}
 
-	return GetImplSpecificOptions[options](base, opts...)
+	return GetImplSpecificOptions(base, opts...)
 }
 
 // WithSessionValues sets session-scoped values for the agent run.
@@ -107,6 +107,54 @@ func GetImplSpecificOptions[T any](base *T, opts ...AgentRunOption) *T {
 	}
 
 	return base
+}
+
+// filterCallbackHandlersForNestedAgents removes callback handlers that have already been applied
+// to the current agent before passing opts to nested inner agents.
+//
+// This is necessary for workflow agents (LoopAgent, SequentialAgent, ParallelAgent) because:
+//  1. Callback handlers designated for the current agent are applied via initAgentCallbacks(),
+//     which stores them in the context.
+//  2. Nested inner agents inherit this context, so they automatically receive these callbacks.
+//  3. If we also pass these handlers in opts to inner agents, they would be applied twice,
+//     causing duplicate callback invocations.
+//
+// Note: This only applies to workflow agents where inner agents inherit context from the parent.
+// For flowAgent's sub-agents (which are peer agents that transfer to each other), the full opts
+// are passed since they don't inherit the parent's callback context.
+func filterCallbackHandlersForNestedAgents(currentAgentName string, opts []AgentRunOption) []AgentRunOption {
+	if len(opts) == 0 {
+		return nil
+	}
+	var filteredOpts []AgentRunOption
+	for i := range opts {
+		opt := opts[i]
+		if opt.implSpecificOptFn == nil {
+			filteredOpts = append(filteredOpts, opt)
+			continue
+		}
+		if _, isCallbackOpt := opt.implSpecificOptFn.(func(*options)); isCallbackOpt {
+			testOpt := &options{}
+			opt.implSpecificOptFn.(func(*options))(testOpt)
+			if len(testOpt.handlers) > 0 {
+				if len(opt.agentNames) == 0 {
+					continue
+				}
+				matched := false
+				for _, name := range opt.agentNames {
+					if name == currentAgentName {
+						matched = true
+						break
+					}
+				}
+				if matched {
+					continue
+				}
+			}
+		}
+		filteredOpts = append(filteredOpts, opt)
+	}
+	return filteredOpts
 }
 
 func filterOptions(agentName string, opts []AgentRunOption) []AgentRunOption {

--- a/adk/flow.go
+++ b/adk/flow.go
@@ -313,7 +313,7 @@ func (a *flowAgent) Run(ctx context.Context, input *AgentInput, opts ...AgentRun
 	input = processedInput
 
 	if wf, ok := a.Agent.(*workflowAgent); ok {
-		return wrapIterWithOnEnd(ctx, wf.Run(ctx, input, opts...))
+		return wrapIterWithOnEnd(ctx, wf.Run(ctx, input, filterCallbackHandlersForNestedAgents(agentName, opts)...))
 	}
 
 	aIter := a.Agent.Run(ctx, input, filterOptions(agentName, opts)...)
@@ -345,10 +345,12 @@ func (a *flowAgent) Resume(ctx context.Context, info *ResumeInfo, opts ...AgentR
 		}
 		iterator, generator := NewAsyncIteratorPair[*AgentEvent]()
 
-		aIter := ra.Resume(ctx, info, opts...)
 		if _, ok := ra.(*workflowAgent); ok {
+			filteredOpts := filterCallbackHandlersForNestedAgents(agentName, opts)
+			aIter := ra.Resume(ctx, info, filteredOpts...)
 			return wrapIterWithOnEnd(ctx, aIter)
 		}
+		aIter := ra.Resume(ctx, info, opts...)
 		go a.run(ctx, ctxForSubAgents, getRunCtx(ctxForSubAgents), aIter, generator, opts...)
 		return iterator
 	}

--- a/adk/flow_test.go
+++ b/adk/flow_test.go
@@ -18,11 +18,13 @@ package adk
 
 import (
 	"context"
+	"sync"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 	"go.uber.org/mock/gomock"
 
+	"github.com/cloudwego/eino/callbacks"
 	mockModel "github.com/cloudwego/eino/internal/mock/components/model"
 	"github.com/cloudwego/eino/schema"
 )
@@ -142,4 +144,83 @@ func TestTransferToAgent(t *testing.T) {
 	// No more events
 	_, ok = iterator.Next()
 	assert.False(t, ok)
+}
+
+func TestTransferToAgentWithDesignatedCallback(t *testing.T) {
+	ctx := context.Background()
+
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	parentModel := mockModel.NewMockToolCallingChatModel(ctrl)
+	childModel := mockModel.NewMockToolCallingChatModel(ctrl)
+
+	parentModel.EXPECT().Generate(gomock.Any(), gomock.Any(), gomock.Any()).
+		Return(schema.AssistantMessage("I'll transfer this to the child agent",
+			[]schema.ToolCall{
+				{
+					ID: "tool-call-1",
+					Function: schema.FunctionCall{
+						Name:      TransferToAgentToolName,
+						Arguments: `{"agent_name": "ChildAgent"}`,
+					},
+				},
+			}), nil).
+		Times(1)
+
+	childModel.EXPECT().Generate(gomock.Any(), gomock.Any(), gomock.Any()).
+		Return(schema.AssistantMessage("Hello from child agent", nil), nil).
+		Times(1)
+
+	parentModel.EXPECT().WithTools(gomock.Any()).Return(parentModel, nil).AnyTimes()
+	childModel.EXPECT().WithTools(gomock.Any()).Return(childModel, nil).AnyTimes()
+
+	parentAgent, err := NewChatModelAgent(ctx, &ChatModelAgentConfig{
+		Name:        "ParentAgent",
+		Description: "Parent agent that will transfer to child",
+		Instruction: "You are a parent agent.",
+		Model:       parentModel,
+	})
+	assert.NoError(t, err)
+
+	childAgent, err := NewChatModelAgent(ctx, &ChatModelAgentConfig{
+		Name:        "ChildAgent",
+		Description: "Child agent that handles specific tasks",
+		Instruction: "You are a child agent.",
+		Model:       childModel,
+	})
+	assert.NoError(t, err)
+
+	flowAgent, err := SetSubAgents(ctx, parentAgent, []Agent{childAgent})
+	assert.NoError(t, err)
+
+	var childCallbackCount int
+	var mu sync.Mutex
+
+	handler := callbacks.NewHandlerBuilder().OnStartFn(
+		func(ctx context.Context, info *callbacks.RunInfo, input callbacks.CallbackInput) context.Context {
+			if info.Component == ComponentOfAgent && info.Name == "ChildAgent" {
+				mu.Lock()
+				childCallbackCount++
+				mu.Unlock()
+			}
+			return ctx
+		}).Build()
+
+	input := &AgentInput{
+		Messages: []Message{
+			schema.UserMessage("Please transfer this to the child agent"),
+		},
+	}
+	ctx, _ = initRunCtx(ctx, flowAgent.Name(ctx), input)
+	iterator := flowAgent.Run(ctx, input, WithCallbacks(handler).DesignateAgent("ChildAgent"))
+
+	for {
+		_, ok := iterator.Next()
+		if !ok {
+			break
+		}
+	}
+
+	assert.Equal(t, 1, childCallbackCount, "designated callback for ChildAgent should fire exactly once during transfer")
 }

--- a/adk/workflow_test.go
+++ b/adk/workflow_test.go
@@ -19,10 +19,12 @@ package adk
 import (
 	"context"
 	"fmt"
+	"sync"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 
+	"github.com/cloudwego/eino/callbacks"
 	"github.com/cloudwego/eino/schema"
 )
 
@@ -1143,6 +1145,145 @@ func TestLoopAgentWithError(t *testing.T) {
 	assert.NotNil(t, errorEvent, "should have received error event")
 	assert.Contains(t, errorEvent.Err.Error(), "error on iteration 3")
 	assert.Equal(t, 3, iterationCount, "loop should stop at iteration 3")
+}
+
+func TestWorkflowCallbackHandlerNotDoubled(t *testing.T) {
+	ctx := context.Background()
+	store := newMyStore()
+
+	var globalCallbackCount int
+	var designatedCallbackCount int
+	var mu sync.Mutex
+
+	globalHandler := callbacks.NewHandlerBuilder().OnStartFn(
+		func(ctx context.Context, info *callbacks.RunInfo, input callbacks.CallbackInput) context.Context {
+			if info.Component == ComponentOfAgent && info.Name == "SubSubAgent" {
+				mu.Lock()
+				globalCallbackCount++
+				mu.Unlock()
+			}
+			return ctx
+		}).Build()
+
+	designatedHandler := callbacks.NewHandlerBuilder().OnStartFn(
+		func(ctx context.Context, info *callbacks.RunInfo, input callbacks.CallbackInput) context.Context {
+			if info.Component == ComponentOfAgent && info.Name == "SubSubAgent" {
+				mu.Lock()
+				designatedCallbackCount++
+				mu.Unlock()
+			}
+			return ctx
+		}).Build()
+
+	iterationCount := 0
+	shouldInterrupt := true
+	subSubAgent := &myAgent{
+		name: "SubSubAgent",
+		runFn: func(ctx context.Context, input *AgentInput, options ...AgentRunOption) *AsyncIterator[*AgentEvent] {
+			iter, generator := NewAsyncIteratorPair[*AgentEvent]()
+			go func() {
+				defer generator.Close()
+				iterationCount++
+				if shouldInterrupt && iterationCount == 2 {
+					generator.Send(Interrupt(ctx, "test_interrupt"))
+					return
+				}
+				generator.Send(&AgentEvent{
+					Output: &AgentOutput{
+						MessageOutput: &MessageVariant{
+							Message: schema.AssistantMessage(fmt.Sprintf("iteration %d", iterationCount), nil),
+							Role:    schema.Assistant,
+						},
+					},
+				})
+			}()
+			return iter
+		},
+		resumeFn: func(ctx context.Context, info *ResumeInfo, opts ...AgentRunOption) *AsyncIterator[*AgentEvent] {
+			iter, generator := NewAsyncIteratorPair[*AgentEvent]()
+			go func() {
+				defer generator.Close()
+				iterationCount++
+				generator.Send(&AgentEvent{
+					Output: &AgentOutput{
+						MessageOutput: &MessageVariant{
+							Message: schema.AssistantMessage(fmt.Sprintf("resumed iteration %d", iterationCount), nil),
+							Role:    schema.Assistant,
+						},
+					},
+				})
+			}()
+			return iter
+		},
+	}
+
+	subWorkflow, err := NewLoopAgent(ctx, &LoopAgentConfig{
+		Name:          "SubWorkflow",
+		SubAgents:     []Agent{subSubAgent},
+		MaxIterations: 2,
+	})
+	assert.NoError(t, err)
+
+	parentWorkflow, err := NewLoopAgent(ctx, &LoopAgentConfig{
+		Name:          "ParentWorkflow",
+		SubAgents:     []Agent{subWorkflow},
+		MaxIterations: 2,
+	})
+	assert.NoError(t, err)
+
+	runner := NewRunner(ctx, RunnerConfig{
+		Agent:           parentWorkflow,
+		CheckPointStore: store,
+	})
+
+	opts := []AgentRunOption{
+		WithCallbacks(globalHandler),
+		WithCallbacks(designatedHandler).DesignateAgent("ParentWorkflow", "SubSubAgent"),
+		WithCheckPointID("cp1"),
+	}
+
+	iterator := runner.Run(ctx, []Message{schema.UserMessage("test")}, opts...)
+
+	var interruptEvent *AgentEvent
+	for {
+		event, ok := iterator.Next()
+		if !ok {
+			break
+		}
+		if event.Action != nil && event.Action.Interrupted != nil {
+			interruptEvent = event
+		}
+	}
+
+	assert.NotNil(t, interruptEvent)
+	assert.Equal(t, 2, iterationCount)
+	assert.Equal(t, 2, globalCallbackCount)
+	assert.Equal(t, 2, designatedCallbackCount)
+
+	shouldInterrupt = false
+	var rootCauseID string
+	for _, intCtx := range interruptEvent.Action.Interrupted.InterruptContexts {
+		if intCtx.IsRootCause {
+			rootCauseID = intCtx.ID
+			break
+		}
+	}
+
+	resumeIter, err := runner.ResumeWithParams(ctx, "cp1", &ResumeParams{
+		Targets: map[string]any{rootCauseID: nil},
+	}, opts...)
+	assert.NoError(t, err)
+
+	for {
+		_, ok := resumeIter.Next()
+		if !ok {
+			break
+		}
+	}
+
+	assert.Equal(t, 5, iterationCount)
+	assert.Equal(t, 5, globalCallbackCount)
+	assert.Equal(t, 5, designatedCallbackCount)
 }
 
 func TestLoopAgentWithBreakLoopFollowedByMoreEvents(t *testing.T) {


### PR DESCRIPTION
## Summary

| Problem | Solution |
|---------|----------|
| Callback handlers were invoked twice in workflow agents (LoopAgent, SequentialAgent, ParallelAgent) | Filter out callback handlers that have already been applied to the current agent before passing opts to nested inner agents |

## Key Insight

**Context-Inherited Callbacks Must Not Be Re-Applied via Options**

Workflow agents have a unique execution model where inner agents inherit the parent's context. When callback handlers are designated for the parent workflow (e.g., `WithCallbacks(handler).DesignateAgent("ParentWorkflow", "ChildAgent")`), they are:

1. Applied via `initAgentCallbacks()` which stores them in the context
2. Automatically inherited by nested inner agents through context propagation

If we also pass these handlers in `opts` to inner agents, they would be applied twice - once via context inheritance and once via explicit opts. This is different from flowAgent's sub-agents, which are peer agents that transfer to each other and don't inherit the parent's callback context.

The fix introduces `filterCallbackHandlersForNestedAgents()` which:
- Removes global callback handlers (no agent designation) since they're already in context
- Removes callback handlers designated for the current agent since they're already applied
- Keeps callback handlers designated for other agents (they need to be passed through)

## Changes

- `adk/call_option.go`: Added `filterCallbackHandlersForNestedAgents()` function with detailed documentation
- `adk/flow.go`: Applied filter for workflow agents in both Run and Resume paths
- `adk/workflow_test.go`: Added `TestWorkflowCallbackHandlerNotDoubled` covering nested workflows with interrupt/resume
- `adk/flow_test.go`: Added `TestTransferToAgentWithDesignatedCallback` for transfer scenarios

---

## 摘要

| 问题 | 解决方案 |
|------|----------|
| workflow agent（LoopAgent、SequentialAgent、ParallelAgent）中 callback handler 被调用两次 | 在将 opts 传递给嵌套内部 agent 之前，过滤掉已经应用到当前 agent 的 callback handler |

## 关键洞察

**通过 context 继承的 callback 不应该通过 options 重复应用**

Workflow agents 有独特的执行模型，内部 agent 会继承父级的 context。当 callback handler 被指定给父 workflow 时（如 `WithCallbacks(handler).DesignateAgent("ParentWorkflow", "ChildAgent")`），它们会：

1. 通过 `initAgentCallbacks()` 应用并存储在 context 中
2. 通过 context 传播自动被嵌套内部 agent 继承

如果我们同时将这些 handler 通过 `opts` 传递给内部 agent，它们会被应用两次——一次通过 context 继承，一次通过显式的 opts。这与 flowAgent 的 sub-agents 不同，后者是相互转移的对等 agent，不继承父级的 callback context。

修复引入了 `filterCallbackHandlersForNestedAgents()` 函数，它会：
- 移除全局 callback handler（没有 agent 指定），因为它们已经在 context 中
- 移除指定给当前 agent 的 callback handler，因为它们已经被应用
- 保留指定给其他 agent 的 callback handler（它们需要被传递）

## 变更

- `adk/call_option.go`: 添加了 `filterCallbackHandlersForNestedAgents()` 函数及详细文档
- `adk/flow.go`: 在 Run 和 Resume 路径中为 workflow agent 应用过滤
- `adk/workflow_test.go`: 添加了 `TestWorkflowCallbackHandlerNotDoubled` 测试，覆盖嵌套 workflow 的 interrupt/resume
- `adk/flow_test.go`: 添加了 `TestTransferToAgentWithDesignatedCallback` 测试 transfer 场景