### PR TITLE
fix(adk): eagerly consume stream in GobEncode to prevent checkpoint failure on model retry

### DIFF
--- a/adk/interrupt_test.go
+++ b/adk/interrupt_test.go
@@ -22,6 +22,7 @@ import (
 	"errors"
 	"fmt"
 	"sync"
+	"sync/atomic"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -2031,4 +2032,116 @@ func TestReturnDirectlyEventSentAfterResume(t *testing.T) {
 		}
 	}
 	assert.True(t, hasDynamicToolAfterResume, "Dynamic tool should be in tool list after resume (bc.toolUpdated path)")
+}
+
+// streamErrorThenToolCallModel simulates a model that:
+// - On the first Stream call: emits several good chunks then an error (triggering retry)
+// - On the second Stream call (retry): returns a tool call message (success)
+type streamErrorThenToolCallModel struct {
+	callCount    int32
+	toolCallName string
+}
+
+func (m *streamErrorThenToolCallModel) Generate(_ context.Context, _ []*schema.Message, _ ...model.Option) (*schema.Message, error) {
+	return schema.AssistantMessage("final answer", nil), nil
+}
+
+func (m *streamErrorThenToolCallModel) Stream(_ context.Context, _ []*schema.Message, _ ...model.Option) (*schema.StreamReader[*schema.Message], error) {
+	count := atomic.AddInt32(&m.callCount, 1)
+
+	sr, sw := schema.Pipe[*schema.Message](10)
+	go func() {
+		defer sw.Close()
+		if count == 1 {
+			// First call: emit good chunks then error
+			sw.Send(schema.AssistantMessage("chunk1", nil), nil)
+			sw.Send(schema.AssistantMessage("chunk2", nil), nil)
+			sw.Send(schema.AssistantMessage("chunk3", nil), nil)
+			sw.Send(nil, errRetryAble)
+			return
+		}
+		// Second call (retry): return tool call
+		sw.Send(schema.AssistantMessage("", []schema.ToolCall{{
+			ID:       "call-1",
+			Function: schema.FunctionCall{Name: m.toolCallName, Arguments: "{}"},
+		}}), nil)
+	}()
+	return sr, nil
+}
+
+func (m *streamErrorThenToolCallModel) WithTools(_ []*schema.ToolInfo) (model.ToolCallingChatModel, error) {
+	return m, nil
+}
+
+// TestStreamRetryThenToolInterruptCheckpoint reproduces a bug where:
+//  1. ChatModelAgent with ModelRetryConfig.MaxRetries = 2
+//  2. First model Stream call emits good chunks then a retryable error
+//  3. Retry succeeds, model returns a tool call
+//  4. The tool triggers an interrupt, causing the Runner to save a checkpoint
+//  5. The checkpoint save fails because the first (failed) model call's stream event
+//     is in the session, and when MessageVariant.GobEncode consumes the stream,
+//     it hits the error chunk and returns an encoding error.
+func TestStreamRetryThenToolInterruptCheckpoint(t *testing.T) {
+	ctx := context.Background()
+
+	interruptToolName := "interrupt_tool"
+	mdl := &streamErrorThenToolCallModel{toolCallName: interruptToolName}
+
+	interruptTool := &interruptingTool{name: interruptToolName}
+
+	agent, err := NewChatModelAgent(ctx, &ChatModelAgentConfig{
+		Name:        "RetryInterruptAgent",
+		Description: "Agent that retries model then tool interrupts",
+		Instruction: "You are a test agent.",
+		Model:       mdl,
+		ModelRetryConfig: &ModelRetryConfig{
+			MaxRetries:  2,
+			IsRetryAble: func(ctx context.Context, err error) bool { return errors.Is(err, errRetryAble) },
+		},
+		ToolsConfig: ToolsConfig{
+			ToolsNodeConfig: compose.ToolsNodeConfig{
+				Tools: []tool.BaseTool{interruptTool},
+			},
+		},
+	})
+	assert.NoError(t, err)
+
+	store := newMyStore()
+	runner := NewRunner(ctx, RunnerConfig{
+		Agent:           agent,
+		EnableStreaming: true,
+		CheckPointStore: store,
+	})
+
+	iter := runner.Run(ctx, []Message{schema.UserMessage("test query")}, WithCheckPointID("retry_interrupt_ckpt"))
+
+	var events []*AgentEvent
+	var checkpointErr error
+	for {
+		event, ok := iter.Next()
+		if !ok {
+			break
+		}
+		events = append(events, event)
+		if event.Err != nil {
+			checkpointErr = event.Err
+			t.Logf("event error: %v", event.Err)
+		}
+	}
+
+	// The bug: checkpoint save fails because the failed stream's error chunk
+	// is encountered during gob encoding of the session events.
+	// If the bug is fixed, checkpointErr should be nil and we should see an interrupt event.
+	assert.NoError(t, checkpointErr, "checkpoint save should not fail due to failed stream's error in session")
+
+	var hasInterrupt bool
+	for _, event := range events {
+		if event.Action != nil && event.Action.Interrupted != nil {
+			hasInterrupt = true
+		}
+	}
+	assert.True(t, hasInterrupt, "should receive an interrupt event from the tool")
+
+	// Verify the model was called twice (first call errored, second succeeded)
+	assert.Equal(t, int32(2), atomic.LoadInt32(&mdl.callCount), "model should be called exactly twice (1 failure + 1 retry)")
 }

--- a/adk/runctx.go
+++ b/adk/runctx.go
@@ -24,8 +24,6 @@ import (
 	"sort"
 	"sync"
 	"time"
-
-	"github.com/cloudwego/eino/schema"
 )
 
 // runSession CheckpointSchema: persisted via serialization.RunCtx (gob).
@@ -65,8 +63,14 @@ type agentEventWrapper struct {
 type otherAgentEventWrapperForEncode agentEventWrapper
 
 func (a *agentEventWrapper) GobEncode() ([]byte, error) {
-	if a.concatenatedMessage != nil && a.Output != nil && a.Output.MessageOutput != nil && a.Output.MessageOutput.IsStreaming {
-		a.Output.MessageOutput.MessageStream = schema.StreamReaderFromArray([]Message{a.concatenatedMessage})
+	if a.Output != nil && a.Output.MessageOutput != nil && a.Output.MessageOutput.IsStreaming {
+		// Materialize the stream before encoding. An unconsumed stream that
+		// ends with a non-EOF error (WillRetryError, ErrStreamCanceled) would
+		// cause MessageVariant.GobEncode to fail. consumeStream replaces the
+		// stream with an error-free, materialized version.
+		if a.concatenatedMessage == nil && a.StreamErr == nil {
+			a.consumeStream()
+		}
 	}
 
 	buf := &bytes.Buffer{}

--- a/adk/utils.go
+++ b/adk/utils.go
@@ -124,16 +124,27 @@ func getMessageFromWrappedEvent(e *agentEventWrapper) (Message, error) {
 		return nil, e.StreamErr
 	}
 
+	e.consumeStream()
+
+	if e.StreamErr != nil {
+		return nil, e.StreamErr
+	}
+	return e.concatenatedMessage, nil
+}
+
+// consumeStream drains the message stream, setting concatenatedMessage on
+// success or StreamErr on failure. The stream is always replaced with an
+// error-free, materialized version safe for gob encoding.
+func (e *agentEventWrapper) consumeStream() {
 	e.mu.Lock()
 	defer e.mu.Unlock()
+
 	if e.concatenatedMessage != nil {
-		return e.concatenatedMessage, nil
+		return
 	}
 
-	var (
-		msgs []Message
-		s    = e.AgentEvent.Output.MessageOutput.MessageStream
-	)
+	s := e.AgentEvent.Output.MessageOutput.MessageStream
+	var msgs []Message
 
 	defer s.Close()
 	for {
@@ -148,14 +159,15 @@ func getMessageFromWrappedEvent(e *agentEventWrapper) (Message, error) {
 			// We intentionally exclude the error from the new stream to ensure gob encoding
 			// compatibility, as the stream may be consumed during serialization.
 			e.AgentEvent.Output.MessageOutput.MessageStream = schema.StreamReaderFromArray(msgs)
-			return nil, err
+			return
 		}
-
 		msgs = append(msgs, msg)
 	}
 
 	if len(msgs) == 0 {
-		return nil, errors.New("no messages in MessageVariant.MessageStream")
+		e.StreamErr = errors.New("no messages in MessageVariant.MessageStream")
+		e.AgentEvent.Output.MessageOutput.MessageStream = schema.StreamReaderFromArray(msgs)
+		return
 	}
 
 	if len(msgs) == 1 {
@@ -166,11 +178,11 @@ func getMessageFromWrappedEvent(e *agentEventWrapper) (Message, error) {
 		if err != nil {
 			e.StreamErr = err
 			e.AgentEvent.Output.MessageOutput.MessageStream = schema.StreamReaderFromArray(msgs)
-			return nil, err
+			return
 		}
 	}
 
-	return e.concatenatedMessage, nil
+	e.AgentEvent.Output.MessageOutput.MessageStream = schema.StreamReaderFromArray([]Message{e.concatenatedMessage})
 }
 
 // copyAgentEvent copies an AgentEvent.

--- a/adk/utils.go
+++ b/adk/utils.go
@@ -116,16 +116,12 @@ func getMessageFromWrappedEvent(e *agentEventWrapper) (Message, error) {
 		return e.AgentEvent.Output.MessageOutput.Message, nil
 	}
 
-	if e.concatenatedMessage != nil {
-		return e.concatenatedMessage, nil
-	}
-
-	// StreamErr is checked after concatenatedMessage because once the stream
-	// is successfully consumed, the concatenated result is always valid even
-	// if a prior call had set StreamErr (defensive). This order also matches
-	// alpha/09 to minimize future rebase conflicts.
 	if e.StreamErr != nil {
 		return nil, e.StreamErr
+	}
+
+	if e.concatenatedMessage != nil {
+		return e.concatenatedMessage, nil
 	}
 
 	e.consumeStream()
@@ -170,8 +166,10 @@ func (e *agentEventWrapper) consumeStream() {
 
 	if len(msgs) == 0 {
 		e.StreamErr = errors.New("no messages in MessageVariant.MessageStream")
-		// Replace the stream even when empty so that MessageVariant.GobEncode
-		// won't attempt to Recv() from the original (possibly broken) stream.
+		// Defensively replace the stream. The defer s.Close() above already
+		// ensures subsequent Recv() returns io.EOF, but we replace it anyway
+		// to make the invariant explicit: after consumeStream, MessageStream
+		// is always safe for MessageVariant.GobEncode to consume.
 		e.AgentEvent.Output.MessageOutput.MessageStream = schema.StreamReaderFromArray(msgs)
 		return
 	}

--- a/adk/utils.go
+++ b/adk/utils.go
@@ -120,6 +120,10 @@ func getMessageFromWrappedEvent(e *agentEventWrapper) (Message, error) {
 		return e.concatenatedMessage, nil
 	}
 
+	// StreamErr is checked after concatenatedMessage because once the stream
+	// is successfully consumed, the concatenated result is always valid even
+	// if a prior call had set StreamErr (defensive). This order also matches
+	// alpha/09 to minimize future rebase conflicts.
 	if e.StreamErr != nil {
 		return nil, e.StreamErr
 	}
@@ -166,6 +170,8 @@ func (e *agentEventWrapper) consumeStream() {
 
 	if len(msgs) == 0 {
 		e.StreamErr = errors.New("no messages in MessageVariant.MessageStream")
+		// Replace the stream even when empty so that MessageVariant.GobEncode
+		// won't attempt to Recv() from the original (possibly broken) stream.
 		e.AgentEvent.Output.MessageOutput.MessageStream = schema.StreamReaderFromArray(msgs)
 		return
 	}

--- a/adk/utils_test.go
+++ b/adk/utils_test.go
@@ -403,3 +403,53 @@ func TestAgentEventWrapper_GobEncoding_WithStreamSuccess(t *testing.T) {
 	assert.Equal(t, int64(67890), decoded.TS)
 	assert.Empty(t, decoded.StreamErr)
 }
+
+func TestConsumeStream_EdgeCases(t *testing.T) {
+	t.Run("double call is no-op", func(t *testing.T) {
+		sr, sw := schema.Pipe[Message](10)
+		go func() {
+			defer sw.Close()
+			sw.Send(schema.AssistantMessage("msg1", nil), nil)
+		}()
+
+		wrapper := &agentEventWrapper{
+			AgentEvent: &AgentEvent{
+				Output: &AgentOutput{
+					MessageOutput: &MessageVariant{
+						IsStreaming:   true,
+						MessageStream: sr,
+					},
+				},
+			},
+		}
+
+		wrapper.consumeStream()
+		assert.NotNil(t, wrapper.concatenatedMessage)
+		assert.Equal(t, "msg1", wrapper.concatenatedMessage.Content)
+
+		// Second call should be a no-op
+		wrapper.consumeStream()
+		assert.Equal(t, "msg1", wrapper.concatenatedMessage.Content)
+	})
+
+	t.Run("empty stream sets StreamErr", func(t *testing.T) {
+		sr, sw := schema.Pipe[Message](10)
+		sw.Close() // immediately close => EOF with 0 messages
+
+		wrapper := &agentEventWrapper{
+			AgentEvent: &AgentEvent{
+				Output: &AgentOutput{
+					MessageOutput: &MessageVariant{
+						IsStreaming:   true,
+						MessageStream: sr,
+					},
+				},
+			},
+		}
+
+		wrapper.consumeStream()
+		assert.Nil(t, wrapper.concatenatedMessage)
+		assert.Error(t, wrapper.StreamErr)
+		assert.Contains(t, wrapper.StreamErr.Error(), "no messages")
+	})
+}


### PR DESCRIPTION
## Summary

| Problem | Solution |
|---------|----------|
| Checkpoint save fails when a model retry's failed stream event is in the session | Eagerly consume unconsumed streams in `GobEncode` before delegating to inner encoder |

## Key Insight

The `eventSenderModel` (inside the retry wrapper) sends a stream event to the session for **every** model attempt, including failed ones. When a later tool triggers an interrupt, `saveCheckpoint` calls `agentEventWrapper.GobEncode` → `MessageVariant.GobEncode`, which tries to `Recv()` from the still-live failed stream and hits the error chunk, causing checkpoint failure.

The fix extracts stream consumption into a `consumeStream()` method and calls it from `GobEncode` when the stream hasn't been materialized yet. This guarantees the stream is replaced with an error-free, materialized version before gob encoding touches it.

## Reproduction Steps

1. `ChatModelAgent` with `ModelRetryConfig.MaxRetries = 2`
2. First model `Stream` call emits good chunks then a retryable error
3. Retry succeeds, model returns a tool call
4. Tool triggers interrupt → Runner saves checkpoint
5. **Before fix:** `"failed to save checkpoint: failed to encode checkpoint: failed to gob encode agent event wrapper: error receiving message stream: <err>"`
6. **After fix:** Checkpoint saves successfully, interrupt event delivered

## Changes

- **`adk/runctx.go`**: Modified `GobEncode` to call `consumeStream()` when stream is unconsumed, ensuring safe gob encoding.
- **`adk/utils.go`**: Extracted stream consumption from `getMessageFromWrappedEvent` into a standalone `consumeStream()` method. Both `GobEncode` and `getMessageFromWrappedEvent` now use it.
- **`adk/interrupt_test.go`**: Added `TestStreamRetryThenToolInterruptCheckpoint` that reproduces and verifies the fix.

## Notes

- This bug has existed since v0.7.14 (when `ModelRetryConfig` was introduced) and is already fixed on `alpha/09`. This PR backports the same fix structure to `main` to minimize future rebase conflicts.

---

## 概要

| 问题 | 解决方案 |
|------|----------|
| Model 重试时，失败流的 event 残留在 session 中导致 checkpoint 保存失败 | 在 `GobEncode` 中提前消费未物化的 stream，防止内层编码器触碰错误 chunk |

## 核心洞察

`eventSenderModel`（位于 retry wrapper 内部）为每次 model 调用尝试（包括失败的）都会向 session 发送 stream event。当后续 tool 触发 interrupt 时，`saveCheckpoint` 调用 `agentEventWrapper.GobEncode` → `MessageVariant.GobEncode`，后者尝试从仍存活的失败 stream 中 `Recv()`，触碰到错误 chunk 导致 checkpoint 序列化失败。

修复方案将 stream 消费逻辑提取为 `consumeStream()` 方法，并在 `GobEncode` 发现 stream 未被消费时主动调用。这保证了 gob 编码前 stream 已被替换为无错误的物化版本。

## 变更

- **`adk/runctx.go`**：修改 `GobEncode`，在 stream 未消费时调用 `consumeStream()`
- **`adk/utils.go`**：从 `getMessageFromWrappedEvent` 提取 `consumeStream()` 方法，两处共用
- **`adk/interrupt_test.go`**：新增 `TestStreamRetryThenToolInterruptCheckpoint` 复现并验证修复
