### PR TITLE
fix(compose): pass through when field mapping input already matches target type

### DIFF
--- a/compose/field_mapping.go
+++ b/compose/field_mapping.go
@@ -213,6 +213,9 @@ func buildFieldMappingConverter[I any]() func(input any) (any, error) {
 	return func(input any) (any, error) {
 		in, ok := input.(map[string]any)
 		if !ok {
+			if reflect.TypeOf(input) == generic.TypeOf[I]() {
+				return input, nil
+			}
 			panic(newUnexpectedInputTypeErr(reflect.TypeOf(map[string]any{}), reflect.TypeOf(input)))
 		}
 
@@ -224,6 +227,9 @@ func buildStreamFieldMappingConverter[I any]() func(input streamReader) streamRe
 	return func(input streamReader) streamReader {
 		s, ok := unpackStreamReader[map[string]any](input)
 		if !ok {
+			if sr, ok := unpackStreamReader[I](input); ok {
+				return packStreamReader(sr)
+			}
 			panic("mappingStreamAssign incoming streamReader chunk type not map[string]any")
 		}
 

--- a/compose/field_mapping_test.go
+++ b/compose/field_mapping_test.go
@@ -1,0 +1,145 @@
+/*
+ * Copyright 2025 CloudWeGo Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package compose
+
+import (
+	"io"
+	"testing"
+
+	"github.com/cloudwego/eino/schema"
+)
+
+type fieldMappingTarget struct {
+	Name string `json:"name"`
+	Age  int    `json:"age"`
+}
+
+func TestBuildFieldMappingConverter_PassThroughWhenInputIsTargetType(t *testing.T) {
+	conv := buildFieldMappingConverter[fieldMappingTarget]()
+
+	in := fieldMappingTarget{Name: "jenny", Age: 30}
+	out, err := conv(in)
+	if err != nil {
+		t.Fatalf("unexpected err: %v", err)
+	}
+	got, ok := out.(fieldMappingTarget)
+	if !ok {
+		t.Fatalf("expected fieldMappingTarget, got %T", out)
+	}
+	if got != in {
+		t.Fatalf("expected %+v, got %+v", in, got)
+	}
+}
+
+func TestBuildFieldMappingConverter_MapInputStillWorks(t *testing.T) {
+	conv := buildFieldMappingConverter[fieldMappingTarget]()
+
+	out, err := conv(map[string]any{"Name": "jenny", "Age": 30})
+	if err != nil {
+		t.Fatalf("unexpected err: %v", err)
+	}
+	got, ok := out.(fieldMappingTarget)
+	if !ok {
+		t.Fatalf("expected fieldMappingTarget, got %T", out)
+	}
+	if got.Name != "jenny" || got.Age != 30 {
+		t.Fatalf("unexpected result %+v", got)
+	}
+}
+
+func TestBuildFieldMappingConverter_UnrelatedTypePanics(t *testing.T) {
+	conv := buildFieldMappingConverter[fieldMappingTarget]()
+
+	defer func() {
+		if r := recover(); r == nil {
+			t.Fatal("expected panic on unrelated input type")
+		}
+	}()
+	_, _ = conv(42)
+}
+
+func TestBuildStreamFieldMappingConverter_PassThroughWhenInputIsTargetType(t *testing.T) {
+	conv := buildStreamFieldMappingConverter[fieldMappingTarget]()
+
+	items := []fieldMappingTarget{{Name: "a", Age: 1}, {Name: "b", Age: 2}}
+	src := packStreamReader(schema.StreamReaderFromArray(items))
+
+	out := conv(src)
+	sr, ok := unpackStreamReader[fieldMappingTarget](out)
+	if !ok {
+		t.Fatalf("expected stream reader of target type")
+	}
+
+	var got []fieldMappingTarget
+	for {
+		v, err := sr.Recv()
+		if err == io.EOF {
+			break
+		}
+		if err != nil {
+			t.Fatalf("recv err: %v", err)
+		}
+		got = append(got, v)
+	}
+	if len(got) != len(items) || got[0] != items[0] || got[1] != items[1] {
+		t.Fatalf("expected %+v, got %+v", items, got)
+	}
+}
+
+func TestBuildStreamFieldMappingConverter_MapInputStillWorks(t *testing.T) {
+	conv := buildStreamFieldMappingConverter[fieldMappingTarget]()
+
+	items := []map[string]any{
+		{"Name": "a", "Age": 1},
+		{"Name": "b", "Age": 2},
+	}
+	src := packStreamReader(schema.StreamReaderFromArray(items))
+
+	out := conv(src)
+	sr, ok := unpackStreamReader[fieldMappingTarget](out)
+	if !ok {
+		t.Fatalf("expected stream reader of target type")
+	}
+
+	var got []fieldMappingTarget
+	for {
+		v, err := sr.Recv()
+		if err == io.EOF {
+			break
+		}
+		if err != nil {
+			t.Fatalf("recv err: %v", err)
+		}
+		got = append(got, v)
+	}
+	if len(got) != 2 || got[0].Name != "a" || got[1].Name != "b" {
+		t.Fatalf("unexpected got %+v", got)
+	}
+}
+
+func TestBuildStreamFieldMappingConverter_UnrelatedTypePanics(t *testing.T) {
+	conv := buildStreamFieldMappingConverter[fieldMappingTarget]()
+
+	src := packStreamReader(schema.StreamReaderFromArray([]int{1, 2, 3}))
+
+	defer func() {
+		if r := recover(); r == nil {
+			t.Fatal("expected panic on unrelated stream chunk type")
+		}
+	}()
+	_ = conv(src)
+}


### PR DESCRIPTION
#### What type of PR is this?

fix

#### Check the PR title.

- [x] This PR title match the format: `<type>(optional scope): <description>`
- [x] The description of this PR title is user-oriented and clear enough for others to understand.

#### (Optional) More detailed description for this PR:

en:
`buildFieldMappingConverter` panics when the incoming value is not a `map[string]any`, but in some workflow topologies the upstream node can emit a value that is already the converter's target type `I` (see #957 for the repro). @nswodewy-code also noted `buildStreamFieldMappingConverter` has the same asymmetry on the stream path.

This PR treats the "already the target type" case as a pass-through in both the sync and stream variants, so the workflow no longer panics when a node happens to emit its successor's declared input type directly. If the input is neither `map[string]any` nor `I`, the original panic is preserved.

#### (Optional) Which issue(s) this PR fixes:

Fixes #957

#### Test plan

Added `compose/field_mapping_test.go` with six table-style cases covering:

1. `buildFieldMappingConverter`: target-type input passes through, `map[string]any` input still converts, unrelated input still panics.
2. `buildStreamFieldMappingConverter`: stream of target type passes through, stream of `map[string]any` still converts, stream of an unrelated type still panics.

Full suite: `go test ./... -count=1 -race -timeout=300s` — all packages green.
