### PR TITLE
feat(adk): reduction middleware add TruncResult.StreamToolResult

### DIFF
--- a/adk/middlewares/reduction/reduction.go
+++ b/adk/middlewares/reduction/reduction.go
@@ -148,9 +148,13 @@ type TruncResult struct {
 	// NeedTrunc indicates whether the tool result should be truncated.
 	NeedTrunc bool
 
-	// ToolResult contains the result returned by the tool after trunc
-	// Required when NeedTrunc is true.
+	// ToolResult contains the result returned by the invokable tool after trunc.
+	// Required when NeedTrunc is true and ToolDetail.ToolResult is not nil.
 	ToolResult *schema.ToolResult
+
+	// StreamToolResult contains the output returned by the streamable tool after trunc.
+	// Required when NeedTrunc is true and ToolDetail.StreamToolResult is not nil.
+	StreamToolResult *schema.StreamReader[*schema.ToolResult]
 
 	// NeedOffload indicates whether the tool result should be offloaded.
 	NeedOffload bool
@@ -390,7 +394,14 @@ func (t *toolReductionMiddleware) WrapStreamableToolCall(_ context.Context, endp
 				return nil, err
 			}
 		}
-		return schema.StreamReaderFromArray([]string{truncResult.ToolResult.Parts[0].Text}), nil
+
+		sr := schema.StreamReaderWithConvert(truncResult.StreamToolResult, func(t *schema.ToolResult) (string, error) {
+			if t == nil || len(t.Parts) == 0 {
+				return "", nil
+			}
+			return t.Parts[0].Text, nil
+		})
+		return sr, nil
 	}, nil
 }
 
@@ -669,8 +680,31 @@ func defaultTokenCounter(_ context.Context, msgs []*schema.Message, tools []*sch
 	return tokens, nil
 }
 
+// defaultTruncHandler applies the same truncation strategy to both non-streaming
+// and streaming tool outputs.
+//
+// Processing steps:
+//  1. Read and join tool output into a complete result:
+//     - Non-streaming: use ToolResult directly.
+//     - Streaming: consume the whole StreamToolResult, then concat all chunks.
+//  2. If output is empty or total text length does not exceed truncMaxLength,
+//     return NeedTrunc=false.
+//  3. If exceeded, replace oversized text parts with truncation notices and
+//     offload the full original content.
+//
+// Streaming-specific behavior:
+//   - Truncation is not incremental. The handler waits until the entire stream is read
+//     before deciding and producing output.
+//   - If stream Recv() returns a non-EOF error, getJointToolResult treats it as
+//     "skip processing" (needProcess=false, err=nil), so this handler returns
+//     NeedTrunc=false and does not propagate that recv error.
+//   - When truncation is applied to a streaming tool result, output is re-emitted as a
+//     buffered single-result stream (not original chunk-by-chunk streaming semantics).
+//
+// If a tool requires strict incremental streaming behavior, provide a custom TruncHandler for that tool.
 func defaultTruncHandler(rootDir string, truncMaxLength int) func(ctx context.Context, detail *ToolDetail) (truncResult *TruncResult, err error) {
 	return func(ctx context.Context, detail *ToolDetail) (offloadInfo *TruncResult, err error) {
+		isStreamResult := detail.StreamToolResult != nil
 		resultParts, needProcess, err := getJointToolResult(detail)
 		if err != nil {
 			return nil, err
@@ -720,13 +754,21 @@ func defaultTruncHandler(rootDir string, truncMaxLength int) func(ctx context.Co
 			resultParts[i].Text = truncNotify
 		}
 
-		return &TruncResult{
+		tr := &TruncResult{
 			NeedTrunc:       true,
-			ToolResult:      &schema.ToolResult{Parts: resultParts},
 			NeedOffload:     true,
 			OffloadFilePath: filePath,
 			OffloadContent:  offloadContent,
-		}, nil
+		}
+		if !isStreamResult {
+			tr.ToolResult = &schema.ToolResult{Parts: resultParts}
+		} else {
+			sr, sw := schema.Pipe[*schema.ToolResult](1)
+			sw.Send(&schema.ToolResult{Parts: resultParts}, nil)
+			sw.Close()
+			tr.StreamToolResult = sr
+		}
+		return tr, nil
 	}
 }
 

--- a/adk/middlewares/reduction/reduction_test.go
+++ b/adk/middlewares/reduction/reduction_test.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"io"
 	"strings"
 	"testing"
 
@@ -103,6 +104,47 @@ hello worldhello worldhello worldhello worldhello worldhello worldhello worldhel
 		expOrigContent := `hello worldhello worldhello worldhello worldhello worldhello worldhello worldhello worldhello worldhello world
 hello worldhello worldhello worldhello worldhello worldhello worldhello worldhello world`
 		assert.Equal(t, expOrigContent, content.Content)
+	})
+
+	t.Run("test streamable line and bypass error", func(t *testing.T) {
+		stWithErr := mockStreamableToolWithError()
+		tCtx := &adk.ToolContext{
+			Name:   "mock_streamable_tool",
+			CallID: "54321",
+		}
+		backend := filesystem.NewInMemoryBackend()
+		config := &Config{
+			SkipTruncation: true,
+			ToolConfig: map[string]*ToolReductionConfig{
+				"mock_streamable_tool": {
+					Backend:        backend,
+					SkipTruncation: false,
+					TruncHandler:   defaultTruncHandler("/tmp", 70),
+				},
+			},
+		}
+		mw, err := New(ctx, config)
+		assert.NoError(t, err)
+		edp, err := mw.WrapStreamableToolCall(ctx, stWithErr.StreamableRun, tCtx)
+		assert.NoError(t, err)
+		resp, err := edp(ctx, `{"value":"asd"}`)
+		assert.NoError(t, err)
+		cnt := 0
+		gotError := false
+		for {
+			_, err := resp.Recv()
+			if err != nil {
+				if err == io.EOF {
+					break
+				}
+				assert.Equal(t, fmt.Errorf("mock error"), err)
+				gotError = true
+				break
+			}
+			cnt++
+		}
+		assert.True(t, gotError)
+		assert.Equal(t, 10, cnt)
 	})
 }
 
@@ -886,6 +928,25 @@ func mockStreamableTool() tool.StreamableTool {
 		for _, part := range splitStrings(s3, 10) {
 			sw.Send(part, nil)
 		}
+		sw.Close()
+		return sr, nil
+	})
+	return t
+}
+
+func mockStreamableToolWithError() tool.StreamableTool {
+	type ContentContainer struct {
+		Value string `json:"value"`
+	}
+	s1 := strings.Repeat("hello world", 10) + "\n"
+	s2 := strings.Repeat("hello world", 8)
+	s3 := s1 + s2
+	t, _ := utils.InferStreamTool("mock_streamable_tool", "test desc", func(ctx context.Context, input ContentContainer) (output *schema.StreamReader[string], err error) {
+		sr, sw := schema.Pipe[string](11)
+		for _, part := range splitStrings(s3, 10) {
+			sw.Send(part, nil)
+		}
+		sw.Send("", fmt.Errorf("mock error"))
 		sw.Close()
 		return sr, nil
 	})


### PR DESCRIPTION
#### What type of PR is this?
<!--
Add one of the following kinds:

build: Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)
ci: Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
docs: Documentation only changes
feat: A new feature
optimize: A new optimization
fix: A bug fix
perf: A code change that improves performance
refactor: A code change that neither fixes a bug nor adds a feature
style: Changes that do not affect the meaning of the code (white space, formatting, missing semi-colons, etc)
test: Adding missing tests or correcting existing tests
chore: Changes to the build process or auxiliary tools and libraries such as documentation generation
-->
feat

#### Check the PR title.
<!--
The description of the title will be attached in Release Notes, 
so please describe it from user-oriented, what this PR does / why we need it.
Please check your PR title with the below requirements:
-->
- [x] This PR title match the format: \<type\>(optional scope): \<description\>
- [x] The description of this PR title is user-oriented and clear enough for others to understand.
- [ ] Attach the PR updating the user documentation if the current PR requires user awareness at the usage level. [User docs repo](https://github.com/cloudwego/cloudwego.github.io)


#### (Optional) Translate the PR title into Chinese.
feat(adk): reduction middleware 新增 TruncResult.StreamToolResult 字段支持流式工具结果


#### (Optional) More detailed description for this PR(en: English/zh: Chinese).
<!--
Provide more detailed info for review(e.g., it's recommended to provide perf data if this is a perf type PR).
-->
en: Add StreamToolResult field to TruncResult in reduction middleware to support truncated streaming tool outputs properly. The defaultTruncHandler now consistently handles both streaming and non-streaming tool outputs, with detailed comments explaining the behavior trade-offs.

zh(optional): 在 reduction middleware 的 TruncResult 中新增 StreamToolResult 字段，以正确支持流式工具输出的截断。defaultTruncHandler 现在统一处理流式和非流式工具输出，并包含详细注释说明其行为权衡。


#### (Optional) Which issue(s) this PR fixes:
<!--
Automatically closes linked issue when PR is merged.
Eg: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

#### (optional) The PR that updates user documentation:
<!--
If the current PR requires user awareness at the usage level, please submit a PR to update user docs. [User docs repo](https://github.com/cloudwego/cloudwego.github.io)
-->
