### PR TITLE
fix: validate ParentIDKey is non-empty in NewIndexer

### DIFF
--- a/flow/indexer/parent/parent.go
+++ b/flow/indexer/parent/parent.go
@@ -96,6 +96,9 @@ func NewIndexer(ctx context.Context, config *Config) (indexer.Indexer, error) {
 	if config.SubIDGenerator == nil {
 		return nil, fmt.Errorf("sub id generator is empty")
 	}
+	if config.ParentIDKey == "" {
+		return nil, fmt.Errorf("[NewIndexer] parentIDKey is required")
+	}
 
 	return &parentIndexer{
 		indexer:        config.Indexer,


### PR DESCRIPTION
Closes #952

## Problem

In `flow/indexer/parent/parent.go`, `NewIndexer` validates `Indexer`, `Transformer`, and `SubIDGenerator` fields but silently accepts an empty `ParentIDKey`. When `ParentIDKey` is empty, `Store()` silently writes every parent document ID to the `""` metadata key, making the parent-child relationship unresolvable for all consumers.

## Fix

Added a validation check for `config.ParentIDKey == ""` in `NewIndexer`, consistent with the existing field validation pattern.

## Testing

Passing empty `ParentIDKey` to `NewIndexer` now returns an error at construction time instead of silently corrupting data at runtime.