### PR TITLE
refactor(adk): improve cancel API naming, enforce recursive teardown, and clean up internal terminology

### DIFF
--- a/adk/cancel.go
+++ b/adk/cancel.go
@@ -56,8 +56,8 @@ const (
 	// Use WithRecursive to propagate the cancel to all descendants — whichever
 	// ChatModel finishes first triggers the cancel.
 	CancelAfterChatModel CancelMode = 1 << iota
-	// CancelAfterToolCalls cancels after the root agent's next set of concurrent
-	// tool calls completes. By default, only the root agent checks this safe-point.
+	// CancelAfterToolCalls cancels after the root agent's next set of tool calls
+	// completes. By default, only the root agent checks this safe-point.
 	// Use WithRecursive to propagate to all descendants.
 	CancelAfterToolCalls
 )
@@ -75,7 +75,7 @@ type CancelHandle struct {
 //     was absorbed into CancelError while cancellation was active
 //   - ErrCancelTimeout: the requested safe-point cancellation timed out and was
 //     escalated to immediate cancellation
-//   - ErrExecutionCompleted: the execution finished before cancellation took effect,
+//   - ErrExecutionEnded: the execution ended before cancellation took effect,
 //     meaning the stream drained to completion without any interrupt
 func (h *CancelHandle) Wait() error {
 	return h.wait()
@@ -110,9 +110,9 @@ func WithAgentCancelMode(mode CancelMode) AgentCancelOption {
 // WithAgentCancelTimeout sets a timeout for the cancel operation.
 // This only applies to safe-point modes (CancelAfterChatModel, CancelAfterToolCalls):
 // if the safe-point hasn't fired within this duration, the cancel escalates to
-// an immediate graph interrupt.
-// For CancelImmediate this timeout is ignored — the graph interrupt fires
-// immediately with timeout=0.
+// CancelImmediate. The escalated cancel still saves a checkpoint, so the execution
+// can be resumed via Runner.Resume or Runner.ResumeWithParams.
+// For CancelImmediate this timeout is ignored — the cancel fires immediately.
 func WithAgentCancelTimeout(timeout time.Duration) AgentCancelOption {
 	return func(config *agentCancelConfig) {
 		config.Timeout = &timeout
@@ -125,6 +125,11 @@ func WithAgentCancelTimeout(timeout time.Duration) AgentCancelOption {
 //   - CancelAfterChatModel / CancelAfterToolCalls: descendants check their own safe-points.
 //   - CancelImmediate: descendants receive explicit immediate-cancel signals for
 //     clean teardown; the root uses a grace period to collect child interrupts.
+//
+// With recursive cancellation, each descendant agent also triggers cancellation
+// and cascades its interrupt information upward. The root agent ultimately
+// produces a complete checkpoint that includes descendant checkpoints, enabling
+// resumption from the exact point where each descendant was interrupted.
 //
 // Once any cancel call includes WithRecursive, the flag stays set for the
 // entire cancel lifecycle (monotonic escalation).
@@ -146,7 +151,7 @@ type AgentCancelInfo struct {
 //
 // Interrupt absorption: when a cancel is active (shouldCancel() == true), ANY
 // interrupt — whether from a cancel safe-point node or from business logic
-// (e.g. compose.Interrupt in a tool) — is converted to a CancelError. The
+// (e.g. tool.Interrupt in a tool) — is converted to a CancelError. The
 // cancel "absorbs" the business interrupt. This is intentional:
 //
 //   - In concurrent execution (parallel workflows, concurrent tool calls),
@@ -155,15 +160,11 @@ type AgentCancelInfo struct {
 //   - Even in sequential execution, treating business interrupts as CancelError
 //     during active cancel gives consistent semantics.
 //   - The business interrupt is NOT lost — the checkpoint preserves the full
-//     interrupt hierarchy. On resume (Runner.Resume), the agent re-executes
-//     the interrupting code path and the business interrupt re-fires naturally.
+//     interrupt hierarchy. On resume (Runner.Resume or Runner.ResumeWithParams),
+//     the agent re-executes the interrupting code path and the business
+//     interrupt re-fires naturally.
 type CancelError struct {
 	Info *AgentCancelInfo
-
-	// CheckPointID is the checkpoint ID associated with this cancel operation.
-	// When non-empty, the cancelled agent's state has been persisted under this ID
-	// and can be resumed via Runner.Resume or GenInputResult.ResumeFromCheckpointID.
-	CheckPointID string
 
 	// InterruptContexts provides the interrupt contexts needed for targeted
 	// resumption via Runner.ResumeWithParams. Each context represents a step
@@ -185,15 +186,15 @@ var (
 	// ErrCancelTimeout is returned by CancelHandle.Wait when the cancel operation timed out.
 	ErrCancelTimeout = errors.New("cancel timed out")
 
-	// ErrExecutionCompleted is returned by CancelHandle.Wait when the agent finished
-	// before the cancel took effect. "Finished" means the event stream was fully
+	// ErrExecutionEnded is returned by CancelHandle.Wait when the agent ended
+	// before the cancel took effect. "Ended" means the event stream was fully
 	// drained without any interrupt — normal completion or a fatal error.
 	//
 	// Note: business interrupts that occur while cancel is active are absorbed
 	// into CancelError (see CancelError doc), so they result in nil (cancel
-	// succeeded), NOT ErrExecutionCompleted. Only execution that completes with
+	// succeeded), NOT ErrExecutionEnded. Only execution that completes with
 	// no interrupt at all produces this error.
-	ErrExecutionCompleted = errors.New("execution already completed")
+	ErrExecutionEnded = errors.New("execution already ended")
 
 	// ErrStreamCanceled is the error sent through the stream when CancelImmediate aborts it.
 	// It is a *StreamCanceledError so it can be gob-serialized during checkpoint save
@@ -699,7 +700,7 @@ func (cc *cancelContext) buildCancelFunc() AgentCancelFunc {
 		st := atomic.LoadInt32(&cc.state)
 		switch st {
 		case stateDone:
-			return ErrExecutionCompleted
+			return ErrExecutionEnded
 		default:
 			if atomic.LoadInt32(&cc.timeoutEscalated) == 1 {
 				return ErrCancelTimeout
@@ -716,7 +717,7 @@ func (cc *cancelContext) buildCancelFunc() AgentCancelFunc {
 		case stateCancelHandled:
 			return newHandle(func() error { return nil }), false
 		case stateDone:
-			return newHandle(func() error { return ErrExecutionCompleted }), false
+			return newHandle(func() error { return ErrExecutionEnded }), false
 		}
 
 		var needImmediate, needTimeoutCtl bool
@@ -730,7 +731,7 @@ func (cc *cancelContext) buildCancelFunc() AgentCancelFunc {
 			return newHandle(func() error { return nil }), false
 		case stateDone:
 			cc.cancelMu.Unlock()
-			return newHandle(func() error { return ErrExecutionCompleted }), false
+			return newHandle(func() error { return ErrExecutionEnded }), false
 		}
 
 		curMode := cc.getMode()
@@ -739,7 +740,7 @@ func (cc *cancelContext) buildCancelFunc() AgentCancelFunc {
 				st = atomic.LoadInt32(&cc.state)
 				cc.cancelMu.Unlock()
 				if st == stateDone {
-					return newHandle(func() error { return ErrExecutionCompleted }), false
+					return newHandle(func() error { return ErrExecutionEnded }), false
 				}
 				return newHandle(waitForCompletion), true
 			}

--- a/adk/cancel_edge_test.go
+++ b/adk/cancel_edge_test.go
@@ -436,88 +436,18 @@ func TestWithCancel_AfterChatModel_WithTools(t *testing.T) {
 }
 
 // TestWithCancel_CancelImmediate_StreamAborted verifies that CancelImmediate
-// during model streaming surfaces ErrStreamCanceled and completes quickly.
-// modelStreamAfterToolCall returns a tool call on the first invocation, then
-// streams chunks slowly on the second invocation. This ensures the agent's
-// ReAct loop stays alive during the slow streaming phase.
-type modelStreamAfterToolCall struct {
-	firstDone     int32
-	chunkInterval time.Duration
-	chunks        []*schema.Message
-	started       chan struct{}
-}
-
-func (m *modelStreamAfterToolCall) Generate(_ context.Context, _ []*schema.Message, _ ...model.Option) (*schema.Message, error) {
-	if atomic.CompareAndSwapInt32(&m.firstDone, 0, 1) {
-		return toolCallMsg(toolCall("c1", "noop_tool", `{"input":"x"}`)), nil
-	}
-	return m.chunks[len(m.chunks)-1], nil
-}
-
-func (m *modelStreamAfterToolCall) Stream(_ context.Context, _ []*schema.Message, _ ...model.Option) (*schema.StreamReader[*schema.Message], error) {
-	if atomic.CompareAndSwapInt32(&m.firstDone, 0, 1) {
-		msg := toolCallMsg(toolCall("c1", "noop_tool", `{"input":"x"}`))
-		return schema.StreamReaderFromArray([]*schema.Message{msg}), nil
-	}
-	r, w := schema.Pipe[*schema.Message](1)
-	go func() {
-		defer w.Close()
-		select {
-		case m.started <- struct{}{}:
-		default:
-		}
-		for _, chunk := range m.chunks {
-			time.Sleep(m.chunkInterval)
-			if closed := w.Send(chunk, nil); closed {
-				return
-			}
-		}
-	}()
-	return r, nil
-}
-
-func (m *modelStreamAfterToolCall) BindTools(_ []*schema.ToolInfo) error { return nil }
-
-// noopTool is a tool that returns immediately.
-type noopTool struct{}
-
-func (t *noopTool) Info(_ context.Context) (*schema.ToolInfo, error) {
-	return &schema.ToolInfo{
-		Name: "noop_tool",
-		Desc: "noop",
-		ParamsOneOf: schema.NewParamsOneOfByParams(map[string]*schema.ParameterInfo{
-			"input": {Type: "string"},
-		}),
-	}, nil
-}
-
-func (t *noopTool) InvokableRun(_ context.Context, _ string, _ ...tool.Option) (string, error) {
-	return "ok", nil
-}
-
+// during model execution surfaces CancelError and completes quickly.
+// Uses blockingChatModel which blocks in Stream(), keeping the agent's run
+// function alive so the cancel context stays in stateRunning.
 func TestWithCancel_CancelImmediate_StreamAborted(t *testing.T) {
 	ctx := context.Background()
 
-	// Model that first calls a tool, then streams slowly on the second call.
-	// This keeps the ReAct loop alive during streaming, preventing the
-	// cancelContext from being marked done prematurely.
-	chunks := make([]*schema.Message, 10)
-	for i := range chunks {
-		chunks[i] = schema.AssistantMessage("chunk", nil)
-	}
-	m := &modelStreamAfterToolCall{
-		chunkInterval: 200 * time.Millisecond,
-		chunks:        chunks,
-		started:       make(chan struct{}, 1),
-	}
+	blk := newBlockingChatModel(schema.AssistantMessage("hello", nil))
 
 	agent, err := NewChatModelAgent(ctx, &ChatModelAgentConfig{
 		Name:        "TestAgent",
 		Description: "test",
-		Model:       m,
-		ToolsConfig: ToolsConfig{
-			ToolsNodeConfig: compose.ToolsNodeConfig{Tools: []tool.BaseTool{&noopTool{}}},
-		},
+		Model:       blk,
 	})
 	require.NoError(t, err)
 
@@ -529,42 +459,26 @@ func TestWithCancel_CancelImmediate_StreamAborted(t *testing.T) {
 	cancelOpt, cancelFn := WithCancel()
 	iter := runner.Run(ctx, []Message{schema.UserMessage("hi")}, cancelOpt)
 
-	// Wait for the model's second call to start streaming
 	select {
-	case <-m.started:
+	case <-blk.started:
 	case <-time.After(5 * time.Second):
-		t.Fatal("model did not start streaming")
+		t.Fatal("model did not start")
 	}
-	// Let a few chunks through, then cancel mid-stream
-	time.Sleep(300 * time.Millisecond)
+	time.Sleep(50 * time.Millisecond)
 
+	start := time.Now()
 	handle, _ := cancelFn()
 	cancelErr := handle.Wait()
 	assert.NoError(t, cancelErr)
+	elapsed := time.Since(start)
+	assert.True(t, elapsed < 2*time.Second, "cancel should complete quickly, elapsed=%v", elapsed)
 
-	var foundStreamCanceled bool
 	var foundCancelError bool
 	for {
 		e, ok := iter.Next()
 		if !ok {
 			break
 		}
-
-		// ErrStreamCanceled appears on MessageStream.Recv(), not AgentEvent.Err
-		if e.Output != nil && e.Output.MessageOutput != nil && e.Output.MessageOutput.IsStreaming &&
-			e.Output.MessageOutput.Role == schema.Assistant {
-			stream := e.Output.MessageOutput.MessageStream
-			for {
-				_, recvErr := stream.Recv()
-				if recvErr != nil {
-					if errors.Is(recvErr, ErrStreamCanceled) {
-						foundStreamCanceled = true
-					}
-					break
-				}
-			}
-		}
-
 		if e.Action != nil && e.Action.Interrupted != nil {
 			foundCancelError = true
 		}
@@ -573,7 +487,6 @@ func TestWithCancel_CancelImmediate_StreamAborted(t *testing.T) {
 			foundCancelError = true
 		}
 	}
-	assert.True(t, foundStreamCanceled, "expected ErrStreamCanceled on MessageStream.Recv()")
 	assert.True(t, foundCancelError, "expected CancelError in event stream")
 }
 

--- a/adk/cancel_edge_test.go
+++ b/adk/cancel_edge_test.go
@@ -34,6 +34,46 @@ import (
 
 // --- helpers shared across edge-case tests ---
 
+// slowStreamingChatModel returns a stream that emits chunks slowly,
+// allowing CancelImmediate to fire mid-stream.
+type slowStreamingChatModel struct {
+	chunkInterval time.Duration
+	chunks        []*schema.Message
+	started       chan struct{}
+}
+
+func newSlowStreamingChatModel(chunkInterval time.Duration, chunks ...*schema.Message) *slowStreamingChatModel {
+	return &slowStreamingChatModel{
+		chunkInterval: chunkInterval,
+		chunks:        chunks,
+		started:       make(chan struct{}, 1),
+	}
+}
+
+func (m *slowStreamingChatModel) Generate(_ context.Context, _ []*schema.Message, _ ...model.Option) (*schema.Message, error) {
+	return m.chunks[len(m.chunks)-1], nil
+}
+
+func (m *slowStreamingChatModel) Stream(_ context.Context, _ []*schema.Message, _ ...model.Option) (*schema.StreamReader[*schema.Message], error) {
+	r, w := schema.Pipe[*schema.Message](1)
+	go func() {
+		defer w.Close()
+		select {
+		case m.started <- struct{}{}:
+		default:
+		}
+		for _, chunk := range m.chunks {
+			time.Sleep(m.chunkInterval)
+			if closed := w.Send(chunk, nil); closed {
+				return
+			}
+		}
+	}()
+	return r, nil
+}
+
+func (m *slowStreamingChatModel) BindTools(_ []*schema.ToolInfo) error { return nil }
+
 // blockingChatModel blocks until unblockCh is closed, then returns a fixed response.
 type blockingChatModel struct {
 	unblockCh chan struct{}
@@ -218,7 +258,7 @@ func TestWithCancel_BeforeExecutionStarts(t *testing.T) {
 	// cancelFn must have already returned (or return quickly now that doneChan is closed).
 	select {
 	case cancelErr := <-cancelDone:
-		// Either nil (cancel handled) or ErrExecutionCompleted is acceptable
+		// Either nil (cancel handled) or ErrExecutionEnded is acceptable
 		// depending on exact timing; what matters is it didn't hang.
 		_ = cancelErr
 	case <-time.After(3 * time.Second):
@@ -229,7 +269,7 @@ func TestWithCancel_BeforeExecutionStarts(t *testing.T) {
 	assert.Equal(t, int32(0), atomic.LoadInt32(&bt.callCount), "tool must not be called")
 }
 
-// TestWithCancel_AfterCompletion verifies cancelFn returns ErrExecutionCompleted
+// TestWithCancel_AfterCompletion verifies cancelFn returns ErrExecutionEnded
 // when called after a normal run finishes.
 func TestWithCancel_AfterCompletion(t *testing.T) {
 	ctx := context.Background()
@@ -254,10 +294,10 @@ func TestWithCancel_AfterCompletion(t *testing.T) {
 
 	handle, _ := cancelFn()
 	cancelErr := handle.Wait()
-	assert.ErrorIs(t, cancelErr, ErrExecutionCompleted)
+	assert.ErrorIs(t, cancelErr, ErrExecutionEnded)
 }
 
-// TestWithCancel_AfterBusinessInterrupt verifies cancelFn returns ErrExecutionCompleted
+// TestWithCancel_AfterBusinessInterrupt verifies cancelFn returns ErrExecutionEnded
 // when called after the agent has been interrupted by business logic.
 func TestWithCancel_AfterBusinessInterrupt(t *testing.T) {
 	ctx := context.Background()
@@ -296,10 +336,10 @@ func TestWithCancel_AfterBusinessInterrupt(t *testing.T) {
 
 	handle, _ := cancelFn()
 	cancelErr := handle.Wait()
-	assert.ErrorIs(t, cancelErr, ErrExecutionCompleted)
+	assert.ErrorIs(t, cancelErr, ErrExecutionEnded)
 }
 
-// TestWithCancel_AfterError verifies cancelFn returns ErrExecutionCompleted
+// TestWithCancel_AfterError verifies cancelFn returns ErrExecutionEnded
 // when called after the agent errors out.
 func TestWithCancel_AfterError(t *testing.T) {
 	ctx := context.Background()
@@ -324,7 +364,7 @@ func TestWithCancel_AfterError(t *testing.T) {
 
 	handle, _ := cancelFn()
 	cancelErr := handle.Wait()
-	assert.ErrorIs(t, cancelErr, ErrExecutionCompleted)
+	assert.ErrorIs(t, cancelErr, ErrExecutionEnded)
 }
 
 // TestWithCancel_TimeoutEscalation tests that WithAgentCancelTimeout causes the
@@ -440,12 +480,17 @@ func TestWithCancel_AfterChatModel_WithTools(t *testing.T) {
 func TestWithCancel_CancelImmediate_StreamAborted(t *testing.T) {
 	ctx := context.Background()
 
-	blk := newBlockingChatModel(schema.AssistantMessage("hello", nil))
+	// Create a model that streams chunks slowly — 10 chunks, 200ms apart
+	chunks := make([]*schema.Message, 10)
+	for i := range chunks {
+		chunks[i] = schema.AssistantMessage("chunk", nil)
+	}
+	slow := newSlowStreamingChatModel(200*time.Millisecond, chunks...)
 
 	agent, err := NewChatModelAgent(ctx, &ChatModelAgentConfig{
 		Name:        "TestAgent",
 		Description: "test",
-		Model:       blk,
+		Model:       slow,
 	})
 	require.NoError(t, err)
 
@@ -457,35 +502,51 @@ func TestWithCancel_CancelImmediate_StreamAborted(t *testing.T) {
 	cancelOpt, cancelFn := WithCancel()
 	iter := runner.Run(ctx, []Message{schema.UserMessage("hi")}, cancelOpt)
 
+	// Wait for the model to start streaming
 	select {
-	case <-blk.started:
+	case <-slow.started:
 	case <-time.After(5 * time.Second):
 		t.Fatal("model did not start")
 	}
-	time.Sleep(50 * time.Millisecond)
+	// Let a few chunks through, then cancel mid-stream
+	time.Sleep(300 * time.Millisecond)
 
-	start := time.Now()
 	handle, _ := cancelFn()
 	cancelErr := handle.Wait()
 	assert.NoError(t, cancelErr)
-	elapsed := time.Since(start)
-	assert.True(t, elapsed < 2*time.Second, "cancel should complete quickly, elapsed=%v", elapsed)
 
 	var foundStreamCanceled bool
+	var foundCancelError bool
 	for {
 		e, ok := iter.Next()
 		if !ok {
 			break
 		}
-		if e.Err != nil && errors.Is(e.Err, ErrStreamCanceled) {
-			foundStreamCanceled = true
+
+		// ErrStreamCanceled appears on MessageStream.Recv(), not AgentEvent.Err
+		if e.Output != nil && e.Output.MessageOutput != nil && e.Output.MessageOutput.IsStreaming {
+			stream := e.Output.MessageOutput.MessageStream
+			for {
+				_, recvErr := stream.Recv()
+				if recvErr != nil {
+					if errors.Is(recvErr, ErrStreamCanceled) {
+						foundStreamCanceled = true
+					}
+					break
+				}
+			}
+		}
+
+		if e.Action != nil && e.Action.Interrupted != nil {
+			foundCancelError = true
 		}
 		var ce *CancelError
 		if e.Err != nil && errors.As(e.Err, &ce) {
-			foundStreamCanceled = true // CancelError wraps stream abort
+			foundCancelError = true
 		}
 	}
-	assert.True(t, foundStreamCanceled, "expected stream-abort error during immediate cancel")
+	assert.True(t, foundStreamCanceled, "expected ErrStreamCanceled on MessageStream.Recv()")
+	assert.True(t, foundCancelError, "expected CancelError in event stream")
 }
 
 // TestWithCancel_MultipleToolsConcurrent verifies that CancelAfterToolCalls
@@ -630,13 +691,11 @@ func TestWithCancel_NoCheckpointStore(t *testing.T) {
 			break
 		}
 	}
-	if assert.NotNil(t, ce, "expected CancelError even without checkpoint store") {
-		assert.Empty(t, ce.CheckPointID, "CheckPointID should be empty without checkpoint store")
-	}
+	assert.NotNil(t, ce, "expected CancelError even without checkpoint store")
 }
 
 // TestWithCancel_ModelError verifies that a model error marks the cancelCtx as
-// done so that a subsequent cancelFn call returns ErrExecutionCompleted.
+// done so that a subsequent cancelFn call returns ErrExecutionEnded.
 func TestWithCancel_ModelError(t *testing.T) {
 	ctx := context.Background()
 
@@ -665,7 +724,7 @@ func TestWithCancel_ModelError(t *testing.T) {
 
 	handle, _ := cancelFn()
 	cancelErr := handle.Wait()
-	assert.ErrorIs(t, cancelErr, ErrExecutionCompleted, "cancelFn should return ErrExecutionCompleted after model error")
+	assert.ErrorIs(t, cancelErr, ErrExecutionEnded, "cancelFn should return ErrExecutionEnded after model error")
 }
 
 // TestWithCancel_Resume_SafePoint covers CancelAfterChatModel and
@@ -1265,4 +1324,144 @@ func TestWithCancel_CancelAfterChatModel_NestedAgentTool(t *testing.T) {
 	}
 
 	assert.True(t, hasCancelError, "CancelError expected from nested agent tool with tools")
+}
+
+// slowStreamingTool implements StreamableTool (but NOT InvokableTool), streaming
+// chunks slowly so CancelImmediate can fire mid-stream.
+type slowStreamingTool struct {
+	name          string
+	chunkInterval time.Duration
+	chunks        []string
+	started       chan struct{}
+}
+
+func (t *slowStreamingTool) Info(_ context.Context) (*schema.ToolInfo, error) {
+	return &schema.ToolInfo{
+		Name: t.name,
+		Desc: "slow streaming tool",
+		ParamsOneOf: schema.NewParamsOneOfByParams(map[string]*schema.ParameterInfo{
+			"input": {Type: "string"},
+		}),
+	}, nil
+}
+
+func (t *slowStreamingTool) StreamableRun(_ context.Context, _ string, _ ...tool.Option) (*schema.StreamReader[string], error) {
+	r, w := schema.Pipe[string](1)
+	go func() {
+		defer w.Close()
+		select {
+		case t.started <- struct{}{}:
+		default:
+		}
+		for _, chunk := range t.chunks {
+			time.Sleep(t.chunkInterval)
+			if closed := w.Send(chunk, nil); closed {
+				return
+			}
+		}
+	}()
+	return r, nil
+}
+
+// toolCallStreamModel returns a tool-call message on the first Stream call,
+// then a plain text response on subsequent calls.
+type toolCallStreamModel struct {
+	callCount int32
+}
+
+func (m *toolCallStreamModel) Generate(_ context.Context, _ []*schema.Message, _ ...model.Option) (*schema.Message, error) {
+	if atomic.AddInt32(&m.callCount, 1) == 1 {
+		return toolCallMsg(toolCall("c1", "slow_tool", `{"input":"x"}`)), nil
+	}
+	return schema.AssistantMessage("done", nil), nil
+}
+
+func (m *toolCallStreamModel) Stream(ctx context.Context, input []*schema.Message, opts ...model.Option) (*schema.StreamReader[*schema.Message], error) {
+	msg, err := m.Generate(ctx, input, opts...)
+	if err != nil {
+		return nil, err
+	}
+	return schema.StreamReaderFromArray([]*schema.Message{msg}), nil
+}
+
+func (m *toolCallStreamModel) BindTools(_ []*schema.ToolInfo) error { return nil }
+
+// TestWithCancel_CancelImmediate_StreamableToolAborted verifies that CancelImmediate
+// during StreamableTool streaming surfaces ErrStreamCanceled on the tool's
+// MessageStream.Recv(), just like it does for ChatModel streaming.
+func TestWithCancel_CancelImmediate_StreamableToolAborted(t *testing.T) {
+	ctx := context.Background()
+
+	tcm := &toolCallStreamModel{}
+	st := &slowStreamingTool{
+		name:          "slow_tool",
+		chunkInterval: 200 * time.Millisecond,
+		chunks:        []string{"a", "b", "c", "d", "e", "f", "g", "h", "i", "j"},
+		started:       make(chan struct{}, 1),
+	}
+
+	agent, err := NewChatModelAgent(ctx, &ChatModelAgentConfig{
+		Name:        "TestAgent",
+		Description: "test",
+		Model:       tcm,
+		ToolsConfig: ToolsConfig{
+			ToolsNodeConfig: compose.ToolsNodeConfig{Tools: []tool.BaseTool{st}},
+		},
+	})
+	require.NoError(t, err)
+
+	runner := NewRunner(ctx, RunnerConfig{
+		Agent:           agent,
+		EnableStreaming: true,
+	})
+
+	cancelOpt, cancelFn := WithCancel()
+	iter := runner.Run(ctx, []Message{schema.UserMessage("hi")}, cancelOpt)
+
+	// Wait for the tool to start streaming
+	select {
+	case <-st.started:
+	case <-time.After(5 * time.Second):
+		t.Fatal("tool did not start streaming")
+	}
+	// Let a few chunks through, then cancel mid-stream
+	time.Sleep(300 * time.Millisecond)
+
+	handle, _ := cancelFn()
+	cancelErr := handle.Wait()
+	assert.NoError(t, cancelErr)
+
+	var foundStreamCanceled bool
+	var foundCancelError bool
+	for {
+		e, ok := iter.Next()
+		if !ok {
+			break
+		}
+
+		// ErrStreamCanceled appears on the tool's MessageStream.Recv()
+		if e.Output != nil && e.Output.MessageOutput != nil && e.Output.MessageOutput.IsStreaming &&
+			e.Output.MessageOutput.Role == schema.Tool {
+			stream := e.Output.MessageOutput.MessageStream
+			for {
+				_, recvErr := stream.Recv()
+				if recvErr != nil {
+					if errors.Is(recvErr, ErrStreamCanceled) {
+						foundStreamCanceled = true
+					}
+					break
+				}
+			}
+		}
+
+		if e.Action != nil && e.Action.Interrupted != nil {
+			foundCancelError = true
+		}
+		var ce *CancelError
+		if e.Err != nil && errors.As(e.Err, &ce) {
+			foundCancelError = true
+		}
+	}
+	assert.True(t, foundStreamCanceled, "expected ErrStreamCanceled on tool's MessageStream.Recv()")
+	assert.True(t, foundCancelError, "expected CancelError in event stream")
 }

--- a/adk/cancel_edge_test.go
+++ b/adk/cancel_edge_test.go
@@ -34,46 +34,6 @@ import (
 
 // --- helpers shared across edge-case tests ---
 
-// slowStreamingChatModel returns a stream that emits chunks slowly,
-// allowing CancelImmediate to fire mid-stream.
-type slowStreamingChatModel struct {
-	chunkInterval time.Duration
-	chunks        []*schema.Message
-	started       chan struct{}
-}
-
-func newSlowStreamingChatModel(chunkInterval time.Duration, chunks ...*schema.Message) *slowStreamingChatModel {
-	return &slowStreamingChatModel{
-		chunkInterval: chunkInterval,
-		chunks:        chunks,
-		started:       make(chan struct{}, 1),
-	}
-}
-
-func (m *slowStreamingChatModel) Generate(_ context.Context, _ []*schema.Message, _ ...model.Option) (*schema.Message, error) {
-	return m.chunks[len(m.chunks)-1], nil
-}
-
-func (m *slowStreamingChatModel) Stream(_ context.Context, _ []*schema.Message, _ ...model.Option) (*schema.StreamReader[*schema.Message], error) {
-	r, w := schema.Pipe[*schema.Message](1)
-	go func() {
-		defer w.Close()
-		select {
-		case m.started <- struct{}{}:
-		default:
-		}
-		for _, chunk := range m.chunks {
-			time.Sleep(m.chunkInterval)
-			if closed := w.Send(chunk, nil); closed {
-				return
-			}
-		}
-	}()
-	return r, nil
-}
-
-func (m *slowStreamingChatModel) BindTools(_ []*schema.ToolInfo) error { return nil }
-
 // blockingChatModel blocks until unblockCh is closed, then returns a fixed response.
 type blockingChatModel struct {
 	unblockCh chan struct{}
@@ -477,20 +437,87 @@ func TestWithCancel_AfterChatModel_WithTools(t *testing.T) {
 
 // TestWithCancel_CancelImmediate_StreamAborted verifies that CancelImmediate
 // during model streaming surfaces ErrStreamCanceled and completes quickly.
+// modelStreamAfterToolCall returns a tool call on the first invocation, then
+// streams chunks slowly on the second invocation. This ensures the agent's
+// ReAct loop stays alive during the slow streaming phase.
+type modelStreamAfterToolCall struct {
+	firstDone     int32
+	chunkInterval time.Duration
+	chunks        []*schema.Message
+	started       chan struct{}
+}
+
+func (m *modelStreamAfterToolCall) Generate(_ context.Context, _ []*schema.Message, _ ...model.Option) (*schema.Message, error) {
+	if atomic.CompareAndSwapInt32(&m.firstDone, 0, 1) {
+		return toolCallMsg(toolCall("c1", "noop_tool", `{"input":"x"}`)), nil
+	}
+	return m.chunks[len(m.chunks)-1], nil
+}
+
+func (m *modelStreamAfterToolCall) Stream(_ context.Context, _ []*schema.Message, _ ...model.Option) (*schema.StreamReader[*schema.Message], error) {
+	if atomic.CompareAndSwapInt32(&m.firstDone, 0, 1) {
+		msg := toolCallMsg(toolCall("c1", "noop_tool", `{"input":"x"}`))
+		return schema.StreamReaderFromArray([]*schema.Message{msg}), nil
+	}
+	r, w := schema.Pipe[*schema.Message](1)
+	go func() {
+		defer w.Close()
+		select {
+		case m.started <- struct{}{}:
+		default:
+		}
+		for _, chunk := range m.chunks {
+			time.Sleep(m.chunkInterval)
+			if closed := w.Send(chunk, nil); closed {
+				return
+			}
+		}
+	}()
+	return r, nil
+}
+
+func (m *modelStreamAfterToolCall) BindTools(_ []*schema.ToolInfo) error { return nil }
+
+// noopTool is a tool that returns immediately.
+type noopTool struct{}
+
+func (t *noopTool) Info(_ context.Context) (*schema.ToolInfo, error) {
+	return &schema.ToolInfo{
+		Name: "noop_tool",
+		Desc: "noop",
+		ParamsOneOf: schema.NewParamsOneOfByParams(map[string]*schema.ParameterInfo{
+			"input": {Type: "string"},
+		}),
+	}, nil
+}
+
+func (t *noopTool) InvokableRun(_ context.Context, _ string, _ ...tool.Option) (string, error) {
+	return "ok", nil
+}
+
 func TestWithCancel_CancelImmediate_StreamAborted(t *testing.T) {
 	ctx := context.Background()
 
-	// Create a model that streams chunks slowly — 10 chunks, 200ms apart
+	// Model that first calls a tool, then streams slowly on the second call.
+	// This keeps the ReAct loop alive during streaming, preventing the
+	// cancelContext from being marked done prematurely.
 	chunks := make([]*schema.Message, 10)
 	for i := range chunks {
 		chunks[i] = schema.AssistantMessage("chunk", nil)
 	}
-	slow := newSlowStreamingChatModel(200*time.Millisecond, chunks...)
+	m := &modelStreamAfterToolCall{
+		chunkInterval: 200 * time.Millisecond,
+		chunks:        chunks,
+		started:       make(chan struct{}, 1),
+	}
 
 	agent, err := NewChatModelAgent(ctx, &ChatModelAgentConfig{
 		Name:        "TestAgent",
 		Description: "test",
-		Model:       slow,
+		Model:       m,
+		ToolsConfig: ToolsConfig{
+			ToolsNodeConfig: compose.ToolsNodeConfig{Tools: []tool.BaseTool{&noopTool{}}},
+		},
 	})
 	require.NoError(t, err)
 
@@ -502,11 +529,11 @@ func TestWithCancel_CancelImmediate_StreamAborted(t *testing.T) {
 	cancelOpt, cancelFn := WithCancel()
 	iter := runner.Run(ctx, []Message{schema.UserMessage("hi")}, cancelOpt)
 
-	// Wait for the model to start streaming
+	// Wait for the model's second call to start streaming
 	select {
-	case <-slow.started:
+	case <-m.started:
 	case <-time.After(5 * time.Second):
-		t.Fatal("model did not start")
+		t.Fatal("model did not start streaming")
 	}
 	// Let a few chunks through, then cancel mid-stream
 	time.Sleep(300 * time.Millisecond)
@@ -524,7 +551,8 @@ func TestWithCancel_CancelImmediate_StreamAborted(t *testing.T) {
 		}
 
 		// ErrStreamCanceled appears on MessageStream.Recv(), not AgentEvent.Err
-		if e.Output != nil && e.Output.MessageOutput != nil && e.Output.MessageOutput.IsStreaming {
+		if e.Output != nil && e.Output.MessageOutput != nil && e.Output.MessageOutput.IsStreaming &&
+			e.Output.MessageOutput.Role == schema.Assistant {
 			stream := e.Output.MessageOutput.MessageStream
 			for {
 				_, recvErr := stream.Recv()

--- a/adk/cancel_test.go
+++ b/adk/cancel_test.go
@@ -650,7 +650,6 @@ func TestWithCancel_WithCheckpoint(t *testing.T) {
 
 		var events []*AgentEvent
 		hasCancelError := false
-		var cancelErrorCheckPointID string
 		for {
 			event, ok := iter.Next()
 			if !ok {
@@ -659,14 +658,12 @@ func TestWithCancel_WithCheckpoint(t *testing.T) {
 			var ce *CancelError
 			if event.Err != nil && errors.As(event.Err, &ce) {
 				hasCancelError = true
-				cancelErrorCheckPointID = ce.CheckPointID
 				continue
 			}
 			events = append(events, event)
 		}
 
 		assert.True(t, hasCancelError, "Should have CancelError event after cancel")
-		assert.Equal(t, "cancel-1", cancelErrorCheckPointID, "CancelError should contain the checkpoint ID")
 	})
 }
 
@@ -1132,7 +1129,7 @@ func TestWithCancel_Resume(t *testing.T) {
 		cancelHandle, _ := resumeCancelFn()
 		close(slowModel2.unblockCh)
 		err = cancelHandle.Wait()
-		assert.True(t, err == nil || errors.Is(err, ErrExecutionCompleted), "unexpected cancel wait error: %v", err)
+		assert.True(t, err == nil || errors.Is(err, ErrExecutionEnded), "unexpected cancel wait error: %v", err)
 
 		start := time.Now()
 		resumeEvents := <-resumeEventsCh
@@ -1148,7 +1145,7 @@ func TestWithCancel_Resume(t *testing.T) {
 				hasCancelError = true
 			}
 		}
-		executionCompletedBeforeCancel := errors.Is(err, ErrExecutionCompleted)
+		executionCompletedBeforeCancel := errors.Is(err, ErrExecutionEnded)
 		assert.True(t, hasCancelError || executionCompletedBeforeCancel, "Resume should have CancelError event after cancel, or execution completed before cancel")
 	})
 }
@@ -1518,10 +1515,10 @@ func TestWithCancel_SequentialAgent(t *testing.T) {
 
 		time.Sleep(50 * time.Millisecond)
 
-		// Cancel should NOT return ErrExecutionCompleted (the bug before the fix)
+		// Cancel should NOT return ErrExecutionEnded (the bug before the fix)
 		handle, _ := cancelFn()
 		err = handle.Wait()
-		assert.NoError(t, err, "Cancel during second agent should succeed, not return ErrExecutionCompleted")
+		assert.NoError(t, err, "Cancel during second agent should succeed, not return ErrExecutionEnded")
 
 		drainEventsAndAssertCancelError(t, iter)
 	})
@@ -2254,7 +2251,6 @@ func TestCancel_SequentialWorkflow_CancelAfterChatModel(t *testing.T) {
 
 	assert.True(t, hasCancelError, "Should have CancelError")
 	assert.Equal(t, CancelAfterChatModel, cancelErr.Info.Mode)
-	assert.NotEmpty(t, cancelErr.CheckPointID, "CancelError should have checkpoint ID")
 	assert.NotNil(t, cancelErr.interruptSignal, "CancelError should have interrupt signal for checkpoint")
 
 	resumeAgent1 := newCancelTestAgentWithToolsFinalAnswer(t, "seq_slow")
@@ -2614,7 +2610,6 @@ func TestCancelImmediate_AgentTool_PreservesChildCheckpoint(t *testing.T) {
 
 	cancelErr := drainCancelError(t, iter)
 	assert.NotNil(t, cancelErr, "Should have CancelError from CancelImmediate through agentTool")
-	assert.NotEmpty(t, cancelErr.CheckPointID)
 	assert.NotNil(t, cancelErr.interruptSignal)
 
 	resumeLeaf, err := NewChatModelAgent(ctx, &ChatModelAgentConfig{
@@ -2809,7 +2804,6 @@ func TestCancelImmediate_MultiLevelNesting(t *testing.T) {
 	elapsed := time.Since(start)
 
 	assert.NotNil(t, cancelErr, "Should have CancelError from multi-level nesting")
-	assert.NotEmpty(t, cancelErr.CheckPointID)
 	assert.NotNil(t, cancelErr.interruptSignal)
 	assert.True(t, elapsed < 5*time.Second, "Should complete quickly, elapsed: %v", elapsed)
 
@@ -3058,7 +3052,6 @@ func TestCancelAfterChatModel_Sequential_Agent1CompletesCancelBeforeAgent2Resume
 	assert.Equal(t, int32(0), atomic.LoadInt32(&model2.callCount),
 		"Agent2 should NOT run (cancel caught at transition after agent1)")
 	assert.Equal(t, int32(0), atomic.LoadInt32(&model3.callCount))
-	assert.NotEmpty(t, cancelErr.CheckPointID)
 
 	resumeModel2 := &gatedChatModel{
 		response: &schema.Message{Role: schema.Assistant, Content: "resumed agent2"},
@@ -3175,7 +3168,6 @@ func TestCancelAfterToolCalls_LoopTransitionBoundary(t *testing.T) {
 	cancelErr := drainCancelError(t, iter)
 	assert.NotNil(t, cancelErr, "Should have CancelError from CancelAfterToolCalls in loop")
 	assert.Equal(t, CancelAfterToolCalls, cancelErr.Info.Mode)
-	assert.NotEmpty(t, cancelErr.CheckPointID)
 }
 
 func TestCancelContext_ActiveChildren_Tracking(t *testing.T) {
@@ -3312,7 +3304,6 @@ func TestCancel_ParallelWorkflow_CancelAfterChatModel(t *testing.T) {
 
 	assert.True(t, hasCancelError, "Should have CancelError from parallel workflow")
 	assert.Equal(t, CancelAfterChatModel, cancelErr.Info.Mode)
-	assert.NotEmpty(t, cancelErr.CheckPointID, "CancelError should have checkpoint ID")
 
 	resumeSlow := newCancelTestAgentWithToolsFinalAnswer(t, "par_slow")
 	resumeFast := newCancelTestAgentWithToolsFinalAnswer(t, "par_fast")
@@ -3394,7 +3385,6 @@ func TestCancel_LoopWorkflow_CancelAfterChatModel(t *testing.T) {
 
 	assert.True(t, hasCancelError, "Should have CancelError from loop workflow")
 	assert.Equal(t, CancelAfterChatModel, cancelErr.Info.Mode)
-	assert.NotEmpty(t, cancelErr.CheckPointID, "CancelError should have checkpoint ID")
 
 	resumeAgent := newCancelTestAgentWithToolsFinalAnswer(t, "loop_inner")
 
@@ -3520,7 +3510,6 @@ func TestCancel_NestedWorkflow_AgentTool_CancelAfterChatModel(t *testing.T) {
 
 	assert.True(t, hasCancelError, "Should have CancelError from deeply nested workflow")
 	assert.Equal(t, CancelAfterChatModel, cancelErr.Info.Mode)
-	assert.NotEmpty(t, cancelErr.CheckPointID, "CancelError should have checkpoint ID")
 	assert.NotNil(t, cancelErr.interruptSignal, "CancelError should carry interrupt signal through agent tree")
 
 	// Phase 2: Resume from checkpoint — new instances to avoid data races
@@ -3670,7 +3659,6 @@ func TestCancel_CancelAfterToolCalls_InSequentialWorkflow(t *testing.T) {
 
 	assert.True(t, hasCancelError, "Should have CancelError after tool calls complete")
 	assert.Equal(t, CancelAfterToolCalls, cancelErr.Info.Mode)
-	assert.NotEmpty(t, cancelErr.CheckPointID, "CancelError should have checkpoint ID")
 
 	// Phase 2: Resume from checkpoint — new instances
 	resumeTool := &slowTool{

--- a/adk/cancel_test.go
+++ b/adk/cancel_test.go
@@ -3714,3 +3714,149 @@ func TestCancel_CancelAfterToolCalls_InSequentialWorkflow(t *testing.T) {
 	}
 	assert.NotEmpty(t, resumeEvents, "Resume should produce events")
 }
+
+// TestCancel_SafePointNeverFires_ErrExecutionEnded verifies the waitForCompletion
+// path where a safe-point cancel is submitted while the agent is running, but
+// the agent finishes without hitting the requested safe-point (e.g.
+// CancelAfterToolCalls on an agent with no tool calls). The cancel CAS succeeds
+// (stateRunning → stateCancelling), but the agent completes normally (markDone →
+// stateDone), so waitForCompletion returns ErrExecutionEnded.
+func TestCancel_SafePointNeverFires_ErrExecutionEnded(t *testing.T) {
+	ctx := context.Background()
+
+	gate := make(chan struct{})
+	done := make(chan struct{}, 1)
+
+	m := &gatedChatModel{
+		gateChan: gate,
+		doneChan: done,
+		response: &schema.Message{
+			Role:    schema.Assistant,
+			Content: "Final answer, no tool calls",
+		},
+	}
+
+	agent, err := NewChatModelAgent(ctx, &ChatModelAgentConfig{
+		Name:        "NoToolAgent",
+		Description: "Agent with no tools",
+		Instruction: "You are a test assistant",
+		Model:       m,
+	})
+	assert.NoError(t, err)
+
+	runner := NewRunner(ctx, RunnerConfig{
+		Agent: agent,
+	})
+
+	cancelOpt, cancelFn := WithCancel()
+	iter := runner.Run(ctx, []Message{schema.UserMessage("hello")}, cancelOpt)
+
+	// Wait a moment for the agent to enter Generate and block on gateChan.
+	runtime.Gosched()
+	time.Sleep(50 * time.Millisecond)
+
+	// Submit a safe-point cancel for tool calls. The agent has no tools,
+	// so this safe-point will never fire.
+	handle, submitted := cancelFn(WithAgentCancelMode(CancelAfterToolCalls))
+	assert.True(t, submitted)
+
+	// Let the model complete. The agent finishes without hitting the tool
+	// calls safe-point → markDone → stateDone → waitForCompletion returns
+	// ErrExecutionEnded.
+	close(gate)
+
+	waitErr := handle.Wait()
+	assert.ErrorIs(t, waitErr, ErrExecutionEnded)
+
+	for {
+		_, ok := iter.Next()
+		if !ok {
+			break
+		}
+	}
+}
+
+// TestBuildCancelFunc_StateDoneUnderLock exercises the race-condition path
+// in buildCancelFunc where the state transitions to stateDone between the
+// lockless check and the locked check (cancel.go L732-734).
+func TestBuildCancelFunc_StateDoneUnderLock(t *testing.T) {
+	cc := newCancelContext()
+	cancelFn := cc.buildCancelFunc()
+
+	// Hold cancelMu so the cancel func blocks when it tries to acquire the lock.
+	cc.cancelMu.Lock()
+
+	type result struct {
+		handle *CancelHandle
+		ok     bool
+	}
+	ch := make(chan result, 1)
+
+	go func() {
+		h, ok := cancelFn(WithAgentCancelMode(CancelAfterToolCalls))
+		ch <- result{h, ok}
+	}()
+
+	// Give the goroutine time to reach the Lock() call.
+	runtime.Gosched()
+	time.Sleep(20 * time.Millisecond)
+
+	// Transition to stateDone while the cancel goroutine is blocked on the lock.
+	cc.markDone()
+
+	// Release the lock. The cancel func resumes and finds stateDone.
+	cc.cancelMu.Unlock()
+
+	r := <-ch
+	assert.False(t, r.ok, "cancel should not be accepted when execution already done")
+	assert.ErrorIs(t, r.handle.Wait(), ErrExecutionEnded)
+}
+
+// TestBuildCancelFunc_CASFailStateDone exercises the race-condition path
+// in buildCancelFunc where the CAS on stateRunning→stateCancelling fails
+// because markDone transitioned stateRunning→stateDone concurrently
+// (cancel.go L742-743).
+func TestBuildCancelFunc_CASFailStateDone(t *testing.T) {
+	// Exercises cancel.go L742-743: CAS(stateRunning→stateCancelling) fails
+	// because markDone transitions stateRunning→stateDone concurrently.
+	//
+	// The window between the state check (L738) and CAS (L739) is extremely
+	// tight. We maximize the chance by having the cancel goroutine block on
+	// cancelMu, then racing markDone with the lock release.
+	hit := false
+	for i := 0; i < 100000 && !hit; i++ {
+		cc := newCancelContext()
+		cancelFn := cc.buildCancelFunc()
+
+		// Hold cancelMu so the cancel goroutine blocks at L725.
+		cc.cancelMu.Lock()
+
+		cancelDone := make(chan struct{})
+		var h *CancelHandle
+		var ok bool
+
+		go func() {
+			defer close(cancelDone)
+			h, ok = cancelFn(WithAgentCancelMode(CancelAfterToolCalls))
+		}()
+
+		// Let the cancel goroutine reach the Lock() call.
+		runtime.Gosched()
+
+		// Release lock and fire markDone concurrently. The cancel goroutine
+		// will acquire the lock and race with markDone on the CAS.
+		go cc.markDone()
+		cc.cancelMu.Unlock()
+
+		<-cancelDone
+
+		if !ok && errors.Is(h.Wait(), ErrExecutionEnded) {
+			hit = true
+		}
+	}
+	if hit {
+		t.Log("Successfully hit CAS-fail → stateDone path")
+	} else {
+		t.Log("CAS race path not triggered (L743 remains a theoretical race edge)")
+	}
+}

--- a/adk/chatmodel.go
+++ b/adk/chatmodel.go
@@ -812,7 +812,7 @@ func (a *ChatModelAgent) handleRunFuncError(
 			// returning false and markDone() executing, a concurrent cancel could
 			// transition stateRunning→stateCancelling. markDone() then does
 			// stateCancelling→stateDone, and the cancel func receives
-			// ErrExecutionCompleted (execution finished before cancel took effect).
+			// ErrExecutionEnded (execution finished before cancel took effect).
 			if !cancelCtx.shouldCancel() {
 				cancelCtx.markDone()
 			}

--- a/adk/prebuilt/planexecute/plan_execute_test.go
+++ b/adk/prebuilt/planexecute/plan_execute_test.go
@@ -1113,7 +1113,7 @@ func TestWithCancel_PlanExecute_DuringExecution(t *testing.T) {
 
 	time.Sleep(50 * time.Millisecond)
 
-	// Cancel should NOT return ErrExecutionCompleted
+	// Cancel should NOT return ErrExecutionEnded
 	handle, _ := cancelFn()
 	err = handle.Wait()
 	assert.NoError(t, err, "Cancel during executor should succeed")

--- a/adk/runner.go
+++ b/adk/runner.go
@@ -219,7 +219,6 @@ func (r *Runner) handleIter(ctx context.Context, aIter *AsyncIterator[*AgentEven
 					cancelCtx.markCancelHandled()
 				}
 				if cancelErr.interruptSignal != nil && checkPointID != nil {
-					cancelErr.CheckPointID = *checkPointID
 					cancelErr.InterruptContexts = core.ToInterruptContexts(cancelErr.interruptSignal, allowedAddressSegmentTypes)
 					err := r.saveCheckPoint(ctx, *checkPointID, &InterruptInfo{}, cancelErr.interruptSignal)
 					if err != nil {

--- a/adk/turn_loop.go
+++ b/adk/turn_loop.go
@@ -363,9 +363,13 @@ type TurnLoopConfig[T any] struct {
 	// Required.
 	GenInput func(ctx context.Context, loop *TurnLoop[T], items []T) (*GenInputResult[T], error)
 
-	// GenResume is called exactly once when the TurnLoop detects a mid-turn
-	// checkpoint on startup (i.e. CheckpointID is configured and the stored
-	// checkpoint has runner state from an interrupted agent execution).
+	// GenResume is called at most once during Run(). When CheckpointID is
+	// configured, Run() queries Store for the checkpoint:
+	//   - If the checkpoint contains runner state (i.e. an agent was interrupted
+	//     mid-turn), Run() calls GenResume to plan a resume turn.
+	//   - Otherwise (no checkpoint, or between-turns checkpoint), GenResume is
+	//     never called and the loop proceeds via GenInput.
+	//
 	// It receives:
 	//   - canceledItems: the items being processed when the prior run was canceled
 	//   - unhandledItems: items buffered but not processed when the prior run exited
@@ -391,16 +395,16 @@ type TurnLoopConfig[T any] struct {
 	//   - tc.Preempted / tc.Stopped: signals while processing events
 	//
 	// Error handling: the returned error is only used when the callback itself
-	// wants to abort the TurnLoop. The TurnLoop already captures CancelError
-	// from the event stream when the turn is stopped or preempted, so the
-	// callback should NOT propagate CancelError. In practice, return a non-nil
-	// error only for callback-internal failures that should terminate the loop;
-	// return nil when the current agent is canceled by an external Stop or
-	// Preempt (Preempt cancels the current agent but the loop continues with
-	// the next turn).
+	// wants to abort the TurnLoop. The callback should NEVER propagate
+	// CancelError — the framework handles it automatically:
+	//   - Stop: the framework propagates CancelError as ExitReason, loop exits.
+	//   - Preempt: the framework does not propagate CancelError; if the callback
+	//     also returns nil, the loop continues with the next turn.
+	// In practice, return a non-nil error only for callback-internal failures
+	// that should terminate the loop.
 	//
-	// Optional. If not provided, events are drained and errors (except CancelError
-	// from Stop-triggered cancellation) are returned as ExitReason.
+	// Optional. If not provided, events are drained and the first error
+	// (including CancelError from Stop) is returned as ExitReason.
 	OnAgentEvents func(ctx context.Context, tc *TurnContext[T], events *AsyncIterator[*AgentEvent]) error
 
 	// Store is the checkpoint store for persistence and resume. Optional.
@@ -442,7 +446,9 @@ type GenInputResult[T any] struct {
 	// Input is the agent input to execute
 	Input *AgentInput
 
-	// RunOpts are the options for this agent run
+	// RunOpts are the options for this agent run.
+	// Note: do not pass WithCheckPointID here; the TurnLoop automatically
+	// injects the checkpointID into the Runner.
 	RunOpts []AgentRunOption
 
 	// Consumed are the items selected for this turn.
@@ -464,6 +470,8 @@ type GenResumeResult[T any] struct {
 	RunCtx context.Context
 
 	// RunOpts are the options for this agent resume run.
+	// Note: do not pass WithCheckPointID here; the TurnLoop automatically
+	// injects the checkpointID into the Runner.
 	RunOpts []AgentRunOption
 
 	// ResumeParams are optional parameters for resuming an interrupted agent.
@@ -581,20 +589,20 @@ type TurnLoopExitState[T any] struct {
 	// by a cancel (Stop with WithImmediate, WithGraceful, or WithGracefulTimeout).
 	// Only populated when ExitReason is a *CancelError — if the agent finishes
 	// normally before the cancel takes effect, CanceledItems is empty.
-	// It can be used to reconstruct GenInput/PrepareAgent inputs when resuming.
+	// On resume, these are passed to GenResume's CanceledItems parameter.
 	CanceledItems []T
 
 	// StopCause is the business-supplied reason passed via WithStopCause.
 	// Empty if Stop was not called or no cause was provided.
 	StopCause string
 
-	// Checkpointed indicates whether a checkpoint save was attempted during cleanup.
+	// CheckpointAttempted indicates whether a checkpoint save was attempted when the loop exited.
 	// True only when Store is configured, CheckpointID is set, Stop() was called,
-	// and the loop was not idle at exit time.
-	Checkpointed bool
+	// the loop was not idle at exit time, and WithSkipCheckpoint was not used.
+	CheckpointAttempted bool
 
 	// CheckpointErr is the error from checkpoint save, if any.
-	// nil when Checkpointed is false (no attempt was made) or when the save succeeded.
+	// nil when CheckpointAttempted is false (no attempt was made) or when the save succeeded.
 	CheckpointErr error
 
 	// TakeLateItems returns items that were pushed after the loop stopped
@@ -604,8 +612,8 @@ type TurnLoopExitState[T any] struct {
 	// This function is idempotent: the first call computes and caches the result;
 	// subsequent calls return the same slice.
 	//
-	// After TakeLateItems is called, any subsequent Push() will panic. This
-	// seals the late buffer and prevents items from being silently lost.
+	// After TakeLateItems is called, any subsequent Push() will panic to
+	// prevent items from being silently lost.
 	//
 	// It is safe to call TakeLateItems from any goroutine after Wait() returns.
 	// If TakeLateItems is never called, late items are simply garbage collected.
@@ -720,9 +728,7 @@ type turnLoopCheckpoint[T any] struct {
 	CanceledItems  []T
 }
 
-// ErrCheckpointStoreNil is returned when a checkpoint operation requires a Store
-// but none was configured in TurnLoopConfig.
-var ErrCheckpointStoreNil = errors.New("checkpoint store is nil")
+
 
 func marshalTurnLoopCheckpoint[T any](c *turnLoopCheckpoint[T]) ([]byte, error) {
 	buf := new(bytes.Buffer)
@@ -742,7 +748,7 @@ func unmarshalTurnLoopCheckpoint[T any](data []byte) (*turnLoopCheckpoint[T], er
 
 func (l *TurnLoop[T]) saveTurnLoopCheckpoint(ctx context.Context, checkPointID string, c *turnLoopCheckpoint[T]) error {
 	if l.config.Store == nil {
-		return ErrCheckpointStoreNil
+		return errors.New("checkpoint store is nil")
 	}
 	data, err := marshalTurnLoopCheckpoint(c)
 	if err != nil {
@@ -831,14 +837,14 @@ type turnLoopPendingResume[T any] struct {
 type SafePoint int
 
 const (
-	// AfterToolCalls allows the agent to finish the current tool-call round
-	// before being cancelled.
-	AfterToolCalls SafePoint = 1 << iota
 	// AfterChatModel allows the agent to finish the current chat-model
 	// call before being cancelled.
-	AfterChatModel
-	// AnySafePoint is shorthand for AfterToolCalls | AfterChatModel.
-	AnySafePoint = AfterToolCalls | AfterChatModel
+	AfterChatModel SafePoint = 1 << iota
+	// AfterToolCalls allows the agent to finish the current tool-call round
+	// before being cancelled.
+	AfterToolCalls
+	// AnySafePoint is shorthand for AfterChatModel | AfterToolCalls.
+	AnySafePoint = AfterChatModel | AfterToolCalls
 )
 
 func (sp SafePoint) toCancelMode() CancelMode {
@@ -879,14 +885,17 @@ func WithGraceful() StopOption {
 }
 
 // WithImmediate aborts the running agent turn as soon as possible.
-// The agent's context is cancelled immediately without waiting for any
-// safe point. Nested agents inside AgentTools are torn down as a side effect.
+// The agent is cancelled immediately without waiting for any safe point.
+// Nested agents inside AgentTools will also receive the cancel signal
+// and be torn down.
 //
 // This is the most aggressive stop mode — typically used when the caller
 // wants to shut down the TurnLoop with no intention of resuming.
 func WithImmediate() StopOption {
 	return func(cfg *stopConfig) {
-		cfg.agentCancelOpts = []AgentCancelOption{}
+		cfg.agentCancelOpts = []AgentCancelOption{
+			WithRecursive(),
+		}
 	}
 }
 
@@ -986,8 +995,9 @@ type PushOption[T any] func(*pushConfig[T])
 // returns or after all tool calls complete), no nested agent is running at
 // the moment of cancellation — nested agents within AgentTools have either
 // not started yet (AfterChatModel) or already finished (AfterToolCalls).
-// If the preemption escalates to immediate via WithPreemptTimeout, any
-// in-flight nested agent is torn down through Go context cancellation.
+// Note: WithPreempt does NOT include WithRecursive (no escalation path exists).
+// WithPreemptTimeout DOES include WithRecursive so that on timeout escalation,
+// nested agents are properly torn down.
 //
 // WithPreempt and WithPreemptTimeout are mutually exclusive; if both are
 // passed to the same Push call, the last one wins.
@@ -1007,7 +1017,8 @@ func WithPreempt[T any](safePoint SafePoint) PushOption[T] {
 
 // WithPreemptTimeout is like WithPreempt but adds a timeout. If the agent has
 // not reached the safe point within timeout, the preemption escalates to
-// immediate cancellation.
+// immediate cancellation. On escalation, nested agents inside AgentTools will
+// also receive the cancel signal and be torn down.
 //
 // safePoint must not be zero; passing SafePoint(0) panics.
 func WithPreemptTimeout[T any](safePoint SafePoint, timeout time.Duration) PushOption[T] {
@@ -1019,6 +1030,7 @@ func WithPreemptTimeout[T any](safePoint SafePoint, timeout time.Duration) PushO
 		cfg.agentCancelOpts = []AgentCancelOption{
 			WithAgentCancelMode(safePoint.toCancelMode()),
 			WithAgentCancelTimeout(timeout),
+			WithRecursive(),
 		}
 	}
 }
@@ -1123,9 +1135,13 @@ func (l *TurnLoop[T]) Run(ctx context.Context) {
 // Push adds an item to the loop's buffer for processing.
 // This method is non-blocking and thread-safe.
 // Returns false if the loop has stopped, true otherwise. If a preemptive push
-// succeeds, the second return value is a channel that is closed when the loop
-// has acknowledged the preempt signal (by either initiating cancellation of the
-// current agent run or reaching a point where no cancellation is needed).
+// succeeds, the second return value is a channel that callers can wait on to
+// confirm the preempt signal has been received and the cancel request submitted
+// — i.e., the current turn is guaranteed to be preempted. Specifically:
+//   - If an agent is running: the channel closes after TurnLoop submits cancel.
+//   - If no agent is running (loop idle or not yet started): the channel closes
+//     immediately (nothing to cancel).
+//
 // If the loop has not been started yet (Run not called), items are buffered
 // and will be processed once Run is called.
 // After Wait() returns, failed pushes can be recovered via TurnLoopExitState.TakeLateItems().
@@ -1491,7 +1507,7 @@ func (l *TurnLoop[T]) run(ctx context.Context) {
 func (l *TurnLoop[T]) setupBridgeStore(spec *turnRunSpec[T], runOpts []AgentRunOption) ([]AgentRunOption, *bridgeStore, error) {
 	store := l.config.Store
 	if store == nil && spec.isResume {
-		return nil, nil, fmt.Errorf("failed to resume agent: %w", ErrCheckpointStoreNil)
+		return nil, nil, fmt.Errorf("failed to resume agent: checkpoint store is nil")
 	}
 	if store == nil {
 		return runOpts, nil, nil
@@ -1768,7 +1784,7 @@ func (l *TurnLoop[T]) cleanup(ctx context.Context) {
 		UnhandledItems: unhandled,
 		CanceledItems:  l.canceledItems,
 		StopCause:      l.stopSig.getStopCause(),
-		Checkpointed:   checkpointed,
+		CheckpointAttempted:   checkpointed,
 		CheckpointErr:  checkpointErr,
 		TakeLateItems: func() []T {
 			takeLateOnce.Do(func() {

--- a/adk/turn_loop.go
+++ b/adk/turn_loop.go
@@ -728,8 +728,6 @@ type turnLoopCheckpoint[T any] struct {
 	CanceledItems  []T
 }
 
-
-
 func marshalTurnLoopCheckpoint[T any](c *turnLoopCheckpoint[T]) ([]byte, error) {
 	buf := new(bytes.Buffer)
 	if err := gob.NewEncoder(buf).Encode(c); err != nil {
@@ -1780,12 +1778,12 @@ func (l *TurnLoop[T]) cleanup(ctx context.Context) {
 	var takeLateResult []T
 
 	l.result = &TurnLoopExitState[T]{
-		ExitReason:     l.runErr,
-		UnhandledItems: unhandled,
-		CanceledItems:  l.canceledItems,
-		StopCause:      l.stopSig.getStopCause(),
-		CheckpointAttempted:   checkpointed,
-		CheckpointErr:  checkpointErr,
+		ExitReason:          l.runErr,
+		UnhandledItems:      unhandled,
+		CanceledItems:       l.canceledItems,
+		StopCause:           l.stopSig.getStopCause(),
+		CheckpointAttempted: checkpointed,
+		CheckpointErr:       checkpointErr,
 		TakeLateItems: func() []T {
 			takeLateOnce.Do(func() {
 				l.lateMu.Lock()

--- a/adk/turn_loop_test.go
+++ b/adk/turn_loop_test.go
@@ -1887,7 +1887,7 @@ func TestTurnLoop_CheckpointSaveError_ReturnsError(t *testing.T) {
 	loop.Stop(WithImmediate())
 	exit := loop.Wait()
 	assert.Error(t, exit.ExitReason)
-	assert.True(t, exit.Checkpointed)
+	assert.True(t, exit.CheckpointAttempted)
 	assert.Error(t, exit.CheckpointErr)
 	assert.Contains(t, exit.CheckpointErr.Error(), "write failed")
 }
@@ -2362,7 +2362,7 @@ func TestTurnLoop_CheckpointSaveError_MergesWithExistingError(t *testing.T) {
 	assert.Error(t, exit.ExitReason)
 	var ce *CancelError
 	assert.True(t, errors.As(exit.ExitReason, &ce), "ExitReason should be CancelError, not merged with checkpoint error")
-	assert.True(t, exit.Checkpointed)
+	assert.True(t, exit.CheckpointAttempted)
 	assert.Error(t, exit.CheckpointErr)
 	assert.Contains(t, exit.CheckpointErr.Error(), "disk full")
 }
@@ -4006,12 +4006,12 @@ func TestTurnLoop_CheckpointErr_SeparateFromExitReason(t *testing.T) {
 
 	// ExitReason should be nil (clean stop), checkpoint error should be separate
 	assert.Nil(t, result.ExitReason)
-	assert.True(t, result.Checkpointed)
+	assert.True(t, result.CheckpointAttempted)
 	assert.Error(t, result.CheckpointErr)
 	assert.Contains(t, result.CheckpointErr.Error(), "storage unavailable")
 }
 
-func TestTurnLoop_Checkpointed_FalseWhenNoStore(t *testing.T) {
+func TestTurnLoop_CheckpointAttempted_FalseWhenNoStore(t *testing.T) {
 	ctx := context.Background()
 
 	loop := NewTurnLoop(TurnLoopConfig[string]{
@@ -4027,11 +4027,11 @@ func TestTurnLoop_Checkpointed_FalseWhenNoStore(t *testing.T) {
 	loop.Run(ctx)
 	result := loop.Wait()
 
-	assert.False(t, result.Checkpointed)
+	assert.False(t, result.CheckpointAttempted)
 	assert.Nil(t, result.CheckpointErr)
 }
 
-func TestTurnLoop_Checkpointed_FalseOnErrorExit(t *testing.T) {
+func TestTurnLoop_CheckpointAttempted_FalseOnErrorExit(t *testing.T) {
 	ctx := context.Background()
 	store := &turnLoopCheckpointStore{m: make(map[string][]byte)}
 	genInputErr := errors.New("gen input failed")
@@ -4068,7 +4068,7 @@ func TestTurnLoop_Checkpointed_FalseOnErrorExit(t *testing.T) {
 
 	// Loop exited from error, not Stop() — checkpoint should not be saved
 	assert.ErrorIs(t, result.ExitReason, genInputErr)
-	assert.False(t, result.Checkpointed)
+	assert.False(t, result.CheckpointAttempted)
 	assert.Nil(t, result.CheckpointErr)
 }
 
@@ -4128,7 +4128,7 @@ func TestTurnLoop_StopConcurrentWithCallbackError_NoCheckpoint(t *testing.T) {
 	// checkpoint should NOT be saved.
 	if result.ExitReason != nil && !errors.As(result.ExitReason, new(*CancelError)) {
 		assert.ErrorIs(t, result.ExitReason, prepareErr)
-		assert.False(t, result.Checkpointed, "should not checkpoint when exit is caused by callback error")
+		assert.False(t, result.CheckpointAttempted, "should not checkpoint when exit is caused by callback error")
 	}
 	// If Stop won the race, that's fine — checkpoint may or may not be saved
 	// depending on idle state. The test is about the error path.
@@ -4220,7 +4220,7 @@ func TestTurnLoop_StopWithSkipCheckpoint(t *testing.T) {
 
 	exit := loop.Wait()
 	assert.NoError(t, exit.ExitReason)
-	assert.False(t, exit.Checkpointed, "checkpoint should be skipped when WithSkipCheckpoint is used")
+	assert.False(t, exit.CheckpointAttempted, "checkpoint should be skipped when WithSkipCheckpoint is used")
 
 	store.mu.Lock()
 	_, exists := store.m[cpID]
@@ -4249,7 +4249,7 @@ func TestTurnLoop_StopWithSkipCheckpoint_DeletesStaleCheckpoint(t *testing.T) {
 	loop1.Stop()
 	loop1.Run(ctx)
 	exit1 := loop1.Wait()
-	assert.True(t, exit1.Checkpointed)
+	assert.True(t, exit1.CheckpointAttempted)
 
 	store.mu.Lock()
 	_, exists := store.m[cpID]
@@ -4270,7 +4270,7 @@ func TestTurnLoop_StopWithSkipCheckpoint_DeletesStaleCheckpoint(t *testing.T) {
 	loop2.Stop(WithSkipCheckpoint())
 	loop2.Run(ctx)
 	exit2 := loop2.Wait()
-	assert.False(t, exit2.Checkpointed, "second loop should skip checkpoint")
+	assert.False(t, exit2.CheckpointAttempted, "second loop should skip checkpoint")
 
 	store.mu.Lock()
 	deleteCalled := store.deleteCalled
@@ -4503,7 +4503,7 @@ func TestTurnLoop_SkipCheckpoint_Sticky(t *testing.T) {
 	loop.Stop()
 
 	exit := loop.Wait()
-	assert.False(t, exit.Checkpointed, "SkipCheckpoint should be sticky across multiple Stop calls")
+	assert.False(t, exit.CheckpointAttempted, "SkipCheckpoint should be sticky across multiple Stop calls")
 
 	store.mu.Lock()
 	_, exists := store.m[cpID]
@@ -5378,7 +5378,133 @@ func TestAttack_SkipCheckpoint_Sticky(t *testing.T) {
 	loop.Stop(WithImmediate())
 
 	exit := loop.Wait()
-	assert.False(t, exit.Checkpointed, "SkipCheckpoint is sticky; checkpoint should be skipped")
+	assert.False(t, exit.CheckpointAttempted, "SkipCheckpoint is sticky; checkpoint should be skipped")
+}
+
+// turnLoopNestedProbeAgent simulates an agent with a nested sub-agent
+// by deriving a child cancelContext. This allows tests to verify that
+// TurnLoop's Stop/Push options correctly propagate recursive cancellation.
+//
+// IMPORTANT: child.markDone() is NOT called by the probe. The test MUST
+// call it (e.g. via t.Cleanup) after verifying propagation to avoid a
+// race between markDone closing child.doneChan and the deriveChild
+// goroutines propagating the cancel signal.
+type turnLoopNestedProbeAgent struct {
+	parentCCCh chan *cancelContext
+	childCCCh  chan *cancelContext
+}
+
+func (a *turnLoopNestedProbeAgent) Name(_ context.Context) string        { return "nested-probe" }
+func (a *turnLoopNestedProbeAgent) Description(_ context.Context) string { return "nested-probe" }
+func (a *turnLoopNestedProbeAgent) Run(ctx context.Context, _ *AgentInput, opts ...AgentRunOption) *AsyncIterator[*AgentEvent] {
+	iter, gen := NewAsyncIteratorPair[*AgentEvent]()
+	o := getCommonOptions(nil, opts...)
+	cc := o.cancelCtx
+
+	child := cc.deriveChild(ctx)
+	a.parentCCCh <- cc
+	a.childCCCh <- child
+
+	go func() {
+		defer gen.Close()
+		<-cc.cancelChan
+		for {
+			if cc.getMode() == CancelImmediate {
+				gen.Send(&AgentEvent{Err: cc.createCancelError()})
+				return
+			}
+			time.Sleep(1 * time.Millisecond)
+		}
+	}()
+	return iter
+}
+
+func TestTurnLoop_Stop_WithImmediate_RecursivePropagation(t *testing.T) {
+	parentCCCh := make(chan *cancelContext, 1)
+	childCCCh := make(chan *cancelContext, 1)
+	probe := &turnLoopNestedProbeAgent{parentCCCh: parentCCCh, childCCCh: childCCCh}
+
+	loop := newAndRunTurnLoop(context.Background(), TurnLoopConfig[string]{
+		GenInput: func(ctx context.Context, _ *TurnLoop[string], items []string) (*GenInputResult[string], error) {
+			return &GenInputResult[string]{
+				Input:    &AgentInput{Messages: []Message{schema.UserMessage(items[0])}},
+				Consumed: items,
+			}, nil
+		},
+		PrepareAgent: func(ctx context.Context, _ *TurnLoop[string], consumed []string) (Agent, error) {
+			return probe, nil
+		},
+	})
+
+	loop.Push("msg1")
+	cc := <-parentCCCh
+	child := <-childCCCh
+	t.Cleanup(func() { child.markDone() })
+
+	loop.Stop(WithImmediate())
+
+	// Child should receive the cancel signal via recursive propagation.
+	select {
+	case <-child.cancelChan:
+	case <-time.After(2 * time.Second):
+		t.Fatal("child did not receive cancel via recursive propagation")
+	}
+
+	// Child should also receive the immediate cancel signal.
+	select {
+	case <-child.immediateChan:
+	case <-time.After(2 * time.Second):
+		t.Fatal("child did not receive immediate cancel via recursive propagation")
+	}
+
+	assert.True(t, cc.isRecursive(), "WithImmediate should set recursive on parent")
+	assert.True(t, child.shouldCancel(), "child should be cancelled")
+	assert.True(t, child.isImmediateCancelled(), "child should have received immediate cancel")
+
+	exit := loop.Wait()
+	var ce *CancelError
+	require.True(t, errors.As(exit.ExitReason, &ce))
+	assert.Equal(t, CancelImmediate, ce.Info.Mode)
+}
+
+func TestTurnLoop_Push_WithPreemptTimeout_RecursivePropagation(t *testing.T) {
+	parentCCCh := make(chan *cancelContext, 2)
+	childCCCh := make(chan *cancelContext, 2)
+	probe := &turnLoopNestedProbeAgent{parentCCCh: parentCCCh, childCCCh: childCCCh}
+
+	loop := newAndRunTurnLoop(context.Background(), TurnLoopConfig[string]{
+		GenInput: func(ctx context.Context, _ *TurnLoop[string], items []string) (*GenInputResult[string], error) {
+			return &GenInputResult[string]{
+				Input:    &AgentInput{Messages: []Message{schema.UserMessage(items[0])}},
+				Consumed: items,
+			}, nil
+		},
+		PrepareAgent: func(ctx context.Context, _ *TurnLoop[string], consumed []string) (Agent, error) {
+			return probe, nil
+		},
+	})
+
+	loop.Push("first")
+	cc := <-parentCCCh
+	child := <-childCCCh
+	t.Cleanup(func() { child.markDone() })
+
+	// Preempt with a very short timeout so it escalates to CancelImmediate quickly.
+	loop.Push("urgent", WithPreemptTimeout[string](AfterChatModel, 10*time.Millisecond))
+
+	// After timeout escalation, child should receive the immediate cancel
+	// via recursive propagation.
+	select {
+	case <-child.immediateChan:
+	case <-time.After(2 * time.Second):
+		t.Fatal("child did not receive immediate cancel after preempt timeout escalation")
+	}
+
+	assert.True(t, cc.isRecursive(), "WithPreemptTimeout should set recursive on parent")
+	assert.True(t, child.isImmediateCancelled(), "child should have received immediate cancel")
+
+	loop.Stop(WithImmediate())
+	loop.Wait()
 }
 
 func TestUntilIdleFor_NonPositive_Panics(t *testing.T) {

--- a/adk/turn_loop_test.go
+++ b/adk/turn_loop_test.go
@@ -5513,3 +5513,18 @@ func TestUntilIdleFor_NonPositive_Panics(t *testing.T) {
 	assert.PanicsWithValue(t, "adk: UntilIdleFor: duration must be positive",
 		func() { UntilIdleFor(-1 * time.Second) })
 }
+
+func TestSaveTurnLoopCheckpoint_NilStore(t *testing.T) {
+	l := &TurnLoop[string]{config: TurnLoopConfig[string]{Store: nil}}
+	err := l.saveTurnLoopCheckpoint(context.Background(), "cp-1", &turnLoopCheckpoint[string]{})
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "checkpoint store is nil")
+}
+
+func TestSetupBridgeStore_NilStore_Resume(t *testing.T) {
+	l := &TurnLoop[string]{config: TurnLoopConfig[string]{Store: nil}}
+	spec := &turnRunSpec[string]{isResume: true}
+	_, _, err := l.setupBridgeStore(spec, nil)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "checkpoint store is nil")
+}


### PR DESCRIPTION
# Cancel API Cleanup and Recursive Teardown Enforcement

## Problem

Several issues accumulated in the ADK cancel and TurnLoop APIs:

1. **Misleading names**: `ErrExecutionFinished` implied success; `Checkpointed` was grammatically ambiguous — neither conveyed the intended neutral/attempt semantics.
2. **Nested agent goroutine leak**: `Stop(WithImmediate())` and `Push(WithPreemptTimeout())` timeout escalation did not propagate cancellation to nested agents inside AgentTools, leaving orphaned goroutines.
3. **Internal terminology leakage**: Public Godoc comments exposed implementation details like `WithRecursive`, "late buffer", and "cleanup" that users should never see.
4. **Redundant API surface**: `ErrCheckpointStoreNil` sentinel and `CancelError.CheckPointID` field existed without clear justification.

## Solution

### Naming
- `ErrExecutionFinished` → `ErrExecutionEnded` — semantically neutral, no success connotation
- `Checkpointed` → `CheckpointAttempted` — clarifies this is an attempt flag, not a success indicator

### Recursive Teardown
- `WithImmediate()` now internally includes recursive propagation so nested agents inside AgentTools receive the cancel signal
- `WithPreemptTimeout()` timeout escalation path now also propagates recursively
- `WithPreempt()` (non-timeout) intentionally does NOT propagate — safe-point guarantee means no nested agent can be running at the cancel boundary

### Cleanup
- Removed `CancelError.CheckPointID` (redundant with `CancelInfo`)
- Removed `ErrCheckpointStoreNil` sentinel (replaced with inline error)
- Scrubbed all public Godoc of internal terms (`WithRecursive`, "late buffer", "cleanup")

### Tests
- Added `turnLoopNestedProbeAgent` mock that simulates nested AgentTools by deriving a child `cancelContext`
- `TestTurnLoop_Stop_WithImmediate_RecursivePropagation`: verifies child receives both cancel and immediate signals
- `TestTurnLoop_Push_WithPreemptTimeout_RecursivePropagation`: verifies timeout escalation propagates to child
- `TestWithCancel_CancelImmediate_StreamableToolAborted`: verifies `ErrStreamCanceled` on StreamableTool flow

## Key Insight

Flat mock agents cannot detect recursive cancellation bugs — the cancel signal stops at the root `cancelContext`. Only by deriving a child context (simulating what `AgentTool` does internally) can tests verify that `WithRecursive` propagation actually reaches nested agents. The `turnLoopNestedProbeAgent` pattern makes this explicit.

## Summary

| Problem | Solution |
|---------|----------|
| `ErrExecutionFinished` implies success | Renamed to `ErrExecutionEnded` |
| `Checkpointed` ambiguous | Renamed to `CheckpointAttempted` |
| Nested agents leak on immediate stop | `WithImmediate()` and timeout escalation now propagate recursively |
| Internal terms in public Godoc | Replaced with user-facing behavior descriptions |
| Redundant `CheckPointID` and `ErrCheckpointStoreNil` | Removed |

---

# Cancel API 清理与递归终止传播

## 问题

ADK 的 cancel 和 TurnLoop API 中累积了几个问题：

1. **命名误导**：`ErrExecutionFinished` 暗示成功；`Checkpointed` 语法上有歧义——两者都无法传达预期的中性/尝试语义。
2. **嵌套 agent goroutine 泄露**：`Stop(WithImmediate())` 和 `Push(WithPreemptTimeout())` 超时升级不会将取消传播到 AgentTools 内的嵌套 agent，导致孤立 goroutine。
3. **内部术语泄露**：公共 Godoc 注释暴露了 `WithRecursive`、"late buffer"、"cleanup" 等用户不应看到的实现细节。
4. **冗余 API 表面**：`ErrCheckpointStoreNil` 哨兵错误和 `CancelError.CheckPointID` 字段缺乏明确的存在理由。

## 解决方案

### 命名
- `ErrExecutionFinished` → `ErrExecutionEnded` —— 语义中性，无成功暗示
- `Checkpointed` → `CheckpointAttempted` —— 明确这是尝试标志，而非成功指示器

### 递归终止
- `WithImmediate()` 现在内部包含递归传播，确保 AgentTools 内的嵌套 agent 收到取消信号
- `WithPreemptTimeout()` 超时升级路径也递归传播
- `WithPreempt()`（非超时）故意不传播——安全点保证在取消边界处没有嵌套 agent 在运行

### 清理
- 移除 `CancelError.CheckPointID`（与 `CancelInfo` 冗余）
- 移除 `ErrCheckpointStoreNil` 哨兵（改为内联错误）
- 清除所有公共 Godoc 中的内部术语

### 测试
- 新增 `turnLoopNestedProbeAgent` mock，通过派生子 `cancelContext` 模拟嵌套 AgentTools
- 验证立即取消和超时升级的递归传播
- 验证 StreamableTool 流上的 `ErrStreamCanceled`

## 核心洞察

扁平 mock agent 无法检测递归取消 bug——取消信号停止在根 `cancelContext`。只有通过派生子 context（模拟 `AgentTool` 的内部行为），测试才能验证递归传播确实到达了嵌套 agent。

## 总结

| 问题 | 解决方案 |
|------|----------|
| `ErrExecutionFinished` 暗示成功 | 重命名为 `ErrExecutionEnded` |
| `Checkpointed` 有歧义 | 重命名为 `CheckpointAttempted` |
| 立即停止时嵌套 agent 泄露 | `WithImmediate()` 和超时升级现在递归传播 |
| 公共 Godoc 中的内部术语 | 替换为面向用户的行为描述 |
| 冗余的 `CheckPointID` 和 `ErrCheckpointStoreNil` | 已移除 |
