### PR TITLE
fix(adk): apply WithSessionValues in ChatModelAgent run/resume

### DIFF
--- a/adk/chatmodel.go
+++ b/adk/chatmodel.go
@@ -952,6 +952,9 @@ func (a *ChatModelAgent) getRunFunc(ctx context.Context) (context.Context, runFu
 func (a *ChatModelAgent) Run(ctx context.Context, input *AgentInput, opts ...AgentRunOption) *AsyncIterator[*AgentEvent] {
 	iterator, generator := NewAsyncIteratorPair[*AgentEvent]()
 
+	o := getCommonOptions(nil, opts...)
+	AddSessionValues(ctx, o.sessionValues)
+
 	ctx, run, bc, err := a.getRunFunc(ctx)
 	if err != nil {
 		go func() {
@@ -1000,6 +1003,9 @@ func (a *ChatModelAgent) Run(ctx context.Context, input *AgentInput, opts ...Age
 
 func (a *ChatModelAgent) Resume(ctx context.Context, info *ResumeInfo, opts ...AgentRunOption) *AsyncIterator[*AgentEvent] {
 	iterator, generator := NewAsyncIteratorPair[*AgentEvent]()
+
+	o := getCommonOptions(nil, opts...)
+	AddSessionValues(ctx, o.sessionValues)
 
 	ctx, run, bc, err := a.getRunFunc(ctx)
 	if err != nil {

--- a/adk/chatmodel_test.go
+++ b/adk/chatmodel_test.go
@@ -84,6 +84,40 @@ func TestChatModelAgentRun(t *testing.T) {
 		assert.False(t, ok)
 	})
 
+	t.Run("WithSessionValuesAppliesToInstructionTemplate", func(t *testing.T) {
+		ctx := context.Background()
+
+		ctrl := gomock.NewController(t)
+		cm := mockModel.NewMockToolCallingChatModel(ctrl)
+		cm.EXPECT().Generate(gomock.Any(), gomock.Any(), gomock.Any()).
+			DoAndReturn(func(_ context.Context, msgs []*schema.Message, _ ...model.Option) (*schema.Message, error) {
+				assert.GreaterOrEqual(t, len(msgs), 2)
+				assert.Equal(t, schema.System, msgs[0].Role)
+				assert.Equal(t, "Hello alice", msgs[0].Content)
+				return schema.AssistantMessage("ok", nil), nil
+			}).
+			Times(1)
+
+		agent, err := NewChatModelAgent(ctx, &ChatModelAgentConfig{
+			Name:        "TestAgent",
+			Description: "Test agent for unit testing",
+			Instruction: "Hello {user}",
+			Model:       cm,
+		})
+		assert.NoError(t, err)
+
+		input := &AgentInput{Messages: []Message{schema.UserMessage("hi")}}
+		ctx, _ = initRunCtx(ctx, "TestAgent", input)
+
+		iterator := agent.Run(ctx, input, WithSessionValues(map[string]any{"user": "alice"}))
+		event, ok := iterator.Next()
+		assert.True(t, ok)
+		assert.NotNil(t, event)
+		assert.Nil(t, event.Err)
+		_, ok = iterator.Next()
+		assert.False(t, ok)
+	})
+
 	t.Run("BasicChatModelWithAgentMiddleware", func(t *testing.T) {
 		ctx := context.Background()
 


### PR DESCRIPTION
## Summary
- apply common `WithSessionValues` options in `ChatModelAgent.Run` and `ChatModelAgent.Resume`
- ensure session values are injected before run-function resolution
- add regression test to verify instruction template formatting uses values from `WithSessionValues`

## Verification
- `go test ./adk -run 'TestChatModelAgentRun/WithSessionValuesAppliesToInstructionTemplate|TestChatModelAgentRun/BasicFunctionality'`
- `go test ./adk -run TestChatModelAgentRun`

Fixes #843