### PR TITLE
refactor(adk): replace AfterToolCallsRewriteState with per-run WithAfterToolCallsHook option

### DIFF
--- a/adk/chatmodel.go
+++ b/adk/chatmodel.go
@@ -54,6 +54,8 @@ type typedChatModelAgentExecCtx[M messageType] struct {
 	// Invariant: any code path that emits model output events MUST check this flag.
 	suppressEventSend  bool
 	retryVerdictSignal *retryVerdictSignal
+
+	afterToolCallsHook func(ctx context.Context) error
 }
 
 func (e *typedChatModelAgentExecCtx[M]) send(event *TypedAgentEvent[M]) {
@@ -87,6 +89,8 @@ type chatModelAgentRunOptions struct {
 	agentToolOptions map[string][]AgentRunOption
 
 	historyModifier func(context.Context, []Message) []Message
+
+	afterToolCallsHook func(ctx context.Context) error
 }
 
 // WithChatModelOptions sets options for the underlying chat model.
@@ -115,6 +119,17 @@ func WithAgentToolRunOptions(opts map[string][]AgentRunOption) AgentRunOption {
 func WithHistoryModifier(f func(context.Context, []Message) []Message) AgentRunOption {
 	return WrapImplSpecificOptFn(func(t *chatModelAgentRunOptions) {
 		t.historyModifier = f
+	})
+}
+
+// WithAfterToolCallsHook registers a per-run hook that fires synchronously after
+// all tool calls in a react iteration complete, before the next ChatModel call.
+//
+// This is suitable for TurnLoop Push+Preempt patterns where the pushed item
+// must be visible to the next turn's GenInput.
+func WithAfterToolCallsHook(fn func(ctx context.Context) error) AgentRunOption {
+	return WrapImplSpecificOptFn(func(t *chatModelAgentRunOptions) {
+		t.afterToolCallsHook = fn
 	})
 }
 
@@ -448,6 +463,8 @@ type typedRunParams[M messageType] struct {
 	cancelCtx      *cancelContext
 	cancelCtxOwned bool
 	composeOpts    []compose.Option
+
+	afterToolCallsHook func(ctx context.Context) error
 }
 
 type typedRunFunc[M messageType] func(ctx context.Context, p *typedRunParams[M])
@@ -1114,6 +1131,7 @@ func (a *TypedChatModelAgent[M]) buildMessageReActRunFunc(ctx context.Context, b
 			generator:                mp.generator,
 			cancelCtx:                cancelCtx,
 			failoverLastSuccessModel: msgModel,
+			afterToolCallsHook:       mp.afterToolCallsHook,
 		})
 
 		// Pre-execution cancel check
@@ -1390,6 +1408,7 @@ func (a *TypedChatModelAgent[M]) Run(ctx context.Context, input *TypedAgentInput
 
 	co := getComposeOptions(opts)
 	co = append(co, compose.WithCheckPointID(bridgeCheckpointID))
+	runOps := GetImplSpecificOptions[chatModelAgentRunOptions](nil, opts...)
 
 	if bc != nil {
 		co = append(co, compose.WithChatModelOption(model.WithTools(bc.toolInfos)))
@@ -1420,14 +1439,15 @@ func (a *TypedChatModelAgent[M]) Run(ctx context.Context, input *TypedAgentInput
 		}
 
 		run(ctx, &typedRunParams[M]{
-			input:          input,
-			generator:      generator,
-			store:          newBridgeStore(),
-			instruction:    instruction,
-			returnDirectly: returnDirectly,
-			cancelCtx:      cancelCtx,
-			cancelCtxOwned: cancelCtxOwned,
-			composeOpts:    co,
+			input:              input,
+			generator:          generator,
+			store:              newBridgeStore(),
+			instruction:        instruction,
+			returnDirectly:     returnDirectly,
+			cancelCtx:          cancelCtx,
+			cancelCtxOwned:     cancelCtxOwned,
+			composeOpts:        co,
+			afterToolCallsHook: runOps.afterToolCallsHook,
 		})
 	}()
 
@@ -1461,6 +1481,7 @@ func (a *TypedChatModelAgent[M]) Resume(ctx context.Context, info *ResumeInfo, o
 
 	co := getComposeOptions(opts)
 	co = append(co, compose.WithCheckPointID(bridgeCheckpointID))
+	resumeRunOps := GetImplSpecificOptions[chatModelAgentRunOptions](nil, opts...)
 
 	if bc != nil {
 		co = append(co, compose.WithChatModelOption(model.WithTools(bc.toolInfos)))
@@ -1541,14 +1562,15 @@ func (a *TypedChatModelAgent[M]) Resume(ctx context.Context, info *ResumeInfo, o
 		}
 
 		run(ctx, &typedRunParams[M]{
-			input:          &TypedAgentInput[M]{EnableStreaming: info.EnableStreaming},
-			generator:      generator,
-			store:          newResumeBridgeStore(bridgeCheckpointID, stateByte),
-			instruction:    instruction,
-			returnDirectly: returnDirectly,
-			cancelCtx:      cancelCtx,
-			cancelCtxOwned: cancelCtxOwned,
-			composeOpts:    co,
+			input:              &TypedAgentInput[M]{EnableStreaming: info.EnableStreaming},
+			generator:          generator,
+			store:              newResumeBridgeStore(bridgeCheckpointID, stateByte),
+			instruction:        instruction,
+			returnDirectly:     returnDirectly,
+			cancelCtx:          cancelCtx,
+			cancelCtxOwned:     cancelCtxOwned,
+			composeOpts:        co,
+			afterToolCallsHook: resumeRunOps.afterToolCallsHook,
 		})
 	}()
 

--- a/adk/handler.go
+++ b/adk/handler.go
@@ -152,14 +152,6 @@ type TypedChatModelAgentMiddleware[M messageType] interface {
 	//   - Tools: the current tool list that was sent to the model
 	AfterModelRewriteState(ctx context.Context, state *TypedChatModelAgentState[M], mc *ModelContext) (context.Context, *TypedChatModelAgentState[M], error)
 
-	// AfterToolCallsRewriteState is called after all concurrent tool calls in an iteration complete.
-	// The input state includes all messages up to and including the tool call results.
-	// The returned state is persisted to the agent's internal state.
-	//
-	// The ToolCallsContext provides metadata about the tool calls that just completed,
-	// derived from the assistant message's ToolCalls field.
-	AfterToolCallsRewriteState(ctx context.Context, state *TypedChatModelAgentState[M], tc *ToolCallsContext) (context.Context, *TypedChatModelAgentState[M], error)
-
 	// WrapInvokableToolCall wraps a tool's synchronous execution with custom behavior.
 	// Return the input endpoint unchanged and nil error if no wrapping is needed.
 	//
@@ -272,10 +264,6 @@ func (b *TypedBaseChatModelAgentMiddleware[M]) BeforeModelRewriteState(ctx conte
 }
 
 func (b *TypedBaseChatModelAgentMiddleware[M]) AfterModelRewriteState(ctx context.Context, state *TypedChatModelAgentState[M], mc *ModelContext) (context.Context, *TypedChatModelAgentState[M], error) {
-	return ctx, state, nil
-}
-
-func (b *TypedBaseChatModelAgentMiddleware[M]) AfterToolCallsRewriteState(ctx context.Context, state *TypedChatModelAgentState[M], tc *ToolCallsContext) (context.Context, *TypedChatModelAgentState[M], error) {
 	return ctx, state, nil
 }
 

--- a/adk/handler_test.go
+++ b/adk/handler_test.go
@@ -111,15 +111,6 @@ func (h *testAfterModelRewriteStateHandler) AfterModelRewriteState(ctx context.C
 	return h.fn(ctx, state, mc)
 }
 
-type testAfterToolCallsHandler struct {
-	*BaseChatModelAgentMiddleware
-	fn func(ctx context.Context, state *ChatModelAgentState, tc *ToolCallsContext) (context.Context, *ChatModelAgentState, error)
-}
-
-func (h *testAfterToolCallsHandler) AfterToolCallsRewriteState(ctx context.Context, state *ChatModelAgentState, tc *ToolCallsContext) (context.Context, *ChatModelAgentState, error) {
-	return h.fn(ctx, state, tc)
-}
-
 type testToolWrapperHandler struct {
 	*BaseChatModelAgentMiddleware
 	wrapInvokableFn  func(context.Context, InvokableToolCallEndpoint, *ToolContext) InvokableToolCallEndpoint
@@ -1830,8 +1821,8 @@ func TestToolContextInWrappers(t *testing.T) {
 	})
 }
 
-func TestAfterToolCallsRewriteState(t *testing.T) {
-	t.Run("ReceivesCorrectToolCallsContext", func(t *testing.T) {
+func TestAfterToolCallsHook(t *testing.T) {
+	t.Run("CalledAfterToolCalls", func(t *testing.T) {
 		ctx := context.Background()
 		ctrl := gomock.NewController(t)
 		cm := mockModel.NewMockToolCallingChatModel(ctrl)
@@ -1853,8 +1844,6 @@ func TestAfterToolCallsRewriteState(t *testing.T) {
 			Return(schema.AssistantMessage("done", nil), nil).Times(1)
 
 		var mu sync.Mutex
-		var capturedTC *ToolCallsContext
-		var capturedState *ChatModelAgentState
 		callCount := 0
 
 		agent, err := NewChatModelAgent(ctx, &ChatModelAgentConfig{
@@ -1866,20 +1855,16 @@ func TestAfterToolCallsRewriteState(t *testing.T) {
 					Tools: []tool.BaseTool{tool1, tool2},
 				},
 			},
-			Handlers: []ChatModelAgentMiddleware{
-				&testAfterToolCallsHandler{fn: func(ctx context.Context, state *ChatModelAgentState, tc *ToolCallsContext) (context.Context, *ChatModelAgentState, error) {
-					mu.Lock()
-					callCount++
-					capturedTC = tc
-					capturedState = &ChatModelAgentState{Messages: append([]Message{}, state.Messages...)}
-					mu.Unlock()
-					return ctx, state, nil
-				}},
-			},
 		})
 		assert.NoError(t, err)
 
-		iter := agent.Run(ctx, &AgentInput{Messages: []Message{schema.UserMessage("test")}})
+		iter := agent.Run(ctx, &AgentInput{Messages: []Message{schema.UserMessage("test")}},
+			WithAfterToolCallsHook(func(ctx context.Context) error {
+				mu.Lock()
+				callCount++
+				mu.Unlock()
+				return nil
+			}))
 		for {
 			_, ok := iter.Next()
 			if !ok {
@@ -1892,27 +1877,6 @@ func TestAfterToolCallsRewriteState(t *testing.T) {
 
 		// Should be called exactly once (one iteration with tool calls)
 		assert.Equal(t, 1, callCount)
-
-		// ToolCallsContext should have the two tool calls
-		assert.NotNil(t, capturedTC)
-		assert.Len(t, capturedTC.ToolCalls, 2)
-		assert.Equal(t, "tool_alpha", capturedTC.ToolCalls[0].Name)
-		assert.Equal(t, "call_1", capturedTC.ToolCalls[0].CallID)
-		assert.Equal(t, "tool_beta", capturedTC.ToolCalls[1].Name)
-		assert.Equal(t, "call_2", capturedTC.ToolCalls[1].CallID)
-
-		// State should contain: system msg + user msg + assistant msg + 2 tool results
-		assert.NotNil(t, capturedState)
-		assert.True(t, len(capturedState.Messages) >= 4, "expected at least 4 messages, got %d", len(capturedState.Messages))
-
-		// Check tool results are in state
-		toolResultCount := 0
-		for _, msg := range capturedState.Messages {
-			if msg.Role == schema.Tool {
-				toolResultCount++
-			}
-		}
-		assert.Equal(t, 2, toolResultCount)
 	})
 
 	t.Run("NotCalledWithoutToolCalls", func(t *testing.T) {
@@ -1930,16 +1894,14 @@ func TestAfterToolCallsRewriteState(t *testing.T) {
 			Name:        "TestAgent",
 			Description: "Test agent",
 			Model:       cm,
-			Handlers: []ChatModelAgentMiddleware{
-				&testAfterToolCallsHandler{fn: func(ctx context.Context, state *ChatModelAgentState, tc *ToolCallsContext) (context.Context, *ChatModelAgentState, error) {
-					callCount++
-					return ctx, state, nil
-				}},
-			},
 		})
 		assert.NoError(t, err)
 
-		iter := agent.Run(ctx, &AgentInput{Messages: []Message{schema.UserMessage("test")}})
+		iter := agent.Run(ctx, &AgentInput{Messages: []Message{schema.UserMessage("test")}},
+			WithAfterToolCallsHook(func(ctx context.Context) error {
+				callCount++
+				return nil
+			}))
 		for {
 			_, ok := iter.Next()
 			if !ok {
@@ -1947,10 +1909,10 @@ func TestAfterToolCallsRewriteState(t *testing.T) {
 			}
 		}
 
-		assert.Equal(t, 0, callCount, "AfterToolCallsRewriteState should not be called when no tool calls happen")
+		assert.Equal(t, 0, callCount, "AfterToolCallsHook should not be called when no tool calls happen")
 	})
 
-	t.Run("CanModifyStatePersistsToNextIteration", func(t *testing.T) {
+	t.Run("ToolResultsInStateBeforeHookFires", func(t *testing.T) {
 		ctx := context.Background()
 		ctrl := gomock.NewController(t)
 		cm := mockModel.NewMockToolCallingChatModel(ctrl)
@@ -1964,13 +1926,11 @@ func TestAfterToolCallsRewriteState(t *testing.T) {
 				{ID: "c1", Function: schema.FunctionCall{Name: "mytool", Arguments: "{}"}},
 			}), nil).Times(1)
 
-		// Second call: capture messages to verify the injected message is present
-		var capturedMsgs []*schema.Message
+		// Second call: final response
 		cm.EXPECT().Generate(gomock.Any(), gomock.Any(), gomock.Any()).
-			DoAndReturn(func(ctx context.Context, msgs []*schema.Message, opts ...interface{}) (*schema.Message, error) {
-				capturedMsgs = append([]*schema.Message{}, msgs...)
-				return schema.AssistantMessage("final", nil), nil
-			}).Times(1)
+			Return(schema.AssistantMessage("final", nil), nil).Times(1)
+
+		var hookToolResultCount int
 
 		agent, err := NewChatModelAgent(ctx, &ChatModelAgentConfig{
 			Name:        "TestAgent",
@@ -1981,17 +1941,22 @@ func TestAfterToolCallsRewriteState(t *testing.T) {
 					Tools: []tool.BaseTool{tool1},
 				},
 			},
-			Handlers: []ChatModelAgentMiddleware{
-				&testAfterToolCallsHandler{fn: func(ctx context.Context, state *ChatModelAgentState, tc *ToolCallsContext) (context.Context, *ChatModelAgentState, error) {
-					// Inject a user message into state
-					state.Messages = append(state.Messages, schema.UserMessage("injected_by_middleware"))
-					return ctx, state, nil
-				}},
-			},
 		})
 		assert.NoError(t, err)
 
-		iter := agent.Run(ctx, &AgentInput{Messages: []Message{schema.UserMessage("original")}})
+		iter := agent.Run(ctx, &AgentInput{Messages: []Message{schema.UserMessage("original")}},
+			WithAfterToolCallsHook(func(ctx context.Context) error {
+				// Verify tool results are already in state when the hook fires
+				_ = compose.ProcessState(ctx, func(_ context.Context, st *State) error {
+					for _, msg := range st.Messages {
+						if msg.Role == schema.Tool {
+							hookToolResultCount++
+						}
+					}
+					return nil
+				})
+				return nil
+			}))
 		for {
 			_, ok := iter.Next()
 			if !ok {
@@ -1999,16 +1964,7 @@ func TestAfterToolCallsRewriteState(t *testing.T) {
 			}
 		}
 
-		// The injected message should be visible in the second model call
-		assert.NotNil(t, capturedMsgs)
-		found := false
-		for _, msg := range capturedMsgs {
-			if msg.Content == "injected_by_middleware" {
-				found = true
-				break
-			}
-		}
-		assert.True(t, found, "Injected message should persist to the next model call")
+		assert.Equal(t, 1, hookToolResultCount, "Tool results should be in state when hook fires")
 	})
 }
 
@@ -2072,7 +2028,7 @@ func TestToolResultNotDuplicated(t *testing.T) {
 			"tool result should appear exactly once, got %d", toolResultCount)
 	})
 
-	t.Run("HandlerInjectedMessagePresentWithoutDuplication", func(t *testing.T) {
+	t.Run("HookInjectedMessagePresentWithoutDuplication", func(t *testing.T) {
 		ctx := context.Background()
 		ctrl := gomock.NewController(t)
 		cm := mockModel.NewMockToolCallingChatModel(ctrl)
@@ -2102,16 +2058,16 @@ func TestToolResultNotDuplicated(t *testing.T) {
 					Tools: []tool.BaseTool{tool1},
 				},
 			},
-			Handlers: []ChatModelAgentMiddleware{
-				&testAfterToolCallsHandler{fn: func(ctx context.Context, state *ChatModelAgentState, tc *ToolCallsContext) (context.Context, *ChatModelAgentState, error) {
-					state.Messages = append(state.Messages, schema.UserMessage("injected"))
-					return ctx, state, nil
-				}},
-			},
 		})
 		assert.NoError(t, err)
 
-		iter := agent.Run(ctx, &AgentInput{Messages: []Message{schema.UserMessage("hello")}})
+		iter := agent.Run(ctx, &AgentInput{Messages: []Message{schema.UserMessage("hello")}},
+			WithAfterToolCallsHook(func(ctx context.Context) error {
+				return compose.ProcessState(ctx, func(_ context.Context, st *State) error {
+					st.Messages = append(st.Messages, schema.UserMessage("injected"))
+					return nil
+				})
+			}))
 		for {
 			_, ok := iter.Next()
 			if !ok {

--- a/adk/handler_test.go
+++ b/adk/handler_test.go
@@ -18,6 +18,7 @@ package adk
 
 import (
 	"context"
+	"fmt"
 	"sync"
 	"testing"
 
@@ -1965,6 +1966,108 @@ func TestAfterToolCallsHook(t *testing.T) {
 		}
 
 		assert.Equal(t, 1, hookToolResultCount, "Tool results should be in state when hook fires")
+	})
+
+	t.Run("HookErrorPropagation", func(t *testing.T) {
+		ctx := context.Background()
+		ctrl := gomock.NewController(t)
+		cm := mockModel.NewMockToolCallingChatModel(ctrl)
+
+		tool1 := &namedTool{name: "mytool"}
+		cm.EXPECT().WithTools(gomock.Any()).Return(cm, nil).AnyTimes()
+
+		cm.EXPECT().Generate(gomock.Any(), gomock.Any(), gomock.Any()).
+			Return(schema.AssistantMessage("calling", []schema.ToolCall{
+				{ID: "c1", Function: schema.FunctionCall{Name: "mytool", Arguments: "{}"}},
+			}), nil).Times(1)
+
+		agent, err := NewChatModelAgent(ctx, &ChatModelAgentConfig{
+			Name:        "TestAgent",
+			Description: "Test agent",
+			Model:       cm,
+			ToolsConfig: ToolsConfig{
+				ToolsNodeConfig: compose.ToolsNodeConfig{
+					Tools: []tool.BaseTool{tool1},
+				},
+			},
+		})
+		assert.NoError(t, err)
+
+		iter := agent.Run(ctx, &AgentInput{Messages: []Message{schema.UserMessage("test")}},
+			WithAfterToolCallsHook(func(ctx context.Context) error {
+				return fmt.Errorf("hook failure")
+			}))
+
+		var sawError bool
+		for {
+			ev, ok := iter.Next()
+			if !ok {
+				break
+			}
+			if ev.Err != nil {
+				assert.Contains(t, ev.Err.Error(), "hook failure")
+				sawError = true
+			}
+		}
+		assert.True(t, sawError, "hook error should propagate as an agent error event")
+	})
+
+	t.Run("HookCalledPerIteration", func(t *testing.T) {
+		ctx := context.Background()
+		ctrl := gomock.NewController(t)
+		cm := mockModel.NewMockToolCallingChatModel(ctrl)
+
+		tool1 := &namedTool{name: "mytool"}
+		cm.EXPECT().WithTools(gomock.Any()).Return(cm, nil).AnyTimes()
+
+		// Iteration 1: tool call
+		cm.EXPECT().Generate(gomock.Any(), gomock.Any(), gomock.Any()).
+			Return(schema.AssistantMessage("calling1", []schema.ToolCall{
+				{ID: "c1", Function: schema.FunctionCall{Name: "mytool", Arguments: "{}"}},
+			}), nil).Times(1)
+
+		// Iteration 2: tool call again
+		cm.EXPECT().Generate(gomock.Any(), gomock.Any(), gomock.Any()).
+			Return(schema.AssistantMessage("calling2", []schema.ToolCall{
+				{ID: "c2", Function: schema.FunctionCall{Name: "mytool", Arguments: "{}"}},
+			}), nil).Times(1)
+
+		// Iteration 3: final answer
+		cm.EXPECT().Generate(gomock.Any(), gomock.Any(), gomock.Any()).
+			Return(schema.AssistantMessage("done", nil), nil).Times(1)
+
+		var mu sync.Mutex
+		hookCount := 0
+
+		agent, err := NewChatModelAgent(ctx, &ChatModelAgentConfig{
+			Name:        "TestAgent",
+			Description: "Test agent",
+			Model:       cm,
+			ToolsConfig: ToolsConfig{
+				ToolsNodeConfig: compose.ToolsNodeConfig{
+					Tools: []tool.BaseTool{tool1},
+				},
+			},
+		})
+		assert.NoError(t, err)
+
+		iter := agent.Run(ctx, &AgentInput{Messages: []Message{schema.UserMessage("test")}},
+			WithAfterToolCallsHook(func(ctx context.Context) error {
+				mu.Lock()
+				hookCount++
+				mu.Unlock()
+				return nil
+			}))
+		for {
+			_, ok := iter.Next()
+			if !ok {
+				break
+			}
+		}
+
+		mu.Lock()
+		defer mu.Unlock()
+		assert.Equal(t, 2, hookCount, "hook should fire once per tool-call iteration")
 	})
 }
 

--- a/adk/react.go
+++ b/adk/react.go
@@ -394,37 +394,20 @@ func newReact(ctx context.Context, config *reactConfig) (reactGraph, error) {
 		compose.WithStreamStatePostHandler(toolPostHandle),
 		compose.WithNodeName(toolNode_))
 
-	// AfterToolCalls node: calls AfterToolCallsRewriteState handlers after all tool calls complete.
+	// AfterToolCalls node: persists tool results to state and fires the after-tool-calls hook.
 	// The graph auto-materializes the ToolsNode stream into []Message before this node.
 	afterToolCalls := func(ctx context.Context, toolResults []Message) ([]Message, error) {
-		var stateMessages []Message
 		_ = compose.ProcessState(ctx, func(_ context.Context, st *State) error {
-			stateMessages = st.Messages
+			st.Messages = append(st.Messages, toolResults...)
 			return nil
 		})
 
-		state := &ChatModelAgentState{Messages: append(stateMessages, toolResults...)}
-
-		if config.modelWrapperConf != nil {
-			assistantMsg := stateMessages[len(stateMessages)-1]
-			tc := &ToolCallsContext{}
-			for _, toolCall := range assistantMsg.ToolCalls {
-				tc.ToolCalls = append(tc.ToolCalls, ToolContext{Name: toolCall.Function.Name, CallID: toolCall.ID})
-			}
-
-			for _, handler := range config.modelWrapperConf.handlers {
-				var err error
-				ctx, state, err = handler.AfterToolCallsRewriteState(ctx, state, tc)
-				if err != nil {
-					return nil, err
-				}
+		execCtx := getTypedChatModelAgentExecCtx[Message](ctx)
+		if execCtx != nil && execCtx.afterToolCallsHook != nil {
+			if err := execCtx.afterToolCallsHook(ctx); err != nil {
+				return nil, err
 			}
 		}
-
-		_ = compose.ProcessState(ctx, func(_ context.Context, st *State) error {
-			st.Messages = state.Messages
-			return nil
-		})
 
 		return toolResults, nil
 	}


### PR DESCRIPTION
# Replace AfterToolCallsRewriteState with WithAfterToolCallsHook

## Problem

`AfterToolCallsRewriteState` is a method on the `TypedChatModelAgentMiddleware` interface — a mandatory interface method that every implementor must satisfy (or embed the base struct to get the no-op). Its only use case is TurnLoop Push+Preempt after tool calls complete.

Adding a method to the middleware interface is expensive API surface for a single use case. It also receives `*TypedChatModelAgentState` and `*ToolCallsContext` as state-rewriting inputs, but the actual requirement is just a synchronization point: "do something after tool calls, synchronously, before the next ChatModel call."

## Solution

Replace the interface method with a per-run `AgentRunOption`:

```go
runner.Run(ctx, input, WithAfterToolCallsHook(func(ctx context.Context) error {
    _, ack := loop.Push(item, WithPreempt(AfterToolCalls))
    <-ack
    return nil
}))
```

The hook has a minimal `func(ctx context.Context) error` signature. It is delivered to the react graph lambda through the existing `typedChatModelAgentExecCtx` (already injected per-run into `ctx`). No new context keys or injection mechanisms.

The `afterToolCallsNode_` lambda is simplified: tool results are now appended to state via a direct `compose.ProcessState` call, then the hook fires. The hook sees the full conversation history including tool responses — correct timing for Push+Preempt.

## Decisions

**Per-run option vs config-level field**: The hook is an `AgentRunOption`, not a `ChatModelAgentConfig` field. This gives per-run flexibility (different TurnLoop Push targets per call) and avoids polluting the build-time config. The hook is plumbed via the existing `typedChatModelAgentExecCtx` → `typedRunParams` chain.

**`func(ctx) error` vs richer signature**: The original method received `*ChatModelAgentState` and `*ToolCallsContext`. The hook drops both. The caller can read/write state via `compose.ProcessState(ctx, ...)` if needed, and doesn't need `ToolCallsContext` for the Push+Preempt pattern. This keeps the signature minimal.

## Key Insight

The `typedChatModelAgentExecCtx` is an ideal carrier for per-run hooks into compiled graph lambdas. The graph is compiled once at agent construction, but each lambda receives the live `ctx` at execution time. The `execCtx` is already injected per-run via `context.WithValue`, so adding a field to it is zero-cost in terms of new plumbing. This pattern avoids both config-level pollution and new context keys.

## Summary

| Problem | Solution |
|---------|----------|
| `AfterToolCallsRewriteState` adds mandatory interface surface for a single use case | Replace with opt-in `WithAfterToolCallsHook` `AgentRunOption` |
| Hook needed per-run flexibility (different TurnLoop targets) | Delivered via `typedChatModelAgentExecCtx`, a per-run ctx injection |

---

# 用 WithAfterToolCallsHook 替换 AfterToolCallsRewriteState

## 问题

`AfterToolCallsRewriteState` 是 `TypedChatModelAgentMiddleware` 接口上的一个方法——每个实现者都必须满足这个接口方法（或者嵌入 base struct 来获取空实现）。它的唯一使用场景是 TurnLoop 在工具调用完成后执行 Push+Preempt。

为单一用例向中间件接口添加方法，API 成本太高。它还接收 `*TypedChatModelAgentState` 和 `*ToolCallsContext` 作为状态重写输入，但实际需求只是一个同步点："在工具调用完成后、下一次 ChatModel 调用之前，同步执行某个操作。"

## 方案

用一个 per-run 的 `AgentRunOption` 替换接口方法：

```go
runner.Run(ctx, input, WithAfterToolCallsHook(func(ctx context.Context) error {
    _, ack := loop.Push(item, WithPreempt(AfterToolCalls))
    <-ack
    return nil
}))
```

Hook 签名为最小化的 `func(ctx context.Context) error`。通过已有的 `typedChatModelAgentExecCtx`（每次运行时已注入 `ctx`）传递到 react 图的 lambda 中。无需新的 context key 或注入机制。

`afterToolCallsNode_` lambda 被简化：工具结果通过 `compose.ProcessState` 直接追加到 state，然后触发 hook。Hook 执行时 state 已包含完整的对话历史（含工具响应）——Push+Preempt 的正确时机。

## 决策

**Per-run option vs config 字段**：Hook 是 `AgentRunOption` 而非 `ChatModelAgentConfig` 字段。这提供了每次运行时的灵活性（不同的 TurnLoop Push 目标），避免污染构建时配置。通过已有的 `typedChatModelAgentExecCtx` → `typedRunParams` 链路传递。

**`func(ctx) error` vs 更丰富的签名**：原方法接收 `*ChatModelAgentState` 和 `*ToolCallsContext`。新 hook 去掉了两者。调用方可以通过 `compose.ProcessState(ctx, ...)` 按需读写状态，Push+Preempt 模式不需要 `ToolCallsContext`。保持签名最小化。

## 关键洞察

`typedChatModelAgentExecCtx` 是将 per-run hook 传递到已编译图 lambda 的理想载体。图在 agent 构建时编译一次，但每个 lambda 在执行时接收实时的 `ctx`。`execCtx` 已通过 `context.WithValue` 按次运行注入，因此向其添加字段在管道层面零成本。这种模式避免了配置污染和新 context key。

## 总结

| 问题 | 方案 |
|------|------|
| `AfterToolCallsRewriteState` 为单一用例增加了强制接口方法 | 替换为可选的 `WithAfterToolCallsHook` `AgentRunOption` |
| Hook 需要 per-run 灵活性（不同的 TurnLoop 目标） | 通过 `typedChatModelAgentExecCtx` 传递（per-run ctx 注入） |
