### PR TITLE
chore(adk): make ChatModelAgent Name/Description optional, validate in AgentTool.Info

### DIFF
--- a/adk/agent_tool.go
+++ b/adk/agent_tool.go
@@ -68,6 +68,10 @@ func withAgentToolEnableStreaming(enabled bool) tool.Option {
 
 // NewAgentTool creates a tool that wraps an agent for invocation.
 //
+// The agent must have a non-empty Name and Description, as they are used as
+// the tool's name and description respectively. This is validated when Info()
+// is called during tool setup.
+//
 // Event Streaming:
 // When EmitInternalEvents is enabled in ToolsConfig, the agent tool will emit AgentEvent
 // from the inner agent to the parent agent's AsyncGenerator, allowing real-time streaming
@@ -107,14 +111,23 @@ type agentTool struct {
 }
 
 func (at *agentTool) Info(ctx context.Context) (*schema.ToolInfo, error) {
+	name := at.agent.Name(ctx)
+	if name == "" {
+		return nil, errors.New("agent tool requires a non-empty Name")
+	}
+	desc := at.agent.Description(ctx)
+	if desc == "" {
+		return nil, errors.New("agent tool requires a non-empty Description")
+	}
+
 	param := at.inputSchema
 	if param == nil {
 		param = defaultAgentToolParam
 	}
 
 	return &schema.ToolInfo{
-		Name:        at.agent.Name(ctx),
-		Desc:        at.agent.Description(ctx),
+		Name:        name,
+		Desc:        desc,
 		ParamsOneOf: param,
 	}, nil
 }

--- a/adk/agent_tool_test.go
+++ b/adk/agent_tool_test.go
@@ -92,6 +92,18 @@ func TestAgentTool_Info(t *testing.T) {
 	assert.NotNil(t, info.ParamsOneOf)
 }
 
+func TestAgentTool_Info_EmptyName(t *testing.T) {
+	agentTool_ := NewAgentTool(context.Background(), newMockAgentForTool("", "desc", nil))
+	_, err := agentTool_.Info(context.Background())
+	assert.ErrorContains(t, err, "non-empty Name")
+}
+
+func TestAgentTool_Info_EmptyDescription(t *testing.T) {
+	agentTool_ := NewAgentTool(context.Background(), newMockAgentForTool("name", "", nil))
+	_, err := agentTool_.Info(context.Background())
+	assert.ErrorContains(t, err, "non-empty Description")
+}
+
 func TestAgentTool_SharedParentSessionValues(t *testing.T) {
 	ctx := context.Background()
 

--- a/adk/chatmodel.go
+++ b/adk/chatmodel.go
@@ -194,9 +194,13 @@ type AgentMiddleware struct {
 
 type ChatModelAgentConfig struct {
 	// Name of the agent. Better be unique across all agents.
+	// Optional. If empty, the agent can still run standalone but cannot be used as
+	// a sub-agent tool via NewAgentTool (which requires a non-empty Name).
 	Name string
 	// Description of the agent's capabilities.
 	// Helps other agents determine whether to transfer tasks to this agent.
+	// Optional. If empty, the agent can still run standalone but cannot be used as
+	// a sub-agent tool via NewAgentTool (which requires a non-empty Description).
 	Description string
 	// Instruction used as the system prompt for this agent.
 	// Optional. If empty, no system prompt will be used.
@@ -341,12 +345,6 @@ type runFunc func(ctx context.Context, input *AgentInput, generator *AsyncGenera
 
 // NewChatModelAgent constructs a chat model-backed agent with the provided config.
 func NewChatModelAgent(ctx context.Context, config *ChatModelAgentConfig) (*ChatModelAgent, error) {
-	if config.Name == "" {
-		return nil, errors.New("agent 'Name' is required")
-	}
-	if config.Description == "" {
-		return nil, errors.New("agent 'Description' is required")
-	}
 	if config.Model == nil {
 		return nil, errors.New("agent 'Model' is required")
 	}


### PR DESCRIPTION
…n AgentTool.Info

Move Name and Description validation from NewChatModelAgent to agentTool.Info(), allowing standalone agents without a name/description while ensuring agent tools still fail early with a clear error during tool setup.

Change-Id: I79677bdb7b3e5ce75fff2b6e53ddaffdc88eb9f7

#### What type of PR is this?
<!--
Add one of the following kinds:

build: Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)
ci: Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
docs: Documentation only changes
feat: A new feature
optimize: A new optimization
fix: A bug fix
perf: A code change that improves performance
refactor: A code change that neither fixes a bug nor adds a feature
style: Changes that do not affect the meaning of the code (white space, formatting, missing semi-colons, etc)
test: Adding missing tests or correcting existing tests
chore: Changes to the build process or auxiliary tools and libraries such as documentation generation
-->

#### Check the PR title.
<!--
The description of the title will be attached in Release Notes, 
so please describe it from user-oriented, what this PR does / why we need it.
Please check your PR title with the below requirements:
-->
- [ ] This PR title match the format: \<type\>(optional scope): \<description\>
- [ ] The description of this PR title is user-oriented and clear enough for others to understand.
- [ ] Attach the PR updating the user documentation if the current PR requires user awareness at the usage level. [User docs repo](https://github.com/cloudwego/cloudwego.github.io)


#### (Optional) Translate the PR title into Chinese.


#### (Optional) More detailed description for this PR(en: English/zh: Chinese).
<!--
Provide more detailed info for review(e.g., it's recommended to provide perf data if this is a perf type PR).
-->
en:
zh(optional): 


#### (Optional) Which issue(s) this PR fixes:
<!--
Automatically closes linked issue when PR is merged.
Eg: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

#### (optional) The PR that updates user documentation:
<!--
If the current PR requires user awareness at the usage level, please submit a PR to update user docs. [User docs repo](https://github.com/cloudwego/cloudwego.github.io)
-->
