### PR TITLE
fix: correct wrong variable in error message in compose/values_merge.go

### DIFF
--- a/compose/values_merge.go
+++ b/compose/values_merge.go
@@ -57,7 +57,7 @@ func mergeValues(vs []any, opts *mergeOptions) (any, error) {
 			sri, ok_ := vs[i+1].(streamReader)
 			if !ok_ {
 				return nil, fmt.Errorf("(mergeStream) unexpected type. "+
-					"expect: %v, got: %v", t0, reflect.TypeOf(vs[i]))
+					"expect: %v, got: %v", t0, reflect.TypeOf(vs[i+1]))
 			}
 
 			if st := sri.getChunkType(); st != t {


### PR DESCRIPTION
## Problem

In `compose/values_merge.go`, the `mergeValues` function contains a wrong variable reference in the error message when a type assertion fails for stream readers.

**Buggy code (line 60):**
```go
sri, ok_ := vs[i+1].(streamReader)
if !ok_ {
    return nil, fmt.Errorf("(mergeStream) unexpected type. "+
        "expect: %v, got: %v", t0, reflect.TypeOf(vs[i]))  // BUG: vs[i] should be vs[i+1]
}
```

The loop iterates `i` from `0` to `len(ss)-1`, checking elements `vs[i+1].(streamReader)`. When the assertion fails, the error message incorrectly reports `reflect.TypeOf(vs[i])` — the **previous** element that already succeeded — instead of `reflect.TypeOf(vs[i+1])` — the element that actually failed.

## Fix

```go
return nil, fmt.Errorf("(mergeStream) unexpected type. "+
    "expect: %v, got: %v", t0, reflect.TypeOf(vs[i+1]))  // FIXED
```

Fixes #974