### PR TITLE
fix(reduction): change dedup flag from struct to boolean

### DIFF
--- a/adk/middlewares/reduction/reduction.go
+++ b/adk/middlewares/reduction/reduction.go
@@ -652,14 +652,21 @@ func defaultClearHandler(rootDir string, needOffload bool, readFileToolName stri
 }
 
 func getMsgOffloadedFlag(msg *schema.Message) (offloaded bool) {
-	return msg.Extra != nil && msg.Extra[msgReducedFlag] != nil
+	if msg.Extra == nil {
+		return false
+	}
+	v, ok := msg.Extra[msgReducedFlag].(bool)
+	if !ok {
+		return false
+	}
+	return v
 }
 
 func setMsgOffloadedFlag(msg *schema.Message) {
 	if msg.Extra == nil {
 		msg.Extra = make(map[string]any)
 	}
-	msg.Extra[msgReducedFlag] = struct{}{}
+	msg.Extra[msgReducedFlag] = true
 }
 
 func getMsgCachedToken(msg *schema.Message) (int64, bool) {


### PR DESCRIPTION
#### What type of PR is this?
<!--
Add one of the following kinds:

build: Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)
ci: Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
docs: Documentation only changes
feat: A new feature
optimize: A new optimization
fix: A bug fix
perf: A code change that improves performance
refactor: A code change that neither fixes a bug nor adds a feature
style: Changes that do not affect the meaning of the code (white space, formatting, missing semi-colons, etc)
test: Adding missing tests or correcting existing tests
chore: Changes to the build process or auxiliary tools and libraries such as documentation generation
-->
fix

#### Check the PR title.
<!--
The description of the title will be attached in Release Notes, 
so please describe it from user-oriented, what this PR does / why we need it.
Please check your PR title with the below requirements:
-->
- [x] This PR title match the format: \<type\>(optional scope): \<description\>
- [x] The description of this PR title is user-oriented and clear enough for others to understand.
- [ ] Attach the PR updating the user documentation if the current PR requires user awareness at the usage level. [User docs repo](https://github.com/cloudwego/cloudwego.github.io)


#### (Optional) Translate the PR title into Chinese.
fix: reduction 中间件去重标记从 struct{} 改为 bool

#### (Optional) More detailed description for this PR(en: English/zh: Chinese).
<!--
Provide more detailed info for review(e.g., it's recommended to provide perf data if this is a perf type PR).
-->
en: This adjustment allows reduction middleware to be compatible with GenericRegister without requiring initialization, thereby solving the issue of error caused by unregistered struct{} during interruptions.

zh(optional): 本调整使 reduction 中间件不需要进行初始化就兼容 GenericRegister，来解决中断时由于未注册 struct 类型引发的报错


#### (Optional) Which issue(s) this PR fixes:
<!--
Automatically closes linked issue when PR is merged.
Eg: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

#### (optional) The PR that updates user documentation:
<!--
If the current PR requires user awareness at the usage level, please submit a PR to update user docs. [User docs repo](https://github.com/cloudwego/cloudwego.github.io)
-->
