### PR TITLE
fix: use resolved router variable instead of config.Router in routerRetriever

### DIFF
--- a/flow/retriever/router/router.go
+++ b/flow/retriever/router/router.go
@@ -97,7 +97,7 @@ func NewRetriever(ctx context.Context, config *Config) (retriever.Retriever, err
 
 	return &routerRetriever{
 		retrievers: config.Retrievers,
-		router:     config.Router,
+		router:     router,
 		fusionFunc: fusion,
 	}, nil
 }


### PR DESCRIPTION
## Summary

Fixes a nil pointer dereference bug in `flow/retriever/router/router.go`.

## Problem

In `NewRetriever`, a local `router` variable is correctly resolved to a default function when `config.Router` is `nil`. However, the struct literal then stores `config.Router` (still `nil`) instead of the local `router` variable. This means calling `Retrieve()` without a custom `Router` configured panics at runtime:

```
runtime error: invalid memory address or nil pointer dereference
```

## Fix

Change the struct initialization to use the resolved `router` variable:

```go
// Before (buggy)
return &routerRetriever{
    retrievers: config.Retrievers,
    router:     config.Router,  // nil when Router not provided
    fusionFunc: fusion,
}, nil

// After (fixed)
return &routerRetriever{
    retrievers: config.Retrievers,
    router:     router,  // always non-nil: either config.Router or the default
    fusionFunc: fusion,
}, nil
```

Closes #954
