### PR TITLE
feat(adk): reduction mw support tool_call & tool_resp messages rewrite

### DIFF
--- a/adk/middlewares/reduction/reduction.go
+++ b/adk/middlewares/reduction/reduction.go
@@ -119,6 +119,15 @@ type Config struct {
 	// Optional. Default is nil.
 	ClearExcludeTools []string
 
+	// ClearMessageRewriter is a pre-process handler before clearing specific tool call and tool response pairs.
+	// You can rewrite tool call and tool messages extracted as parameters and return a rearranged message slice.
+	// This can be useful when you want to remove some tool calls (e.g., write_file / edit_file) and rewrite them
+	// as a user message (e.g. <system-reminder>).
+	// Returned messages will replace the original tool call and tool messages and will count towards ClearAtLeastTokens.
+	// If returned messagesAfterRewrite is nil, tool call and tool messages will be removed.
+	// Optional. Default is nil, which means no rewrite.
+	ClearMessageRewriter func(ctx context.Context, toolCallMsg adk.Message, toolResponseMsgs []adk.Message) (messagesAfterRewrite []adk.Message, err error)
+
 	// ClearPostProcess is clear post process handler.
 	// Optional.
 	ClearPostProcess func(ctx context.Context, state *adk.ChatModelAgentState) context.Context
@@ -232,6 +241,7 @@ func (t *Config) copyAndFillDefaults() (*Config, error) {
 		ClearRetentionSuffixLimit: t.ClearRetentionSuffixLimit,
 		ClearAtLeastTokens:        t.ClearAtLeastTokens,
 		ClearExcludeTools:         t.ClearExcludeTools,
+		ClearMessageRewriter:      t.ClearMessageRewriter,
 		ClearPostProcess:          t.ClearPostProcess,
 	}
 	if cfg.TokenCounter == nil {
@@ -591,19 +601,15 @@ func (t *toolReductionMiddleware) BeforeModelRewriteState(ctx context.Context, s
 	if start >= end {
 		return ctx, state, nil
 	}
-
 	var (
-		offloadStash       []*offloadStashItem
 		editTarget         []*schema.Message
 		clearAtLeastTokens = t.config.ClearAtLeastTokens
+		offloadStash       []*offloadStashItem
 	)
 
-	if clearAtLeastTokens > 0 {
-		editTarget = append(editTarget, state.Messages[:start]...)
-		editTarget = append(editTarget, copyMessages(state.Messages[start:end])...)
-		editTarget = append(editTarget, state.Messages[end:]...)
-	} else {
-		editTarget = state.Messages
+	editTarget, end, err = t.applyClearRewrite(ctx, state, start, end, clearAtLeastTokens)
+	if err != nil {
+		return ctx, state, err
 	}
 
 	// recursively handle
@@ -712,14 +718,80 @@ func (t *toolReductionMiddleware) BeforeModelRewriteState(ctx context.Context, s
 				return ctx, state, writeErr
 			}
 		}
-		state.Messages = editTarget // replace original state messages
 	}
+
+	state.Messages = editTarget // replace original state messages
 
 	if t.config.ClearPostProcess != nil {
 		ctx = t.config.ClearPostProcess(ctx, state)
 	}
 
 	return ctx, state, nil
+}
+
+func (t *toolReductionMiddleware) applyClearRewrite(ctx context.Context, state *adk.ChatModelAgentState, start, end int, clearAtLeastTokens int64) (
+	[]*schema.Message, int, error) {
+	var (
+		editTarget      []*schema.Message
+		needProcessPart []*schema.Message
+	)
+
+	editTarget = append(editTarget, state.Messages[:start]...)
+
+	if clearAtLeastTokens > 0 {
+		needProcessPart = copyMessages(state.Messages[start:end])
+	} else {
+		needProcessPart = state.Messages[start:end]
+	}
+
+	if t.config.ClearMessageRewriter != nil {
+		var (
+			rewritten  []*schema.Message
+			origLength = len(needProcessPart)
+		)
+		for i := 0; i < len(needProcessPart); {
+			msg := needProcessPart[i]
+			switch msg.Role {
+			case schema.System, schema.User:
+				rewritten = append(rewritten, msg)
+				i++
+			case schema.Tool:
+				i++
+			case schema.Assistant:
+				if len(msg.ToolCalls) == 0 {
+					rewritten = append(rewritten, msg)
+					i++
+					continue
+				}
+				var (
+					toolResponseMessages []adk.Message
+					trStart, trEnd       = i + 1, i + len(msg.ToolCalls) + 1
+				)
+				if trStart >= trEnd || trStart >= len(needProcessPart) || trEnd > len(needProcessPart) {
+					toolResponseMessages = nil
+				} else {
+					toolResponseMessages = needProcessPart[trStart:trEnd]
+				}
+
+				rewrittenMessages, rewriteErr := t.config.ClearMessageRewriter(ctx, msg, toolResponseMessages)
+				if rewriteErr != nil {
+					return nil, 0, rewriteErr
+				}
+				rewritten = append(rewritten, rewrittenMessages...)
+				i = trEnd
+			default: // unexpected
+				return nil, 0, fmt.Errorf("[applyClearRewrite] unexpected message role: %v", msg.Role)
+			}
+		}
+		editTarget = append(editTarget, rewritten...)
+		editTarget = append(editTarget, state.Messages[end:]...)
+		end = end - origLength + len(rewritten)
+	} else {
+		editTarget = append(editTarget, needProcessPart...)
+		editTarget = append(editTarget, state.Messages[end:]...)
+	}
+
+	return editTarget, end, nil
 }
 
 type offloadStashItem struct {

--- a/adk/middlewares/reduction/reduction.go
+++ b/adk/middlewares/reduction/reduction.go
@@ -104,6 +104,14 @@ type Config struct {
 	// Optional. Default is nil.
 	ClearExcludeTools []string
 
+	// ClearRewriteMessagesHandler is a pre-process handler before clearing specific tool call and tool response pairs.
+	// You can rewrite assistant and tool message pairs extracted as parameters and return a rearranged message slice.
+	// This can be useful when you want to remove some tool calls (e.g., write_file / edit_file) and rewrite them
+	// as a user message (e.g. <system-reminder>).
+	// Returned messages will replace the original assistant and tool response messages and will count towards ClearAtLeastTokens.
+	// Optional. Default is nil.
+	ClearRewriteMessagesHandler func(ctx context.Context, assistantMessage adk.Message, toolResponses []adk.Message) (messagesAfterRewrite []adk.Message, err error)
+
 	// ClearPostProcess is clear post process handler.
 	// Optional.
 	ClearPostProcess func(ctx context.Context, state *adk.ChatModelAgentState) context.Context
@@ -201,19 +209,20 @@ type ClearResult struct {
 
 func (t *Config) copyAndFillDefaults() (*Config, error) {
 	cfg := &Config{
-		Backend:                   t.Backend,
-		SkipTruncation:            t.SkipTruncation,
-		SkipClear:                 t.SkipClear,
-		ReadFileToolName:          t.ReadFileToolName,
-		RootDir:                   t.RootDir,
-		MaxLengthForTrunc:         t.MaxLengthForTrunc,
-		TruncExcludeTools:         t.TruncExcludeTools,
-		TokenCounter:              t.TokenCounter,
-		MaxTokensForClear:         t.MaxTokensForClear,
-		ClearRetentionSuffixLimit: t.ClearRetentionSuffixLimit,
-		ClearAtLeastTokens:        t.ClearAtLeastTokens,
-		ClearExcludeTools:         t.ClearExcludeTools,
-		ClearPostProcess:          t.ClearPostProcess,
+		Backend:                     t.Backend,
+		SkipTruncation:              t.SkipTruncation,
+		SkipClear:                   t.SkipClear,
+		ReadFileToolName:            t.ReadFileToolName,
+		RootDir:                     t.RootDir,
+		MaxLengthForTrunc:           t.MaxLengthForTrunc,
+		TruncExcludeTools:           t.TruncExcludeTools,
+		TokenCounter:                t.TokenCounter,
+		MaxTokensForClear:           t.MaxTokensForClear,
+		ClearRetentionSuffixLimit:   t.ClearRetentionSuffixLimit,
+		ClearAtLeastTokens:          t.ClearAtLeastTokens,
+		ClearExcludeTools:           t.ClearExcludeTools,
+		ClearRewriteMessagesHandler: t.ClearRewriteMessagesHandler,
+		ClearPostProcess:            t.ClearPostProcess,
 	}
 	if cfg.TokenCounter == nil {
 		cfg.TokenCounter = defaultTokenCounter
@@ -464,19 +473,15 @@ func (t *toolReductionMiddleware) BeforeModelRewriteState(ctx context.Context, s
 	if start >= end {
 		return ctx, state, nil
 	}
-
 	var (
-		offloadStash       []*offloadStashItem
 		editTarget         []*schema.Message
 		clearAtLeastTokens = t.config.ClearAtLeastTokens
+		offloadStash       []*offloadStashItem
 	)
 
-	if clearAtLeastTokens > 0 {
-		editTarget = append(editTarget, state.Messages[:start]...)
-		editTarget = append(editTarget, copyMessages(state.Messages[start:end])...)
-		editTarget = append(editTarget, state.Messages[end:]...)
-	} else {
-		editTarget = state.Messages
+	editTarget, end, err = t.applyClearRewrite(ctx, state, start, end, clearAtLeastTokens)
+	if err != nil {
+		return ctx, state, err
 	}
 
 	// recursively handle
@@ -585,14 +590,80 @@ func (t *toolReductionMiddleware) BeforeModelRewriteState(ctx context.Context, s
 				return ctx, state, writeErr
 			}
 		}
-		state.Messages = editTarget // replace original state messages
 	}
+
+	state.Messages = editTarget // replace original state messages
 
 	if t.config.ClearPostProcess != nil {
 		ctx = t.config.ClearPostProcess(ctx, state)
 	}
 
 	return ctx, state, nil
+}
+
+func (t *toolReductionMiddleware) applyClearRewrite(ctx context.Context, state *adk.ChatModelAgentState, start, end int, clearAtLeastTokens int64) (
+	[]*schema.Message, int, error) {
+	var (
+		editTarget      []*schema.Message
+		needProcessPart []*schema.Message
+	)
+
+	editTarget = append(editTarget, state.Messages[:start]...)
+
+	if clearAtLeastTokens > 0 {
+		needProcessPart = copyMessages(state.Messages[start:end])
+	} else {
+		needProcessPart = state.Messages[start:end]
+	}
+
+	if t.config.ClearRewriteMessagesHandler != nil {
+		var (
+			rewritten  []*schema.Message
+			origLength = len(needProcessPart)
+		)
+		for i := 0; i < len(needProcessPart); {
+			msg := needProcessPart[i]
+			switch msg.Role {
+			case schema.System, schema.User:
+				rewritten = append(rewritten, msg)
+				i++
+			case schema.Tool:
+				i++
+			case schema.Assistant:
+				if len(msg.ToolCalls) == 0 {
+					rewritten = append(rewritten, msg)
+					i++
+					continue
+				}
+				var (
+					toolResponseMessages []adk.Message
+					trStart, trEnd       = i + 1, i + len(msg.ToolCalls) + 1
+				)
+				if trStart >= trEnd || trStart >= len(needProcessPart) || trEnd > len(needProcessPart) {
+					toolResponseMessages = nil
+				} else {
+					toolResponseMessages = needProcessPart[trStart:trEnd]
+				}
+
+				rewrittenMessages, rewriteErr := t.config.ClearRewriteMessagesHandler(ctx, msg, toolResponseMessages)
+				if rewriteErr != nil {
+					return nil, 0, rewriteErr
+				}
+				rewritten = append(rewritten, rewrittenMessages...)
+				i = trEnd
+			default: // unexpected
+				i++
+			}
+		}
+		editTarget = append(editTarget, rewritten...)
+		editTarget = append(editTarget, state.Messages[end:]...)
+		end = end - origLength + len(rewritten)
+	} else {
+		editTarget = append(editTarget, needProcessPart...)
+		editTarget = append(editTarget, state.Messages[end:]...)
+	}
+
+	return editTarget, end, nil
 }
 
 type offloadStashItem struct {

--- a/adk/middlewares/reduction/reduction_test.go
+++ b/adk/middlewares/reduction/reduction_test.go
@@ -2261,3 +2261,491 @@ func TestReductionMiddlewareEnhancedTrunc(t *testing.T) {
 		assert.EqualError(t, err, "truncation: no backend for offload")
 	})
 }
+
+func TestClearRewriteMessagesHandler(t *testing.T) {
+	ctx := context.Background()
+	it := mockInvokableTool()
+	st := mockStreamableTool()
+	tools := []tool.BaseTool{it, st}
+	var toolsInfo []*schema.ToolInfo
+	for _, bt := range tools {
+		ti, _ := bt.Info(ctx)
+		toolsInfo = append(toolsInfo, ti)
+	}
+
+	tokenCounter := func(_ context.Context, msgs []adk.Message, _ []*schema.ToolInfo) (int64, error) {
+		return int64(1000), nil
+	}
+
+	t.Run("test all tools hit - rewrite to system reminder", func(t *testing.T) {
+		config := &Config{
+			SkipTruncation:     true,
+			TokenCounter:       tokenCounter,
+			MaxTokensForClear:  10,
+			ClearAtLeastTokens: 0,
+			ClearMessageRewriter: func(ctx context.Context, assistantMessage adk.Message, toolResponses []adk.Message) (messagesAfterRewrite []adk.Message, err error) {
+				return []adk.Message{
+					schema.UserMessage("<system-reminder>write_file and edit_file executed successfully</system-reminder>"),
+				}, nil
+			},
+		}
+
+		mw, err := New(ctx, config)
+		assert.NoError(t, err)
+		_, s, err := mw.BeforeModelRewriteState(ctx, &adk.ChatModelAgentState{
+			Messages: []adk.Message{
+				schema.SystemMessage("you are a helpful assistant"),
+				schema.UserMessage("user request"),
+				schema.AssistantMessage("", []schema.ToolCall{
+					{
+						ID:       "call_1",
+						Type:     "function",
+						Function: schema.FunctionCall{Name: "write_file", Arguments: `{"file": "test.txt", "content": "hello"}`},
+					},
+					{
+						ID:       "call_2",
+						Type:     "function",
+						Function: schema.FunctionCall{Name: "edit_file", Arguments: `{"file": "test.txt", "changes": "add"}`},
+					},
+				}),
+				schema.ToolMessage("write success", "call_1"),
+				schema.ToolMessage("edit success", "call_2"),
+				schema.AssistantMessage("done", nil),
+				schema.AssistantMessage("", []schema.ToolCall{{ID: "dummy", Type: "function", Function: schema.FunctionCall{Name: "dummy_tool"}}}),
+			},
+		}, &adk.ModelContext{
+			Tools: toolsInfo,
+		})
+		assert.NoError(t, err)
+		assert.Len(t, s.Messages, 5)
+		assert.Equal(t, schema.User, s.Messages[2].Role)
+		assert.Equal(t, "<system-reminder>write_file and edit_file executed successfully</system-reminder>", s.Messages[2].Content)
+		assert.Equal(t, schema.Assistant, s.Messages[3].Role)
+		assert.Equal(t, "done", s.Messages[3].Content)
+	})
+
+	t.Run("test remove tool call and tool responses", func(t *testing.T) {
+		config := &Config{
+			SkipTruncation:     true,
+			TokenCounter:       tokenCounter,
+			MaxTokensForClear:  10,
+			ClearAtLeastTokens: 0,
+			ClearMessageRewriter: func(ctx context.Context, assistantMessage adk.Message, toolResponses []adk.Message) (messagesAfterRewrite []adk.Message, err error) {
+				return []adk.Message{}, nil
+			},
+		}
+
+		mw, err := New(ctx, config)
+		assert.NoError(t, err)
+		_, s, err := mw.BeforeModelRewriteState(ctx, &adk.ChatModelAgentState{
+			Messages: []adk.Message{
+				schema.SystemMessage("you are a helpful assistant"),
+				schema.UserMessage("user request"),
+				schema.AssistantMessage("", []schema.ToolCall{
+					{
+						ID:       "call_1",
+						Type:     "function",
+						Function: schema.FunctionCall{Name: "write_file", Arguments: `{"file": "test.txt", "content": "hello"}`},
+					},
+					{
+						ID:       "call_2",
+						Type:     "function",
+						Function: schema.FunctionCall{Name: "edit_file", Arguments: `{"file": "test.txt", "changes": "add"}`},
+					},
+				}),
+				schema.ToolMessage("write success", "call_1"),
+				schema.ToolMessage("edit success", "call_2"),
+				schema.AssistantMessage("", []schema.ToolCall{{ID: "dummy", Type: "function", Function: schema.FunctionCall{Name: "dummy_tool"}}}),
+				schema.ToolMessage("dummy dummy", "dummy"),
+				schema.AssistantMessage("done", nil),
+			},
+		}, &adk.ModelContext{
+			Tools: toolsInfo,
+		})
+		assert.NoError(t, err)
+		assert.Len(t, s.Messages, 5)
+		assert.Equal(t, schema.Assistant, s.Messages[2].Role)
+		assert.Equal(t, schema.Tool, s.Messages[3].Role)
+		assert.Equal(t, "dummy dummy", s.Messages[3].Content)
+		assert.Equal(t, schema.Assistant, s.Messages[4].Role)
+		assert.Equal(t, "done", s.Messages[4].Content)
+	})
+
+	t.Run("test partial tools hit - keep unhit tools and rewrite hit ones", func(t *testing.T) {
+		config := &Config{
+			SkipTruncation:     true,
+			TokenCounter:       tokenCounter,
+			MaxTokensForClear:  10,
+			ClearAtLeastTokens: 0,
+			ClearExcludeTools:  []string{"get_weather"},
+			ClearMessageRewriter: func(ctx context.Context, assistantMessage adk.Message, toolResponses []adk.Message) (messagesAfterRewrite []adk.Message, err error) {
+				hitToolIDs := map[string]bool{"call_1": true}
+
+				newToolCalls := make([]schema.ToolCall, 0)
+				newToolResponses := make([]adk.Message, 0)
+
+				for i, tc := range assistantMessage.ToolCalls {
+					if !hitToolIDs[tc.ID] {
+						newToolCalls = append(newToolCalls, tc)
+						if i < len(toolResponses) {
+							newToolResponses = append(newToolResponses, toolResponses[i])
+						}
+					}
+				}
+
+				result := []adk.Message{
+					schema.UserMessage("<system-reminder>write_file executed successfully</system-reminder>"),
+				}
+				if len(newToolCalls) > 0 {
+					result = append(result, schema.AssistantMessage("", newToolCalls))
+					result = append(result, newToolResponses...)
+				}
+				return result, nil
+			},
+		}
+
+		mw, err := New(ctx, config)
+		assert.NoError(t, err)
+		_, s, err := mw.BeforeModelRewriteState(ctx, &adk.ChatModelAgentState{
+			Messages: []adk.Message{
+				schema.SystemMessage("you are a helpful assistant"),
+				schema.UserMessage("user request"),
+				schema.AssistantMessage("", []schema.ToolCall{
+					{
+						ID:       "call_1",
+						Type:     "function",
+						Function: schema.FunctionCall{Name: "write_file", Arguments: `{"file": "test.txt", "content": "hello"}`},
+					},
+					{
+						ID:       "call_2",
+						Type:     "function",
+						Function: schema.FunctionCall{Name: "get_weather", Arguments: `{"location": "London"}`},
+					},
+				}),
+				schema.ToolMessage("write success", "call_1"),
+				schema.ToolMessage("sunny", "call_2"),
+				schema.AssistantMessage("", []schema.ToolCall{{ID: "dummy", Type: "function", Function: schema.FunctionCall{Name: "dummy_tool"}}}),
+			},
+		}, &adk.ModelContext{
+			Tools: toolsInfo,
+		})
+		assert.NoError(t, err)
+		assert.Len(t, s.Messages, 6)
+		assert.Equal(t, schema.User, s.Messages[2].Role)
+		assert.Equal(t, "<system-reminder>write_file executed successfully</system-reminder>", s.Messages[2].Content)
+		assert.Equal(t, schema.Assistant, s.Messages[3].Role)
+		assert.Len(t, s.Messages[3].ToolCalls, 1)
+		assert.Equal(t, "call_2", s.Messages[3].ToolCalls[0].ID)
+		assert.Equal(t, schema.Tool, s.Messages[4].Role)
+		assert.Equal(t, "sunny", s.Messages[4].Content)
+	})
+
+	t.Run("test mixed messages with system/user before", func(t *testing.T) {
+		config := &Config{
+			SkipTruncation:     true,
+			TokenCounter:       tokenCounter,
+			MaxTokensForClear:  10,
+			ClearAtLeastTokens: 0,
+			ClearMessageRewriter: func(ctx context.Context, assistantMessage adk.Message, toolResponses []adk.Message) (messagesAfterRewrite []adk.Message, err error) {
+				return []adk.Message{
+					schema.UserMessage("<system-reminder>tool executed</system-reminder>"),
+				}, nil
+			},
+		}
+
+		mw, err := New(ctx, config)
+		assert.NoError(t, err)
+		_, s, err := mw.BeforeModelRewriteState(ctx, &adk.ChatModelAgentState{
+			Messages: []adk.Message{
+				schema.SystemMessage("you are a helpful assistant"),
+				schema.UserMessage("first request"),
+				schema.AssistantMessage("", []schema.ToolCall{
+					{
+						ID:       "call_1",
+						Type:     "function",
+						Function: schema.FunctionCall{Name: "write_file", Arguments: `{"file": "test.txt"}`},
+					},
+				}),
+				schema.ToolMessage("success", "call_1"),
+				schema.UserMessage("second request"),
+				schema.AssistantMessage("", []schema.ToolCall{{ID: "dummy", Type: "function", Function: schema.FunctionCall{Name: "dummy_tool"}}}),
+			},
+		}, &adk.ModelContext{
+			Tools: toolsInfo,
+		})
+		assert.NoError(t, err)
+		assert.Len(t, s.Messages, 5)
+		assert.Equal(t, schema.System, s.Messages[0].Role)
+		assert.Equal(t, schema.User, s.Messages[1].Role)
+		assert.Equal(t, schema.User, s.Messages[2].Role)
+		assert.Equal(t, "<system-reminder>tool executed</system-reminder>", s.Messages[2].Content)
+		assert.Equal(t, schema.User, s.Messages[3].Role)
+	})
+
+	t.Run("test mixed messages with system/user before", func(t *testing.T) {
+		config := &Config{
+			SkipTruncation:     true,
+			TokenCounter:       tokenCounter,
+			MaxTokensForClear:  10,
+			ClearAtLeastTokens: 0,
+			ClearMessageRewriter: func(ctx context.Context, assistantMessage adk.Message, toolResponses []adk.Message) (messagesAfterRewrite []adk.Message, err error) {
+				return []adk.Message{
+					schema.UserMessage("<system-reminder>tool executed</system-reminder>"),
+				}, nil
+			},
+		}
+
+		mw, err := New(ctx, config)
+		assert.NoError(t, err)
+		_, s, err := mw.BeforeModelRewriteState(ctx, &adk.ChatModelAgentState{
+			Messages: []adk.Message{
+				schema.SystemMessage("you are a helpful assistant"),
+				schema.UserMessage("first request"),
+				schema.AssistantMessage("", []schema.ToolCall{
+					{
+						ID:       "call_1",
+						Type:     "function",
+						Function: schema.FunctionCall{Name: "write_file", Arguments: `{"file": "test.txt"}`},
+					},
+				}),
+				schema.ToolMessage("success", "call_1"),
+				schema.UserMessage("second request"),
+				schema.AssistantMessage("", []schema.ToolCall{{ID: "dummy", Type: "function", Function: schema.FunctionCall{Name: "dummy_tool"}}}),
+			},
+		}, &adk.ModelContext{
+			Tools: toolsInfo,
+		})
+		assert.NoError(t, err)
+		assert.Len(t, s.Messages, 5)
+		assert.Equal(t, schema.System, s.Messages[0].Role)
+		assert.Equal(t, schema.User, s.Messages[1].Role)
+		assert.Equal(t, schema.User, s.Messages[2].Role)
+		assert.Equal(t, "<system-reminder>tool executed</system-reminder>", s.Messages[2].Content)
+		assert.Equal(t, schema.User, s.Messages[3].Role)
+	})
+
+	t.Run("test assistant message without tool calls - keep as is", func(t *testing.T) {
+		handlerCalled := false
+		config := &Config{
+			SkipTruncation:     true,
+			TokenCounter:       tokenCounter,
+			MaxTokensForClear:  10,
+			ClearAtLeastTokens: 0,
+			ClearMessageRewriter: func(ctx context.Context, assistantMessage adk.Message, toolResponses []adk.Message) (messagesAfterRewrite []adk.Message, err error) {
+				handlerCalled = true
+				return nil, nil
+			},
+		}
+
+		mw, err := New(ctx, config)
+		assert.NoError(t, err)
+		_, s, err := mw.BeforeModelRewriteState(ctx, &adk.ChatModelAgentState{
+			Messages: []adk.Message{
+				schema.SystemMessage("you are a helpful assistant"),
+				schema.UserMessage("user request"),
+				schema.AssistantMessage("regular response without tools", nil),
+				schema.AssistantMessage("", []schema.ToolCall{{ID: "dummy", Type: "function", Function: schema.FunctionCall{Name: "dummy_tool"}}}),
+			},
+		}, &adk.ModelContext{
+			Tools: toolsInfo,
+		})
+		assert.NoError(t, err)
+		assert.False(t, handlerCalled)
+		assert.Len(t, s.Messages, 4)
+		assert.Equal(t, schema.Assistant, s.Messages[2].Role)
+		assert.Equal(t, "regular response without tools", s.Messages[2].Content)
+	})
+
+	t.Run("test clear not meeting threshold - should keep original messages", func(t *testing.T) {
+		originalTokenCount := int64(1000)
+		rewrittenTokenCount := int64(999)
+		callCount := 0
+
+		config := &Config{
+			SkipTruncation: true,
+			TokenCounter: func(_ context.Context, msgs []adk.Message, _ []*schema.ToolInfo) (int64, error) {
+				callCount++
+				if callCount == 1 {
+					return originalTokenCount, nil
+				}
+				return rewrittenTokenCount, nil
+			},
+			MaxTokensForClear:  10,
+			ClearAtLeastTokens: 10,
+			ClearMessageRewriter: func(ctx context.Context, assistantMessage adk.Message, toolResponses []adk.Message) (messagesAfterRewrite []adk.Message, err error) {
+				return []adk.Message{
+					schema.UserMessage("<system-reminder>tool executed</system-reminder>"),
+				}, nil
+			},
+		}
+
+		originalMessages := []adk.Message{
+			schema.SystemMessage("you are a helpful assistant"),
+			schema.UserMessage("user request"),
+			schema.AssistantMessage("", []schema.ToolCall{
+				{
+					ID:       "call_1",
+					Type:     "function",
+					Function: schema.FunctionCall{Name: "write_file", Arguments: `{"file": "test.txt"}`},
+				},
+			}),
+			schema.ToolMessage("success", "call_1"),
+			schema.AssistantMessage("", []schema.ToolCall{{ID: "dummy", Type: "function", Function: schema.FunctionCall{Name: "dummy_tool"}}}),
+		}
+
+		mw, err := New(ctx, config)
+		assert.NoError(t, err)
+		_, s, err := mw.BeforeModelRewriteState(ctx, &adk.ChatModelAgentState{
+			Messages: originalMessages,
+		}, &adk.ModelContext{
+			Tools: toolsInfo,
+		})
+		assert.NoError(t, err)
+		assert.Len(t, s.Messages, len(originalMessages))
+		for i := range originalMessages {
+			assert.Equal(t, originalMessages[i].Role, s.Messages[i].Role)
+			assert.Equal(t, originalMessages[i].Content, s.Messages[i].Content)
+		}
+	})
+
+	t.Run("test applyClearRewrite with default role", func(t *testing.T) {
+		config := &Config{
+			SkipTruncation:     true,
+			TokenCounter:       tokenCounter,
+			MaxTokensForClear:  10,
+			ClearAtLeastTokens: 0,
+			ClearMessageRewriter: func(ctx context.Context, assistantMessage adk.Message, toolResponses []adk.Message) (messagesAfterRewrite []adk.Message, err error) {
+				return []adk.Message{}, nil
+			},
+		}
+
+		mw, err := New(ctx, config)
+		assert.NoError(t, err)
+
+		unknownRoleMsg := &schema.Message{
+			Role:    "unknown_role",
+			Content: "unknown",
+		}
+
+		_, s, err := mw.BeforeModelRewriteState(ctx, &adk.ChatModelAgentState{
+			Messages: []adk.Message{
+				schema.SystemMessage("you are a helpful assistant"),
+				schema.UserMessage("user request"),
+				unknownRoleMsg,
+				schema.AssistantMessage("", []schema.ToolCall{{ID: "dummy", Type: "function", Function: schema.FunctionCall{Name: "dummy_tool"}}}),
+			},
+		}, &adk.ModelContext{
+			Tools: toolsInfo,
+		})
+		assert.NoError(t, err)
+		assert.NotNil(t, s)
+	})
+
+	t.Run("test applyClearRewrite with rewrite error", func(t *testing.T) {
+		expectedErr := fmt.Errorf("rewrite error")
+		config := &Config{
+			SkipTruncation:     true,
+			TokenCounter:       tokenCounter,
+			MaxTokensForClear:  10,
+			ClearAtLeastTokens: 0,
+			ClearMessageRewriter: func(ctx context.Context, assistantMessage adk.Message, toolResponses []adk.Message) (messagesAfterRewrite []adk.Message, err error) {
+				return nil, expectedErr
+			},
+		}
+
+		mw, err := New(ctx, config)
+		assert.NoError(t, err)
+
+		_, _, err = mw.BeforeModelRewriteState(ctx, &adk.ChatModelAgentState{
+			Messages: []adk.Message{
+				schema.SystemMessage("you are a helpful assistant"),
+				schema.UserMessage("user request"),
+				schema.AssistantMessage("", []schema.ToolCall{
+					{
+						ID:       "call_1",
+						Type:     "function",
+						Function: schema.FunctionCall{Name: "write_file", Arguments: `{"file": "test.txt"}`},
+					},
+				}),
+				schema.ToolMessage("success", "call_1"),
+				schema.AssistantMessage("", []schema.ToolCall{{ID: "dummy", Type: "function", Function: schema.FunctionCall{Name: "dummy_tool"}}}),
+			},
+		}, &adk.ModelContext{
+			Tools: toolsInfo,
+		})
+		assert.Error(t, err)
+		assert.Equal(t, expectedErr, err)
+	})
+
+	t.Run("test applyClearRewrite with missing tool responses", func(t *testing.T) {
+		config := &Config{
+			SkipTruncation:     true,
+			TokenCounter:       tokenCounter,
+			MaxTokensForClear:  10,
+			ClearAtLeastTokens: 0,
+			ClearMessageRewriter: func(ctx context.Context, assistantMessage adk.Message, toolResponses []adk.Message) (messagesAfterRewrite []adk.Message, err error) {
+				assert.Nil(t, toolResponses)
+				return []adk.Message{
+					schema.UserMessage("<system-reminder>tool executed</system-reminder>"),
+				}, nil
+			},
+		}
+
+		mw, err := New(ctx, config)
+		assert.NoError(t, err)
+		_, s, err := mw.BeforeModelRewriteState(ctx, &adk.ChatModelAgentState{
+			Messages: []adk.Message{
+				schema.SystemMessage("you are a helpful assistant"),
+				schema.UserMessage("user request"),
+				schema.AssistantMessage("", []schema.ToolCall{
+					{
+						ID:       "call_1",
+						Type:     "function",
+						Function: schema.FunctionCall{Name: "write_file", Arguments: `{"file": "test.txt"}`},
+					},
+				}),
+				schema.AssistantMessage("", []schema.ToolCall{{ID: "dummy", Type: "function", Function: schema.FunctionCall{Name: "dummy_tool"}}}),
+			},
+		}, &adk.ModelContext{
+			Tools: toolsInfo,
+		})
+		assert.NoError(t, err)
+		assert.NotNil(t, s)
+	})
+
+	t.Run("test applyClearRewrite with clearAtLeastTokens > 0", func(t *testing.T) {
+		config := &Config{
+			SkipTruncation:     true,
+			TokenCounter:       tokenCounter,
+			MaxTokensForClear:  10,
+			ClearAtLeastTokens: 10,
+			ClearMessageRewriter: func(ctx context.Context, assistantMessage adk.Message, toolResponses []adk.Message) (messagesAfterRewrite []adk.Message, err error) {
+				return []adk.Message{
+					schema.UserMessage("<system-reminder>tool executed</system-reminder>"),
+				}, nil
+			},
+		}
+
+		mw, err := New(ctx, config)
+		assert.NoError(t, err)
+		_, s, err := mw.BeforeModelRewriteState(ctx, &adk.ChatModelAgentState{
+			Messages: []adk.Message{
+				schema.SystemMessage("you are a helpful assistant"),
+				schema.UserMessage("user request"),
+				schema.AssistantMessage("", []schema.ToolCall{
+					{
+						ID:       "call_1",
+						Type:     "function",
+						Function: schema.FunctionCall{Name: "write_file", Arguments: `{"file": "test.txt"}`},
+					},
+				}),
+				schema.ToolMessage("success", "call_1"),
+				schema.AssistantMessage("", []schema.ToolCall{{ID: "dummy", Type: "function", Function: schema.FunctionCall{Name: "dummy_tool"}}}),
+			},
+		}, &adk.ModelContext{
+			Tools: toolsInfo,
+		})
+		assert.NoError(t, err)
+		assert.NotNil(t, s)
+	})
+}

--- a/adk/middlewares/reduction/reduction_test.go
+++ b/adk/middlewares/reduction/reduction_test.go
@@ -1623,3 +1623,491 @@ func TestCopyMessages(t *testing.T) {
 		assert.Len(t, result[0].AssistantGenMultiContent, 1)
 	})
 }
+
+func TestClearRewriteMessagesHandler(t *testing.T) {
+	ctx := context.Background()
+	it := mockInvokableTool()
+	st := mockStreamableTool()
+	tools := []tool.BaseTool{it, st}
+	var toolsInfo []*schema.ToolInfo
+	for _, bt := range tools {
+		ti, _ := bt.Info(ctx)
+		toolsInfo = append(toolsInfo, ti)
+	}
+
+	tokenCounter := func(_ context.Context, msgs []adk.Message, _ []*schema.ToolInfo) (int64, error) {
+		return int64(1000), nil
+	}
+
+	t.Run("test all tools hit - rewrite to system reminder", func(t *testing.T) {
+		config := &Config{
+			SkipTruncation:     true,
+			TokenCounter:       tokenCounter,
+			MaxTokensForClear:  10,
+			ClearAtLeastTokens: 0,
+			ClearRewriteMessagesHandler: func(ctx context.Context, assistantMessage adk.Message, toolResponses []adk.Message) (messagesAfterRewrite []adk.Message, err error) {
+				return []adk.Message{
+					schema.UserMessage("<system-reminder>write_file and edit_file executed successfully</system-reminder>"),
+				}, nil
+			},
+		}
+
+		mw, err := New(ctx, config)
+		assert.NoError(t, err)
+		_, s, err := mw.BeforeModelRewriteState(ctx, &adk.ChatModelAgentState{
+			Messages: []adk.Message{
+				schema.SystemMessage("you are a helpful assistant"),
+				schema.UserMessage("user request"),
+				schema.AssistantMessage("", []schema.ToolCall{
+					{
+						ID:       "call_1",
+						Type:     "function",
+						Function: schema.FunctionCall{Name: "write_file", Arguments: `{"file": "test.txt", "content": "hello"}`},
+					},
+					{
+						ID:       "call_2",
+						Type:     "function",
+						Function: schema.FunctionCall{Name: "edit_file", Arguments: `{"file": "test.txt", "changes": "add"}`},
+					},
+				}),
+				schema.ToolMessage("write success", "call_1"),
+				schema.ToolMessage("edit success", "call_2"),
+				schema.AssistantMessage("done", nil),
+				schema.AssistantMessage("", []schema.ToolCall{{ID: "dummy", Type: "function", Function: schema.FunctionCall{Name: "dummy_tool"}}}),
+			},
+		}, &adk.ModelContext{
+			Tools: toolsInfo,
+		})
+		assert.NoError(t, err)
+		assert.Len(t, s.Messages, 5)
+		assert.Equal(t, schema.User, s.Messages[2].Role)
+		assert.Equal(t, "<system-reminder>write_file and edit_file executed successfully</system-reminder>", s.Messages[2].Content)
+		assert.Equal(t, schema.Assistant, s.Messages[3].Role)
+		assert.Equal(t, "done", s.Messages[3].Content)
+	})
+
+	t.Run("test remove tool call and tool responses", func(t *testing.T) {
+		config := &Config{
+			SkipTruncation:     true,
+			TokenCounter:       tokenCounter,
+			MaxTokensForClear:  10,
+			ClearAtLeastTokens: 0,
+			ClearRewriteMessagesHandler: func(ctx context.Context, assistantMessage adk.Message, toolResponses []adk.Message) (messagesAfterRewrite []adk.Message, err error) {
+				return []adk.Message{}, nil
+			},
+		}
+
+		mw, err := New(ctx, config)
+		assert.NoError(t, err)
+		_, s, err := mw.BeforeModelRewriteState(ctx, &adk.ChatModelAgentState{
+			Messages: []adk.Message{
+				schema.SystemMessage("you are a helpful assistant"),
+				schema.UserMessage("user request"),
+				schema.AssistantMessage("", []schema.ToolCall{
+					{
+						ID:       "call_1",
+						Type:     "function",
+						Function: schema.FunctionCall{Name: "write_file", Arguments: `{"file": "test.txt", "content": "hello"}`},
+					},
+					{
+						ID:       "call_2",
+						Type:     "function",
+						Function: schema.FunctionCall{Name: "edit_file", Arguments: `{"file": "test.txt", "changes": "add"}`},
+					},
+				}),
+				schema.ToolMessage("write success", "call_1"),
+				schema.ToolMessage("edit success", "call_2"),
+				schema.AssistantMessage("", []schema.ToolCall{{ID: "dummy", Type: "function", Function: schema.FunctionCall{Name: "dummy_tool"}}}),
+				schema.ToolMessage("dummy dummy", "dummy"),
+				schema.AssistantMessage("done", nil),
+			},
+		}, &adk.ModelContext{
+			Tools: toolsInfo,
+		})
+		assert.NoError(t, err)
+		assert.Len(t, s.Messages, 5)
+		assert.Equal(t, schema.Assistant, s.Messages[2].Role)
+		assert.Equal(t, schema.Tool, s.Messages[3].Role)
+		assert.Equal(t, "dummy dummy", s.Messages[3].Content)
+		assert.Equal(t, schema.Assistant, s.Messages[4].Role)
+		assert.Equal(t, "done", s.Messages[4].Content)
+	})
+
+	t.Run("test partial tools hit - keep unhit tools and rewrite hit ones", func(t *testing.T) {
+		config := &Config{
+			SkipTruncation:     true,
+			TokenCounter:       tokenCounter,
+			MaxTokensForClear:  10,
+			ClearAtLeastTokens: 0,
+			ClearExcludeTools:  []string{"get_weather"},
+			ClearRewriteMessagesHandler: func(ctx context.Context, assistantMessage adk.Message, toolResponses []adk.Message) (messagesAfterRewrite []adk.Message, err error) {
+				hitToolIDs := map[string]bool{"call_1": true}
+
+				newToolCalls := make([]schema.ToolCall, 0)
+				newToolResponses := make([]adk.Message, 0)
+
+				for i, tc := range assistantMessage.ToolCalls {
+					if !hitToolIDs[tc.ID] {
+						newToolCalls = append(newToolCalls, tc)
+						if i < len(toolResponses) {
+							newToolResponses = append(newToolResponses, toolResponses[i])
+						}
+					}
+				}
+
+				result := []adk.Message{
+					schema.UserMessage("<system-reminder>write_file executed successfully</system-reminder>"),
+				}
+				if len(newToolCalls) > 0 {
+					result = append(result, schema.AssistantMessage("", newToolCalls))
+					result = append(result, newToolResponses...)
+				}
+				return result, nil
+			},
+		}
+
+		mw, err := New(ctx, config)
+		assert.NoError(t, err)
+		_, s, err := mw.BeforeModelRewriteState(ctx, &adk.ChatModelAgentState{
+			Messages: []adk.Message{
+				schema.SystemMessage("you are a helpful assistant"),
+				schema.UserMessage("user request"),
+				schema.AssistantMessage("", []schema.ToolCall{
+					{
+						ID:       "call_1",
+						Type:     "function",
+						Function: schema.FunctionCall{Name: "write_file", Arguments: `{"file": "test.txt", "content": "hello"}`},
+					},
+					{
+						ID:       "call_2",
+						Type:     "function",
+						Function: schema.FunctionCall{Name: "get_weather", Arguments: `{"location": "London"}`},
+					},
+				}),
+				schema.ToolMessage("write success", "call_1"),
+				schema.ToolMessage("sunny", "call_2"),
+				schema.AssistantMessage("", []schema.ToolCall{{ID: "dummy", Type: "function", Function: schema.FunctionCall{Name: "dummy_tool"}}}),
+			},
+		}, &adk.ModelContext{
+			Tools: toolsInfo,
+		})
+		assert.NoError(t, err)
+		assert.Len(t, s.Messages, 6)
+		assert.Equal(t, schema.User, s.Messages[2].Role)
+		assert.Equal(t, "<system-reminder>write_file executed successfully</system-reminder>", s.Messages[2].Content)
+		assert.Equal(t, schema.Assistant, s.Messages[3].Role)
+		assert.Len(t, s.Messages[3].ToolCalls, 1)
+		assert.Equal(t, "call_2", s.Messages[3].ToolCalls[0].ID)
+		assert.Equal(t, schema.Tool, s.Messages[4].Role)
+		assert.Equal(t, "sunny", s.Messages[4].Content)
+	})
+
+	t.Run("test mixed messages with system/user before", func(t *testing.T) {
+		config := &Config{
+			SkipTruncation:     true,
+			TokenCounter:       tokenCounter,
+			MaxTokensForClear:  10,
+			ClearAtLeastTokens: 0,
+			ClearRewriteMessagesHandler: func(ctx context.Context, assistantMessage adk.Message, toolResponses []adk.Message) (messagesAfterRewrite []adk.Message, err error) {
+				return []adk.Message{
+					schema.UserMessage("<system-reminder>tool executed</system-reminder>"),
+				}, nil
+			},
+		}
+
+		mw, err := New(ctx, config)
+		assert.NoError(t, err)
+		_, s, err := mw.BeforeModelRewriteState(ctx, &adk.ChatModelAgentState{
+			Messages: []adk.Message{
+				schema.SystemMessage("you are a helpful assistant"),
+				schema.UserMessage("first request"),
+				schema.AssistantMessage("", []schema.ToolCall{
+					{
+						ID:       "call_1",
+						Type:     "function",
+						Function: schema.FunctionCall{Name: "write_file", Arguments: `{"file": "test.txt"}`},
+					},
+				}),
+				schema.ToolMessage("success", "call_1"),
+				schema.UserMessage("second request"),
+				schema.AssistantMessage("", []schema.ToolCall{{ID: "dummy", Type: "function", Function: schema.FunctionCall{Name: "dummy_tool"}}}),
+			},
+		}, &adk.ModelContext{
+			Tools: toolsInfo,
+		})
+		assert.NoError(t, err)
+		assert.Len(t, s.Messages, 5)
+		assert.Equal(t, schema.System, s.Messages[0].Role)
+		assert.Equal(t, schema.User, s.Messages[1].Role)
+		assert.Equal(t, schema.User, s.Messages[2].Role)
+		assert.Equal(t, "<system-reminder>tool executed</system-reminder>", s.Messages[2].Content)
+		assert.Equal(t, schema.User, s.Messages[3].Role)
+	})
+
+	t.Run("test mixed messages with system/user before", func(t *testing.T) {
+		config := &Config{
+			SkipTruncation:     true,
+			TokenCounter:       tokenCounter,
+			MaxTokensForClear:  10,
+			ClearAtLeastTokens: 0,
+			ClearRewriteMessagesHandler: func(ctx context.Context, assistantMessage adk.Message, toolResponses []adk.Message) (messagesAfterRewrite []adk.Message, err error) {
+				return []adk.Message{
+					schema.UserMessage("<system-reminder>tool executed</system-reminder>"),
+				}, nil
+			},
+		}
+
+		mw, err := New(ctx, config)
+		assert.NoError(t, err)
+		_, s, err := mw.BeforeModelRewriteState(ctx, &adk.ChatModelAgentState{
+			Messages: []adk.Message{
+				schema.SystemMessage("you are a helpful assistant"),
+				schema.UserMessage("first request"),
+				schema.AssistantMessage("", []schema.ToolCall{
+					{
+						ID:       "call_1",
+						Type:     "function",
+						Function: schema.FunctionCall{Name: "write_file", Arguments: `{"file": "test.txt"}`},
+					},
+				}),
+				schema.ToolMessage("success", "call_1"),
+				schema.UserMessage("second request"),
+				schema.AssistantMessage("", []schema.ToolCall{{ID: "dummy", Type: "function", Function: schema.FunctionCall{Name: "dummy_tool"}}}),
+			},
+		}, &adk.ModelContext{
+			Tools: toolsInfo,
+		})
+		assert.NoError(t, err)
+		assert.Len(t, s.Messages, 5)
+		assert.Equal(t, schema.System, s.Messages[0].Role)
+		assert.Equal(t, schema.User, s.Messages[1].Role)
+		assert.Equal(t, schema.User, s.Messages[2].Role)
+		assert.Equal(t, "<system-reminder>tool executed</system-reminder>", s.Messages[2].Content)
+		assert.Equal(t, schema.User, s.Messages[3].Role)
+	})
+
+	t.Run("test assistant message without tool calls - keep as is", func(t *testing.T) {
+		handlerCalled := false
+		config := &Config{
+			SkipTruncation:     true,
+			TokenCounter:       tokenCounter,
+			MaxTokensForClear:  10,
+			ClearAtLeastTokens: 0,
+			ClearRewriteMessagesHandler: func(ctx context.Context, assistantMessage adk.Message, toolResponses []adk.Message) (messagesAfterRewrite []adk.Message, err error) {
+				handlerCalled = true
+				return nil, nil
+			},
+		}
+
+		mw, err := New(ctx, config)
+		assert.NoError(t, err)
+		_, s, err := mw.BeforeModelRewriteState(ctx, &adk.ChatModelAgentState{
+			Messages: []adk.Message{
+				schema.SystemMessage("you are a helpful assistant"),
+				schema.UserMessage("user request"),
+				schema.AssistantMessage("regular response without tools", nil),
+				schema.AssistantMessage("", []schema.ToolCall{{ID: "dummy", Type: "function", Function: schema.FunctionCall{Name: "dummy_tool"}}}),
+			},
+		}, &adk.ModelContext{
+			Tools: toolsInfo,
+		})
+		assert.NoError(t, err)
+		assert.False(t, handlerCalled)
+		assert.Len(t, s.Messages, 4)
+		assert.Equal(t, schema.Assistant, s.Messages[2].Role)
+		assert.Equal(t, "regular response without tools", s.Messages[2].Content)
+	})
+
+	t.Run("test clear not meeting threshold - should keep original messages", func(t *testing.T) {
+		originalTokenCount := int64(1000)
+		rewrittenTokenCount := int64(999)
+		callCount := 0
+
+		config := &Config{
+			SkipTruncation: true,
+			TokenCounter: func(_ context.Context, msgs []adk.Message, _ []*schema.ToolInfo) (int64, error) {
+				callCount++
+				if callCount == 1 {
+					return originalTokenCount, nil
+				}
+				return rewrittenTokenCount, nil
+			},
+			MaxTokensForClear:  10,
+			ClearAtLeastTokens: 10,
+			ClearRewriteMessagesHandler: func(ctx context.Context, assistantMessage adk.Message, toolResponses []adk.Message) (messagesAfterRewrite []adk.Message, err error) {
+				return []adk.Message{
+					schema.UserMessage("<system-reminder>tool executed</system-reminder>"),
+				}, nil
+			},
+		}
+
+		originalMessages := []adk.Message{
+			schema.SystemMessage("you are a helpful assistant"),
+			schema.UserMessage("user request"),
+			schema.AssistantMessage("", []schema.ToolCall{
+				{
+					ID:       "call_1",
+					Type:     "function",
+					Function: schema.FunctionCall{Name: "write_file", Arguments: `{"file": "test.txt"}`},
+				},
+			}),
+			schema.ToolMessage("success", "call_1"),
+			schema.AssistantMessage("", []schema.ToolCall{{ID: "dummy", Type: "function", Function: schema.FunctionCall{Name: "dummy_tool"}}}),
+		}
+
+		mw, err := New(ctx, config)
+		assert.NoError(t, err)
+		_, s, err := mw.BeforeModelRewriteState(ctx, &adk.ChatModelAgentState{
+			Messages: originalMessages,
+		}, &adk.ModelContext{
+			Tools: toolsInfo,
+		})
+		assert.NoError(t, err)
+		assert.Len(t, s.Messages, len(originalMessages))
+		for i := range originalMessages {
+			assert.Equal(t, originalMessages[i].Role, s.Messages[i].Role)
+			assert.Equal(t, originalMessages[i].Content, s.Messages[i].Content)
+		}
+	})
+
+	t.Run("test applyClearRewrite with default role", func(t *testing.T) {
+		config := &Config{
+			SkipTruncation:     true,
+			TokenCounter:       tokenCounter,
+			MaxTokensForClear:  10,
+			ClearAtLeastTokens: 0,
+			ClearRewriteMessagesHandler: func(ctx context.Context, assistantMessage adk.Message, toolResponses []adk.Message) (messagesAfterRewrite []adk.Message, err error) {
+				return []adk.Message{}, nil
+			},
+		}
+
+		mw, err := New(ctx, config)
+		assert.NoError(t, err)
+
+		unknownRoleMsg := &schema.Message{
+			Role:    "unknown_role",
+			Content: "unknown",
+		}
+
+		_, s, err := mw.BeforeModelRewriteState(ctx, &adk.ChatModelAgentState{
+			Messages: []adk.Message{
+				schema.SystemMessage("you are a helpful assistant"),
+				schema.UserMessage("user request"),
+				unknownRoleMsg,
+				schema.AssistantMessage("", []schema.ToolCall{{ID: "dummy", Type: "function", Function: schema.FunctionCall{Name: "dummy_tool"}}}),
+			},
+		}, &adk.ModelContext{
+			Tools: toolsInfo,
+		})
+		assert.NoError(t, err)
+		assert.NotNil(t, s)
+	})
+
+	t.Run("test applyClearRewrite with rewrite error", func(t *testing.T) {
+		expectedErr := fmt.Errorf("rewrite error")
+		config := &Config{
+			SkipTruncation:     true,
+			TokenCounter:       tokenCounter,
+			MaxTokensForClear:  10,
+			ClearAtLeastTokens: 0,
+			ClearRewriteMessagesHandler: func(ctx context.Context, assistantMessage adk.Message, toolResponses []adk.Message) (messagesAfterRewrite []adk.Message, err error) {
+				return nil, expectedErr
+			},
+		}
+
+		mw, err := New(ctx, config)
+		assert.NoError(t, err)
+
+		_, _, err = mw.BeforeModelRewriteState(ctx, &adk.ChatModelAgentState{
+			Messages: []adk.Message{
+				schema.SystemMessage("you are a helpful assistant"),
+				schema.UserMessage("user request"),
+				schema.AssistantMessage("", []schema.ToolCall{
+					{
+						ID:       "call_1",
+						Type:     "function",
+						Function: schema.FunctionCall{Name: "write_file", Arguments: `{"file": "test.txt"}`},
+					},
+				}),
+				schema.ToolMessage("success", "call_1"),
+				schema.AssistantMessage("", []schema.ToolCall{{ID: "dummy", Type: "function", Function: schema.FunctionCall{Name: "dummy_tool"}}}),
+			},
+		}, &adk.ModelContext{
+			Tools: toolsInfo,
+		})
+		assert.Error(t, err)
+		assert.Equal(t, expectedErr, err)
+	})
+
+	t.Run("test applyClearRewrite with missing tool responses", func(t *testing.T) {
+		config := &Config{
+			SkipTruncation:     true,
+			TokenCounter:       tokenCounter,
+			MaxTokensForClear:  10,
+			ClearAtLeastTokens: 0,
+			ClearRewriteMessagesHandler: func(ctx context.Context, assistantMessage adk.Message, toolResponses []adk.Message) (messagesAfterRewrite []adk.Message, err error) {
+				assert.Nil(t, toolResponses)
+				return []adk.Message{
+					schema.UserMessage("<system-reminder>tool executed</system-reminder>"),
+				}, nil
+			},
+		}
+
+		mw, err := New(ctx, config)
+		assert.NoError(t, err)
+		_, s, err := mw.BeforeModelRewriteState(ctx, &adk.ChatModelAgentState{
+			Messages: []adk.Message{
+				schema.SystemMessage("you are a helpful assistant"),
+				schema.UserMessage("user request"),
+				schema.AssistantMessage("", []schema.ToolCall{
+					{
+						ID:       "call_1",
+						Type:     "function",
+						Function: schema.FunctionCall{Name: "write_file", Arguments: `{"file": "test.txt"}`},
+					},
+				}),
+				schema.AssistantMessage("", []schema.ToolCall{{ID: "dummy", Type: "function", Function: schema.FunctionCall{Name: "dummy_tool"}}}),
+			},
+		}, &adk.ModelContext{
+			Tools: toolsInfo,
+		})
+		assert.NoError(t, err)
+		assert.NotNil(t, s)
+	})
+
+	t.Run("test applyClearRewrite with clearAtLeastTokens > 0", func(t *testing.T) {
+		config := &Config{
+			SkipTruncation:     true,
+			TokenCounter:       tokenCounter,
+			MaxTokensForClear:  10,
+			ClearAtLeastTokens: 10,
+			ClearRewriteMessagesHandler: func(ctx context.Context, assistantMessage adk.Message, toolResponses []adk.Message) (messagesAfterRewrite []adk.Message, err error) {
+				return []adk.Message{
+					schema.UserMessage("<system-reminder>tool executed</system-reminder>"),
+				}, nil
+			},
+		}
+
+		mw, err := New(ctx, config)
+		assert.NoError(t, err)
+		_, s, err := mw.BeforeModelRewriteState(ctx, &adk.ChatModelAgentState{
+			Messages: []adk.Message{
+				schema.SystemMessage("you are a helpful assistant"),
+				schema.UserMessage("user request"),
+				schema.AssistantMessage("", []schema.ToolCall{
+					{
+						ID:       "call_1",
+						Type:     "function",
+						Function: schema.FunctionCall{Name: "write_file", Arguments: `{"file": "test.txt"}`},
+					},
+				}),
+				schema.ToolMessage("success", "call_1"),
+				schema.AssistantMessage("", []schema.ToolCall{{ID: "dummy", Type: "function", Function: schema.FunctionCall{Name: "dummy_tool"}}}),
+			},
+		}, &adk.ModelContext{
+			Tools: toolsInfo,
+		})
+		assert.NoError(t, err)
+		assert.NotNil(t, s)
+	})
+}


### PR DESCRIPTION
#### What type of PR is this?
<!--
Add one of the following kinds:

build: Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)
ci: Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
docs: Documentation only changes
feat: A new feature
optimize: A new optimization
fix: A bug fix
perf: A code change that improves performance
refactor: A code change that neither fixes a bug nor adds a feature
style: Changes that do not affect the meaning of the code (white space, formatting, missing semi-colons, etc)
test: Adding missing tests or correcting existing tests
chore: Changes to the build process or auxiliary tools and libraries such as documentation generation
-->
feat

#### Check the PR title.
<!--
The description of the title will be attached in Release Notes, 
so please describe it from user-oriented, what this PR does / why we need it.
Please check your PR title with the below requirements:
-->
- [x] This PR title match the format: \<type\>(optional scope): \<description\>
- [x] The description of this PR title is user-oriented and clear enough for others to understand.
- [ ] Attach the PR updating the user documentation if the current PR requires user awareness at the usage level. [User docs repo](https://github.com/cloudwego/cloudwego.github.io)



#### (Optional) Translate the PR title into Chinese.
feat(adk/reduction): 新增 ClearRewriteMessagesHandler 功能，支持工具调用 / 工具返回消息消息重写



#### (Optional) More detailed description for this PR(en: English/zh: Chinese).
<!--
Provide more detailed info for review(e.g., it's recommended to provide perf data if this is a perf type PR).
-->
en:
This PR adds a new `ClearRewriteMessagesHandler` to the reduction middleware, allowing users to rewrite assistant and tool message pairs through this preprocessing step before actual tool cleanup. 

Since directly removing parameters of certain tool calls (such as write_file/edit_file) may cause hallucination, rewriting them as <system-reminder> user messages can both retain the tool call records and remove a large amount of content context.



zh(optional): 
本 PR 为 reduction 中间件新增了 `ClearRewriteMessagesHandler` 功能，允许用户在实际的工具清理前，通过这个预处理环节重写助手和工具消息对。

由于直接移除某些工具调用（如 write_file/edit_file）的参数可能导致幻觉，此时将其重写为 <system-reminder> user 消息既可以保留工具调用记录，又可以移除大量的 content 上下文。



#### (Optional) Which issue(s) this PR fixes:
<!--
Automatically closes linked issue when PR is merged.
Eg: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->



#### (optional) The PR that updates user documentation:
<!--
If the current PR requires user awareness at the usage level, please submit a PR to update user docs. [User docs repo](https://github.com/cloudwego/cloudwego.github.io)
-->
