### PR TITLE
fix(plantask): resolve listed task file paths in TaskList and TaskCreate

### DIFF
--- a/adk/middlewares/plantask/backend_test.go
+++ b/adk/middlewares/plantask/backend_test.go
@@ -46,7 +46,7 @@ func (b *inMemoryBackend) LsInfo(ctx context.Context, req *LsInfoRequest) ([]Fil
 	for path := range b.files {
 		dir := filepath.Dir(path)
 		if dir == reqPath {
-			result = append(result, FileInfo{Path: path})
+			result = append(result, FileInfo{Path: filepath.Base(path)})
 		}
 	}
 	return result, nil

--- a/adk/middlewares/plantask/task.go
+++ b/adk/middlewares/plantask/task.go
@@ -18,6 +18,7 @@ package plantask
 
 import (
 	"context"
+	"path/filepath"
 	"regexp"
 
 	"github.com/cloudwego/eino/adk/middlewares/filesystem"
@@ -88,6 +89,14 @@ func appendUnique(slice []string, items ...string) []string {
 		}
 	}
 	return slice
+}
+
+func resolveListedFilePath(baseDir, listedPath string) string {
+	if filepath.IsAbs(listedPath) {
+		return listedPath
+	}
+
+	return filepath.Join(baseDir, listedPath)
 }
 
 func hasCyclicDependency(taskMap map[string]*task, blockerID, blockedID string) bool {

--- a/adk/middlewares/plantask/task_create.go
+++ b/adk/middlewares/plantask/task_create.go
@@ -106,8 +106,9 @@ func (t *taskCreateTool) InvokableRun(ctx context.Context, argumentsInJSON strin
 	for _, file := range files {
 		fileName := filepath.Base(file.Path)
 		if fileName == highWatermarkFileName {
+			filePath := resolveListedFilePath(t.BaseDir, file.Path)
 			content, readErr := t.Backend.Read(ctx, &ReadRequest{
-				FilePath: file.Path,
+				FilePath: filePath,
 			})
 			if readErr != nil {
 				return "", fmt.Errorf("%s read highwatermark file %s failed, err: %w", TaskCreateToolName, file.Path, readErr)

--- a/adk/middlewares/plantask/task_list.go
+++ b/adk/middlewares/plantask/task_list.go
@@ -74,8 +74,9 @@ func listTasks(ctx context.Context, backend Backend, baseDir string) ([]*task, e
 			continue
 		}
 
+		filePath := resolveListedFilePath(baseDir, file.Path)
 		content, err := backend.Read(ctx, &ReadRequest{
-			FilePath: file.Path,
+			FilePath: filePath,
 		})
 		if err != nil {
 			return nil, fmt.Errorf("%s read task file %s failed, err: %w", TaskListToolName, file.Path, err)


### PR DESCRIPTION
## Summary

This PR fixes a path handling bug in `plantask` when `Backend.LsInfo` returns file names or relative paths instead of full file paths.

It updates both `TaskList` and `TaskCreate` to resolve listed entries against `baseDir` before reading them, and aligns the `plantask` test backend with the documented backend contract so the failing scenario is actually covered by tests.

## Problem

`plantask` currently assumes that `Backend.LsInfo` returns full file paths.

In practice, the backend contract allows `FileInfo.Path` to be a file name or a relative path. Because of that, `TaskList` may fail when it reads a listed task file directly:

```text
TaskList read task file 1.json failed, err: file not found: /1.json
```

The same assumption also exists in `TaskCreate` when it scans `LsInfo` results and reads `.highwatermark`.

## Root Cause

`TaskList` lists files from `baseDir`, but passes `file.Path` directly to `Read` without resolving it first.

That only works when `LsInfo` returns absolute paths. If the backend returns `1.json`, `TaskList` does not join it with `baseDir` before calling `Read`.

`TaskCreate` has the same issue when handling `.highwatermark`.

## Solution

This PR introduces a shared helper for resolving listed file paths:

- keep the path as-is when `LsInfo` already returns an absolute path
- join it with `baseDir` when `LsInfo` returns a file name or relative path

The same logic is applied in both places:

- `TaskList` when reading task files
- `TaskCreate` when reading `.highwatermark`

## Test Coverage

This PR also updates the `plantask` test backend to return basename-style paths from `LsInfo`, which is closer to the documented backend behavior.

That makes the tests cover the real failing scenario instead of masking it with full paths.

## Validation

Validated locally with:

```bash
go test -race ./...
go test -bench=. -benchmem -run=none ./...
golangci-lint run --timeout 5m
```

All passed.

Fixes #932
