### PR TITLE
fix(adk): remove GobEncode/GobDecode from State to fix checkpoint backward compatibility

### DIFF
--- a/adk/react.go
+++ b/adk/react.go
@@ -99,33 +99,13 @@ func (s *State) setRetryAttempt(attempt int) {
 	s.internals[stateKeyRetryAttempt] = attempt
 }
 
-const (
-	stateKeyReturnDirectlyToolCallID = "_returnDirectlyToolCallID"
-	stateKeyToolGenActions           = "_toolGenActions"
-	stateKeyRemainingIterations      = "_remainingIterations"
-)
-
 func (s *State) getReturnDirectlyToolCallID() string {
-	if s.internals == nil {
-		return ""
-	}
-	if v, ok := s.internals[stateKeyReturnDirectlyToolCallID].(string); ok {
-		return v
-	}
-	return ""
+	return s.ReturnDirectlyToolCallID
 }
 
 func (s *State) setReturnDirectlyToolCallID(id string) {
-	if s.internals == nil {
-		s.internals = make(map[string]any)
-	}
-	s.internals[stateKeyReturnDirectlyToolCallID] = id
 	s.ReturnDirectlyToolCallID = id
 	s.HasReturnDirectly = id != ""
-}
-
-func (s *State) getToolGenActions() map[string]*AgentAction {
-	return s.ToolGenActions
 }
 
 func (s *State) setToolGenAction(key string, action *AgentAction) {
@@ -137,15 +117,11 @@ func (s *State) setToolGenAction(key string, action *AgentAction) {
 }
 
 func (s *State) popToolGenAction(key string) *AgentAction {
-	if s.internals == nil {
+	if s.ToolGenActions == nil {
 		return nil
 	}
-	actions, ok := s.internals[stateKeyToolGenActions].(map[string]*AgentAction)
-	if !ok || actions == nil {
-		return nil
-	}
-	action := actions[key]
-	delete(actions, key)
+	action := s.ToolGenActions[key]
+	delete(s.ToolGenActions, key)
 	return action
 }
 


### PR DESCRIPTION
## Summary

- Remove `GobEncode`/`GobDecode` methods from `State` to restore plain struct gob encoding, fixing checkpoint backward compatibility
- Migrate `RemainingIterations` and `ToolGenActions` getters/setters to use exported fields directly instead of `internals` map, ensuring these values survive serialization (both gob and compose `InternalSerializer`)

## Background

PR #809 added `GobEncode`/`GobDecode` to `State` via a `stateSerialization` intermediate struct. This changed `State`'s gob wire format from **plain struct** to **GobEncoder** type.

Old checkpoints (saved before #809) encode `State` as a plain gob struct. After #809, the local `State` type has `GobDecoder`, making it a "GobEncoder" type in gob's view. When gob tries to decode old data, it finds a struct wire format but expects a GobEncoder wire format — these are **incompatible at the wire level**, and `GobDecode()` is never called:

```
gob: decoding into local type *adk.State, received remote type State
```

This is because gob embeds the encoding method into the wire type metadata. Adding `GobEncoder` is a **one-way** breaking change — the new decoder cannot read old data, regardless of what `GobDecode` implements.

## Changes

### 1. Remove `GobEncode`/`GobDecode`

Restore plain struct gob encoding so `State` is backward compatible with old checkpoints. Plain struct encoding automatically handles field additions/removals by matching field names.

### 2. Use exported fields for `RemainingIterations` and `ToolGenActions`

Before this fix, setters like `setRemainingIterations` and `setToolGenAction` only wrote to the unexported `internals` map, while the corresponding exported fields (`RemainingIterations`, `ToolGenActions`) remained zero values. Since both gob and compose's `InternalSerializer` only serialize **exported** fields, these values were silently lost during:

- Compose graph `deepCopyState` (uses `InternalSerializer`, serializes exported fields only)
- ADK checkpoint save/load (uses gob, encodes exported fields only without `GobEncoder`)

This caused `RemainingIterations` to be 0 after resume, immediately triggering `ErrExceedMaxIterations`.

Now getters/setters directly read/write the exported fields, ensuring values survive all serialization paths.

## Test plan

- [x] `go build ./adk/...` passes
- [x] `go test -race ./adk/...` all pass
- [ ] Verify old checkpoint data can be deserialized after this fix

🤖 Generated with [Claude Code](https://claude.com/claude-code)