### PR TITLE
fix(adk): remove direct log.Printf calls from retryModelWrapper

### DIFF
--- a/adk/retry_chatmodel.go
+++ b/adk/retry_chatmodel.go
@@ -21,7 +21,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"log"
 	"math/rand"
 	"time"
 
@@ -202,7 +201,6 @@ func (r *retryModelWrapper) Generate(ctx context.Context, input []*schema.Messag
 
 		lastErr = err
 		if attempt < r.config.MaxRetries {
-			log.Printf("retrying ChatModel.Generate (attempt %d/%d): %v", attempt+1, r.config.MaxRetries, err)
 			time.Sleep(backoffFunc(ctx, attempt+1))
 		}
 	}
@@ -243,7 +241,6 @@ func (r *retryModelWrapper) Stream(ctx context.Context, input []*schema.Message,
 			}
 			lastErr = err
 			if attempt < r.config.MaxRetries {
-				log.Printf("retrying ChatModel.Stream (attempt %d/%d): %v", attempt+1, r.config.MaxRetries, err)
 				time.Sleep(backoffFunc(ctx, attempt+1))
 			}
 			continue
@@ -265,7 +262,6 @@ func (r *retryModelWrapper) Stream(ctx context.Context, input []*schema.Message,
 
 		lastErr = streamErr
 		if attempt < r.config.MaxRetries {
-			log.Printf("retrying ChatModel.Stream (attempt %d/%d): %v", attempt+1, r.config.MaxRetries, streamErr)
 			time.Sleep(backoffFunc(ctx, attempt+1))
 		}
 	}


### PR DESCRIPTION
Fixes #938

## Problem

`retry_chatmodel.go` calls `log.Printf` directly for retry events, which outputs to the user's terminal and interferes with their application output (e.g., TUI applications).

## Solution

Remove all three `log.Printf` calls. Users can already observe retry events via the `WillRetryError` emitted through `AgentEvent`, and can implement custom logging in their `IsRetryAble` callback if needed.

## Testing

The behavior change is straightforward: retry attempts no longer print to the terminal. Existing tests continue to pass since they don't assert on log output.