### PR TITLE
refactor(filesystem): optimize Read to return FileContent and avoid allocations

### DIFF
--- a/adk/filesystem/backend.go
+++ b/adk/filesystem/backend.go
@@ -54,15 +54,13 @@ type GrepMatch struct {
 
 // LsInfoRequest contains parameters for listing file information.
 type LsInfoRequest struct {
-	// Path specifies the absolute directory path to list.
-	// It must be an absolute path starting with '/'.
-	// An empty string is treated as the root directory ("/").
+	// Path specifies the directory path to list.
 	Path string
 }
 
 // ReadRequest contains parameters for reading file content.
 type ReadRequest struct {
-	// FilePath is the absolute path to the file to be read. Must start with '/'.
+	// FilePath is the path to the file to be read.
 	FilePath string
 
 	// Offset specifies the starting line number (1-based) for reading.
@@ -90,7 +88,6 @@ type GrepRequest struct {
 	Pattern string
 
 	// Path is an optional directory path to limit the search scope.
-	// If empty, the search is performed from the working directory.
 	Path string
 
 	// ===== File Filtering =====
@@ -141,14 +138,12 @@ type GlobInfoRequest struct {
 	Pattern string
 
 	// Path is the base directory from which to start the search.
-	// The glob pattern is applied relative to this path. Defaults to the root directory ("/").
 	Path string
 }
 
 // WriteRequest contains parameters for writing file content.
 type WriteRequest struct {
-	// FilePath is the absolute path of the file to write. Must start with '/'.
-	// Creates the file if it does not exist, overwrites if it exists.
+	// FilePath is the path of the file to write.
 	FilePath string
 
 	// Content is the data to be written to the file.
@@ -157,7 +152,7 @@ type WriteRequest struct {
 
 // EditRequest contains parameters for editing file content.
 type EditRequest struct {
-	// FilePath is the absolute path of the file to edit. Must start with '/'.
+	// FilePath is the path of the file to edit.
 	FilePath string
 
 	// OldString is the exact string to be replaced. It must be non-empty and will be matched literally, including whitespace.
@@ -172,6 +167,10 @@ type EditRequest struct {
 	// If true, all occurrences of OldString are replaced.
 	// If false, the operation fails unless OldString appears exactly once in the file.
 	ReplaceAll bool
+}
+
+type FileContent struct {
+	Content string
 }
 
 // Backend is a pluggable, unified file backend protocol interface.
@@ -191,7 +190,7 @@ type Backend interface {
 	// Returns:
 	//   - string: The file content read
 	//   - error: Error if file does not exist or read fails
-	Read(ctx context.Context, req *ReadRequest) (string, error)
+	Read(ctx context.Context, req *ReadRequest) (*FileContent, error)
 
 	// GrepRaw searches for content matching the specified pattern in files.
 	//

--- a/adk/filesystem/backend_inmemory.go
+++ b/adk/filesystem/backend_inmemory.go
@@ -133,7 +133,7 @@ func mustParseTime(s string) time.Time {
 }
 
 // Read reads file content with offset and limit.
-func (b *InMemoryBackend) Read(ctx context.Context, req *ReadRequest) (string, error) {
+func (b *InMemoryBackend) Read(ctx context.Context, req *ReadRequest) (*FileContent, error) {
 	b.mu.RLock()
 	defer b.mu.RUnlock()
 
@@ -141,38 +141,53 @@ func (b *InMemoryBackend) Read(ctx context.Context, req *ReadRequest) (string, e
 
 	entry, exists := b.files[filePath]
 	if !exists {
-		return "", fmt.Errorf("file not found: %s", filePath)
+		return nil, fmt.Errorf("file not found: %s", filePath)
 	}
 
-	offset := req.Offset
+	// Convert 1-based offset to 0-based index; values < 1 default to line 1
+	offset := req.Offset - 1
 	if offset < 0 {
 		offset = 0
 	}
 	limit := req.Limit
 	if limit <= 0 {
-		limit = 200
+		limit = 2000
 	}
 
-	lines := strings.Split(entry.content, "\n")
-	totalLines := len(lines)
+	content := entry.content
 
-	if offset >= totalLines {
-		return "", nil
+	// Fast path: no offset, content fits within limit — return as-is
+	if offset == 0 {
+		lineCount := strings.Count(content, "\n") + 1
+		if lineCount <= limit {
+			return &FileContent{Content: content}, nil
+		}
 	}
 
-	end := offset + limit
-	if end > totalLines {
-		end = totalLines
+	// Skip `offset` lines by scanning for newlines directly
+	start := 0
+	for i := 0; i < offset; i++ {
+		idx := strings.IndexByte(content[start:], '\n')
+		if idx == -1 {
+			// offset exceeds total lines
+			return &FileContent{}, nil
+		}
+		start += idx + 1
 	}
 
-	sb := &strings.Builder{}
-	i := offset
-	for ; i < end-1; i++ {
-		sb.WriteString(fmt.Sprintf("%6d\t%s\n", i+1, lines[i]))
+	// Find the end position after `limit` lines
+	end := start
+	for i := 0; i < limit; i++ {
+		idx := strings.IndexByte(content[end:], '\n')
+		if idx == -1 {
+			// Reached the end of content
+			return &FileContent{Content: content[start:]}, nil
+		}
+		end += idx + 1
 	}
-	sb.WriteString(fmt.Sprintf("%6d\t%s", i+1, lines[i]))
 
-	return sb.String(), nil
+	// Trim the trailing newline from the last included line
+	return &FileContent{Content: content[start : end-1]}, nil
 }
 
 // GrepRaw returns matches for the given pattern.

--- a/adk/filesystem/backend_inmemory_test.go
+++ b/adk/filesystem/backend_inmemory_test.go
@@ -46,9 +46,9 @@ func TestInMemoryBackend_WriteAndRead(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Read failed: %v", err)
 	}
-	expected := "     1\tline1\n     2\tline2\n     3\tline3\n     4\tline4\n     5\tline5"
-	if content != expected {
-		t.Errorf("Read content mismatch. Expected: %q, Got: %q", expected, content)
+	expected := "line1\nline2\nline3\nline4\nline5"
+	if content.Content != expected {
+		t.Errorf("Read content mismatch. Expected: %q, Got: %q", expected, content.Content)
 	}
 
 	// Test Read - with offset and limit
@@ -60,9 +60,9 @@ func TestInMemoryBackend_WriteAndRead(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Read with offset failed: %v", err)
 	}
-	expected = "     2\tline2\n     3\tline3"
-	if content != expected {
-		t.Errorf("Read with offset content mismatch. Expected: %q, Got: %q", expected, content)
+	expected = "line1\nline2"
+	if content.Content != expected {
+		t.Errorf("Read with offset content mismatch. Expected: %q, Got: %q", expected, content.Content)
 	}
 
 	// Test Read - non-existent file
@@ -160,9 +160,9 @@ func TestInMemoryBackend_Edit(t *testing.T) {
 		FilePath: "/edit2.txt",
 		Limit:    100,
 	})
-	expected := "     1\thi world\n     2\thi again\n     3\thi world"
-	if content != expected {
-		t.Errorf("Edit (replace all) content mismatch. Expected: %q, Got: %q", expected, content)
+	expected := "hi world\nhi again\nhi world"
+	if content.Content != expected {
+		t.Errorf("Edit (replace all) content mismatch. Expected: %q, Got: %q", expected, content.Content)
 	}
 
 	// Test Edit - non-existent file
@@ -1153,9 +1153,9 @@ func TestInMemoryBackend_Read_EdgeCases(t *testing.T) {
 		if err != nil {
 			t.Fatalf("Read failed: %v", err)
 		}
-		expected := "     1\tline1\n     2\tline2"
-		if content != expected {
-			t.Errorf("Expected: %q, Got: %q", expected, content)
+		expected := "line1\nline2"
+		if content.Content != expected {
+			t.Errorf("Expected: %q, Got: %q", expected, content.Content)
 		}
 	})
 
@@ -1168,8 +1168,8 @@ func TestInMemoryBackend_Read_EdgeCases(t *testing.T) {
 		if err != nil {
 			t.Fatalf("Read failed: %v", err)
 		}
-		if content != "" {
-			t.Errorf("Expected empty content, got: %q", content)
+		if content.Content != "" {
+			t.Errorf("Expected empty content, got: %q", content.Content)
 		}
 	})
 
@@ -1182,7 +1182,7 @@ func TestInMemoryBackend_Read_EdgeCases(t *testing.T) {
 		if err != nil {
 			t.Fatalf("Read failed: %v", err)
 		}
-		lines := strings.Split(content, "\n")
+		lines := strings.Split(content.Content, "\n")
 		if len(lines) != 3 {
 			t.Errorf("Expected 3 lines, got %d", len(lines))
 		}
@@ -1197,9 +1197,9 @@ func TestInMemoryBackend_Read_EdgeCases(t *testing.T) {
 		if err != nil {
 			t.Fatalf("Read failed: %v", err)
 		}
-		lines := strings.Split(content, "\n")
-		if len(lines) != 2 {
-			t.Errorf("Expected 2 lines, got %d", len(lines))
+		lines := strings.Split(content.Content, "\n")
+		if len(lines) != 3 {
+			t.Errorf("Expected 3 lines, got %d", len(lines))
 		}
 	})
 }
@@ -1300,7 +1300,7 @@ func TestInMemoryBackend_Edit_EdgeCases(t *testing.T) {
 			FilePath: "/test.txt",
 			Limit:    100,
 		})
-		if !strings.Contains(content, "FOO") {
+		if !strings.Contains(content.Content, "FOO") {
 			t.Error("Expected content to contain 'FOO'")
 		}
 	})
@@ -1325,10 +1325,10 @@ func TestInMemoryBackend_Edit_EdgeCases(t *testing.T) {
 			FilePath: "/test.txt",
 			Limit:    100,
 		})
-		if strings.Contains(content, "foo") {
+		if strings.Contains(content.Content, "foo") {
 			t.Error("Expected all 'foo' to be replaced")
 		}
-		fooCount := strings.Count(content, "FOO")
+		fooCount := strings.Count(content.Content, "FOO")
 		if fooCount != 3 {
 			t.Errorf("Expected 3 occurrences of 'FOO', got %d", fooCount)
 		}
@@ -1364,7 +1364,7 @@ func TestInMemoryBackend_NormalizePath(t *testing.T) {
 			if err != nil {
 				t.Errorf("Failed to read normalized path %s (from %s): %v", tc.normalizedPath, tc.inputPath, err)
 			}
-			if !strings.Contains(content, "content") {
+			if !strings.Contains(content.Content, "content") {
 				t.Errorf("Content not found for normalized path %s (from %s)", tc.normalizedPath, tc.inputPath)
 			}
 		}
@@ -2211,6 +2211,149 @@ func TestInMemoryBackend_GrepRaw_ComplexScenarios(t *testing.T) {
 			if filepath.Base(match.Path) != "main.go" {
 				t.Errorf("Expected filename 'main.go', got: %s", match.Path)
 			}
+		}
+	})
+}
+
+func TestInMemoryBackend_Read_Scenarios(t *testing.T) {
+	ctx := context.Background()
+
+	t.Run("empty file returns empty content", func(t *testing.T) {
+		backend := NewInMemoryBackend()
+		backend.Write(ctx, &WriteRequest{FilePath: "/empty.txt", Content: ""})
+
+		content, err := backend.Read(ctx, &ReadRequest{FilePath: "/empty.txt"})
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if content.Content != "" {
+			t.Errorf("expected empty content, got %q", content.Content)
+		}
+	})
+
+	t.Run("single-line file without newline", func(t *testing.T) {
+		backend := NewInMemoryBackend()
+		backend.Write(ctx, &WriteRequest{FilePath: "/single.txt", Content: "hello"})
+
+		content, err := backend.Read(ctx, &ReadRequest{FilePath: "/single.txt"})
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if content.Content != "hello" {
+			t.Errorf("expected %q, got %q", "hello", content.Content)
+		}
+	})
+
+	t.Run("offset 0 and offset 1 both start from first line", func(t *testing.T) {
+		backend := NewInMemoryBackend()
+		backend.Write(ctx, &WriteRequest{FilePath: "/f.txt", Content: "a\nb\nc"})
+
+		c0, _ := backend.Read(ctx, &ReadRequest{FilePath: "/f.txt", Offset: 0, Limit: 1})
+		c1, _ := backend.Read(ctx, &ReadRequest{FilePath: "/f.txt", Offset: 1, Limit: 1})
+		if c0.Content != c1.Content {
+			t.Errorf("Offset=0 (%q) and Offset=1 (%q) should return the same first line", c0.Content, c1.Content)
+		}
+		if c0.Content != "a" {
+			t.Errorf("expected first line %q, got %q", "a", c0.Content)
+		}
+	})
+
+	t.Run("file with trailing newline preserves trailing empty line", func(t *testing.T) {
+		backend := NewInMemoryBackend()
+		backend.Write(ctx, &WriteRequest{FilePath: "/trail.txt", Content: "line1\nline2\n"})
+
+		content, err := backend.Read(ctx, &ReadRequest{FilePath: "/trail.txt"})
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if content.Content != "line1\nline2\n" {
+			t.Errorf("expected %q, got %q", "line1\nline2\n", content.Content)
+		}
+		lines := strings.Split(content.Content, "\n")
+		if len(lines) != 3 { // ["line1", "line2", ""]
+			t.Errorf("expected 3 elements from split, got %d", len(lines))
+		}
+	})
+
+	t.Run("offset exactly at last line", func(t *testing.T) {
+		backend := NewInMemoryBackend()
+		backend.Write(ctx, &WriteRequest{FilePath: "/f.txt", Content: "a\nb\nc"})
+
+		// Offset=3 (1-based) → last line "c"
+		content, err := backend.Read(ctx, &ReadRequest{FilePath: "/f.txt", Offset: 3, Limit: 10})
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if content.Content != "c" {
+			t.Errorf("expected %q, got %q", "c", content.Content)
+		}
+	})
+
+	t.Run("offset one beyond last line returns empty", func(t *testing.T) {
+		backend := NewInMemoryBackend()
+		backend.Write(ctx, &WriteRequest{FilePath: "/f.txt", Content: "a\nb\nc"})
+
+		content, err := backend.Read(ctx, &ReadRequest{FilePath: "/f.txt", Offset: 4, Limit: 10})
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if content.Content != "" {
+			t.Errorf("expected empty content, got %q", content.Content)
+		}
+	})
+
+	t.Run("limit=1 reads exactly one line", func(t *testing.T) {
+		backend := NewInMemoryBackend()
+		backend.Write(ctx, &WriteRequest{FilePath: "/f.txt", Content: "a\nb\nc"})
+
+		for i, expected := range []string{"a", "b", "c"} {
+			content, err := backend.Read(ctx, &ReadRequest{FilePath: "/f.txt", Offset: i + 1, Limit: 1})
+			if err != nil {
+				t.Fatalf("line %d: unexpected error: %v", i+1, err)
+			}
+			if content.Content != expected {
+				t.Errorf("line %d: expected %q, got %q", i+1, expected, content.Content)
+			}
+		}
+	})
+
+	t.Run("sliding window reads consecutive ranges correctly", func(t *testing.T) {
+		backend := NewInMemoryBackend()
+		backend.Write(ctx, &WriteRequest{FilePath: "/f.txt", Content: "l1\nl2\nl3\nl4\nl5"})
+
+		tests := []struct {
+			offset   int
+			limit    int
+			expected string
+		}{
+			{1, 2, "l1\nl2"},
+			{2, 2, "l2\nl3"},
+			{3, 2, "l3\nl4"},
+			{4, 2, "l4\nl5"},
+			{5, 2, "l5"},
+		}
+		for _, tt := range tests {
+			content, err := backend.Read(ctx, &ReadRequest{FilePath: "/f.txt", Offset: tt.offset, Limit: tt.limit})
+			if err != nil {
+				t.Fatalf("offset=%d limit=%d: unexpected error: %v", tt.offset, tt.limit, err)
+			}
+			if content.Content != tt.expected {
+				t.Errorf("offset=%d limit=%d: expected %q, got %q", tt.offset, tt.limit, tt.expected, content.Content)
+			}
+		}
+	})
+
+	t.Run("file with only newlines", func(t *testing.T) {
+		backend := NewInMemoryBackend()
+		backend.Write(ctx, &WriteRequest{FilePath: "/newlines.txt", Content: "\n\n\n"})
+
+		content, err := backend.Read(ctx, &ReadRequest{FilePath: "/newlines.txt", Offset: 2, Limit: 1})
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		// Line 2 is an empty string between two newlines
+		if content.Content != "" {
+			t.Errorf("expected empty line content, got %q", content.Content)
 		}
 	})
 }

--- a/adk/middlewares/filesystem/backend.go
+++ b/adk/middlewares/filesystem/backend.go
@@ -29,3 +29,4 @@ type GrepRequest = filesystem.GrepRequest
 type GlobInfoRequest = filesystem.GlobInfoRequest
 type WriteRequest = filesystem.WriteRequest
 type EditRequest = filesystem.EditRequest
+type FileContent = filesystem.FileContent

--- a/adk/middlewares/filesystem/filesystem.go
+++ b/adk/middlewares/filesystem/filesystem.go
@@ -561,11 +561,31 @@ func newReadFileTool(fs filesystem.Backend, name string, desc string) (tool.Base
 		return nil, err
 	}
 	return utils.InferTool(toolName, d, func(ctx context.Context, input readFileArgs) (string, error) {
-		return fs.Read(ctx, &filesystem.ReadRequest{
+		if input.Offset <= 0 {
+			input.Offset = 1
+		}
+
+		fileCt, err := fs.Read(ctx, &filesystem.ReadRequest{
 			FilePath: input.FilePath,
 			Offset:   input.Offset,
 			Limit:    input.Limit,
 		})
+		if err != nil {
+			return "", err
+		}
+
+		startLine := input.Offset
+		lines := strings.Split(fileCt.Content, "\n")
+		var b strings.Builder
+		for i, line := range lines {
+			if i < len(lines)-1 {
+				fmt.Fprintf(&b, "%6d\t%s\n", startLine+i, line)
+			} else {
+				fmt.Fprintf(&b, "%6d\t%s", startLine+i, line)
+			}
+
+		}
+		return b.String(), nil
 	})
 }
 

--- a/adk/middlewares/filesystem/filesystem_test.go
+++ b/adk/middlewares/filesystem/filesystem_test.go
@@ -138,7 +138,7 @@ func TestReadFileTool(t *testing.T) {
 		{
 			name:     "read with offset",
 			input:    `{"file_path": "/file1.txt", "offset": 2, "limit": 2}`,
-			expected: "     3\tline3\n     4\tline4",
+			expected: "     2\tline2\n     3\tline3",
 		},
 		{
 			name:     "read with default limit",
@@ -230,7 +230,7 @@ func TestWriteFileTool(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Failed to read written file: %v", err)
 	}
-	if content != "     1\tnew content" {
+	if content.Content != "new content" {
 		t.Errorf("Expected written content to be 'new content', got %q", content)
 	}
 }
@@ -255,14 +255,14 @@ func TestEditFileTool(t *testing.T) {
 			setupFile:    "/edit1.txt",
 			setupContent: "hello world\nhello again\nhello world",
 			input:        `{"file_path": "/edit1.txt", "old_string": "hello again", "new_string": "hi", "replace_all": false}`,
-			expected:     "     1\thello world\n     2\thi\n     3\thello world",
+			expected:     "hello world\nhi\nhello world",
 		},
 		{
 			name:         "replace all occurrences",
 			setupFile:    "/edit2.txt",
 			setupContent: "hello world\nhello again\nhello world",
 			input:        `{"file_path": "/edit2.txt", "old_string": "hello", "new_string": "hi", "replace_all": true}`,
-			expected:     "     1\thi world\n     2\thi again\n     3\thi world",
+			expected:     "hi world\nhi again\nhi world",
 		},
 		{
 			name:         "non-existent file",
@@ -309,8 +309,8 @@ func TestEditFileTool(t *testing.T) {
 			if err != nil {
 				t.Fatalf("edit_file tool failed: %v", err)
 			}
-			if result != tt.expected {
-				t.Errorf("Expected %q, got %q", tt.expected, result)
+			if result.Content != tt.expected {
+				t.Errorf("Expected %q, got %q", tt.expected, result.Content)
 			}
 		})
 	}
@@ -412,7 +412,7 @@ func TestGrepTool(t *testing.T) {
 			expected: "/dir1/file3.txt:2\n\nFound 2 total occurrences across 1 file.", // only in file3.txt
 		},
 		{
-			name:     "grep with path filter",
+			name:     "grep  withpath filter",
 			input:    `{"pattern": "package", "path": "/dir2", "output_mode": "count"}`,
 			expected: "/dir2/file5.go:1\n\nFound 1 total occurrence across 1 file.", // only in dir2/file5.go
 		},
@@ -1515,13 +1515,13 @@ func TestGetFilesystemTools_DisableAllTools(t *testing.T) {
 	backend := setupTestBackend()
 
 	config := &MiddlewareConfig{
-		Backend:            backend,
-		LsToolConfig:       &ToolConfig{Disable: true},
-		ReadFileToolConfig: &ToolConfig{Disable: true},
+		Backend:             backend,
+		LsToolConfig:        &ToolConfig{Disable: true},
+		ReadFileToolConfig:  &ToolConfig{Disable: true},
 		WriteFileToolConfig: &ToolConfig{Disable: true},
-		EditFileToolConfig: &ToolConfig{Disable: true},
-		GlobToolConfig:     &ToolConfig{Disable: true},
-		GrepToolConfig:     &ToolConfig{Disable: true},
+		EditFileToolConfig:  &ToolConfig{Disable: true},
+		GlobToolConfig:      &ToolConfig{Disable: true},
+		GrepToolConfig:      &ToolConfig{Disable: true},
 	}
 
 	tools, err := getFilesystemTools(ctx, config)

--- a/adk/middlewares/filesystem/large_tool_result_test.go
+++ b/adk/middlewares/filesystem/large_tool_result_test.go
@@ -44,12 +44,12 @@ func (m *mockBackend) Write(ctx context.Context, req *WriteRequest) error {
 	return nil
 }
 
-func (m *mockBackend) Read(ctx context.Context, req *ReadRequest) (string, error) {
+func (m *mockBackend) Read(ctx context.Context, req *ReadRequest) (*FileContent, error) {
 	content, ok := m.files[req.FilePath]
 	if !ok {
-		return "", errors.New("file not found")
+		return nil, errors.New("file not found")
 	}
-	return content, nil
+	return &FileContent{Content: content}, nil
 }
 
 func (m *mockBackend) LsInfo(ctx context.Context, _ *LsInfoRequest) ([]FileInfo, error) {
@@ -590,8 +590,8 @@ func (f *failingBackend) Write(ctx context.Context, req *WriteRequest) error {
 	return nil
 }
 
-func (f *failingBackend) Read(ctx context.Context, req *ReadRequest) (string, error) {
-	return "", nil
+func (f *failingBackend) Read(ctx context.Context, req *ReadRequest) (*FileContent, error) {
+	return &FileContent{}, nil
 }
 
 func (f *failingBackend) LsInfo(ctx context.Context, _ *LsInfoRequest) ([]FileInfo, error) {

--- a/adk/middlewares/plantask/backend_test.go
+++ b/adk/middlewares/plantask/backend_test.go
@@ -22,6 +22,8 @@ import (
 	"path/filepath"
 	"strings"
 	"sync"
+
+	fspkg "github.com/cloudwego/eino/adk/filesystem"
 )
 
 type inMemoryBackend struct {
@@ -50,15 +52,15 @@ func (b *inMemoryBackend) LsInfo(ctx context.Context, req *LsInfoRequest) ([]Fil
 	return result, nil
 }
 
-func (b *inMemoryBackend) Read(ctx context.Context, req *ReadRequest) (string, error) {
+func (b *inMemoryBackend) Read(ctx context.Context, req *ReadRequest) (*fspkg.FileContent, error) {
 	b.mu.RLock()
 	defer b.mu.RUnlock()
 
 	content, ok := b.files[req.FilePath]
 	if !ok {
-		return "", errors.New("file not found")
+		return nil, errors.New("file not found")
 	}
-	return content, nil
+	return &fspkg.FileContent{Content: content}, nil
 }
 
 func (b *inMemoryBackend) Write(ctx context.Context, req *WriteRequest) error {

--- a/adk/middlewares/plantask/task.go
+++ b/adk/middlewares/plantask/task.go
@@ -65,7 +65,7 @@ type Backend interface {
 	// LsInfo lists file information in the specified directory.
 	LsInfo(ctx context.Context, req *LsInfoRequest) ([]FileInfo, error)
 	// Read reads the content of a file.
-	Read(ctx context.Context, req *ReadRequest) (string, error)
+	Read(ctx context.Context, req *ReadRequest) (*filesystem.FileContent, error)
 	// Write writes content to a file, creating it if it doesn't exist.
 	Write(ctx context.Context, req *WriteRequest) error
 	// Delete removes a file from storage.

--- a/adk/middlewares/plantask/task_create.go
+++ b/adk/middlewares/plantask/task_create.go
@@ -112,9 +112,9 @@ func (t *taskCreateTool) InvokableRun(ctx context.Context, argumentsInJSON strin
 			if readErr != nil {
 				return "", fmt.Errorf("%s read highwatermark file %s failed, err: %w", TaskCreateToolName, file.Path, readErr)
 			}
-			if content != "" {
+			if content.Content != "" {
 				var val int64
-				if _, scanErr := fmt.Sscanf(content, "%d", &val); scanErr == nil {
+				if _, scanErr := fmt.Sscanf(content.Content, "%d", &val); scanErr == nil {
 					highwatermark = val
 				}
 			}

--- a/adk/middlewares/plantask/task_create_test.go
+++ b/adk/middlewares/plantask/task_create_test.go
@@ -47,7 +47,7 @@ func TestTaskCreateTool(t *testing.T) {
 	assert.NoError(t, err)
 
 	var taskData task
-	err = sonic.UnmarshalString(content, &taskData)
+	err = sonic.UnmarshalString(content.Content, &taskData)
 	assert.NoError(t, err)
 	assert.Equal(t, "1", taskData.ID)
 	assert.Equal(t, "Test Task", taskData.Subject)
@@ -57,7 +57,7 @@ func TestTaskCreateTool(t *testing.T) {
 
 	hwContent, err := backend.Read(ctx, &ReadRequest{FilePath: filepath.Join(baseDir, highWatermarkFileName)})
 	assert.NoError(t, err)
-	assert.Equal(t, "1", hwContent)
+	assert.Equal(t, "1", hwContent.Content)
 
 	result, err = tool.InvokableRun(ctx, `{"subject": "Second Task", "description": "Second description"}`)
 	assert.NoError(t, err)
@@ -65,7 +65,7 @@ func TestTaskCreateTool(t *testing.T) {
 
 	hwContent, err = backend.Read(ctx, &ReadRequest{FilePath: filepath.Join(baseDir, highWatermarkFileName)})
 	assert.NoError(t, err)
-	assert.Equal(t, "2", hwContent)
+	assert.Equal(t, "2", hwContent.Content)
 }
 
 func TestTaskCreateToolWithMetadata(t *testing.T) {
@@ -84,7 +84,7 @@ func TestTaskCreateToolWithMetadata(t *testing.T) {
 	assert.NoError(t, err)
 
 	var taskData task
-	err = sonic.UnmarshalString(content, &taskData)
+	err = sonic.UnmarshalString(content.Content, &taskData)
 	assert.NoError(t, err)
 	assert.Equal(t, "value1", taskData.Metadata["key1"])
 	assert.Equal(t, "value2", taskData.Metadata["key2"])

--- a/adk/middlewares/plantask/task_get.go
+++ b/adk/middlewares/plantask/task_get.go
@@ -88,7 +88,7 @@ func (t *taskGetTool) InvokableRun(ctx context.Context, argumentsInJSON string, 
 	}
 
 	taskData := &task{}
-	err = sonic.UnmarshalString(content, taskData)
+	err = sonic.UnmarshalString(content.Content, taskData)
 	if err != nil {
 		return "", fmt.Errorf("%s get Task #%s failed, err: %w", TaskGetToolName, params.TaskID, err)
 	}

--- a/adk/middlewares/plantask/task_list.go
+++ b/adk/middlewares/plantask/task_list.go
@@ -82,7 +82,7 @@ func listTasks(ctx context.Context, backend Backend, baseDir string) ([]*task, e
 		}
 
 		taskData := &task{}
-		err = sonic.UnmarshalString(content, taskData)
+		err = sonic.UnmarshalString(content.Content, taskData)
 		if err != nil {
 			return nil, fmt.Errorf("%s parse task file %s failed, err: %w", TaskListToolName, file.Path, err)
 		}

--- a/adk/middlewares/plantask/task_update.go
+++ b/adk/middlewares/plantask/task_update.go
@@ -166,7 +166,7 @@ func (t *taskUpdateTool) InvokableRun(ctx context.Context, argumentsInJSON strin
 	}
 
 	taskData := &task{}
-	err = sonic.UnmarshalString(content, taskData)
+	err = sonic.UnmarshalString(content.Content, taskData)
 	if err != nil {
 		return "", fmt.Errorf("%s parse Task #%s failed, err: %w", TaskUpdateToolName, params.TaskID, err)
 	}
@@ -341,7 +341,7 @@ func (t *taskUpdateTool) addBlockedByToTask(ctx context.Context, targetTaskID, b
 	}
 
 	targetTask := &task{}
-	if unmarshalErr := sonic.UnmarshalString(content, targetTask); unmarshalErr != nil {
+	if unmarshalErr := sonic.UnmarshalString(content.Content, targetTask); unmarshalErr != nil {
 		return fmt.Errorf("failed to parse task #%s: %w", targetTaskID, unmarshalErr)
 	}
 
@@ -368,7 +368,7 @@ func (t *taskUpdateTool) addBlocksToTask(ctx context.Context, targetTaskID, bloc
 	}
 
 	targetTask := &task{}
-	if unmarshalErr := sonic.UnmarshalString(content, targetTask); unmarshalErr != nil {
+	if unmarshalErr := sonic.UnmarshalString(content.Content, targetTask); unmarshalErr != nil {
 		return fmt.Errorf("failed to parse task #%s: %w", targetTaskID, unmarshalErr)
 	}
 

--- a/adk/middlewares/plantask/task_update_test.go
+++ b/adk/middlewares/plantask/task_update_test.go
@@ -58,7 +58,7 @@ func TestTaskUpdateTool(t *testing.T) {
 	content, err := backend.Read(ctx, &ReadRequest{FilePath: filepath.Join(baseDir, "1.json")})
 	assert.NoError(t, err)
 	var updated task
-	_ = sonic.UnmarshalString(content, &updated)
+	_ = sonic.UnmarshalString(content.Content, &updated)
 	assert.Equal(t, taskStatusInProgress, updated.Status)
 
 	result, err = tool.InvokableRun(ctx, `{"taskId": "1", "subject": "New Subject", "description": "New description"}`)
@@ -67,7 +67,7 @@ func TestTaskUpdateTool(t *testing.T) {
 	assert.Contains(t, result, "description")
 
 	content, _ = backend.Read(ctx, &ReadRequest{FilePath: filepath.Join(baseDir, "1.json")})
-	_ = sonic.UnmarshalString(content, &updated)
+	_ = sonic.UnmarshalString(content.Content, &updated)
 	assert.Equal(t, "New Subject", updated.Subject)
 	assert.Equal(t, "New description", updated.Description)
 }
@@ -97,7 +97,7 @@ func TestTaskUpdateToolOwnerAndMetadata(t *testing.T) {
 
 	content, _ := backend.Read(ctx, &ReadRequest{FilePath: filepath.Join(baseDir, "1.json")})
 	var updated task
-	_ = sonic.UnmarshalString(content, &updated)
+	_ = sonic.UnmarshalString(content.Content, &updated)
 	assert.Equal(t, "agent1", updated.Owner)
 
 	result, err = tool.InvokableRun(ctx, `{"taskId": "1", "metadata": {"key1": "value1", "key2": "value2"}}`)
@@ -105,7 +105,7 @@ func TestTaskUpdateToolOwnerAndMetadata(t *testing.T) {
 	assert.Contains(t, result, "metadata")
 
 	content, _ = backend.Read(ctx, &ReadRequest{FilePath: filepath.Join(baseDir, "1.json")})
-	_ = sonic.UnmarshalString(content, &updated)
+	_ = sonic.UnmarshalString(content.Content, &updated)
 	assert.Equal(t, "value1", updated.Metadata["key1"])
 	assert.Equal(t, "value2", updated.Metadata["key2"])
 
@@ -114,7 +114,7 @@ func TestTaskUpdateToolOwnerAndMetadata(t *testing.T) {
 
 	content, _ = backend.Read(ctx, &ReadRequest{FilePath: filepath.Join(baseDir, "1.json")})
 	var updated2 task
-	_ = sonic.UnmarshalString(content, &updated2)
+	_ = sonic.UnmarshalString(content.Content, &updated2)
 	_, key1Exists := updated2.Metadata["key1"]
 	assert.False(t, key1Exists)
 	assert.Equal(t, "value2", updated2.Metadata["key2"])
@@ -179,7 +179,7 @@ func TestTaskUpdateToolBlocks(t *testing.T) {
 
 	content, _ := backend.Read(ctx, &ReadRequest{FilePath: filepath.Join(baseDir, "1.json")})
 	var updated task
-	_ = sonic.UnmarshalString(content, &updated)
+	_ = sonic.UnmarshalString(content.Content, &updated)
 	assert.Equal(t, []string{"2", "3"}, updated.Blocks)
 
 	result, err = tool.InvokableRun(ctx, `{"taskId": "1", "addBlockedBy": ["4"]}`)
@@ -187,7 +187,7 @@ func TestTaskUpdateToolBlocks(t *testing.T) {
 	assert.Contains(t, result, "blockedBy")
 
 	content, _ = backend.Read(ctx, &ReadRequest{FilePath: filepath.Join(baseDir, "1.json")})
-	_ = sonic.UnmarshalString(content, &updated)
+	_ = sonic.UnmarshalString(content.Content, &updated)
 	assert.Equal(t, []string{"4"}, updated.BlockedBy)
 }
 
@@ -324,14 +324,14 @@ func TestTaskUpdateToolBlocksDeduplication(t *testing.T) {
 
 	content, _ := backend.Read(ctx, &ReadRequest{FilePath: filepath.Join(baseDir, "1.json")})
 	var updated task
-	_ = sonic.UnmarshalString(content, &updated)
+	_ = sonic.UnmarshalString(content.Content, &updated)
 	assert.Equal(t, []string{"2", "4"}, updated.Blocks)
 
 	_, err = tool.InvokableRun(ctx, `{"taskId": "1", "addBlockedBy": ["3", "5", "5"]}`)
 	assert.NoError(t, err)
 
 	content, _ = backend.Read(ctx, &ReadRequest{FilePath: filepath.Join(baseDir, "1.json")})
-	_ = sonic.UnmarshalString(content, &updated)
+	_ = sonic.UnmarshalString(content.Content, &updated)
 	assert.Equal(t, []string{"3", "5"}, updated.BlockedBy)
 }
 
@@ -381,19 +381,19 @@ func TestTaskUpdateToolBidirectionalBlocks(t *testing.T) {
 
 	content1, _ := backend.Read(ctx, &ReadRequest{FilePath: filepath.Join(baseDir, "1.json")})
 	var updatedTask1 task
-	_ = sonic.UnmarshalString(content1, &updatedTask1)
+	_ = sonic.UnmarshalString(content1.Content, &updatedTask1)
 	assert.Equal(t, []string{"2", "3"}, updatedTask1.Blocks)
 	assert.Empty(t, updatedTask1.BlockedBy)
 
 	content2, _ := backend.Read(ctx, &ReadRequest{FilePath: filepath.Join(baseDir, "2.json")})
 	var updatedTask2 task
-	_ = sonic.UnmarshalString(content2, &updatedTask2)
+	_ = sonic.UnmarshalString(content2.Content, &updatedTask2)
 	assert.Empty(t, updatedTask2.Blocks)
 	assert.Equal(t, []string{"1"}, updatedTask2.BlockedBy)
 
 	content3, _ := backend.Read(ctx, &ReadRequest{FilePath: filepath.Join(baseDir, "3.json")})
 	var updatedTask3 task
-	_ = sonic.UnmarshalString(content3, &updatedTask3)
+	_ = sonic.UnmarshalString(content3.Content, &updatedTask3)
 	assert.Empty(t, updatedTask3.Blocks)
 	assert.Equal(t, []string{"1"}, updatedTask3.BlockedBy)
 }
@@ -444,19 +444,19 @@ func TestTaskUpdateToolBidirectionalBlockedBy(t *testing.T) {
 
 	content3, _ := backend.Read(ctx, &ReadRequest{FilePath: filepath.Join(baseDir, "3.json")})
 	var updatedTask3 task
-	_ = sonic.UnmarshalString(content3, &updatedTask3)
+	_ = sonic.UnmarshalString(content3.Content, &updatedTask3)
 	assert.Empty(t, updatedTask3.Blocks)
 	assert.Equal(t, []string{"1", "2"}, updatedTask3.BlockedBy)
 
 	content1, _ := backend.Read(ctx, &ReadRequest{FilePath: filepath.Join(baseDir, "1.json")})
 	var updatedTask1 task
-	_ = sonic.UnmarshalString(content1, &updatedTask1)
+	_ = sonic.UnmarshalString(content1.Content, &updatedTask1)
 	assert.Equal(t, []string{"3"}, updatedTask1.Blocks)
 	assert.Empty(t, updatedTask1.BlockedBy)
 
 	content2, _ := backend.Read(ctx, &ReadRequest{FilePath: filepath.Join(baseDir, "2.json")})
 	var updatedTask2 task
-	_ = sonic.UnmarshalString(content2, &updatedTask2)
+	_ = sonic.UnmarshalString(content2.Content, &updatedTask2)
 	assert.Equal(t, []string{"3"}, updatedTask2.Blocks)
 	assert.Empty(t, updatedTask2.BlockedBy)
 }
@@ -562,19 +562,19 @@ func TestTaskUpdateToolCyclicDependencyDetection(t *testing.T) {
 
 	content1, _ := backend.Read(ctx, &ReadRequest{FilePath: filepath.Join(baseDir, "1.json")})
 	var updatedTask1 task
-	_ = sonic.UnmarshalString(content1, &updatedTask1)
+	_ = sonic.UnmarshalString(content1.Content, &updatedTask1)
 	assert.Equal(t, []string{"2"}, updatedTask1.Blocks)
 	assert.Empty(t, updatedTask1.BlockedBy)
 
 	content2, _ := backend.Read(ctx, &ReadRequest{FilePath: filepath.Join(baseDir, "2.json")})
 	var updatedTask2 task
-	_ = sonic.UnmarshalString(content2, &updatedTask2)
+	_ = sonic.UnmarshalString(content2.Content, &updatedTask2)
 	assert.Equal(t, []string{"3"}, updatedTask2.Blocks)
 	assert.Equal(t, []string{"1"}, updatedTask2.BlockedBy)
 
 	content3, _ := backend.Read(ctx, &ReadRequest{FilePath: filepath.Join(baseDir, "3.json")})
 	var updatedTask3 task
-	_ = sonic.UnmarshalString(content3, &updatedTask3)
+	_ = sonic.UnmarshalString(content3.Content, &updatedTask3)
 	assert.Empty(t, updatedTask3.Blocks)
 	assert.Equal(t, []string{"2"}, updatedTask3.BlockedBy)
 }
@@ -630,14 +630,14 @@ func TestTaskUpdateToolDeleteCleansDependencies(t *testing.T) {
 	content2, err := backend.Read(ctx, &ReadRequest{FilePath: filepath.Join(baseDir, "2.json")})
 	assert.NoError(t, err)
 	var updatedTask2 task
-	_ = sonic.UnmarshalString(content2, &updatedTask2)
+	_ = sonic.UnmarshalString(content2.Content, &updatedTask2)
 	assert.Equal(t, []string{"3"}, updatedTask2.Blocks)
 	assert.Empty(t, updatedTask2.BlockedBy)
 
 	content3, err := backend.Read(ctx, &ReadRequest{FilePath: filepath.Join(baseDir, "3.json")})
 	assert.NoError(t, err)
 	var updatedTask3 task
-	_ = sonic.UnmarshalString(content3, &updatedTask3)
+	_ = sonic.UnmarshalString(content3.Content, &updatedTask3)
 	assert.Empty(t, updatedTask3.Blocks)
 	assert.Equal(t, []string{"2"}, updatedTask3.BlockedBy)
 }
@@ -734,6 +734,6 @@ func TestTaskUpdateToolNoDeleteWhenNotAllCompleted(t *testing.T) {
 
 	content1, _ := backend.Read(ctx, &ReadRequest{FilePath: filepath.Join(baseDir, "1.json")})
 	var updatedTask1 task
-	_ = sonic.UnmarshalString(content1, &updatedTask1)
+	_ = sonic.UnmarshalString(content1.Content, &updatedTask1)
 	assert.Equal(t, taskStatusCompleted, updatedTask1.Status)
 }

--- a/adk/middlewares/reduction/reduction_test.go
+++ b/adk/middlewares/reduction/reduction_test.go
@@ -65,9 +65,9 @@ func TestReductionMiddlewareTrunc(t *testing.T) {
 		assert.Equal(t, exp, resp)
 		content, err := backend.Read(ctx, &filesystem.ReadRequest{FilePath: "/tmp/trunc/12345"})
 		assert.NoError(t, err)
-		expOrigContent := `     1	hello worldhello worldhello worldhello worldhello worldhello worldhello worldhello worldhello worldhello world
-     2	hello worldhello worldhello worldhello worldhello worldhello worldhello worldhello world`
-		assert.Equal(t, expOrigContent, content)
+		expOrigContent := `hello worldhello worldhello worldhello worldhello worldhello worldhello worldhello worldhello worldhello world
+hello worldhello worldhello worldhello worldhello worldhello worldhello worldhello world`
+		assert.Equal(t, expOrigContent, content.Content)
 	})
 
 	t.Run("test streamable line and max length trunc", func(t *testing.T) {
@@ -100,9 +100,9 @@ func TestReductionMiddlewareTrunc(t *testing.T) {
 		assert.Equal(t, exp, s)
 		content, err := backend.Read(ctx, &filesystem.ReadRequest{FilePath: "/tmp/trunc/54321"})
 		assert.NoError(t, err)
-		expOrigContent := `     1	hello worldhello worldhello worldhello worldhello worldhello worldhello worldhello worldhello worldhello world
-     2	hello worldhello worldhello worldhello worldhello worldhello worldhello worldhello world`
-		assert.Equal(t, expOrigContent, content)
+		expOrigContent := `hello worldhello worldhello worldhello worldhello worldhello worldhello worldhello worldhello worldhello world
+hello worldhello worldhello worldhello worldhello worldhello worldhello worldhello world`
+		assert.Equal(t, expOrigContent, content.Content)
 	})
 }
 
@@ -183,8 +183,8 @@ func TestReductionMiddlewareClear(t *testing.T) {
 			FilePath: "/tmp/clear/call_987654321",
 		})
 		assert.NoError(t, err)
-		fileContent = strings.TrimPrefix(strings.TrimSpace(fileContent), "1\t")
-		assert.Equal(t, "Sunny", fileContent)
+		fileContentStr := strings.TrimPrefix(strings.TrimSpace(fileContent.Content), "1\t")
+		assert.Equal(t, "Sunny", fileContentStr)
 	})
 
 	t.Run("test default clear without offloading", func(t *testing.T) {
@@ -334,9 +334,9 @@ func TestReductionMiddlewareClear(t *testing.T) {
 			FilePath: "/tmp/call_987654321",
 		})
 		assert.NoError(t, err)
-		fileContent = strings.TrimPrefix(strings.TrimSpace(fileContent), "1\t")
+		fileContentStr := strings.TrimPrefix(strings.TrimSpace(fileContent.Content), "1\t")
 		oc := &OffloadContent{}
-		err = json.Unmarshal([]byte(fileContent), oc)
+		err = json.Unmarshal([]byte(fileContentStr), oc)
 		assert.NoError(t, err)
 		assert.Equal(t, &OffloadContent{
 			Arguments: map[string]string{
@@ -407,8 +407,8 @@ func TestReductionMiddlewareClear(t *testing.T) {
 			FilePath: "/tmp/clear/call_987654321",
 		})
 		assert.NoError(t, err)
-		fileContent = strings.TrimPrefix(strings.TrimSpace(fileContent), "1\t")
-		assert.Equal(t, "Sunny", fileContent)
+		fileContentStr := strings.TrimPrefix(strings.TrimSpace(fileContent.Content), "1\t")
+		assert.Equal(t, "Sunny", fileContentStr)
 
 		msgs = append(msgs, []*schema.Message{
 			schema.AssistantMessage("", []schema.ToolCall{

--- a/adk/middlewares/skill/filesystem_backend.go
+++ b/adk/middlewares/skill/filesystem_backend.go
@@ -121,14 +121,14 @@ func (b *filesystemBackend) list(ctx context.Context) ([]Skill, error) {
 }
 
 func (b *filesystemBackend) loadSkillFromFile(ctx context.Context, path string) (Skill, error) {
-	data, err := b.backend.Read(ctx, &filesystem.ReadRequest{
+	fileContent, err := b.backend.Read(ctx, &filesystem.ReadRequest{
 		FilePath: path,
 	})
 	if err != nil {
 		return Skill{}, fmt.Errorf("failed to read file: %w", err)
 	}
 
-	data = stripLineNumbers(data)
+	data := stripLineNumbers(fileContent.Content)
 
 	frontmatter, content, err := parseFrontmatter(data)
 	if err != nil {


### PR DESCRIPTION
refactor(filesystem): optimize Read to return FileContent and avoid allocations

- Change Backend.Read return type from string to FileContent struct for extensibility
- Optimize InMemoryBackend.Read to use strings.IndexByte scanning instead of
  strings.Split/Join, eliminating unnecessary allocations for large files
- Add fast path for the common case (no offset, content within limit)
- Fix default limit from 200 to 2000 to match ReadRequest documentation
- Fix offset to be strictly 1-based as documented in ReadRequest
- Move line number formatting from backend to middleware layer (separation of concerns)
- Add comprehensive Read edge case tests
