### PR TITLE
refactor(adk): move tool lists into agent state and migrate middlewares to BeforeModelRewriteState

### DIFF
--- a/adk/chatmodel.go
+++ b/adk/chatmodel.go
@@ -203,12 +203,15 @@ type TypedChatModelAgentState[M messageType] struct {
 	// Messages contains all messages in the current conversation session.
 	Messages []M
 
-	// ToolInfos contains the tools visible to the model (emitted as model.WithTools).
-	// BeforeModelRewriteState handlers should read and modify this field instead of ModelContext.Tools.
+	// ToolInfos contains the tool definitions passed to the model via model.WithTools.
+	// BeforeModelRewriteState handlers can read and modify this field to control which tools
+	// the model sees on each call.
 	ToolInfos []*schema.ToolInfo
 
-	// DeferredToolInfos contains tools for native server-side search (emitted as model.WithDeferredTools).
-	// Only used when UseModelToolSearch is true. Nil otherwise.
+	// DeferredToolInfos contains tool definitions for server-side deferred retrieval,
+	// passed to the model via model.WithDeferredTools. These tools are not included in the
+	// immediate tool list but can be discovered by the model through its native search capability.
+	// Nil when not in use.
 	DeferredToolInfos []*schema.ToolInfo
 }
 
@@ -383,11 +386,13 @@ type TypedChatModelAgentConfig[M messageType] struct {
 	//     both the tool info list passed to ChatModel AND the actual tools available for
 	//     execution. Changes persist for the entire agent run.
 	//
-	//  2. In WrapModel: Create a model wrapper that modifies the tool info list per model
-	//     request using model.WithTools(toolInfos). This ONLY affects the tool info list
-	//     passed to ChatModel, NOT the actual tools available for execution. Use this for
-	//     dynamic tool filtering/selection based on conversation context. The modification
-	//     is scoped to this model request only.
+	//  2. In BeforeModelRewriteState: Modify state.ToolInfos and state.DeferredToolInfos directly.
+	//     This affects the tool info list passed to ChatModel for this and all subsequent model
+	//     calls (changes are persisted in state). This is the recommended approach for dynamic
+	//     tool filtering/selection based on conversation context.
+	//
+	// Modifying tools in WrapModel (e.g. via model.WithTools) is discouraged: changes there
+	// are NOT persisted in state, only affect a single model call, and break prompt cache.
 	Handlers []TypedChatModelAgentMiddleware[M]
 
 	// ModelRetryConfig configures retry behavior for the ChatModel.
@@ -764,7 +769,7 @@ type execContext struct {
 	toolInfos      []*schema.ToolInfo
 	unwrappedTools []tool.BaseTool
 
-	toolSearchTool *schema.ToolInfo // set by BeforeAgent when UseModelToolSearch is true
+	toolSearchTool *schema.ToolInfo // set by BeforeAgent when the model supports native tool search
 
 	rebuildGraph bool // whether needs to instantiate a new graph because of topology changes due to tool modifications
 	toolUpdated  bool // whether needs to pass a compose.WithToolList option to ToolsNode due to tool list change

--- a/adk/chatmodel.go
+++ b/adk/chatmodel.go
@@ -202,6 +202,14 @@ func newDefaultGenModelInput[M messageType]() TypedGenModelInput[M] {
 type TypedChatModelAgentState[M messageType] struct {
 	// Messages contains all messages in the current conversation session.
 	Messages []M
+
+	// ToolInfos contains the tools visible to the model (emitted as model.WithTools).
+	// BeforeModelRewriteState handlers should read and modify this field instead of ModelContext.Tools.
+	ToolInfos []*schema.ToolInfo
+
+	// DeferredToolInfos contains tools for native server-side search (emitted as model.WithDeferredTools).
+	// Only used when UseModelToolSearch is true. Nil otherwise.
+	DeferredToolInfos []*schema.ToolInfo
 }
 
 // ChatModelAgentState is the default state type using *schema.Message.
@@ -756,6 +764,8 @@ type execContext struct {
 	toolInfos      []*schema.ToolInfo
 	unwrappedTools []tool.BaseTool
 
+	toolSearchTool *schema.ToolInfo // set by BeforeAgent when UseModelToolSearch is true
+
 	rebuildGraph bool // whether needs to instantiate a new graph because of topology changes due to tool modifications
 	toolUpdated  bool // whether needs to pass a compose.WithToolList option to ToolsNode due to tool list change
 }
@@ -786,6 +796,7 @@ func (a *TypedChatModelAgent[M]) applyBeforeAgent(ctx context.Context, ec *execC
 			ToolAliases:          ec.toolsNodeConf.ToolAliases,
 		},
 		returnDirectly: runCtx.ReturnDirectly,
+		toolSearchTool: runCtx.ToolSearchTool,
 		toolUpdated:    true,
 		rebuildGraph: (len(ec.toolsNodeConf.Tools) == 0 && len(runCtx.Tools) > 0) ||
 			(len(ec.returnDirectly) == 0 && len(runCtx.ReturnDirectly) > 0),
@@ -1393,6 +1404,9 @@ func (a *TypedChatModelAgent[M]) Run(ctx context.Context, input *TypedAgentInput
 
 	if bc != nil {
 		co = append(co, compose.WithChatModelOption(model.WithTools(bc.toolInfos)))
+		if bc.toolSearchTool != nil {
+			co = append(co, compose.WithChatModelOption(model.WithToolSearchTool(bc.toolSearchTool)))
+		}
 		if bc.toolUpdated {
 			co = append(co, compose.WithToolsNodeOption(compose.WithToolList(bc.toolsNodeConf.Tools...)))
 		}
@@ -1464,6 +1478,9 @@ func (a *TypedChatModelAgent[M]) Resume(ctx context.Context, info *ResumeInfo, o
 
 	if bc != nil {
 		co = append(co, compose.WithChatModelOption(model.WithTools(bc.toolInfos)))
+		if bc.toolSearchTool != nil {
+			co = append(co, compose.WithChatModelOption(model.WithToolSearchTool(bc.toolSearchTool)))
+		}
 		if bc.toolUpdated {
 			co = append(co, compose.WithToolsNodeOption(compose.WithToolList(bc.toolsNodeConf.Tools...)))
 		}

--- a/adk/handler.go
+++ b/adk/handler.go
@@ -57,6 +57,10 @@ type ToolCallsContext struct {
 type ModelContext struct {
 	// Tools contains the current tool list configured for the agent.
 	// This is populated at request time with the tools that will be sent to the model.
+	//
+	// Deprecated: Use TypedChatModelAgentState.ToolInfos in BeforeModelRewriteState instead.
+	// ModelContext.Tools remains populated for backward compatibility with existing WrapModel handlers,
+	// but new code should read and modify state.ToolInfos which is the source of truth for the model call.
 	Tools []*schema.ToolInfo
 
 	// ModelRetryConfig contains the retry configuration for the model.
@@ -94,6 +98,11 @@ type ChatModelAgentContext struct {
 	// This is based on the return directly map configured for the agent, plus any modifications
 	// by previous BeforeAgent handlers.
 	ReturnDirectly map[string]bool
+
+	// ToolSearchTool is the tool info for the model's native tool search capability.
+	// Set by toolsearch middleware in BeforeAgent when UseModelToolSearch is true.
+	// The framework wires this into model.WithToolSearchTool at Run/Resume time.
+	ToolSearchTool *schema.ToolInfo
 }
 
 // TypedChatModelAgentMiddleware defines the interface for customizing TypedChatModelAgent behavior.

--- a/adk/handler.go
+++ b/adk/handler.go
@@ -100,8 +100,7 @@ type ChatModelAgentContext struct {
 	ReturnDirectly map[string]bool
 
 	// ToolSearchTool is the tool info for the model's native tool search capability.
-	// Set by toolsearch middleware in BeforeAgent when UseModelToolSearch is true.
-	// The framework wires this into model.WithToolSearchTool at Run/Resume time.
+	// When set by a BeforeAgent handler, the framework passes it to the model via model.WithToolSearchTool.
 	ToolSearchTool *schema.ToolInfo
 }
 
@@ -145,9 +144,11 @@ type TypedChatModelAgentMiddleware[M messageType] interface {
 	//
 	// The ChatModelAgentState struct provides access to:
 	//   - Messages: the conversation history
+	//   - ToolInfos: the tool list that will be sent to the model (modifiable)
+	//   - DeferredToolInfos: tools for server-side search (modifiable, nil if unused)
 	//
-	// The ModelContext struct provides read-only access to:
-	//   - Tools: the current tool list that will be sent to the model
+	// This is the recommended place to modify messages and tools before a model call.
+	// Changes here are persisted in state and reflected in subsequent iterations.
 	BeforeModelRewriteState(ctx context.Context, state *TypedChatModelAgentState[M], mc *ModelContext) (context.Context, *TypedChatModelAgentState[M], error)
 
 	// AfterModelRewriteState is called after each model invocation.
@@ -156,9 +157,8 @@ type TypedChatModelAgentMiddleware[M messageType] interface {
 	//
 	// The ChatModelAgentState struct provides access to:
 	//   - Messages: the conversation history including the model's response
-	//
-	// The ModelContext struct provides read-only access to:
-	//   - Tools: the current tool list that was sent to the model
+	//   - ToolInfos: the tool list that was sent to the model
+	//   - DeferredToolInfos: tools for server-side search (nil if unused)
 	AfterModelRewriteState(ctx context.Context, state *TypedChatModelAgentState[M], mc *ModelContext) (context.Context, *TypedChatModelAgentState[M], error)
 
 	// AfterToolCallsRewriteState is called after all concurrent tool calls in an iteration complete.
@@ -217,7 +217,7 @@ type TypedChatModelAgentMiddleware[M messageType] interface {
 	//   - CallID: The unique identifier for this specific tool call
 	WrapEnhancedStreamableToolCall(ctx context.Context, endpoint EnhancedStreamableToolCallEndpoint, tCtx *ToolContext) (EnhancedStreamableToolCallEndpoint, error)
 
-	// WrapModel wraps a chat model with custom behavior.
+	// WrapModel wraps a chat model with custom behavior around the actual model call.
 	// Return the input model unchanged and nil error if no wrapping is needed.
 	//
 	// This method is called at request time when the model is about to be invoked.
@@ -225,8 +225,21 @@ type TypedChatModelAgentMiddleware[M messageType] interface {
 	// only need to intercept Generate/Stream calls. Tool binding (WithTools) is handled
 	// separately by the framework and does not flow through user wrappers.
 	//
-	// The mc parameter contains the current tool configuration:
-	//   - Tools: The tool infos that will be sent to the model
+	// Recommended use cases (behavior around the model call itself):
+	//   - Model call retry logic
+	//   - Model failover (switching to a backup model)
+	//   - Sending events (e.g. streaming progress)
+	//   - Processing or transforming the response stream
+	//   - Changing call configurations (temperature, top_p, etc.)
+	//
+	// Discouraged use cases (use BeforeModelRewriteState instead):
+	//   - Modifying input messages: changes here are NOT persisted in state, only
+	//     affect a single model call, and break prompt cache across iterations.
+	//   - Modifying the tool list: use state.ToolInfos / state.DeferredToolInfos in
+	//     BeforeModelRewriteState, which is the source of truth for tool configuration.
+	//
+	// The mc parameter provides read-only context about the current model call:
+	//   - Tools: The tool infos that will be sent to the model (Deprecated: read state.ToolInfos instead)
 	WrapModel(ctx context.Context, m model.BaseModel[M], mc *ModelContext) (model.BaseModel[M], error)
 }
 

--- a/adk/middlewares/agentsmd/agentsmd.go
+++ b/adk/middlewares/agentsmd/agentsmd.go
@@ -25,7 +25,6 @@ import (
 	"fmt"
 
 	"github.com/cloudwego/eino/adk"
-	"github.com/cloudwego/eino/components/model"
 	"github.com/cloudwego/eino/schema"
 )
 
@@ -78,92 +77,77 @@ type middleware struct {
 	loader *loaderConfig
 }
 
-// WrapModel returns a proxy model that prepends Agents.md content to the input
-// messages on every Generate/Stream call. The injected message is never written
-// back to ChatModelAgentState, so summarization and reduction middlewares are
-// unaffected.
-func (m *middleware) WrapModel(_ context.Context, cm model.BaseChatModel, _ *adk.ModelContext) (model.BaseChatModel, error) {
-	return &agentMDModel{
-		inner:  cm,
-		loader: m.loader,
-	}, nil
-}
-
-// agentMDModel wraps a BaseChatModel to prepend Agents.md content to input.
-type agentMDModel struct {
-	inner  model.BaseChatModel
-	loader *loaderConfig
-}
-
-func (m *agentMDModel) Generate(ctx context.Context, input []*schema.Message, opts ...model.Option) (*schema.Message, error) {
-	messages, err := m.prependAgentMD(ctx, input)
-	if err != nil {
-		return nil, err
-	}
-	return m.inner.Generate(ctx, messages, opts...)
-}
-
-func (m *agentMDModel) Stream(ctx context.Context, input []*schema.Message, opts ...model.Option) (*schema.StreamReader[*schema.Message], error) {
-	messages, err := m.prependAgentMD(ctx, input)
-	if err != nil {
-		return nil, err
-	}
-	return m.inner.Stream(ctx, messages, opts...)
-}
-
 const agentsMDCacheKey = "__agentsmd_content_cache__"
+const agentsMDExtraKey = "__agentsmd_content__"
 
-// prependAgentMD loads the current Agents.md content and inserts it before the
-// first User role message. If all configured agent files are empty (or skipped),
-// the original input is returned unchanged.
-// The loaded content is cached in RunLocalValue for the duration of the agent Run().
-func (m *agentMDModel) prependAgentMD(ctx context.Context, input []*schema.Message) ([]*schema.Message, error) {
-	var content string
+// BeforeModelRewriteState injects Agents.md content as a User message before
+// the first User message in the conversation. The injected message is tagged
+// with an Extra key so that repeated invocations are idempotent.
+func (m *middleware) BeforeModelRewriteState(ctx context.Context, state *adk.ChatModelAgentState, mc *adk.ModelContext) (context.Context, *adk.ChatModelAgentState, error) {
+	// Idempotent: if we already injected, return early.
+	for _, msg := range state.Messages {
+		if msg.Extra != nil {
+			if _, ok := msg.Extra[agentsMDExtraKey]; ok {
+				return ctx, state, nil
+			}
+		}
+	}
 
-	// Try to get cached content from RunLocalValue.
+	content, err := m.loadContent(ctx)
+	if err != nil {
+		return ctx, nil, err
+	}
+	if content == "" {
+		return ctx, state, nil
+	}
+
+	msg := schema.UserMessage(fmt.Sprintf("<system-reminder>\n%s\n</system-reminder>", content))
+	msg.Extra = map[string]any{agentsMDExtraKey: true}
+
+	nState := *state
+	nState.Messages = insertBeforeFirstUser(state.Messages, msg)
+	return ctx, &nState, nil
+}
+
+// loadContent retrieves the Agents.md content, using a per-Run cache to avoid
+// reloading on every model call within the same Run().
+func (m *middleware) loadContent(ctx context.Context) (string, error) {
 	if cached, found, err := adk.GetRunLocalValue(ctx, agentsMDCacheKey); err == nil && found {
 		if s, ok := cached.(string); ok {
-			content = s
+			return s, nil
 		}
 	}
 
-	if content == "" {
-		var err error
-		content, err = m.loader.load(ctx)
-		if err != nil {
-			return nil, fmt.Errorf("[agentsmd]: failed to load agent files: %w", err)
-		}
-		// Cache the loaded content for subsequent model calls in this Run().
-		if content != "" {
-			_ = adk.SetRunLocalValue(ctx, agentsMDCacheKey, content)
-		}
-	}
-	if content == "" {
-		return input, nil
+	content, err := m.loader.load(ctx)
+	if err != nil {
+		return "", fmt.Errorf("[agentsmd]: failed to load agent files: %w", err)
 	}
 
-	agentMDMsg := &schema.Message{
-		Role:    schema.User,
-		Content: content,
+	if content != "" {
+		_ = adk.SetRunLocalValue(ctx, agentsMDCacheKey, content)
 	}
 
-	// Insert agentMDMsg before the first User role message.
-	messages := make([]*schema.Message, 0, len(input)+1)
+	return content, nil
+}
+
+// insertBeforeFirstUser inserts newMsg before the first User role message.
+// If no User message is found, newMsg is appended at the end.
+func insertBeforeFirstUser(msgs []*schema.Message, newMsg *schema.Message) []*schema.Message {
+	result := make([]*schema.Message, 0, len(msgs)+1)
 	inserted := false
-	for i, msg := range input {
+	for i, msg := range msgs {
 		if !inserted && msg.Role == schema.User {
-			messages = append(messages, agentMDMsg)
-			messages = append(messages, input[i:]...)
+			result = append(result, newMsg)
+			result = append(result, msgs[i:]...)
 			inserted = true
 			break
 		}
-		messages = append(messages, msg)
+		result = append(result, msg)
 	}
 	if !inserted {
-		// No User message found; append at the end as fallback.
-		messages = append(messages, agentMDMsg)
+		result = append(result, newMsg)
 	}
-	return messages, nil
+	return result
 }
 
 func (c *Config) validate() error {

--- a/adk/middlewares/agentsmd/agentsmd_test.go
+++ b/adk/middlewares/agentsmd/agentsmd_test.go
@@ -23,26 +23,12 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/cloudwego/eino/adk"
 	"github.com/cloudwego/eino/adk/filesystem"
-	"github.com/cloudwego/eino/components/model"
 	"github.com/cloudwego/eino/schema"
 )
 
 // --- test helpers ---
-
-type mockModel struct {
-	lastInput []*schema.Message
-}
-
-func (m *mockModel) Generate(_ context.Context, input []*schema.Message, _ ...model.Option) (*schema.Message, error) {
-	m.lastInput = input
-	return &schema.Message{Role: schema.Assistant, Content: "ok"}, nil
-}
-
-func (m *mockModel) Stream(_ context.Context, input []*schema.Message, _ ...model.Option) (*schema.StreamReader[*schema.Message], error) {
-	m.lastInput = input
-	return nil, nil
-}
 
 type memBackend struct {
 	files map[string]string
@@ -121,31 +107,28 @@ func TestMiddleware_BasicInjection(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	mock := &mockModel{}
-	wrapped, err := mw.WrapModel(ctx, mock, nil)
+	userMsg := &schema.Message{Role: schema.User, Content: "hello"}
+	state := &adk.ChatModelAgentState{Messages: []*schema.Message{userMsg}}
+
+	_, state, err = mw.BeforeModelRewriteState(ctx, state, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	userMsg := &schema.Message{Role: schema.User, Content: "hello"}
-	if _, err = wrapped.Generate(ctx, []*schema.Message{userMsg}); err != nil {
-		t.Fatal(err)
+	if len(state.Messages) != 2 {
+		t.Fatalf("expected 2 messages, got %d", len(state.Messages))
 	}
-
-	if len(mock.lastInput) != 2 {
-		t.Fatalf("expected 2 messages, got %d", len(mock.lastInput))
+	if state.Messages[0].Role != schema.User {
+		t.Fatalf("expected first message role User, got %s", state.Messages[0].Role)
 	}
-	if mock.lastInput[0].Role != schema.User {
-		t.Fatalf("expected first message role User, got %s", mock.lastInput[0].Role)
+	if !strings.Contains(state.Messages[0].Content, "You are a helpful assistant.") {
+		t.Fatalf("expected agent.md content in first message, got %q", state.Messages[0].Content)
 	}
-	if !strings.Contains(mock.lastInput[0].Content, "You are a helpful assistant.") {
-		t.Fatalf("expected agent.md content in first message, got %q", mock.lastInput[0].Content)
+	if !strings.Contains(state.Messages[0].Content, "<system-reminder>") {
+		t.Fatalf("expected system-reminder tag, got %q", state.Messages[0].Content)
 	}
-	if !strings.Contains(mock.lastInput[0].Content, "<system-reminder>") {
-		t.Fatalf("expected system-reminder tag, got %q", mock.lastInput[0].Content)
-	}
-	if mock.lastInput[1].Content != "hello" {
-		t.Fatalf("expected original message preserved, got %q", mock.lastInput[1].Content)
+	if state.Messages[1].Content != "hello" {
+		t.Fatalf("expected original message preserved, got %q", state.Messages[1].Content)
 	}
 }
 
@@ -160,17 +143,13 @@ func TestMiddleware_MultipleFiles(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	mock := &mockModel{}
-	wrapped, err := mw.WrapModel(ctx, mock, nil)
+	state := &adk.ChatModelAgentState{Messages: []*schema.Message{{Role: schema.User, Content: "hi"}}}
+	_, state, err = mw.BeforeModelRewriteState(ctx, state, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	if _, err = wrapped.Generate(ctx, []*schema.Message{{Role: schema.User, Content: "hi"}}); err != nil {
-		t.Fatal(err)
-	}
-
-	content := mock.lastInput[0].Content
+	content := state.Messages[0].Content
 	idxA := strings.Index(content, "instruction A")
 	idxB := strings.Index(content, "instruction B")
 	if idxA < 0 || idxB < 0 {
@@ -192,17 +171,13 @@ func TestMiddleware_ImportResolution(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	mock := &mockModel{}
-	wrapped, err := mw.WrapModel(ctx, mock, nil)
+	state := &adk.ChatModelAgentState{Messages: []*schema.Message{{Role: schema.User, Content: "hi"}}}
+	_, state, err = mw.BeforeModelRewriteState(ctx, state, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	if _, err = wrapped.Generate(ctx, []*schema.Message{{Role: schema.User, Content: "hi"}}); err != nil {
-		t.Fatal(err)
-	}
-
-	content := mock.lastInput[0].Content
+	content := state.Messages[0].Content
 	// Original text should be preserved with @path intact.
 	if !strings.Contains(content, "main instructions") {
 		t.Fatalf("should contain original text, got %q", content)
@@ -234,17 +209,13 @@ func TestMiddleware_RecursiveImport(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	mock := &mockModel{}
-	wrapped, err := mw.WrapModel(ctx, mock, nil)
+	state := &adk.ChatModelAgentState{Messages: []*schema.Message{{Role: schema.User, Content: "hi"}}}
+	_, state, err = mw.BeforeModelRewriteState(ctx, state, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	if _, err = wrapped.Generate(ctx, []*schema.Message{{Role: schema.User, Content: "hi"}}); err != nil {
-		t.Fatal(err)
-	}
-
-	content := mock.lastInput[0].Content
+	content := state.Messages[0].Content
 	// All three files should appear as separate sections.
 	for _, section := range []string{"Contents of /a.md", "Contents of /b.md", "Contents of /c.md"} {
 		if !strings.Contains(content, section) {
@@ -283,19 +254,14 @@ func TestMiddleware_MaxImportDepth(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	mock := &mockModel{}
-	wrapped, err := mw.WrapModel(ctx, mock, nil)
-	if err != nil {
-		t.Fatal(err)
-	}
-
 	// Import failure at depth > 5 is logged, not returned as error.
-	_, err = wrapped.Generate(ctx, []*schema.Message{{Role: schema.User, Content: "hi"}})
+	state := &adk.ChatModelAgentState{Messages: []*schema.Message{{Role: schema.User, Content: "hi"}}}
+	_, state, err = mw.BeforeModelRewriteState(ctx, state, nil)
 	if err != nil {
 		t.Fatalf("expected no error (depth exceeded is logged), got %v", err)
 	}
 	// Levels 0-5 should be present as sections; level 6 fails silently.
-	content := mock.lastInput[0].Content
+	content := state.Messages[0].Content
 	for i := 0; i <= 5; i++ {
 		want := fmt.Sprintf("Contents of /level%d.md", i)
 		if !strings.Contains(content, want) {
@@ -318,19 +284,14 @@ func TestMiddleware_CircularImport(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	mock := &mockModel{}
-	wrapped, err := mw.WrapModel(ctx, mock, nil)
-	if err != nil {
-		t.Fatal(err)
-	}
-
 	// Circular import failure is logged, not returned as error.
-	_, err = wrapped.Generate(ctx, []*schema.Message{{Role: schema.User, Content: "hi"}})
+	state := &adk.ChatModelAgentState{Messages: []*schema.Message{{Role: schema.User, Content: "hi"}}}
+	_, state, err = mw.BeforeModelRewriteState(ctx, state, nil)
 	if err != nil {
 		t.Fatalf("expected no error (circular import is logged), got %v", err)
 	}
 	// /a.md and /b.md should both be present; the circular ref from b->a is skipped.
-	content := mock.lastInput[0].Content
+	content := state.Messages[0].Content
 	if !strings.Contains(content, "Contents of /a.md") {
 		t.Fatalf("expected /a.md section, got %q", content)
 	}
@@ -354,17 +315,13 @@ func TestMiddleware_MaxBytesLimit(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	mock := &mockModel{}
-	wrapped, err := mw.WrapModel(ctx, mock, nil)
+	state := &adk.ChatModelAgentState{Messages: []*schema.Message{{Role: schema.User, Content: "hi"}}}
+	_, state, err = mw.BeforeModelRewriteState(ctx, state, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	if _, err = wrapped.Generate(ctx, []*schema.Message{{Role: schema.User, Content: "hi"}}); err != nil {
-		t.Fatal(err)
-	}
-
-	content := mock.lastInput[0].Content
+	content := state.Messages[0].Content
 	if !strings.Contains(content, "AAAA") {
 		t.Fatal("first file should be included")
 	}
@@ -373,7 +330,7 @@ func TestMiddleware_MaxBytesLimit(t *testing.T) {
 	}
 }
 
-func TestMiddleware_NotPersistedInState(t *testing.T) {
+func TestMiddleware_InjectedInState(t *testing.T) {
 	b := newMemBackend()
 	b.set("/agent.md", "agent instructions")
 
@@ -383,25 +340,29 @@ func TestMiddleware_NotPersistedInState(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	mock := &mockModel{}
-	wrapped, err := mw.WrapModel(ctx, mock, nil)
+	originalMsgs := []*schema.Message{{Role: schema.User, Content: "hello"}}
+	state := &adk.ChatModelAgentState{Messages: originalMsgs}
+	_, newState, err := mw.BeforeModelRewriteState(ctx, state, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	originalMsgs := []*schema.Message{{Role: schema.User, Content: "hello"}}
-	if _, err = wrapped.Generate(ctx, originalMsgs); err != nil {
-		t.Fatal(err)
-	}
-
+	// The original slice should not be modified (new slice is returned).
 	if len(originalMsgs) != 1 {
-		t.Fatalf("original messages should not be modified, got %d messages", len(originalMsgs))
+		t.Fatalf("original messages slice should not be modified, got %d messages", len(originalMsgs))
 	}
 	if originalMsgs[0].Content != "hello" {
 		t.Fatalf("original message should be unchanged, got %q", originalMsgs[0].Content)
 	}
-	if len(mock.lastInput) != 2 {
-		t.Fatalf("model should receive 2 messages, got %d", len(mock.lastInput))
+	// The returned state should have the injected message.
+	if len(newState.Messages) != 2 {
+		t.Fatalf("new state should have 2 messages (injected + original), got %d", len(newState.Messages))
+	}
+	if !strings.Contains(newState.Messages[0].Content, "agent instructions") {
+		t.Fatalf("expected agentmd content in first message, got %q", newState.Messages[0].Content)
+	}
+	if newState.Messages[1].Content != "hello" {
+		t.Fatalf("expected original user message preserved, got %q", newState.Messages[1].Content)
 	}
 }
 
@@ -416,17 +377,13 @@ func TestMiddleware_AbsoluteImportPath(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	mock := &mockModel{}
-	wrapped, err := mw.WrapModel(ctx, mock, nil)
+	state := &adk.ChatModelAgentState{Messages: []*schema.Message{{Role: schema.User, Content: "hi"}}}
+	_, state, err = mw.BeforeModelRewriteState(ctx, state, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	if _, err = wrapped.Generate(ctx, []*schema.Message{{Role: schema.User, Content: "hi"}}); err != nil {
-		t.Fatal(err)
-	}
-
-	content := mock.lastInput[0].Content
+	content := state.Messages[0].Content
 	// @path preserved in original text.
 	if !strings.Contains(content, "@/shared/imported.md") {
 		t.Fatalf("@import reference should be preserved, got %q", content)
@@ -452,17 +409,13 @@ func TestMiddleware_ImportAsSeparateSection(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	mock := &mockModel{}
-	wrapped, err := mw.WrapModel(ctx, mock, nil)
+	state := &adk.ChatModelAgentState{Messages: []*schema.Message{{Role: schema.User, Content: "hi"}}}
+	_, state, err = mw.BeforeModelRewriteState(ctx, state, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	if _, err = wrapped.Generate(ctx, []*schema.Message{{Role: schema.User, Content: "hi"}}); err != nil {
-		t.Fatal(err)
-	}
-
-	content := mock.lastInput[0].Content
+	content := state.Messages[0].Content
 	// Original text preserved with @paths intact.
 	if !strings.Contains(content, "Please read @sub/rules.md and also @sub/style.md for guidance.") {
 		t.Fatalf("original text with @paths should be preserved, got %q", content)
@@ -921,32 +874,6 @@ func TestLoader_AtSignInNormalText(t *testing.T) {
 	}
 }
 
-func TestMiddleware_Stream(t *testing.T) {
-	b := newMemBackend()
-	b.set("/agent.md", "stream test")
-
-	ctx := context.Background()
-	mw, err := New(ctx, &Config{Backend: b, AgentsMDFiles: []string{"/agent.md"}})
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	mock := &mockModel{}
-	wrapped, err := mw.WrapModel(ctx, mock, nil)
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	_, _ = wrapped.Stream(ctx, []*schema.Message{{Role: schema.User, Content: "hi"}})
-
-	if len(mock.lastInput) != 2 {
-		t.Fatalf("expected 2 messages for stream, got %d", len(mock.lastInput))
-	}
-	if !strings.Contains(mock.lastInput[0].Content, "stream test") {
-		t.Fatalf("expected agent.md content in stream input, got %q", mock.lastInput[0].Content)
-	}
-}
-
 func TestLoader_MaxBytesWithImports(t *testing.T) {
 	// Two top-level files that both import the same shared file.
 	// Budget should account for imported file bytes.
@@ -997,40 +924,10 @@ func TestMiddleware_GenerateError(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	mock := &mockModel{}
-	wrapped, err := mw.WrapModel(ctx, mock, nil)
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	_, err = wrapped.Generate(ctx, []*schema.Message{{Role: schema.User, Content: "hi"}})
+	state := &adk.ChatModelAgentState{Messages: []*schema.Message{{Role: schema.User, Content: "hi"}}}
+	_, _, err = mw.BeforeModelRewriteState(ctx, state, nil)
 	if err == nil {
 		t.Fatal("expected error when backend read fails with non-ErrNotExist")
-	}
-	if !strings.Contains(err.Error(), "failed to load agent files") {
-		t.Fatalf("unexpected error: %v", err)
-	}
-}
-
-func TestMiddleware_StreamError(t *testing.T) {
-	// Non-ErrNotExist errors (e.g. permission denied) should propagate.
-	b := &errBackend{}
-
-	ctx := context.Background()
-	mw, err := New(ctx, &Config{Backend: b, AgentsMDFiles: []string{"/file.md"}})
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	mock := &mockModel{}
-	wrapped, err := mw.WrapModel(ctx, mock, nil)
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	_, err = wrapped.Stream(ctx, []*schema.Message{{Role: schema.User, Content: "hi"}})
-	if err == nil {
-		t.Fatal("expected error when backend read fails with non-ErrNotExist for stream")
 	}
 	if !strings.Contains(err.Error(), "failed to load agent files") {
 		t.Fatalf("unexpected error: %v", err)
@@ -1102,7 +999,7 @@ func TestFormatContent_Empty(t *testing.T) {
 
 func TestMiddleware_AllFilesEmpty(t *testing.T) {
 	// When all agent files have empty content, loader returns "" and
-	// prependAgentMD returns the original input unchanged.
+	// BeforeModelRewriteState returns the original state unchanged.
 	b := newMemBackend()
 	b.set("/agent.md", "")
 
@@ -1112,22 +1009,18 @@ func TestMiddleware_AllFilesEmpty(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	mock := &mockModel{}
-	wrapped, err := mw.WrapModel(ctx, mock, nil)
+	userMsg := []*schema.Message{{Role: schema.User, Content: "hello"}}
+	state := &adk.ChatModelAgentState{Messages: userMsg}
+	_, state, err = mw.BeforeModelRewriteState(ctx, state, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
-
-	userMsg := []*schema.Message{{Role: schema.User, Content: "hello"}}
-	if _, err = wrapped.Generate(ctx, userMsg); err != nil {
-		t.Fatal(err)
-	}
 	// Empty file produces no agentmd content, so original messages pass through unchanged.
-	if len(mock.lastInput) != 1 {
-		t.Fatalf("expected 1 message (no agentmd prepended), got %d", len(mock.lastInput))
+	if len(state.Messages) != 1 {
+		t.Fatalf("expected 1 message (no agentmd prepended), got %d", len(state.Messages))
 	}
-	if mock.lastInput[0].Content != "hello" {
-		t.Fatalf("expected original message unchanged, got %q", mock.lastInput[0].Content)
+	if state.Messages[0].Content != "hello" {
+		t.Fatalf("expected original message unchanged, got %q", state.Messages[0].Content)
 	}
 }
 
@@ -1260,7 +1153,7 @@ func TestLoader_OnLoadWarningCallback(t *testing.T) {
 	}
 }
 
-func TestMiddleware_MissingFile_Generate(t *testing.T) {
+func TestMiddleware_MissingFile(t *testing.T) {
 	b := newMemBackend()
 	// /missing.md not set — will fail to read
 
@@ -1273,48 +1166,15 @@ func TestMiddleware_MissingFile_Generate(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	mock := &mockModel{}
-	wrapped, err := mw.WrapModel(ctx, mock, nil)
-	if err != nil {
-		t.Fatal(err)
-	}
-
 	userMsg := []*schema.Message{{Role: schema.User, Content: "hello"}}
-	_, err = wrapped.Generate(ctx, userMsg)
+	state := &adk.ChatModelAgentState{Messages: userMsg}
+	_, state, err = mw.BeforeModelRewriteState(ctx, state, nil)
 	if err != nil {
 		t.Fatalf("expected no error for missing file, got %v", err)
 	}
 	// No agent.md content, so original messages should be passed through unchanged.
-	if len(mock.lastInput) != 1 {
-		t.Fatalf("expected 1 message (no agentmd prepended), got %d", len(mock.lastInput))
-	}
-}
-
-func TestMiddleware_MissingFile_Stream(t *testing.T) {
-	b := newMemBackend()
-
-	ctx := context.Background()
-	mw, err := New(ctx, &Config{
-		Backend:       b,
-		AgentsMDFiles: []string{"/missing.md"},
-	})
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	mock := &mockModel{}
-	wrapped, err := mw.WrapModel(ctx, mock, nil)
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	userMsg := []*schema.Message{{Role: schema.User, Content: "hello"}}
-	_, err = wrapped.Stream(ctx, userMsg)
-	if err != nil {
-		t.Fatalf("expected no error for missing file, got %v", err)
-	}
-	if len(mock.lastInput) != 1 {
-		t.Fatalf("expected 1 message (no agentmd prepended), got %d", len(mock.lastInput))
+	if len(state.Messages) != 1 {
+		t.Fatalf("expected 1 message (no agentmd prepended), got %d", len(state.Messages))
 	}
 }
 
@@ -1328,35 +1188,31 @@ func TestMiddleware_InsertBeforeFirstUserMessage(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	mock := &mockModel{}
-	wrapped, err := mw.WrapModel(ctx, mock, nil)
-	if err != nil {
-		t.Fatal(err)
-	}
-
 	// Input has a System message before the User message.
 	input := []*schema.Message{
 		{Role: schema.System, Content: "system prompt"},
 		{Role: schema.User, Content: "hello"},
 	}
-	if _, err = wrapped.Generate(ctx, input); err != nil {
+	state := &adk.ChatModelAgentState{Messages: input}
+	_, state, err = mw.BeforeModelRewriteState(ctx, state, nil)
+	if err != nil {
 		t.Fatal(err)
 	}
 
-	if len(mock.lastInput) != 3 {
-		t.Fatalf("expected 3 messages, got %d", len(mock.lastInput))
+	if len(state.Messages) != 3 {
+		t.Fatalf("expected 3 messages, got %d", len(state.Messages))
 	}
-	if mock.lastInput[0].Role != schema.System {
-		t.Fatalf("expected first message role System, got %s", mock.lastInput[0].Role)
+	if state.Messages[0].Role != schema.System {
+		t.Fatalf("expected first message role System, got %s", state.Messages[0].Role)
 	}
-	if mock.lastInput[0].Content != "system prompt" {
-		t.Fatalf("expected system prompt preserved, got %q", mock.lastInput[0].Content)
+	if state.Messages[0].Content != "system prompt" {
+		t.Fatalf("expected system prompt preserved, got %q", state.Messages[0].Content)
 	}
-	if mock.lastInput[1].Role != schema.User || !strings.Contains(mock.lastInput[1].Content, "agent instructions") {
-		t.Fatalf("expected agentmd message before user message, got role=%s content=%q", mock.lastInput[1].Role, mock.lastInput[1].Content)
+	if state.Messages[1].Role != schema.User || !strings.Contains(state.Messages[1].Content, "agent instructions") {
+		t.Fatalf("expected agentmd message before user message, got role=%s content=%q", state.Messages[1].Role, state.Messages[1].Content)
 	}
-	if mock.lastInput[2].Role != schema.User || mock.lastInput[2].Content != "hello" {
-		t.Fatalf("expected original user message at index 2, got role=%s content=%q", mock.lastInput[2].Role, mock.lastInput[2].Content)
+	if state.Messages[2].Role != schema.User || state.Messages[2].Content != "hello" {
+		t.Fatalf("expected original user message at index 2, got role=%s content=%q", state.Messages[2].Role, state.Messages[2].Content)
 	}
 }
 
@@ -1370,32 +1226,28 @@ func TestMiddleware_InsertWithNoUserMessage(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	mock := &mockModel{}
-	wrapped, err := mw.WrapModel(ctx, mock, nil)
-	if err != nil {
-		t.Fatal(err)
-	}
-
 	// Input has no User message at all.
 	input := []*schema.Message{
 		{Role: schema.System, Content: "system prompt"},
 		{Role: schema.Assistant, Content: "assistant reply"},
 	}
-	if _, err = wrapped.Generate(ctx, input); err != nil {
+	state := &adk.ChatModelAgentState{Messages: input}
+	_, state, err = mw.BeforeModelRewriteState(ctx, state, nil)
+	if err != nil {
 		t.Fatal(err)
 	}
 
-	if len(mock.lastInput) != 3 {
-		t.Fatalf("expected 3 messages, got %d", len(mock.lastInput))
+	if len(state.Messages) != 3 {
+		t.Fatalf("expected 3 messages, got %d", len(state.Messages))
 	}
-	if mock.lastInput[0].Role != schema.System {
-		t.Fatalf("expected System at index 0, got %s", mock.lastInput[0].Role)
+	if state.Messages[0].Role != schema.System {
+		t.Fatalf("expected System at index 0, got %s", state.Messages[0].Role)
 	}
-	if mock.lastInput[1].Role != schema.Assistant {
-		t.Fatalf("expected Assistant at index 1, got %s", mock.lastInput[1].Role)
+	if state.Messages[1].Role != schema.Assistant {
+		t.Fatalf("expected Assistant at index 1, got %s", state.Messages[1].Role)
 	}
-	if mock.lastInput[2].Role != schema.User || !strings.Contains(mock.lastInput[2].Content, "agent instructions") {
-		t.Fatalf("expected agentmd appended at end, got role=%s content=%q", mock.lastInput[2].Role, mock.lastInput[2].Content)
+	if state.Messages[2].Role != schema.User || !strings.Contains(state.Messages[2].Content, "agent instructions") {
+		t.Fatalf("expected agentmd appended at end, got role=%s content=%q", state.Messages[2].Role, state.Messages[2].Content)
 	}
 }
 
@@ -1416,5 +1268,75 @@ func TestLoader_ImportIOError(t *testing.T) {
 	}
 	if !strings.Contains(err.Error(), "I/O error") {
 		t.Fatalf("expected I/O error, got: %v", err)
+	}
+}
+
+func TestMiddleware_Idempotency(t *testing.T) {
+	// Calling BeforeModelRewriteState twice should NOT duplicate the agentsmd message.
+	// The marker in msg.Extra[agentsMDExtraKey] prevents re-injection.
+	b := newMemBackend()
+	b.set("/agent.md", "agent instructions")
+
+	ctx := context.Background()
+	mw, err := New(ctx, &Config{Backend: b, AgentsMDFiles: []string{"/agent.md"}})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	state := &adk.ChatModelAgentState{Messages: []*schema.Message{{Role: schema.User, Content: "hello"}}}
+	_, state, err = mw.BeforeModelRewriteState(ctx, state, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(state.Messages) != 2 {
+		t.Fatalf("expected 2 messages after first call, got %d", len(state.Messages))
+	}
+
+	// Call again with the same state (which now contains the marker message).
+	_, state, err = mw.BeforeModelRewriteState(ctx, state, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(state.Messages) != 2 {
+		t.Fatalf("expected 2 messages after second call (idempotent), got %d", len(state.Messages))
+	}
+	if !strings.Contains(state.Messages[0].Content, "agent instructions") {
+		t.Fatalf("expected agentmd content preserved, got %q", state.Messages[0].Content)
+	}
+}
+
+func TestMiddleware_ReinsertAfterRemoval(t *testing.T) {
+	// If the marker message is removed from state.Messages, calling
+	// BeforeModelRewriteState should re-insert it.
+	b := newMemBackend()
+	b.set("/agent.md", "agent instructions")
+
+	ctx := context.Background()
+	mw, err := New(ctx, &Config{Backend: b, AgentsMDFiles: []string{"/agent.md"}})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	state := &adk.ChatModelAgentState{Messages: []*schema.Message{{Role: schema.User, Content: "hello"}}}
+	_, state, err = mw.BeforeModelRewriteState(ctx, state, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(state.Messages) != 2 {
+		t.Fatalf("expected 2 messages after first call, got %d", len(state.Messages))
+	}
+
+	// Simulate removal of the marker message (e.g., by summarization).
+	// Keep only the original user message.
+	state = &adk.ChatModelAgentState{Messages: []*schema.Message{{Role: schema.User, Content: "hello"}}}
+	_, state, err = mw.BeforeModelRewriteState(ctx, state, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(state.Messages) != 2 {
+		t.Fatalf("expected 2 messages after re-insert, got %d", len(state.Messages))
+	}
+	if !strings.Contains(state.Messages[0].Content, "agent instructions") {
+		t.Fatalf("expected agentmd content re-inserted, got %q", state.Messages[0].Content)
 	}
 }

--- a/adk/middlewares/dynamictool/toolsearch/toolsearch.go
+++ b/adk/middlewares/dynamictool/toolsearch/toolsearch.go
@@ -144,6 +144,7 @@ func (m *middleware) BeforeAgent(ctx context.Context, runCtx *adk.ChatModelAgent
 }
 
 const toolSearchInitializedKey = "__toolsearch_initialized__"
+const toolSearchReminderExtraKey = "__toolsearch_reminder__"
 
 func (m *middleware) isInitialized(ctx context.Context) bool {
 	val, ok, err := adk.GetRunLocalValue(ctx, toolSearchInitializedKey)
@@ -161,7 +162,7 @@ func (m *middleware) markInitialized(ctx context.Context) {
 func (m *middleware) ensureReminder(msgs []*schema.Message) []*schema.Message {
 	for _, msg := range msgs {
 		if msg.Extra != nil {
-			if v, ok := msg.Extra["__toolsearch_reminder__"]; ok {
+			if v, ok := msg.Extra[toolSearchReminderExtraKey]; ok {
 				if b, _ := v.(bool); b {
 					return msgs
 				}
@@ -175,14 +176,14 @@ func (m *middleware) ensureReminder(msgs []*schema.Message) []*schema.Message {
 		if msg.Role != schema.System && !inserted {
 			inserted = true
 			reminder := schema.UserMessage(m.sr)
-			reminder.Extra = map[string]any{"__toolsearch_reminder__": true}
+			reminder.Extra = map[string]any{toolSearchReminderExtraKey: true}
 			result = append(result, reminder)
 		}
 		result = append(result, msg)
 	}
 	if !inserted {
 		reminder := schema.UserMessage(m.sr)
-		reminder.Extra = map[string]any{"__toolsearch_reminder__": true}
+		reminder.Extra = map[string]any{toolSearchReminderExtraKey: true}
 		result = append(result, reminder)
 	}
 	return result
@@ -233,17 +234,20 @@ func (m *middleware) BeforeModelRewriteState(ctx context.Context, state *adk.Cha
 		m.markInitialized(ctx)
 
 		if m.useModelToolSearch {
-			// Mode 2: extract dynamic tools into DeferredToolInfos, strip from ToolInfos, remove tool_search
+			// Model-native search: move dynamic tools to DeferredToolInfos for server-side retrieval,
+			// keep only static tools in ToolInfos, and remove the tool_search tool (the model handles search itself).
 			state.DeferredToolInfos = m.extractDynamicTools(state.ToolInfos)
 			state.ToolInfos = m.stripDynamicTools(state.ToolInfos)
 			state.ToolInfos = removeTool(state.ToolInfos, toolSearchToolName)
 		} else {
-			// Mode 1: strip dynamic tools from ToolInfos (keep tool_search)
+			// Client-side search: hide dynamic tools initially; they become visible
+			// only after the model calls tool_search and forward selection adds them back.
 			state.ToolInfos = m.stripDynamicTools(state.ToolInfos)
 		}
 	}
 
-	// Forward selection (Mode 1 only): add tools selected via tool_search results
+	// Forward selection (client-side search only): scan tool_search results in the
+	// conversation history and add the selected dynamic tools back to ToolInfos.
 	if !m.useModelToolSearch {
 		existing := toolNameSet(state.ToolInfos)
 		for _, msg := range state.Messages {

--- a/adk/middlewares/dynamictool/toolsearch/toolsearch.go
+++ b/adk/middlewares/dynamictool/toolsearch/toolsearch.go
@@ -29,7 +29,6 @@ import (
 
 	"github.com/cloudwego/eino/adk"
 	"github.com/cloudwego/eino/adk/internal"
-	"github.com/cloudwego/eino/components/model"
 	"github.com/cloudwego/eino/components/tool"
 	"github.com/cloudwego/eino/schema"
 )
@@ -138,66 +137,136 @@ func (m *middleware) BeforeAgent(ctx context.Context, runCtx *adk.ChatModelAgent
 	copy(nRunCtx.Tools, runCtx.Tools)
 	nRunCtx.Tools = append(nRunCtx.Tools, newToolSearchTool(m.mapOfDynamicTools, m.useModelToolSearch))
 	nRunCtx.Tools = append(nRunCtx.Tools, m.dynamicTools...)
+	if m.useModelToolSearch {
+		nRunCtx.ToolSearchTool = getToolSearchToolInfo()
+	}
 	return ctx, &nRunCtx, nil
 }
 
-func (m *middleware) WrapModel(_ context.Context, cm model.BaseChatModel, mc *adk.ModelContext) (model.BaseChatModel, error) {
-	return &wrapper{
-		allTools:           mc.Tools,
-		cm:                 cm,
-		dynamicToolInfos:   m.dynamicToolInfos,
-		reminder:           m.sr,
-		useModelToolSearch: m.useModelToolSearch,
-	}, nil
-}
+const toolSearchInitializedKey = "__toolsearch_initialized__"
 
-type wrapper struct {
-	allTools           []*schema.ToolInfo
-	dynamicToolInfos   []*schema.ToolInfo
-	reminder           string
-	useModelToolSearch bool
-
-	cm model.BaseChatModel
-}
-
-func (w *wrapper) Generate(ctx context.Context, input []*schema.Message, opts ...model.Option) (*schema.Message, error) {
-	toolsOpts, err := w.resolveTools(ctx, input)
-	if err != nil {
-		return nil, fmt.Errorf("failed to load dynamic tools: %w", err)
+func (m *middleware) isInitialized(ctx context.Context) bool {
+	val, ok, err := adk.GetRunLocalValue(ctx, toolSearchInitializedKey)
+	if err != nil || !ok {
+		return false
 	}
-	return w.cm.Generate(ctx, w.insertReminder(input), append(opts, toolsOpts...)...)
+	b, _ := val.(bool)
+	return b
 }
 
-func (w *wrapper) Stream(ctx context.Context, input []*schema.Message, opts ...model.Option) (*schema.StreamReader[*schema.Message], error) {
-	toolsOpts, err := w.resolveTools(ctx, input)
-	if err != nil {
-		return nil, fmt.Errorf("failed to load dynamic tools: %w", err)
-	}
-	return w.cm.Stream(ctx, w.insertReminder(input), append(opts, toolsOpts...)...)
+func (m *middleware) markInitialized(ctx context.Context) {
+	_ = adk.SetRunLocalValue(ctx, toolSearchInitializedKey, true)
 }
 
-func (w *wrapper) resolveTools(ctx context.Context, input []*schema.Message) ([]model.Option, error) {
-	if w.useModelToolSearch {
-		// Model handles tool search natively; remove all dynamic tools from the list.
-		return calculateTools(ctx, w.allTools, w.dynamicToolInfos, nil, w.useModelToolSearch)
-	}
-	return calculateTools(ctx, w.allTools, w.dynamicToolInfos, input, w.useModelToolSearch)
-}
-
-func (w *wrapper) insertReminder(input []*schema.Message) []*schema.Message {
-	inserted := false
-	ret := make([]*schema.Message, 0, len(input)+1)
-	for _, m := range input {
-		if m.Role != schema.System && !inserted {
-			inserted = true
-			ret = append(ret, schema.UserMessage(w.reminder))
+func (m *middleware) ensureReminder(msgs []*schema.Message) []*schema.Message {
+	for _, msg := range msgs {
+		if msg.Extra != nil {
+			if v, ok := msg.Extra["__toolsearch_reminder__"]; ok {
+				if b, _ := v.(bool); b {
+					return msgs
+				}
+			}
 		}
-		ret = append(ret, m)
+	}
+
+	result := make([]*schema.Message, 0, len(msgs)+1)
+	inserted := false
+	for _, msg := range msgs {
+		if msg.Role != schema.System && !inserted {
+			inserted = true
+			reminder := schema.UserMessage(m.sr)
+			reminder.Extra = map[string]any{"__toolsearch_reminder__": true}
+			result = append(result, reminder)
+		}
+		result = append(result, msg)
 	}
 	if !inserted {
-		ret = append(ret, schema.UserMessage(w.reminder))
+		reminder := schema.UserMessage(m.sr)
+		reminder.Extra = map[string]any{"__toolsearch_reminder__": true}
+		result = append(result, reminder)
 	}
-	return ret
+	return result
+}
+
+func (m *middleware) extractDynamicTools(tools []*schema.ToolInfo) []*schema.ToolInfo {
+	var result []*schema.ToolInfo
+	for _, t := range tools {
+		if _, ok := m.mapOfDynamicTools[t.Name]; ok {
+			result = append(result, t)
+		}
+	}
+	return result
+}
+
+func (m *middleware) stripDynamicTools(tools []*schema.ToolInfo) []*schema.ToolInfo {
+	var result []*schema.ToolInfo
+	for _, t := range tools {
+		if _, ok := m.mapOfDynamicTools[t.Name]; !ok {
+			result = append(result, t)
+		}
+	}
+	return result
+}
+
+func removeTool(tools []*schema.ToolInfo, name string) []*schema.ToolInfo {
+	var result []*schema.ToolInfo
+	for _, t := range tools {
+		if t.Name != name {
+			result = append(result, t)
+		}
+	}
+	return result
+}
+
+func toolNameSet(tools []*schema.ToolInfo) map[string]bool {
+	m := make(map[string]bool, len(tools))
+	for _, t := range tools {
+		m[t.Name] = true
+	}
+	return m
+}
+
+func (m *middleware) BeforeModelRewriteState(ctx context.Context, state *adk.ChatModelAgentState, mc *adk.ModelContext) (context.Context, *adk.ChatModelAgentState, error) {
+	state.Messages = m.ensureReminder(state.Messages)
+
+	if !m.isInitialized(ctx) {
+		m.markInitialized(ctx)
+
+		if m.useModelToolSearch {
+			// Mode 2: extract dynamic tools into DeferredToolInfos, strip from ToolInfos, remove tool_search
+			state.DeferredToolInfos = m.extractDynamicTools(state.ToolInfos)
+			state.ToolInfos = m.stripDynamicTools(state.ToolInfos)
+			state.ToolInfos = removeTool(state.ToolInfos, toolSearchToolName)
+		} else {
+			// Mode 1: strip dynamic tools from ToolInfos (keep tool_search)
+			state.ToolInfos = m.stripDynamicTools(state.ToolInfos)
+		}
+	}
+
+	// Forward selection (Mode 1 only): add tools selected via tool_search results
+	if !m.useModelToolSearch {
+		existing := toolNameSet(state.ToolInfos)
+		for _, msg := range state.Messages {
+			if msg.Role != schema.Tool || msg.ToolName != toolSearchToolName {
+				continue
+			}
+			var result toolSearchResult
+			if err := json.Unmarshal([]byte(msg.Content), &result); err != nil {
+				continue
+			}
+			for _, name := range result.Matches {
+				if existing[name] {
+					continue
+				}
+				if info, ok := m.mapOfDynamicTools[name]; ok {
+					state.ToolInfos = append(state.ToolInfos, info)
+					existing[name] = true
+				}
+			}
+		}
+	}
+
+	return ctx, state, nil
 }
 
 func newToolSearchTool(tools map[string]*schema.ToolInfo, useModelToolSearch bool) tool.BaseTool {
@@ -500,73 +569,4 @@ func splitCamelCase(s string) []string {
 	parts = append(parts, string(runes[start:]))
 
 	return parts
-}
-
-// getToolNames extracts just tool names from a slice of BaseTools (used by calculateTools).
-func getToolNames(tools []*schema.ToolInfo) []string {
-	ret := make([]string, 0, len(tools))
-	for _, t := range tools {
-		ret = append(ret, t.Name)
-	}
-	return ret
-}
-
-func extractSelectedTools(_ context.Context, messages []*schema.Message) ([]string, error) {
-	var selectedTools []string
-	for _, message := range messages {
-		if message.Role != schema.Tool || message.ToolName != toolSearchToolName {
-			continue
-		}
-
-		result := &toolSearchResult{}
-		err := json.Unmarshal([]byte(message.Content), result)
-		if err != nil {
-			return nil, fmt.Errorf("failed to unmarshal tool search tool result: %w", err)
-		}
-		selectedTools = append(selectedTools, result.Matches...)
-	}
-	return selectedTools, nil
-}
-
-func invertSelect[T comparable](all []T, selected []T) map[T]struct{} {
-	selectedSet := make(map[T]struct{}, len(selected))
-	for _, s := range selected {
-		selectedSet[s] = struct{}{}
-	}
-
-	result := make(map[T]struct{})
-	for _, item := range all {
-		if _, ok := selectedSet[item]; !ok {
-			result[item] = struct{}{}
-		}
-	}
-	return result
-}
-
-func calculateTools(ctx context.Context, all []*schema.ToolInfo, dynamicTools []*schema.ToolInfo, messages []*schema.Message, useModelToolSearch bool) ([]model.Option, error) {
-	var err error
-	var ret []model.Option
-	var selectedToolNames []string
-	if !useModelToolSearch {
-		selectedToolNames, err = extractSelectedTools(ctx, messages)
-		if err != nil {
-			return nil, err
-		}
-	}
-	dynamicToolNames := getToolNames(dynamicTools)
-	if useModelToolSearch {
-		// if useModelToolSearch, register tool search tool by WithToolSearchTool
-		dynamicToolNames = append(dynamicToolNames, toolSearchToolName)
-		ret = append(ret, model.WithToolSearchTool(getToolSearchToolInfo()))
-	}
-	removeMap := invertSelect(dynamicToolNames, selectedToolNames)
-	tools := make([]*schema.ToolInfo, 0, len(all)-len(dynamicTools))
-	for _, info := range all {
-		if _, ok := removeMap[info.Name]; ok {
-			continue
-		}
-		tools = append(tools, info)
-	}
-	ret = append(ret, model.WithTools(tools))
-	return ret, nil
 }

--- a/adk/middlewares/dynamictool/toolsearch/toolsearch_test.go
+++ b/adk/middlewares/dynamictool/toolsearch/toolsearch_test.go
@@ -451,7 +451,7 @@ func TestEnsureReminder(t *testing.T) {
 		assert.Equal(t, schema.System, got[0].Role)
 		assert.Equal(t, schema.User, got[1].Role)
 		assert.Equal(t, "<reminder>", got[1].Content)
-		assert.Equal(t, true, got[1].Extra["__toolsearch_reminder__"])
+		assert.Equal(t, true, got[1].Extra[toolSearchReminderExtraKey])
 		assert.Equal(t, schema.User, got[2].Role)
 		assert.Equal(t, "hi", got[2].Content)
 	})
@@ -488,7 +488,7 @@ func TestEnsureReminder(t *testing.T) {
 
 	t.Run("idempotent: does not insert twice", func(t *testing.T) {
 		input := []*schema.Message{
-			{Role: schema.User, Content: "<reminder>", Extra: map[string]any{"__toolsearch_reminder__": true}},
+			{Role: schema.User, Content: "<reminder>", Extra: map[string]any{toolSearchReminderExtraKey: true}},
 			{Role: schema.User, Content: "hi"},
 		}
 		got := m.ensureReminder(input)
@@ -592,15 +592,7 @@ func TestBeforeModelRewriteState_Mode1_Initialization(t *testing.T) {
 	assert.Nil(t, state.DeferredToolInfos, "Mode 1 should not populate DeferredToolInfos")
 
 	// Verify reminder was inserted.
-	hasReminder := false
-	for _, msg := range state.Messages {
-		if msg.Extra != nil {
-			if v, _ := msg.Extra["__toolsearch_reminder__"].(bool); v {
-				hasReminder = true
-			}
-		}
-	}
-	assert.True(t, hasReminder, "reminder should be inserted")
+	assert.Equal(t, 1, countReminders(state.Messages), "reminder should be inserted")
 }
 
 func TestBeforeModelRewriteState_Mode1_ForwardSelection(t *testing.T) {
@@ -623,7 +615,7 @@ func TestBeforeModelRewriteState_Mode1_ForwardSelection(t *testing.T) {
 	state := &adk.ChatModelAgentState{
 		Messages: []*schema.Message{
 			{Role: schema.System, Content: "sys"},
-			{Role: schema.User, Content: "hello", Extra: map[string]any{"__toolsearch_reminder__": true}},
+			{Role: schema.User, Content: "hello", Extra: map[string]any{toolSearchReminderExtraKey: true}},
 			schema.AssistantMessage("", []schema.ToolCall{
 				{ID: "tc1", Function: schema.FunctionCall{Name: toolSearchToolName, Arguments: `{"query":"select:dynamic_tool_a"}`}},
 			}),
@@ -724,7 +716,7 @@ func TestBeforeModelRewriteState_ReminderReinsertAfterRemoval(t *testing.T) {
 	for _, msg := range state.Messages {
 		isReminder := false
 		if msg.Extra != nil {
-			if v, ok := msg.Extra["__toolsearch_reminder__"].(bool); ok && v {
+			if v, ok := msg.Extra[toolSearchReminderExtraKey].(bool); ok && v {
 				isReminder = true
 			}
 		}
@@ -747,10 +739,290 @@ func countReminders(msgs []*schema.Message) int {
 	count := 0
 	for _, msg := range msgs {
 		if msg.Extra != nil {
-			if v, _ := msg.Extra["__toolsearch_reminder__"].(bool); v {
+			if v, _ := msg.Extra[toolSearchReminderExtraKey].(bool); v {
 				count++
 			}
 		}
 	}
 	return count
+}
+
+// ---------------------------------------------------------------------------
+// Edge-case tests for BeforeModelRewriteState
+// ---------------------------------------------------------------------------
+
+func TestBeforeModelRewriteState_Mode1_MultipleToolSearchResultsAcrossTurns(t *testing.T) {
+	ctx := context.Background()
+
+	dynamicA := &simpleTool{name: "dynamic_tool_a", desc: "Dynamic tool A"}
+	dynamicB := &simpleTool{name: "dynamic_tool_b", desc: "Dynamic tool B"}
+	dynamicC := &simpleTool{name: "dynamic_tool_c", desc: "Dynamic tool C"}
+
+	mw, err := New(ctx, &Config{
+		DynamicTools:       []tool.BaseTool{dynamicA, dynamicB, dynamicC},
+		UseModelToolSearch: false,
+	})
+	require.NoError(t, err)
+
+	m := mw.(*middleware)
+
+	// Build two separate tool_search result messages, each selecting a different tool.
+	resultA, _ := json.Marshal(toolSearchResult{Matches: []string{"dynamic_tool_a"}})
+	resultB, _ := json.Marshal(toolSearchResult{Matches: []string{"dynamic_tool_b"}})
+
+	state := &adk.ChatModelAgentState{
+		Messages: []*schema.Message{
+			{Role: schema.System, Content: "sys"},
+			{Role: schema.User, Content: "reminder", Extra: map[string]any{toolSearchReminderExtraKey: true}},
+			schema.AssistantMessage("", []schema.ToolCall{
+				{ID: "tc1", Function: schema.FunctionCall{Name: toolSearchToolName, Arguments: `{"query":"select:dynamic_tool_a"}`}},
+			}),
+			{Role: schema.Tool, ToolName: toolSearchToolName, Content: string(resultA)},
+			schema.AssistantMessage("", []schema.ToolCall{
+				{ID: "tc2", Function: schema.FunctionCall{Name: toolSearchToolName, Arguments: `{"query":"select:dynamic_tool_b"}`}},
+			}),
+			{Role: schema.Tool, ToolName: toolSearchToolName, Content: string(resultB)},
+		},
+		ToolInfos: []*schema.ToolInfo{
+			ti("static_tool", "Static tool"),
+			getToolSearchToolInfo(),
+		},
+	}
+
+	_, state, err = m.BeforeModelRewriteState(ctx, state, nil)
+	require.NoError(t, err)
+
+	names := toolNames(state.ToolInfos)
+	assert.Contains(t, names, "dynamic_tool_a", "dynamic_tool_a should be added from first tool_search result")
+	assert.Contains(t, names, "dynamic_tool_b", "dynamic_tool_b should be added from second tool_search result")
+	assert.NotContains(t, names, "dynamic_tool_c", "dynamic_tool_c was never selected")
+	assert.Contains(t, names, "static_tool", "static_tool should remain")
+	assert.Contains(t, names, "tool_search", "tool_search should remain")
+}
+
+func TestBeforeModelRewriteState_Mode1_MalformedJSONInToolSearchResult(t *testing.T) {
+	ctx := context.Background()
+
+	dynamicA := &simpleTool{name: "dynamic_tool_a", desc: "Dynamic tool A"}
+
+	mw, err := New(ctx, &Config{
+		DynamicTools:       []tool.BaseTool{dynamicA},
+		UseModelToolSearch: false,
+	})
+	require.NoError(t, err)
+
+	m := mw.(*middleware)
+
+	state := &adk.ChatModelAgentState{
+		Messages: []*schema.Message{
+			{Role: schema.System, Content: "sys"},
+			{Role: schema.User, Content: "reminder", Extra: map[string]any{toolSearchReminderExtraKey: true}},
+			schema.AssistantMessage("", []schema.ToolCall{
+				{ID: "tc1", Function: schema.FunctionCall{Name: toolSearchToolName, Arguments: `{"query":"select:dynamic_tool_a"}`}},
+			}),
+			{Role: schema.Tool, ToolName: toolSearchToolName, Content: `{invalid json!!!`},
+		},
+		ToolInfos: []*schema.ToolInfo{
+			ti("static_tool", "Static tool"),
+			getToolSearchToolInfo(),
+		},
+	}
+
+	_, state, err = m.BeforeModelRewriteState(ctx, state, nil)
+	require.NoError(t, err, "malformed JSON in tool_search result should not cause an error")
+
+	names := toolNames(state.ToolInfos)
+	assert.NotContains(t, names, "dynamic_tool_a", "malformed JSON result should be skipped")
+	assert.Contains(t, names, "static_tool")
+	assert.Contains(t, names, "tool_search")
+}
+
+func TestBeforeModelRewriteState_Mode1_NonExistentToolInForwardSelection(t *testing.T) {
+	ctx := context.Background()
+
+	dynamicA := &simpleTool{name: "dynamic_tool_a", desc: "Dynamic tool A"}
+
+	mw, err := New(ctx, &Config{
+		DynamicTools:       []tool.BaseTool{dynamicA},
+		UseModelToolSearch: false,
+	})
+	require.NoError(t, err)
+
+	m := mw.(*middleware)
+
+	resultJSON, _ := json.Marshal(toolSearchResult{Matches: []string{"nonexistent_tool", "dynamic_tool_a"}})
+
+	state := &adk.ChatModelAgentState{
+		Messages: []*schema.Message{
+			{Role: schema.User, Content: "reminder", Extra: map[string]any{toolSearchReminderExtraKey: true}},
+			schema.AssistantMessage("", []schema.ToolCall{
+				{ID: "tc1", Function: schema.FunctionCall{Name: toolSearchToolName, Arguments: `{"query":"select:nonexistent_tool,dynamic_tool_a"}`}},
+			}),
+			{Role: schema.Tool, ToolName: toolSearchToolName, Content: string(resultJSON)},
+		},
+		ToolInfos: []*schema.ToolInfo{
+			ti("static_tool", "Static tool"),
+			getToolSearchToolInfo(),
+		},
+	}
+
+	_, state, err = m.BeforeModelRewriteState(ctx, state, nil)
+	require.NoError(t, err, "nonexistent tool in forward selection should not cause an error")
+
+	names := toolNames(state.ToolInfos)
+	assert.Contains(t, names, "dynamic_tool_a", "valid tool should be added")
+	assert.NotContains(t, names, "nonexistent_tool", "nonexistent tool should be silently ignored")
+}
+
+func TestBeforeModelRewriteState_Mode2_EmptyToolInfos(t *testing.T) {
+	ctx := context.Background()
+
+	dynamicA := &simpleTool{name: "dynamic_tool_a", desc: "Dynamic tool A"}
+
+	mw, err := New(ctx, &Config{
+		DynamicTools:       []tool.BaseTool{dynamicA},
+		UseModelToolSearch: true,
+	})
+	require.NoError(t, err)
+
+	m := mw.(*middleware)
+
+	state := &adk.ChatModelAgentState{
+		Messages: []*schema.Message{
+			{Role: schema.User, Content: "hello"},
+		},
+		ToolInfos: []*schema.ToolInfo{}, // empty, not nil
+	}
+
+	_, state, err = m.BeforeModelRewriteState(ctx, state, nil)
+	require.NoError(t, err, "empty ToolInfos should not cause an error")
+
+	assert.Empty(t, state.ToolInfos, "ToolInfos should be empty")
+	assert.Empty(t, state.DeferredToolInfos, "DeferredToolInfos should be empty when no dynamic tools found in ToolInfos")
+}
+
+func TestBeforeModelRewriteState_Mode1_DoubleInitWithoutComposeContext(t *testing.T) {
+	ctx := context.Background()
+
+	dynamicA := &simpleTool{name: "dynamic_tool_a", desc: "Dynamic tool A"}
+	dynamicB := &simpleTool{name: "dynamic_tool_b", desc: "Dynamic tool B"}
+
+	mw, err := New(ctx, &Config{
+		DynamicTools:       []tool.BaseTool{dynamicA, dynamicB},
+		UseModelToolSearch: false,
+	})
+	require.NoError(t, err)
+
+	m := mw.(*middleware)
+
+	resultJSON, _ := json.Marshal(toolSearchResult{Matches: []string{"dynamic_tool_a"}})
+
+	state := &adk.ChatModelAgentState{
+		Messages: []*schema.Message{
+			{Role: schema.User, Content: "reminder", Extra: map[string]any{toolSearchReminderExtraKey: true}},
+			schema.AssistantMessage("", []schema.ToolCall{
+				{ID: "tc1", Function: schema.FunctionCall{Name: toolSearchToolName, Arguments: `{"query":"select:dynamic_tool_a"}`}},
+			}),
+			{Role: schema.Tool, ToolName: toolSearchToolName, Content: string(resultJSON)},
+		},
+		ToolInfos: []*schema.ToolInfo{
+			ti("static_tool", "Static tool"),
+			getToolSearchToolInfo(),
+			ti("dynamic_tool_a", "Dynamic tool A"),
+		},
+	}
+
+	// First call: init runs (strips dynamic_tool_a), then forward selection re-adds it.
+	_, state, err = m.BeforeModelRewriteState(ctx, state, nil)
+	require.NoError(t, err)
+
+	names := toolNames(state.ToolInfos)
+	assert.Contains(t, names, "dynamic_tool_a",
+		"forward selection should re-add dynamic_tool_a even after init re-strips it")
+	assert.Contains(t, names, "static_tool")
+	assert.Contains(t, names, "tool_search")
+
+	// Second call: init runs AGAIN (no compose ctx), verify behavior is stable.
+	_, state2, err := m.BeforeModelRewriteState(ctx, state, nil)
+	require.NoError(t, err)
+
+	names2 := toolNames(state2.ToolInfos)
+	assert.Contains(t, names2, "dynamic_tool_a",
+		"second call should also have dynamic_tool_a re-added by forward selection")
+}
+
+func TestBeforeModelRewriteState_ToolInfosSliceMutation(t *testing.T) {
+	ctx := context.Background()
+
+	dynamicA := &simpleTool{name: "dynamic_tool_a", desc: "Dynamic tool A"}
+
+	mw, err := New(ctx, &Config{
+		DynamicTools:       []tool.BaseTool{dynamicA},
+		UseModelToolSearch: false,
+	})
+	require.NoError(t, err)
+
+	m := mw.(*middleware)
+
+	// Create ToolInfos with excess capacity so append could mutate in place.
+	originalToolInfos := make([]*schema.ToolInfo, 2, 10)
+	originalToolInfos[0] = ti("static_tool", "Static tool")
+	originalToolInfos[1] = getToolSearchToolInfo()
+
+	originalLen := len(originalToolInfos)
+
+	resultJSON, _ := json.Marshal(toolSearchResult{Matches: []string{"dynamic_tool_a"}})
+
+	state := &adk.ChatModelAgentState{
+		Messages: []*schema.Message{
+			{Role: schema.User, Content: "reminder", Extra: map[string]any{toolSearchReminderExtraKey: true}},
+			schema.AssistantMessage("", []schema.ToolCall{
+				{ID: "tc1", Function: schema.FunctionCall{Name: toolSearchToolName, Arguments: `{"query":"select:dynamic_tool_a"}`}},
+			}),
+			{Role: schema.Tool, ToolName: toolSearchToolName, Content: string(resultJSON)},
+		},
+		ToolInfos: originalToolInfos,
+	}
+
+	_, newState, err := m.BeforeModelRewriteState(ctx, state, nil)
+	require.NoError(t, err)
+
+	newNames := toolNames(newState.ToolInfos)
+	assert.Contains(t, newNames, "dynamic_tool_a")
+	assert.Equal(t, originalLen, len(originalToolInfos),
+		"original ToolInfos slice length should not be mutated by the middleware")
+}
+
+// ---------------------------------------------------------------------------
+// modelToolSearchTool (Mode 2) tests
+// ---------------------------------------------------------------------------
+
+func TestModelToolSearchTool(t *testing.T) {
+	ctx := context.Background()
+
+	tools := makeToolMap(
+		ti("alpha", "Alpha tool description"),
+		ti("beta", "Beta tool description"),
+	)
+	mts := &modelToolSearchTool{tools: tools}
+
+	// Info should return the standard tool_search tool info.
+	info, err := mts.Info(ctx)
+	require.NoError(t, err)
+	assert.Equal(t, toolSearchToolName, info.Name)
+
+	// InvokableRun with a valid query selecting "alpha".
+	arg := &schema.ToolArgument{Text: searchJSON("select:alpha", nil)}
+	result, err := mts.InvokableRun(ctx, arg)
+	require.NoError(t, err)
+	require.Len(t, result.Parts, 1)
+	assert.Equal(t, schema.ToolPartTypeToolSearchResult, result.Parts[0].Type)
+	require.NotNil(t, result.Parts[0].ToolSearchResult)
+	assert.Len(t, result.Parts[0].ToolSearchResult.Tools, 1)
+	assert.Equal(t, "alpha", result.Parts[0].ToolSearchResult.Tools[0].Name)
+
+	// InvokableRun with an empty query should return error.
+	argEmpty := &schema.ToolArgument{Text: `{"query":""}`}
+	_, err = mts.InvokableRun(ctx, argEmpty)
+	assert.Error(t, err)
 }

--- a/adk/middlewares/dynamictool/toolsearch/toolsearch_test.go
+++ b/adk/middlewares/dynamictool/toolsearch/toolsearch_test.go
@@ -353,20 +353,17 @@ func TestMiddlewareFlow(t *testing.T) {
 	toolsPerCall := cm.getToolsPerCall()
 	require.Len(t, toolsPerCall, 3, "expected 3 Generate calls")
 
-	// Call 1: tool_search + static_tool; dynamic tools are hidden.
-	assert.Contains(t, toolsPerCall[0], "tool_search")
+	// Call 1: static_tool visible; dynamic tools are hidden.
 	assert.Contains(t, toolsPerCall[0], "static_tool")
 	assert.NotContains(t, toolsPerCall[0], "dynamic_tool_a")
 	assert.NotContains(t, toolsPerCall[0], "dynamic_tool_b")
 
 	// Call 2: after selecting dynamic_tool_a, it becomes visible.
-	assert.Contains(t, toolsPerCall[1], "tool_search")
 	assert.Contains(t, toolsPerCall[1], "static_tool")
 	assert.Contains(t, toolsPerCall[1], "dynamic_tool_a")
 	assert.NotContains(t, toolsPerCall[1], "dynamic_tool_b")
 
 	// Call 3: same as call 2.
-	assert.Contains(t, toolsPerCall[2], "tool_search")
 	assert.Contains(t, toolsPerCall[2], "static_tool")
 	assert.Contains(t, toolsPerCall[2], "dynamic_tool_a")
 	assert.NotContains(t, toolsPerCall[2], "dynamic_tool_b")
@@ -438,22 +435,23 @@ func TestSplitCamelCase(t *testing.T) {
 }
 
 // ---------------------------------------------------------------------------
-// TestInsertReminder
+// TestEnsureReminder
 // ---------------------------------------------------------------------------
 
-func TestInsertReminder(t *testing.T) {
-	w := &wrapper{reminder: "<reminder>"}
+func TestEnsureReminder(t *testing.T) {
+	m := &middleware{sr: "<reminder>"}
 
 	t.Run("normal: system then user", func(t *testing.T) {
 		input := []*schema.Message{
 			{Role: schema.System, Content: "sys"},
 			{Role: schema.User, Content: "hi"},
 		}
-		got := w.insertReminder(input)
+		got := m.ensureReminder(input)
 		require.Len(t, got, 3)
 		assert.Equal(t, schema.System, got[0].Role)
 		assert.Equal(t, schema.User, got[1].Role)
 		assert.Equal(t, "<reminder>", got[1].Content)
+		assert.Equal(t, true, got[1].Extra["__toolsearch_reminder__"])
 		assert.Equal(t, schema.User, got[2].Role)
 		assert.Equal(t, "hi", got[2].Content)
 	})
@@ -463,16 +461,15 @@ func TestInsertReminder(t *testing.T) {
 			{Role: schema.System, Content: "sys1"},
 			{Role: schema.System, Content: "sys2"},
 		}
-		got := w.insertReminder(input)
+		got := m.ensureReminder(input)
 		require.Len(t, got, 3)
-		// Reminder appended at the end since no non-system message found during iteration.
 		assert.Equal(t, schema.System, got[0].Role)
 		assert.Equal(t, schema.System, got[1].Role)
 		assert.Equal(t, "<reminder>", got[2].Content)
 	})
 
 	t.Run("empty input", func(t *testing.T) {
-		got := w.insertReminder(nil)
+		got := m.ensureReminder(nil)
 		require.Len(t, got, 1)
 		assert.Equal(t, "<reminder>", got[0].Content)
 	})
@@ -482,118 +479,278 @@ func TestInsertReminder(t *testing.T) {
 			{Role: schema.User, Content: "hi"},
 			{Role: schema.Assistant, Content: "hello"},
 		}
-		got := w.insertReminder(input)
+		got := m.ensureReminder(input)
 		require.Len(t, got, 3)
-		// Reminder inserted before the first non-system message.
 		assert.Equal(t, "<reminder>", got[0].Content)
 		assert.Equal(t, "hi", got[1].Content)
 		assert.Equal(t, "hello", got[2].Content)
 	})
-}
 
-// ---------------------------------------------------------------------------
-// TestExtractSelectedTools
-// ---------------------------------------------------------------------------
-
-func TestExtractSelectedTools(t *testing.T) {
-	ctx := context.Background()
-
-	t.Run("accumulates from multiple tool_search results", func(t *testing.T) {
-		messages := []*schema.Message{
-			{Role: schema.Tool, ToolName: toolSearchToolName, Content: `{"matches":["tool_a"]}`},
-			{Role: schema.Tool, ToolName: toolSearchToolName, Content: `{"matches":["tool_b","tool_c"]}`},
+	t.Run("idempotent: does not insert twice", func(t *testing.T) {
+		input := []*schema.Message{
+			{Role: schema.User, Content: "<reminder>", Extra: map[string]any{"__toolsearch_reminder__": true}},
+			{Role: schema.User, Content: "hi"},
 		}
-		got, err := extractSelectedTools(ctx, messages)
-		require.NoError(t, err)
-		assert.Equal(t, []string{"tool_a", "tool_b", "tool_c"}, got)
-	})
-
-	t.Run("ignores non tool_search messages", func(t *testing.T) {
-		messages := []*schema.Message{
-			{Role: schema.User, Content: "hello"},
-			{Role: schema.Tool, ToolName: "other_tool", Content: `{"matches":["should_ignore"]}`},
-			{Role: schema.Assistant, Content: "world"},
-			{Role: schema.Tool, ToolName: toolSearchToolName, Content: `{"matches":["tool_a"]}`},
-		}
-		got, err := extractSelectedTools(ctx, messages)
-		require.NoError(t, err)
-		assert.Equal(t, []string{"tool_a"}, got)
-	})
-
-	t.Run("malformed JSON returns error", func(t *testing.T) {
-		messages := []*schema.Message{
-			{Role: schema.Tool, ToolName: toolSearchToolName, Content: `not json`},
-		}
-		_, err := extractSelectedTools(ctx, messages)
-		assert.Error(t, err)
-	})
-
-	t.Run("nil messages returns nil", func(t *testing.T) {
-		got, err := extractSelectedTools(ctx, nil)
-		require.NoError(t, err)
-		assert.Nil(t, got)
+		got := m.ensureReminder(input)
+		require.Len(t, got, 2)
+		assert.Equal(t, "<reminder>", got[0].Content)
+		assert.Equal(t, "hi", got[1].Content)
 	})
 }
 
 // ---------------------------------------------------------------------------
-// TestCalculateTools
+// TestHelperFunctions
 // ---------------------------------------------------------------------------
 
-func TestCalculateTools(t *testing.T) {
+func TestHelperFunctions(t *testing.T) {
+	t.Run("extractDynamicTools", func(t *testing.T) {
+		m := &middleware{
+			mapOfDynamicTools: map[string]*schema.ToolInfo{
+				"dyn_a": ti("dyn_a", "A"),
+				"dyn_b": ti("dyn_b", "B"),
+			},
+		}
+		tools := []*schema.ToolInfo{ti("static", "S"), ti("dyn_a", "A"), ti("dyn_b", "B")}
+		got := m.extractDynamicTools(tools)
+		assert.Len(t, got, 2)
+		names := toolNames(got)
+		assert.Equal(t, []string{"dyn_a", "dyn_b"}, names)
+	})
+
+	t.Run("stripDynamicTools", func(t *testing.T) {
+		m := &middleware{
+			mapOfDynamicTools: map[string]*schema.ToolInfo{
+				"dyn_a": ti("dyn_a", "A"),
+				"dyn_b": ti("dyn_b", "B"),
+			},
+		}
+		tools := []*schema.ToolInfo{ti("static", "S"), ti("dyn_a", "A"), ti("tool_search", "TS")}
+		got := m.stripDynamicTools(tools)
+		names := toolNames(got)
+		assert.Equal(t, []string{"static", "tool_search"}, names)
+	})
+
+	t.Run("removeTool", func(t *testing.T) {
+		tools := []*schema.ToolInfo{ti("a", "A"), ti("b", "B"), ti("c", "C")}
+		got := removeTool(tools, "b")
+		names := toolNames(got)
+		assert.Equal(t, []string{"a", "c"}, names)
+	})
+
+	t.Run("toolNameSet", func(t *testing.T) {
+		tools := []*schema.ToolInfo{ti("x", "X"), ti("y", "Y")}
+		got := toolNameSet(tools)
+		assert.True(t, got["x"])
+		assert.True(t, got["y"])
+		assert.False(t, got["z"])
+	})
+}
+
+// ---------------------------------------------------------------------------
+// TestBeforeModelRewriteState — direct unit tests for BeforeModelRewriteState
+// ---------------------------------------------------------------------------
+
+// Note: these tests call BeforeModelRewriteState without a full compose context,
+// so RunLocalValue (used by isInitialized/markInitialized) always returns error.
+// This means every call re-runs the initialization block. Tests are designed
+// accordingly: they test single-call behavior or provide pre-initialized state.
+
+func TestBeforeModelRewriteState_Mode1_Initialization(t *testing.T) {
 	ctx := context.Background()
 
-	staticTool := ti("static_tool", "static")
-	toolSearchInfo := getToolSearchToolInfo()
-	dynA := ti("dynamic_a", "A")
-	dynB := ti("dynamic_b", "B")
+	dynamicA := &simpleTool{name: "dynamic_tool_a", desc: "Dynamic tool A"}
+	dynamicB := &simpleTool{name: "dynamic_tool_b", desc: "Dynamic tool B"}
 
-	allTools := []*schema.ToolInfo{staticTool, toolSearchInfo, dynA, dynB}
-	dynamicTools := []*schema.ToolInfo{dynA, dynB}
+	mw, err := New(ctx, &Config{
+		DynamicTools:       []tool.BaseTool{dynamicA, dynamicB},
+		UseModelToolSearch: false,
+	})
+	require.NoError(t, err)
 
-	t.Run("no selection: dynamic tools hidden", func(t *testing.T) {
-		messages := []*schema.Message{
+	m := mw.(*middleware)
+
+	// Simulate state: static_tool + tool_search + dynamic tools (as would come from backfill).
+	state := &adk.ChatModelAgentState{
+		Messages: []*schema.Message{
+			{Role: schema.System, Content: "sys"},
 			{Role: schema.User, Content: "hello"},
-		}
-		opts, err := calculateTools(ctx, allTools, dynamicTools, messages, false)
-		require.NoError(t, err)
+		},
+		ToolInfos: []*schema.ToolInfo{
+			ti("static_tool", "Static tool"),
+			getToolSearchToolInfo(),
+			ti("dynamic_tool_a", "Dynamic tool A"),
+			ti("dynamic_tool_b", "Dynamic tool B"),
+		},
+	}
 
-		options := model.GetCommonOptions(nil, opts...)
-		var names []string
-		for _, t := range options.Tools {
-			names = append(names, t.Name)
+	// Initialization strips dynamic tools, keeps tool_search and static tools.
+	_, state, err = m.BeforeModelRewriteState(ctx, state, nil)
+	require.NoError(t, err)
+
+	names := toolNames(state.ToolInfos)
+	assert.Equal(t, []string{"static_tool", "tool_search"}, names)
+	assert.Nil(t, state.DeferredToolInfos, "Mode 1 should not populate DeferredToolInfos")
+
+	// Verify reminder was inserted.
+	hasReminder := false
+	for _, msg := range state.Messages {
+		if msg.Extra != nil {
+			if v, _ := msg.Extra["__toolsearch_reminder__"].(bool); v {
+				hasReminder = true
+			}
 		}
-		sort.Strings(names)
-		assert.Equal(t, []string{"static_tool", "tool_search"}, names)
+	}
+	assert.True(t, hasReminder, "reminder should be inserted")
+}
+
+func TestBeforeModelRewriteState_Mode1_ForwardSelection(t *testing.T) {
+	ctx := context.Background()
+
+	dynamicA := &simpleTool{name: "dynamic_tool_a", desc: "Dynamic tool A"}
+	dynamicB := &simpleTool{name: "dynamic_tool_b", desc: "Dynamic tool B"}
+
+	mw, err := New(ctx, &Config{
+		DynamicTools:       []tool.BaseTool{dynamicA, dynamicB},
+		UseModelToolSearch: false,
 	})
+	require.NoError(t, err)
 
-	t.Run("partial selection: selected tool visible", func(t *testing.T) {
-		messages := []*schema.Message{
-			{Role: schema.Tool, ToolName: toolSearchToolName, Content: `{"matches":["dynamic_a"]}`},
-		}
-		opts, err := calculateTools(ctx, allTools, dynamicTools, messages, false)
-		require.NoError(t, err)
+	m := mw.(*middleware)
 
-		options := model.GetCommonOptions(nil, opts...)
-		var names []string
-		for _, t := range options.Tools {
-			names = append(names, t.Name)
-		}
-		sort.Strings(names)
-		assert.Equal(t, []string{"dynamic_a", "static_tool", "tool_search"}, names)
+	// Simulate state AFTER initialization (dynamic tools already stripped).
+	// Include a tool_search result message that selected dynamic_tool_a.
+	toolSearchResultJSON, _ := json.Marshal(toolSearchResult{Matches: []string{"dynamic_tool_a"}})
+	state := &adk.ChatModelAgentState{
+		Messages: []*schema.Message{
+			{Role: schema.System, Content: "sys"},
+			{Role: schema.User, Content: "hello", Extra: map[string]any{"__toolsearch_reminder__": true}},
+			schema.AssistantMessage("", []schema.ToolCall{
+				{ID: "tc1", Function: schema.FunctionCall{Name: toolSearchToolName, Arguments: `{"query":"select:dynamic_tool_a"}`}},
+			}),
+			{Role: schema.Tool, ToolName: toolSearchToolName, Content: string(toolSearchResultJSON)},
+		},
+		ToolInfos: []*schema.ToolInfo{
+			ti("static_tool", "Static tool"),
+			getToolSearchToolInfo(),
+		},
+	}
+
+	// Forward selection should add dynamic_tool_a from the tool_search result.
+	// Note: init block runs (no compose ctx) but ToolInfos has no dynamic tools to strip.
+	_, state, err = m.BeforeModelRewriteState(ctx, state, nil)
+	require.NoError(t, err)
+
+	names := toolNames(state.ToolInfos)
+	assert.Equal(t, []string{"dynamic_tool_a", "static_tool", "tool_search"}, names)
+
+	// Call again: forward selection should be idempotent (dynamic_tool_a already present).
+	_, state, err = m.BeforeModelRewriteState(ctx, state, nil)
+	require.NoError(t, err)
+
+	names = toolNames(state.ToolInfos)
+	assert.Equal(t, []string{"dynamic_tool_a", "static_tool", "tool_search"}, names)
+}
+
+func TestBeforeModelRewriteState_Mode2_DeferredToolInfos(t *testing.T) {
+	ctx := context.Background()
+
+	dynamicA := &simpleTool{name: "dynamic_tool_a", desc: "Dynamic tool A"}
+	dynamicB := &simpleTool{name: "dynamic_tool_b", desc: "Dynamic tool B"}
+
+	mw, err := New(ctx, &Config{
+		DynamicTools:       []tool.BaseTool{dynamicA, dynamicB},
+		UseModelToolSearch: true,
 	})
+	require.NoError(t, err)
 
-	t.Run("useModelToolSearch: dynamic tools and tool_search removed from WithTools", func(t *testing.T) {
-		opts, err := calculateTools(ctx, allTools, dynamicTools, nil, true)
-		require.NoError(t, err)
+	m := mw.(*middleware)
 
-		options := model.GetCommonOptions(nil, opts...)
-		var names []string
-		for _, t := range options.Tools {
-			names = append(names, t.Name)
-		}
-		assert.Equal(t, []string{"static_tool"}, names)
-		// ToolSearchTool should be set.
-		assert.NotNil(t, options.ToolSearchTool)
-		assert.Equal(t, toolSearchToolName, options.ToolSearchTool.Name)
+	state := &adk.ChatModelAgentState{
+		Messages: []*schema.Message{
+			{Role: schema.User, Content: "hello"},
+		},
+		ToolInfos: []*schema.ToolInfo{
+			ti("static_tool", "Static tool"),
+			getToolSearchToolInfo(),
+			ti("dynamic_tool_a", "Dynamic tool A"),
+			ti("dynamic_tool_b", "Dynamic tool B"),
+		},
+	}
+
+	_, state, err = m.BeforeModelRewriteState(ctx, state, nil)
+	require.NoError(t, err)
+
+	// Mode 2: static tools in ToolInfos (tool_search removed), dynamic in DeferredToolInfos.
+	names := toolNames(state.ToolInfos)
+	assert.Equal(t, []string{"static_tool"}, names, "ToolInfos should only have static tools")
+
+	deferredNames := toolNames(state.DeferredToolInfos)
+	assert.Equal(t, []string{"dynamic_tool_a", "dynamic_tool_b"}, deferredNames, "DeferredToolInfos should have all dynamic tools")
+}
+
+func TestBeforeModelRewriteState_ReminderReinsertAfterRemoval(t *testing.T) {
+	ctx := context.Background()
+
+	dynamicA := &simpleTool{name: "dynamic_tool_a", desc: "Dynamic tool A"}
+
+	mw, err := New(ctx, &Config{
+		DynamicTools:       []tool.BaseTool{dynamicA},
+		UseModelToolSearch: false,
 	})
+	require.NoError(t, err)
+
+	m := mw.(*middleware)
+
+	state := &adk.ChatModelAgentState{
+		Messages: []*schema.Message{
+			{Role: schema.User, Content: "hello"},
+		},
+		ToolInfos: []*schema.ToolInfo{
+			ti("static_tool", "Static tool"),
+			getToolSearchToolInfo(),
+			ti("dynamic_tool_a", "Dynamic tool A"),
+		},
+	}
+
+	// First call: reminder inserted.
+	_, state, err = m.BeforeModelRewriteState(ctx, state, nil)
+	require.NoError(t, err)
+
+	reminderCount := countReminders(state.Messages)
+	assert.Equal(t, 1, reminderCount)
+
+	// Simulate summarization removing the reminder message.
+	var msgsWithoutReminder []*schema.Message
+	for _, msg := range state.Messages {
+		isReminder := false
+		if msg.Extra != nil {
+			if v, ok := msg.Extra["__toolsearch_reminder__"].(bool); ok && v {
+				isReminder = true
+			}
+		}
+		if !isReminder {
+			msgsWithoutReminder = append(msgsWithoutReminder, msg)
+		}
+	}
+	state.Messages = msgsWithoutReminder
+	assert.Equal(t, 0, countReminders(state.Messages), "reminder should be gone")
+
+	// Next call: reminder should be re-inserted.
+	_, state, err = m.BeforeModelRewriteState(ctx, state, nil)
+	require.NoError(t, err)
+
+	reminderCount = countReminders(state.Messages)
+	assert.Equal(t, 1, reminderCount, "reminder should be re-inserted after removal")
+}
+
+func countReminders(msgs []*schema.Message) int {
+	count := 0
+	for _, msg := range msgs {
+		if msg.Extra != nil {
+			if v, _ := msg.Extra["__toolsearch_reminder__"].(bool); v {
+				count++
+			}
+		}
+	}
+	return count
 }

--- a/adk/middlewares/reduction/reduction.go
+++ b/adk/middlewares/reduction/reduction.go
@@ -430,7 +430,7 @@ func (t *toolReductionMiddleware) BeforeModelRewriteState(ctx context.Context, s
 	)
 
 	// init msg tokens
-	estimatedTokens, err = t.config.TokenCounter(ctx, state.Messages, mc.Tools)
+	estimatedTokens, err = t.config.TokenCounter(ctx, state.Messages, state.ToolInfos)
 	if err != nil {
 		return ctx, state, err
 	}
@@ -567,7 +567,7 @@ func (t *toolReductionMiddleware) BeforeModelRewriteState(ctx context.Context, s
 	}
 
 	if clearAtLeastTokens > 0 {
-		estimatedTokensAfterClear, err := t.config.TokenCounter(ctx, editTarget, mc.Tools)
+		estimatedTokensAfterClear, err := t.config.TokenCounter(ctx, editTarget, state.ToolInfos)
 		if err != nil {
 			return ctx, state, err
 		}

--- a/adk/react.go
+++ b/adk/react.go
@@ -35,12 +35,12 @@ type typedState[M messageType] struct {
 	Messages []M
 	Extra    map[string]any
 
-	// ToolInfos contains the tools visible to the model (emitted as model.WithTools).
+	// ToolInfos contains the tool definitions passed to the model via model.WithTools.
 	// Managed by the framework and modifiable by BeforeModelRewriteState handlers.
 	ToolInfos []*schema.ToolInfo
 
-	// DeferredToolInfos contains tools for native server-side search (emitted as model.WithDeferredTools).
-	// Only used when UseModelToolSearch is true (Mode 2). Nil otherwise.
+	// DeferredToolInfos contains tool definitions for server-side deferred retrieval,
+	// passed to the model via model.WithDeferredTools. Nil when not in use.
 	DeferredToolInfos []*schema.ToolInfo
 
 	// Internal fields below - do not access directly.

--- a/adk/react.go
+++ b/adk/react.go
@@ -35,6 +35,14 @@ type typedState[M messageType] struct {
 	Messages []M
 	Extra    map[string]any
 
+	// ToolInfos contains the tools visible to the model (emitted as model.WithTools).
+	// Managed by the framework and modifiable by BeforeModelRewriteState handlers.
+	ToolInfos []*schema.ToolInfo
+
+	// DeferredToolInfos contains tools for native server-side search (emitted as model.WithDeferredTools).
+	// Only used when UseModelToolSearch is true (Mode 2). Nil otherwise.
+	DeferredToolInfos []*schema.ToolInfo
+
 	// Internal fields below - do not access directly.
 	// Kept exported for backward compatibility with existing checkpoints.
 	HasReturnDirectly        bool

--- a/adk/wrappers.go
+++ b/adk/wrappers.go
@@ -834,13 +834,35 @@ func (w *typedStateModelWrapper[M]) wrapStreamEndpoint(endpoint typedStreamEndpo
 }
 
 func (w *typedStateModelWrapper[M]) Generate(ctx context.Context, input []M, opts ...model.Option) (M, error) {
-	var stateMessages []M
+	var (
+		stateMessages          []M
+		stateToolInfos         []*schema.ToolInfo
+		stateDeferredToolInfos []*schema.ToolInfo
+	)
 	_ = compose.ProcessState(ctx, func(_ context.Context, st *typedState[M]) error {
 		stateMessages = st.Messages
+		stateToolInfos = st.ToolInfos
+		stateDeferredToolInfos = st.DeferredToolInfos
 		return nil
 	})
 
-	state := &TypedChatModelAgentState[M]{Messages: stateMessages}
+	// Backfill: old checkpoints or fresh starts have nil ToolInfos.
+	// Use compose-level tools from opts (which always reflects the latest bc.toolInfos)
+	// rather than w.toolInfos (which may be stale if the graph was reused).
+	if stateToolInfos == nil {
+		composeLevelOpts := model.GetCommonOptions(&model.Options{}, opts...)
+		if composeLevelOpts.Tools != nil {
+			stateToolInfos = composeLevelOpts.Tools
+		} else {
+			stateToolInfos = w.toolInfos
+		}
+	}
+
+	state := &TypedChatModelAgentState[M]{
+		Messages:          stateMessages,
+		ToolInfos:         stateToolInfos,
+		DeferredToolInfos: stateDeferredToolInfos,
+	}
 
 	if msgState, ok := any(state).(*ChatModelAgentState); ok {
 		for _, m := range w.middlewares {
@@ -865,13 +887,26 @@ func (w *typedStateModelWrapper[M]) Generate(ctx context.Context, input []M, opt
 		}
 	}
 
+	// Persist state (including tool infos) after BeforeModelRewriteState.
 	_ = compose.ProcessState(ctx, func(_ context.Context, st *typedState[M]) error {
 		st.Messages = state.Messages
+		st.ToolInfos = state.ToolInfos
+		st.DeferredToolInfos = state.DeferredToolInfos
 		return nil
 	})
 
+	// Derive model options from state. Append after caller opts so state takes precedence
+	// (model.GetCommonOptions applies left-to-right, last wins).
+	// Use explicit copy to avoid mutating the caller's opts slice.
+	derivedOpts := make([]model.Option, len(opts), len(opts)+2)
+	copy(derivedOpts, opts)
+	derivedOpts = append(derivedOpts, model.WithTools(state.ToolInfos))
+	if state.DeferredToolInfos != nil {
+		derivedOpts = append(derivedOpts, model.WithDeferredTools(state.DeferredToolInfos))
+	}
+
 	wrappedEndpoint := w.wrapGenerateEndpoint(w.inner.Generate)
-	result, err := wrappedEndpoint(ctx, state.Messages, opts...)
+	result, err := wrappedEndpoint(ctx, state.Messages, derivedOpts...)
 	if err != nil {
 		var zero M
 		return zero, err
@@ -908,8 +943,11 @@ func (w *typedStateModelWrapper[M]) Generate(ctx context.Context, input []M, opt
 		}
 	}
 
+	// Persist state (including tool infos) after AfterModelRewriteState.
 	_ = compose.ProcessState(ctx, func(_ context.Context, st *typedState[M]) error {
 		st.Messages = state.Messages
+		st.ToolInfos = state.ToolInfos
+		st.DeferredToolInfos = state.DeferredToolInfos
 		return nil
 	})
 
@@ -921,13 +959,35 @@ func (w *typedStateModelWrapper[M]) Generate(ctx context.Context, input []M, opt
 }
 
 func (w *typedStateModelWrapper[M]) Stream(ctx context.Context, input []M, opts ...model.Option) (*schema.StreamReader[M], error) {
-	var stateMessages []M
+	var (
+		stateMessages          []M
+		stateToolInfos         []*schema.ToolInfo
+		stateDeferredToolInfos []*schema.ToolInfo
+	)
 	_ = compose.ProcessState(ctx, func(_ context.Context, st *typedState[M]) error {
 		stateMessages = st.Messages
+		stateToolInfos = st.ToolInfos
+		stateDeferredToolInfos = st.DeferredToolInfos
 		return nil
 	})
 
-	state := &TypedChatModelAgentState[M]{Messages: stateMessages}
+	// Backfill: old checkpoints or fresh starts have nil ToolInfos.
+	// Use compose-level tools from opts (which always reflects the latest bc.toolInfos)
+	// rather than w.toolInfos (which may be stale if the graph was reused).
+	if stateToolInfos == nil {
+		composeLevelOpts := model.GetCommonOptions(&model.Options{}, opts...)
+		if composeLevelOpts.Tools != nil {
+			stateToolInfos = composeLevelOpts.Tools
+		} else {
+			stateToolInfos = w.toolInfos
+		}
+	}
+
+	state := &TypedChatModelAgentState[M]{
+		Messages:          stateMessages,
+		ToolInfos:         stateToolInfos,
+		DeferredToolInfos: stateDeferredToolInfos,
+	}
 
 	if msgState, ok := any(state).(*ChatModelAgentState); ok {
 		for _, m := range w.middlewares {
@@ -950,13 +1010,26 @@ func (w *typedStateModelWrapper[M]) Stream(ctx context.Context, input []M, opts 
 		}
 	}
 
+	// Persist state (including tool infos) after BeforeModelRewriteState.
 	_ = compose.ProcessState(ctx, func(_ context.Context, st *typedState[M]) error {
 		st.Messages = state.Messages
+		st.ToolInfos = state.ToolInfos
+		st.DeferredToolInfos = state.DeferredToolInfos
 		return nil
 	})
 
+	// Derive model options from state. Append after caller opts so state takes precedence
+	// (model.GetCommonOptions applies left-to-right, last wins).
+	// Use explicit copy to avoid mutating the caller's opts slice.
+	derivedOpts := make([]model.Option, len(opts), len(opts)+2)
+	copy(derivedOpts, opts)
+	derivedOpts = append(derivedOpts, model.WithTools(state.ToolInfos))
+	if state.DeferredToolInfos != nil {
+		derivedOpts = append(derivedOpts, model.WithDeferredTools(state.DeferredToolInfos))
+	}
+
 	wrappedEndpoint := w.wrapStreamEndpoint(w.inner.Stream)
-	stream, err := wrappedEndpoint(ctx, state.Messages, opts...)
+	stream, err := wrappedEndpoint(ctx, state.Messages, derivedOpts...)
 	if err != nil {
 		return nil, err
 	}
@@ -992,8 +1065,11 @@ func (w *typedStateModelWrapper[M]) Stream(ctx context.Context, input []M, opts 
 		}
 	}
 
+	// Persist state (including tool infos) after AfterModelRewriteState.
 	_ = compose.ProcessState(ctx, func(_ context.Context, st *typedState[M]) error {
 		st.Messages = state.Messages
+		st.ToolInfos = state.ToolInfos
+		st.DeferredToolInfos = state.DeferredToolInfos
 		return nil
 	})
 


### PR DESCRIPTION
# Move Tool Lists into Agent State; Migrate Middlewares to BeforeModelRewriteState

## Problem

Tool lists (`[]ToolInfo`, deferred `[]ToolInfo`) were invisible to `BeforeModelRewriteState` handlers — they lived only in compose-level options and `ModelContext.Tools`. This forced middlewares like **toolsearch** and **agentsmd** to use `WrapModel` to intercept the model call, even though their logic is state manipulation (inserting messages, adjusting tool visibility), not model wrapping.

Consequences:
- Toolsearch injected a transient reminder message on every model call that was never persisted — if summarization ran, the reminder vanished silently.
- Agentsmd prepended content on every call without any way to detect if it was already present.
- Reduction had to read `mc.Tools` (a `WrapModel`-scoped value) for token counting, coupling it to the wrong lifecycle phase.

## Solution

**Add `ToolInfos` and `DeferredToolInfos` to the agent state.** The framework reads these before `BeforeModelRewriteState`, backfills from compose-level options when nil (old checkpoint resume), then derives `model.WithTools` / `model.WithDeferredTools` from state after handlers run. State-derived options are appended *after* caller options so they take precedence (last-wins semantics of `GetCommonOptions`).

**Migrate toolsearch to `BeforeModelRewriteState` with forward selection.** On first call, strip dynamic tools from `state.ToolInfos` (keep only static + `tool_search`). On each subsequent call, scan `tool_search` result messages and add discovered dynamic tools. Mode 2 (`UseModelToolSearch`) splits tools into `ToolInfos` (static) and `DeferredToolInfos` (all dynamic) for server-side search.

**Migrate agentsmd to `BeforeModelRewriteState` with marker-based idempotent insertion.** Content is tagged with `Extra["__agentsmd_content__"]`. If the marker is present, skip. If absent (e.g. removed by summarization), re-insert.

**Deprecate `ModelContext.Tools`** in favor of `state.ToolInfos`. `mc.Tools` is still populated for backward compat with third-party `WrapModel` handlers.

## Key Insight

**Backfill must read compose-level options, not the wrapper's cached `toolInfos`.** When `rebuildGraph=false` (graph reused across runs), the `typedStateModelWrapper.toolInfos` field is stale — it reflects the tool list at graph build time. But `applyBeforeAgent` computes the correct, up-to-date tool list each run and passes it via `compose.WithChatModelOption(model.WithTools(...))`. The backfill extracts this from `opts` via `model.GetCommonOptions`, falling back to `w.toolInfos` only as a last resort.

**Forward selection is simpler and more intuitive than inverse selection.** The old toolsearch used inverse selection: start with all tools, remove unselected ones via `invertSelect`. With tool lists in state, forward selection is natural: start with static tools only, append discovered dynamic tools as `tool_search` results arrive. This also means `DeferredToolInfos` stays nil in Mode 1 — it's only meaningful for Mode 2 (model-native search).

## Decisions

### Why marker-based idempotency instead of RunLocalValue flags?

Both toolsearch and agentsmd need to detect whether their injected messages survived summarization. Using `RunLocalValue("initialized")` only tracks whether init ran — it can't detect message removal. Marker-based detection (`msg.Extra["__key__"]`) directly answers "is my message still in the conversation?" and naturally handles the re-insertion case.

### Why deprecate `mc.Tools` instead of removing it?

Third-party `WrapModel` handlers may read `mc.Tools`. Removing it would be a breaking change. Instead, `mc.Tools` remains populated from the same source but is documented as deprecated. New code should use `state.ToolInfos` in `BeforeModelRewriteState`.

## Summary

| Problem | Solution |
|---------|----------|
| Tool lists invisible to `BeforeModelRewriteState` | Add `ToolInfos`/`DeferredToolInfos` to state; framework derives model options from state |
| Toolsearch forced into `WrapModel` for state manipulation | Migrate to `BeforeModelRewriteState` with forward selection |
| Agentsmd content lost after summarization, no detection | Marker-based idempotent insertion; re-insert if marker gone |
| Reduction reads `mc.Tools` from wrong lifecycle phase | Read `state.ToolInfos` instead |
| Old checkpoint resume has nil `ToolInfos` | Backfill from compose-level options (not stale wrapper cache) |

---

# 将工具列表移入 Agent 状态；迁移中间件至 BeforeModelRewriteState

## 问题

工具列表 (`[]ToolInfo`, deferred `[]ToolInfo`) 对 `BeforeModelRewriteState` handler 不可见——它们只存在于 compose 层选项和 `ModelContext.Tools` 中。这迫使 **toolsearch** 和 **agentsmd** 等中间件使用 `WrapModel` 来拦截模型调用，尽管它们的逻辑本质是状态操作（插入消息、调整工具可见性），而非模型包装。

后果：
- Toolsearch 在每次模型调用时注入的临时提醒消息从未持久化——如果执行了摘要，提醒会悄然消失。
- Agentsmd 在每次调用时都会前置内容，无法检测是否已经存在。
- Reduction 必须从 `mc.Tools`（`WrapModel` 作用域的值）读取工具列表来计算 token，耦合了错误的生命周期阶段。

## 解决方案

**将 `ToolInfos` 和 `DeferredToolInfos` 添加到 agent state。** 框架在 `BeforeModelRewriteState` 之前读取这些字段，当为 nil 时（旧 checkpoint 恢复）从 compose 层选项回填，然后在 handler 执行后从 state 派生 `model.WithTools` / `model.WithDeferredTools`。state 派生的选项追加在调用方选项*之后*，利用 `GetCommonOptions` 的 last-wins 语义确保优先级。

**将 toolsearch 迁移至 `BeforeModelRewriteState`，采用正向选择。** 首次调用时，从 `state.ToolInfos` 中剥离动态工具（仅保留静态 + `tool_search`）。后续每次调用，扫描 `tool_search` 结果消息并添加已发现的动态工具。Mode 2 (`UseModelToolSearch`) 将工具拆分为 `ToolInfos`（静态）和 `DeferredToolInfos`（全部动态）以支持服务端搜索。

**将 agentsmd 迁移至 `BeforeModelRewriteState`，采用标记式幂等插入。** 内容通过 `Extra["__agentsmd_content__"]` 标记。若标记存在则跳过；若不存在（例如被摘要删除），则重新插入。

**弃用 `ModelContext.Tools`**，改用 `state.ToolInfos`。`mc.Tools` 仍会被填充以兼容第三方 `WrapModel` handler。

## 核心洞察

**回填必须读取 compose 层选项，而非 wrapper 缓存的 `toolInfos`。** 当 `rebuildGraph=false`（图跨运行复用）时，`typedStateModelWrapper.toolInfos` 是过期的——它反映的是图构建时的工具列表。但 `applyBeforeAgent` 每次运行都会计算正确的、最新的工具列表，并通过 `compose.WithChatModelOption(model.WithTools(...))` 传递。回填通过 `model.GetCommonOptions` 从 `opts` 中提取，仅在万不得已时才回退到 `w.toolInfos`。

**正向选择比反向选择更简洁直观。** 旧的 toolsearch 使用反向选择：从所有工具开始，通过 `invertSelect` 移除未选中的。工具列表在 state 中后，正向选择更为自然：从仅有静态工具开始，随 `tool_search` 结果到来逐步添加发现的动态工具。

## 总结

| 问题 | 解决方案 |
|------|---------|
| 工具列表对 `BeforeModelRewriteState` 不可见 | 在 state 中添加 `ToolInfos`/`DeferredToolInfos`；框架从 state 派生模型选项 |
| Toolsearch 被迫使用 `WrapModel` 进行状态操作 | 迁移至 `BeforeModelRewriteState`，采用正向选择 |
| Agentsmd 内容在摘要后丢失，无法检测 | 标记式幂等插入；标记消失时重新插入 |
| Reduction 从错误的生命周期阶段读取 `mc.Tools` | 改为读取 `state.ToolInfos` |
| 旧 checkpoint 恢复时 `ToolInfos` 为 nil | 从 compose 层选项回填（非过期的 wrapper 缓存）|
