### PR TITLE
fix(schema): add missing CompletionTokensDetails.ReasoningTokens handling in ConcatMessages

### DIFF
--- a/schema/message.go
+++ b/schema/message.go
@@ -1909,6 +1909,10 @@ func ConcatMessages(msgs []*Message) (*Message, error) {
 				if msg.ResponseMeta.Usage.PromptTokenDetails.CachedTokens > ret.ResponseMeta.Usage.PromptTokenDetails.CachedTokens {
 					ret.ResponseMeta.Usage.PromptTokenDetails.CachedTokens = msg.ResponseMeta.Usage.PromptTokenDetails.CachedTokens
 				}
+
+				if msg.ResponseMeta.Usage.CompletionTokensDetails.ReasoningTokens > ret.ResponseMeta.Usage.CompletionTokensDetails.ReasoningTokens {
+					ret.ResponseMeta.Usage.CompletionTokensDetails.ReasoningTokens = msg.ResponseMeta.Usage.CompletionTokensDetails.ReasoningTokens
+				}
 			}
 
 			if msg.ResponseMeta.LogProbs != nil {

--- a/schema/message_test.go
+++ b/schema/message_test.go
@@ -159,6 +159,9 @@ func TestConcatMessage(t *testing.T) {
 					PromptTokenDetails: PromptTokenDetails{
 						CachedTokens: 15,
 					},
+					CompletionTokensDetails: CompletionTokensDetails{
+						ReasoningTokens: 8,
+					},
 					TotalTokens: 45,
 				},
 			},
@@ -178,6 +181,9 @@ func TestConcatMessage(t *testing.T) {
 						PromptTokenDetails: PromptTokenDetails{
 							CachedTokens: 10,
 						},
+						CompletionTokensDetails: CompletionTokensDetails{
+							ReasoningTokens: 5,
+						},
 						TotalTokens: 30,
 					},
 				},
@@ -196,6 +202,9 @@ func TestConcatMessage(t *testing.T) {
 						PromptTokens:     30,
 						PromptTokenDetails: PromptTokenDetails{
 							CachedTokens: 15,
+						},
+						CompletionTokensDetails: CompletionTokensDetails{
+							ReasoningTokens: 8,
 						},
 						TotalTokens: 45,
 					},


### PR DESCRIPTION
## Summary

- `ConcatMessages` merges `TokenUsage` fields (`PromptTokens`, `CompletionTokens`, `TotalTokens`, `PromptTokenDetails.CachedTokens`) when concatenating streamed messages, but omits `CompletionTokensDetails.ReasoningTokens`, causing reasoning token counts to be lost after stream concatenation.
- This PR adds the missing `CompletionTokensDetails.ReasoningTokens` handling, using the same "keep the larger value" strategy as the other token fields.
- Updated existing test case `response_meta` to cover `ReasoningTokens`.

## Test plan

- [x] Updated `TestConcatMessage/response_meta` to include `CompletionTokensDetails.ReasoningTokens` in both input messages and expected output
- [x] All existing tests pass (`go test ./schema/ -run TestConcatMessage -v`)


Made with [Cursor](https://cursor.com)