### PR TITLE
feat(adk): reduction middleware support TruncExcludeTools

### DIFF
--- a/adk/middlewares/reduction/reduction.go
+++ b/adk/middlewares/reduction/reduction.go
@@ -76,6 +76,10 @@ type Config struct {
 	// Required. Default is 50000.
 	MaxLengthForTrunc int
 
+	// TruncExcludeTools is list of tool names whose tool results should never be truncated.
+	// Optional. Default is nil.
+	TruncExcludeTools []string
+
 	// TokenCounter is used to count the number of tokens in the conversation messages.
 	// It is used to determine when to trigger clearing based on token usage, and token usage after clearing.
 	// Required.
@@ -203,6 +207,7 @@ func (t *Config) copyAndFillDefaults() (*Config, error) {
 		ReadFileToolName:          t.ReadFileToolName,
 		RootDir:                   t.RootDir,
 		MaxLengthForTrunc:         t.MaxLengthForTrunc,
+		TruncExcludeTools:         t.TruncExcludeTools,
 		TokenCounter:              t.TokenCounter,
 		MaxTokensForClear:         t.MaxTokensForClear,
 		ClearRetentionSuffixLimit: t.ClearRetentionSuffixLimit,
@@ -270,6 +275,10 @@ func New(_ context.Context, config *Config) (adk.ChatModelAgentMiddleware, error
 	if !defaultReductionConfig.SkipClear {
 		defaultReductionConfig.ClearHandler = defaultClearHandler(config.RootDir, config.Backend != nil, config.ReadFileToolName)
 	}
+	excludeTruncTools := make(map[string]struct{}, len(config.TruncExcludeTools))
+	for _, toolName := range config.TruncExcludeTools {
+		excludeTruncTools[toolName] = struct{}{}
+	}
 	excludeClearTools := make(map[string]struct{}, len(config.ClearExcludeTools))
 	for _, toolName := range config.ClearExcludeTools {
 		excludeClearTools[toolName] = struct{}{}
@@ -278,6 +287,7 @@ func New(_ context.Context, config *Config) (adk.ChatModelAgentMiddleware, error
 	return &toolReductionMiddleware{
 		config:            config,
 		defaultConfig:     defaultReductionConfig,
+		excludeTruncTools: excludeTruncTools,
 		excludeClearTools: excludeClearTools,
 	}, nil
 }
@@ -288,6 +298,7 @@ type toolReductionMiddleware struct {
 	config        *Config
 	defaultConfig *ToolReductionConfig
 
+	excludeTruncTools map[string]struct{}
 	excludeClearTools map[string]struct{}
 }
 
@@ -307,6 +318,9 @@ func (t *toolReductionMiddleware) getToolConfig(toolName string, sc scene) *Tool
 func (t *toolReductionMiddleware) WrapInvokableToolCall(_ context.Context, endpoint adk.InvokableToolCallEndpoint, tCtx *adk.ToolContext) (adk.InvokableToolCallEndpoint, error) {
 	cfg := t.getToolConfig(tCtx.Name, sceneTruncation)
 	if cfg == nil || cfg.TruncHandler == nil {
+		return endpoint, nil
+	}
+	if _, excluded := t.excludeTruncTools[tCtx.Name]; excluded {
 		return endpoint, nil
 	}
 
@@ -353,6 +367,9 @@ func (t *toolReductionMiddleware) WrapStreamableToolCall(_ context.Context, endp
 	if cfg == nil || cfg.TruncHandler == nil {
 		return endpoint, nil
 	}
+	if _, excluded := t.excludeTruncTools[tCtx.Name]; excluded {
+		return endpoint, nil
+	}
 
 	return func(ctx context.Context, argumentsInJSON string, opts ...tool.Option) (*schema.StreamReader[string], error) {
 		output, err := endpoint(ctx, argumentsInJSON, opts...)
@@ -363,7 +380,6 @@ func (t *toolReductionMiddleware) WrapStreamableToolCall(_ context.Context, endp
 		readers := output.Copy(2)
 		output = readers[0]
 		origResp := readers[1]
-		defer output.Close()
 
 		detail := &ToolDetail{
 			ToolContext: tCtx,

--- a/adk/middlewares/reduction/reduction_test.go
+++ b/adk/middlewares/reduction/reduction_test.go
@@ -146,6 +146,116 @@ hello worldhello worldhello worldhello worldhello worldhello worldhello worldhel
 		assert.True(t, gotError)
 		assert.Equal(t, 10, cnt)
 	})
+
+	t.Run("test TruncExcludeTools with invokable tool", func(t *testing.T) {
+		tCtx := &adk.ToolContext{
+			Name:   "important_tool",
+			CallID: "12345",
+		}
+		backend := filesystem.NewInMemoryBackend()
+		config := &Config{
+			Backend:           backend,
+			TruncExcludeTools: []string{"important_tool"},
+			MaxLengthForTrunc: 70,
+		}
+
+		mw, err := New(ctx, config)
+		assert.NoError(t, err)
+
+		edp, err := mw.WrapInvokableToolCall(ctx, it.InvokableRun, tCtx)
+		assert.NoError(t, err)
+
+		resp, err := edp(ctx, `{"value":"asd"}`)
+		assert.NoError(t, err)
+
+		expOrigContent := `hello worldhello worldhello worldhello worldhello worldhello worldhello worldhello worldhello worldhello world
+hello worldhello worldhello worldhello worldhello worldhello worldhello worldhello world`
+		assert.Equal(t, expOrigContent, resp)
+
+		_, err = backend.Read(ctx, &filesystem.ReadRequest{FilePath: "/tmp/trunc/12345"})
+		assert.Error(t, err)
+	})
+
+	t.Run("test TruncExcludeTools with streamable tool", func(t *testing.T) {
+		tCtx := &adk.ToolContext{
+			Name:   "important_stream_tool",
+			CallID: "54321",
+		}
+		backend := filesystem.NewInMemoryBackend()
+		config := &Config{
+			Backend:           backend,
+			TruncExcludeTools: []string{"important_stream_tool"},
+			MaxLengthForTrunc: 70,
+		}
+
+		mw, err := New(ctx, config)
+		assert.NoError(t, err)
+
+		edp, err := mw.WrapStreamableToolCall(ctx, st.StreamableRun, tCtx)
+		assert.NoError(t, err)
+
+		resp, err := edp(ctx, `{"value":"asd"}`)
+		assert.NoError(t, err)
+
+		var fullOutput strings.Builder
+		for {
+			chunk, recvErr := resp.Recv()
+			if recvErr != nil {
+				if recvErr == io.EOF {
+					break
+				}
+				assert.Fail(t, "unexpected error", recvErr)
+			}
+			fullOutput.WriteString(chunk)
+		}
+		resp.Close()
+
+		expOrigContent := `hello worldhello worldhello worldhello worldhello worldhello worldhello worldhello worldhello worldhello world
+hello worldhello worldhello worldhello worldhello worldhello worldhello worldhello world`
+		assert.Equal(t, expOrigContent, fullOutput.String())
+
+		_, err = backend.Read(ctx, &filesystem.ReadRequest{FilePath: "/tmp/trunc/54321"})
+		assert.Error(t, err)
+	})
+
+	t.Run("test mixed tools with TruncExcludeTools", func(t *testing.T) {
+		excludedToolCtx := &adk.ToolContext{
+			Name:   "excluded_tool",
+			CallID: "excluded_123",
+		}
+		normalToolCtx := &adk.ToolContext{
+			Name:   "normal_tool",
+			CallID: "normal_456",
+		}
+		backend := filesystem.NewInMemoryBackend()
+		config := &Config{
+			Backend:           backend,
+			TruncExcludeTools: []string{"excluded_tool"},
+			MaxLengthForTrunc: 70,
+		}
+
+		mw, err := New(ctx, config)
+		assert.NoError(t, err)
+
+		excludedEdp, err := mw.WrapInvokableToolCall(ctx, it.InvokableRun, excludedToolCtx)
+		assert.NoError(t, err)
+		excludedResp, err := excludedEdp(ctx, `{"value":"asd"}`)
+		assert.NoError(t, err)
+		expOrigContent := `hello worldhello worldhello worldhello worldhello worldhello worldhello worldhello worldhello worldhello world
+hello worldhello worldhello worldhello worldhello worldhello worldhello worldhello world`
+		assert.Equal(t, expOrigContent, excludedResp)
+
+		normalEdp, err := mw.WrapInvokableToolCall(ctx, it.InvokableRun, normalToolCtx)
+		assert.NoError(t, err)
+		normalResp, err := normalEdp(ctx, `{"value":"asd"}`)
+		assert.NoError(t, err)
+		assert.NotEqual(t, expOrigContent, normalResp)
+		assert.Contains(t, normalResp, "persisted-output")
+
+		content, err := backend.Read(ctx, &filesystem.ReadRequest{FilePath: "/tmp/trunc/normal_456"})
+		assert.NoError(t, err)
+		assert.Equal(t, expOrigContent, content.Content)
+	})
 }
 
 func TestReductionMiddlewareClear(t *testing.T) {


### PR DESCRIPTION
#### What type of PR is this?
<!--
Add one of the following kinds:

build: Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)
ci: Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
docs: Documentation only changes
feat: A new feature
optimize: A new optimization
fix: A bug fix
perf: A code change that improves performance
refactor: A code change that neither fixes a bug nor adds a feature
style: Changes that do not affect the meaning of the code (white space, formatting, missing semi-colons, etc)
test: Adding missing tests or correcting existing tests
chore: Changes to the build process or auxiliary tools and libraries such as documentation generation
-->
feat & fix

#### Check the PR title.
<!--
The description of the title will be attached in Release Notes, 
so please describe it from user-oriented, what this PR does / why we need it.
Please check your PR title with the below requirements:
-->
- [x] This PR title match the format: \<type\>(optional scope): \<description\>
- [x] The description of this PR title is user-oriented and clear enough for others to understand.
- [ ] Attach the PR updating the user documentation if the current PR requires user awareness at the usage level. [User docs repo](https://github.com/cloudwego/cloudwego.github.io)


#### (Optional) Translate the PR title into Chinese.


#### (Optional) More detailed description for this PR(en: English/zh: Chinese).
<!--
Provide more detailed info for review(e.g., it's recommended to provide perf data if this is a perf type PR).
-->
en:
1. reduction middleware support TruncExcludeTools
2. fix tool streaming output is prematurely closed during asynchronous processing by TruncHandler

zh(optional): 
1. reduction 中间件支持按名称配置不需要截断的工具
2. 修复流式工具输出截断时，输出流被提前关闭，导致 TruncHandler 消费报错的问题


#### (Optional) Which issue(s) this PR fixes:
<!--
Automatically closes linked issue when PR is merged.
Eg: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

#### (optional) The PR that updates user documentation:
<!--
If the current PR requires user awareness at the usage level, please submit a PR to update user docs. [User docs repo](https://github.com/cloudwego/cloudwego.github.io)
-->
