### PR TITLE
feat(adk): generify ModelRetryConfig, ModelFailoverConfig, ModelContext, and DeepAgent for AgenticMessage support

### DIFF
--- a/adk/agent_tool.go
+++ b/adk/agent_tool.go
@@ -165,6 +165,11 @@ func (at *typedAgentTool[M]) InvokableRun(ctx context.Context, argumentsInJSON s
 		if at.fullChatHistoryAsInput {
 			var zero M
 			if _, ok := any(zero).(*schema.Message); !ok {
+				// fullChatHistoryAsInput is only supported for *schema.Message agents and will not
+				// be extended to *schema.AgenticMessage. The chat history format and role semantics
+				// differ fundamentally between Message and AgenticMessage, and the history rewriting
+				// logic (role attribution, system message filtering, transfer messages) is specific
+				// to the Message model.
 				return "", fmt.Errorf("fullChatHistoryAsInput is only supported for *schema.Message agents")
 			}
 			msgInput, histErr := getReactChatHistory(ctx, at.agent.Name(ctx))
@@ -235,6 +240,10 @@ func (at *typedAgentTool[M]) InvokableRun(ctx context.Context, argumentsInJSON s
 					gen.Send(msgEvent)
 					event = any(tmp).(*TypedAgentEvent[M])
 				} else {
+					// Cross-message-type agent tools are not supported and will not be supported.
+					// An AgenticMessage agent cannot be used as a tool within a Message agent's
+					// event stream. The agent tool still executes correctly and returns its text
+					// result; only real-time event streaming to the parent is blocked.
 					return "", fmt.Errorf("cross-message-type agent tools are not supported: cannot use an AgenticMessage agent as a tool of a Message agent")
 				}
 			}

--- a/adk/agent_tool.go
+++ b/adk/agent_tool.go
@@ -104,7 +104,7 @@ func NewAgentTool(_ context.Context, agent Agent, options ...AgentToolOption) to
 }
 
 // NewTypedAgentTool creates a new agent tool that wraps a TypedAgent as a tool.BaseTool.
-func NewTypedAgentTool[M messageType](_ context.Context, agent TypedAgent[M], options ...AgentToolOption) tool.BaseTool {
+func NewTypedAgentTool[M MessageType](_ context.Context, agent TypedAgent[M], options ...AgentToolOption) tool.BaseTool {
 	opts := &AgentToolOptions{}
 	for _, opt := range options {
 		opt(opts)
@@ -117,7 +117,7 @@ func NewTypedAgentTool[M messageType](_ context.Context, agent TypedAgent[M], op
 	}
 }
 
-type typedAgentTool[M messageType] struct {
+type typedAgentTool[M MessageType] struct {
 	agent TypedAgent[M]
 
 	fullChatHistoryAsInput bool
@@ -374,7 +374,7 @@ func getReactChatHistory(ctx context.Context, destAgentName string) ([]Message, 
 	return history, nil
 }
 
-func newTypedUserMessages[M messageType](text string) []M {
+func newTypedUserMessages[M MessageType](text string) []M {
 	var zero M
 	switch any(zero).(type) {
 	case *schema.Message:
@@ -386,7 +386,7 @@ func newTypedUserMessages[M messageType](text string) []M {
 	}
 }
 
-func newTypedInvokableAgentToolRunner[M messageType](agent TypedAgent[M], store compose.CheckPointStore, enableStreaming bool) *TypedRunner[M] {
+func newTypedInvokableAgentToolRunner[M MessageType](agent TypedAgent[M], store compose.CheckPointStore, enableStreaming bool) *TypedRunner[M] {
 	return &TypedRunner[M]{
 		a:               agent,
 		enableStreaming: enableStreaming,

--- a/adk/agentic_test.go
+++ b/adk/agentic_test.go
@@ -55,18 +55,18 @@ func (m *mockAgenticModel) Stream(ctx context.Context, input []*schema.AgenticMe
 
 type testAgenticMiddleware struct {
 	*TypedBaseChatModelAgentMiddleware[*schema.AgenticMessage]
-	beforeFn func(context.Context, *TypedChatModelAgentState[*schema.AgenticMessage], *ModelContext) (context.Context, *TypedChatModelAgentState[*schema.AgenticMessage], error)
-	afterFn  func(context.Context, *TypedChatModelAgentState[*schema.AgenticMessage], *ModelContext) (context.Context, *TypedChatModelAgentState[*schema.AgenticMessage], error)
+	beforeFn func(context.Context, *TypedChatModelAgentState[*schema.AgenticMessage], *TypedModelContext[*schema.AgenticMessage]) (context.Context, *TypedChatModelAgentState[*schema.AgenticMessage], error)
+	afterFn  func(context.Context, *TypedChatModelAgentState[*schema.AgenticMessage], *TypedModelContext[*schema.AgenticMessage]) (context.Context, *TypedChatModelAgentState[*schema.AgenticMessage], error)
 }
 
-func (m *testAgenticMiddleware) BeforeModelRewriteState(ctx context.Context, state *TypedChatModelAgentState[*schema.AgenticMessage], mc *ModelContext) (context.Context, *TypedChatModelAgentState[*schema.AgenticMessage], error) {
+func (m *testAgenticMiddleware) BeforeModelRewriteState(ctx context.Context, state *TypedChatModelAgentState[*schema.AgenticMessage], mc *TypedModelContext[*schema.AgenticMessage]) (context.Context, *TypedChatModelAgentState[*schema.AgenticMessage], error) {
 	if m.beforeFn != nil {
 		return m.beforeFn(ctx, state, mc)
 	}
 	return ctx, state, nil
 }
 
-func (m *testAgenticMiddleware) AfterModelRewriteState(ctx context.Context, state *TypedChatModelAgentState[*schema.AgenticMessage], mc *ModelContext) (context.Context, *TypedChatModelAgentState[*schema.AgenticMessage], error) {
+func (m *testAgenticMiddleware) AfterModelRewriteState(ctx context.Context, state *TypedChatModelAgentState[*schema.AgenticMessage], mc *TypedModelContext[*schema.AgenticMessage]) (context.Context, *TypedChatModelAgentState[*schema.AgenticMessage], error) {
 	if m.afterFn != nil {
 		return m.afterFn(ctx, state, mc)
 	}
@@ -399,11 +399,11 @@ func TestAgenticChatModelAgentRun_WithMiddleware(t *testing.T) {
 	afterModelExecuted := false
 
 	mw := &testAgenticMiddleware{
-		beforeFn: func(ctx context.Context, state *TypedChatModelAgentState[*schema.AgenticMessage], mc *ModelContext) (context.Context, *TypedChatModelAgentState[*schema.AgenticMessage], error) {
+		beforeFn: func(ctx context.Context, state *TypedChatModelAgentState[*schema.AgenticMessage], mc *TypedModelContext[*schema.AgenticMessage]) (context.Context, *TypedChatModelAgentState[*schema.AgenticMessage], error) {
 			state.Messages = append(state.Messages, schema.UserAgenticMessage("extra"))
 			return ctx, state, nil
 		},
-		afterFn: func(ctx context.Context, state *TypedChatModelAgentState[*schema.AgenticMessage], mc *ModelContext) (context.Context, *TypedChatModelAgentState[*schema.AgenticMessage], error) {
+		afterFn: func(ctx context.Context, state *TypedChatModelAgentState[*schema.AgenticMessage], mc *TypedModelContext[*schema.AgenticMessage]) (context.Context, *TypedChatModelAgentState[*schema.AgenticMessage], error) {
 			assert.Len(t, state.Messages, 4)
 			afterModelExecuted = true
 			return ctx, state, nil
@@ -455,7 +455,7 @@ func TestAgenticAfterModel_NoTools_ModifyDoesNotAffectEvent(t *testing.T) {
 		Model:       m,
 		Handlers: []TypedChatModelAgentMiddleware[*schema.AgenticMessage]{
 			&testAgenticMiddleware{
-				afterFn: func(ctx context.Context, state *TypedChatModelAgentState[*schema.AgenticMessage], mc *ModelContext) (context.Context, *TypedChatModelAgentState[*schema.AgenticMessage], error) {
+				afterFn: func(ctx context.Context, state *TypedChatModelAgentState[*schema.AgenticMessage], mc *TypedModelContext[*schema.AgenticMessage]) (context.Context, *TypedChatModelAgentState[*schema.AgenticMessage], error) {
 					capturedMessages = make([]*schema.AgenticMessage, len(state.Messages))
 					copy(capturedMessages, state.Messages)
 					state.Messages = append(state.Messages, agenticAssistantMessage("appended content"))

--- a/adk/agentic_test.go
+++ b/adk/agentic_test.go
@@ -20,7 +20,9 @@ import (
 	"context"
 	"errors"
 	"io"
+	"sync/atomic"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -1352,4 +1354,328 @@ func TestConcatMessageStream_AgenticClosesStream(t *testing.T) {
 	_, recvErr := r.Recv()
 	assert.Error(t, recvErr,
 		"stream should be closed after concatMessageStream returns")
+}
+
+// --- Agentic retry/failover stream test helpers ---
+
+func agenticStreamWithMidError(chunks []*schema.AgenticMessage, err error) *schema.StreamReader[*schema.AgenticMessage] {
+	sr, sw := schema.Pipe[*schema.AgenticMessage](len(chunks) + 1)
+	go func() {
+		defer sw.Close()
+		for _, c := range chunks {
+			sw.Send(c, nil)
+		}
+		sw.Send(nil, err)
+	}()
+	return sr
+}
+
+func agenticStreamOK(chunks []*schema.AgenticMessage) *schema.StreamReader[*schema.AgenticMessage] {
+	sr, sw := schema.Pipe[*schema.AgenticMessage](len(chunks))
+	go func() {
+		defer sw.Close()
+		for _, c := range chunks {
+			sw.Send(c, nil)
+		}
+	}()
+	return sr
+}
+
+func drainTypedAgenticEvents(t *testing.T, iter *AsyncIterator[*TypedAgentEvent[*schema.AgenticMessage]]) *schema.AgenticMessage {
+	t.Helper()
+	var lastMsg *schema.AgenticMessage
+	for {
+		ev, ok := iter.Next()
+		if !ok {
+			break
+		}
+		if ev.Err != nil {
+			var willRetry *WillRetryError
+			if errors.As(ev.Err, &willRetry) {
+				continue
+			}
+			t.Fatalf("unexpected error event: %v", ev.Err)
+		}
+		if ev.Output != nil && ev.Output.MessageOutput != nil {
+			if ev.Output.MessageOutput.IsStreaming && ev.Output.MessageOutput.MessageStream != nil {
+				sr := ev.Output.MessageOutput.MessageStream
+				for {
+					chunk, err := sr.Recv()
+					if err != nil {
+						break
+					}
+					lastMsg = chunk
+				}
+			} else if ev.Output.MessageOutput.Message != nil {
+				lastMsg = ev.Output.MessageOutput.Message
+			}
+		}
+	}
+	return lastMsg
+}
+
+func TestAgenticRetryWithShouldRetry_Generate(t *testing.T) {
+	ctx := context.Background()
+
+	var callCount int32
+	var shouldRetryCalls int32
+	genErr := errors.New("transient generate error")
+
+	m := &mockAgenticModel{
+		generateFn: func(_ context.Context, _ []*schema.AgenticMessage, _ ...model.Option) (*schema.AgenticMessage, error) {
+			n := atomic.AddInt32(&callCount, 1)
+			if n == 1 {
+				return nil, genErr
+			}
+			return agenticMsg("retry ok"), nil
+		},
+	}
+
+	agent, err := NewTypedChatModelAgent[*schema.AgenticMessage](ctx, &TypedChatModelAgentConfig[*schema.AgenticMessage]{
+		Name:        "retry-gen-agent",
+		Description: "test retry generate",
+		Model:       m,
+		ModelRetryConfig: &TypedModelRetryConfig[*schema.AgenticMessage]{
+			MaxRetries: 1,
+			ShouldRetry: func(_ context.Context, retryCtx *TypedRetryContext[*schema.AgenticMessage]) *TypedRetryDecision[*schema.AgenticMessage] {
+				n := atomic.AddInt32(&shouldRetryCalls, 1)
+				if n == 1 {
+					assert.Nil(t, retryCtx.OutputMessage, "OutputMessage should be nil when Generate returns error")
+					assert.ErrorIs(t, retryCtx.Err, genErr, "Err should be the generate error")
+					assert.Equal(t, 1, retryCtx.RetryAttempt)
+					return &TypedRetryDecision[*schema.AgenticMessage]{Retry: true}
+				}
+				return &TypedRetryDecision[*schema.AgenticMessage]{Retry: false}
+			},
+			BackoffFunc: func(_ context.Context, _ int) time.Duration { return time.Millisecond },
+		},
+	})
+	require.NoError(t, err)
+
+	runner := NewTypedRunner[*schema.AgenticMessage](TypedRunnerConfig[*schema.AgenticMessage]{Agent: agent})
+	iter := runner.Run(ctx, []*schema.AgenticMessage{schema.UserAgenticMessage("hello")})
+
+	msg := drainTypedAgenticEvents(t, iter)
+	require.NotNil(t, msg, "should have received a final message")
+	assert.Equal(t, "retry ok", agenticTextContent(msg))
+	assert.Equal(t, int32(2), atomic.LoadInt32(&callCount), "model should be called twice")
+	assert.Equal(t, int32(2), atomic.LoadInt32(&shouldRetryCalls), "ShouldRetry should be called for both attempts")
+}
+
+func TestAgenticRetryWithShouldRetry_Stream(t *testing.T) {
+	ctx := context.Background()
+
+	var streamCallCount int32
+	var shouldRetryCalls int32
+	streamErr := errors.New("mid-stream error")
+
+	m := &mockAgenticModel{
+		generateFn: func(_ context.Context, _ []*schema.AgenticMessage, _ ...model.Option) (*schema.AgenticMessage, error) {
+			return nil, errors.New("generate should not be called")
+		},
+		streamFn: func(_ context.Context, _ []*schema.AgenticMessage, _ ...model.Option) (*schema.StreamReader[*schema.AgenticMessage], error) {
+			n := atomic.AddInt32(&streamCallCount, 1)
+			if n == 1 {
+				return agenticStreamWithMidError(
+					[]*schema.AgenticMessage{agenticMsg("partial")},
+					streamErr,
+				), nil
+			}
+			return agenticStreamOK([]*schema.AgenticMessage{agenticMsg("stream ok")}), nil
+		},
+	}
+
+	agent, err := NewTypedChatModelAgent[*schema.AgenticMessage](ctx, &TypedChatModelAgentConfig[*schema.AgenticMessage]{
+		Name:        "retry-stream-agent",
+		Description: "test retry stream",
+		Model:       m,
+		ModelRetryConfig: &TypedModelRetryConfig[*schema.AgenticMessage]{
+			MaxRetries: 1,
+			ShouldRetry: func(_ context.Context, retryCtx *TypedRetryContext[*schema.AgenticMessage]) *TypedRetryDecision[*schema.AgenticMessage] {
+				n := atomic.AddInt32(&shouldRetryCalls, 1)
+				if n == 1 {
+					assert.NotNil(t, retryCtx.OutputMessage, "OutputMessage should be non-nil from partial stream")
+					assert.Error(t, retryCtx.Err, "Err should be the stream error")
+					return &TypedRetryDecision[*schema.AgenticMessage]{Retry: true}
+				}
+				return nil
+			},
+			BackoffFunc: func(_ context.Context, _ int) time.Duration { return time.Millisecond },
+		},
+	})
+	require.NoError(t, err)
+
+	runner := NewTypedRunner[*schema.AgenticMessage](TypedRunnerConfig[*schema.AgenticMessage]{
+		Agent:          agent,
+		EnableStreaming: true,
+	})
+	iter := runner.Run(ctx, []*schema.AgenticMessage{schema.UserAgenticMessage("hello")})
+
+	var lastMsg *schema.AgenticMessage
+	for {
+		ev, ok := iter.Next()
+		if !ok {
+			break
+		}
+		if ev.Err != nil {
+			var willRetry *WillRetryError
+			if errors.As(ev.Err, &willRetry) {
+				continue
+			}
+			t.Fatalf("unexpected error: %v", ev.Err)
+		}
+		if ev.Output != nil && ev.Output.MessageOutput != nil {
+			if ev.Output.MessageOutput.IsStreaming && ev.Output.MessageOutput.MessageStream != nil {
+				sr := ev.Output.MessageOutput.MessageStream
+				for {
+					chunk, err := sr.Recv()
+					if err != nil {
+						break
+					}
+					lastMsg = chunk
+				}
+			} else if ev.Output.MessageOutput.Message != nil {
+				lastMsg = ev.Output.MessageOutput.Message
+			}
+		}
+	}
+	require.NotNil(t, lastMsg, "should have received final stream message")
+	assert.Contains(t, agenticTextContent(lastMsg), "stream ok")
+	assert.Equal(t, int32(2), atomic.LoadInt32(&shouldRetryCalls), "ShouldRetry should be called for both attempts")
+}
+
+func TestAgenticFailoverGenerate(t *testing.T) {
+	ctx := context.Background()
+
+	m1Err := errors.New("m1 generate failed")
+	var m1Calls, m2Calls int32
+
+	m1 := &mockAgenticModel{
+		generateFn: func(_ context.Context, _ []*schema.AgenticMessage, _ ...model.Option) (*schema.AgenticMessage, error) {
+			atomic.AddInt32(&m1Calls, 1)
+			return nil, m1Err
+		},
+	}
+	m2 := &mockAgenticModel{
+		generateFn: func(_ context.Context, _ []*schema.AgenticMessage, _ ...model.Option) (*schema.AgenticMessage, error) {
+			atomic.AddInt32(&m2Calls, 1)
+			return agenticMsg("failover ok"), nil
+		},
+	}
+
+	agent, err := NewTypedChatModelAgent[*schema.AgenticMessage](ctx, &TypedChatModelAgentConfig[*schema.AgenticMessage]{
+		Name:        "failover-gen-agent",
+		Description: "test failover generate",
+		Model:       m1,
+		ModelFailoverConfig: &TypedModelFailoverConfig[*schema.AgenticMessage]{
+			MaxRetries: 1,
+			ShouldFailover: func(_ context.Context, _ *schema.AgenticMessage, err error) bool {
+				return err != nil
+			},
+			GetFailoverModel: func(_ context.Context, failoverCtx *TypedFailoverContext[*schema.AgenticMessage]) (model.BaseModel[*schema.AgenticMessage], []*schema.AgenticMessage, error) {
+				assert.Equal(t, uint(1), failoverCtx.FailoverAttempt)
+				assert.Nil(t, failoverCtx.LastOutputMessage, "LastOutputMessage should be nil when Generate returns error")
+				assert.ErrorIs(t, failoverCtx.LastErr, m1Err)
+				return m2, nil, nil
+			},
+		},
+	})
+	require.NoError(t, err)
+
+	runner := NewTypedRunner[*schema.AgenticMessage](TypedRunnerConfig[*schema.AgenticMessage]{Agent: agent})
+	iter := runner.Run(ctx, []*schema.AgenticMessage{schema.UserAgenticMessage("hello")})
+
+	msg := drainTypedAgenticEvents(t, iter)
+	require.NotNil(t, msg)
+	assert.Equal(t, "failover ok", agenticTextContent(msg))
+	assert.Equal(t, int32(1), atomic.LoadInt32(&m1Calls))
+	assert.Equal(t, int32(1), atomic.LoadInt32(&m2Calls))
+}
+
+func TestAgenticFailoverStream_MidStreamError(t *testing.T) {
+	ctx := context.Background()
+
+	streamErr := errors.New("m1 mid-stream error")
+	var m1Calls, m2Calls int32
+	var capturedLastOutput *schema.AgenticMessage
+
+	m1 := &mockAgenticModel{
+		generateFn: func(_ context.Context, _ []*schema.AgenticMessage, _ ...model.Option) (*schema.AgenticMessage, error) {
+			return nil, errors.New("unused")
+		},
+		streamFn: func(_ context.Context, _ []*schema.AgenticMessage, _ ...model.Option) (*schema.StreamReader[*schema.AgenticMessage], error) {
+			atomic.AddInt32(&m1Calls, 1)
+			return agenticStreamWithMidError(
+				[]*schema.AgenticMessage{agenticMsg("partial chunk")},
+				streamErr,
+			), nil
+		},
+	}
+	m2 := &mockAgenticModel{
+		generateFn: func(_ context.Context, _ []*schema.AgenticMessage, _ ...model.Option) (*schema.AgenticMessage, error) {
+			return nil, errors.New("unused")
+		},
+		streamFn: func(_ context.Context, _ []*schema.AgenticMessage, _ ...model.Option) (*schema.StreamReader[*schema.AgenticMessage], error) {
+			atomic.AddInt32(&m2Calls, 1)
+			return agenticStreamOK([]*schema.AgenticMessage{agenticMsg("failover stream ok")}), nil
+		},
+	}
+
+	agent, err := NewTypedChatModelAgent[*schema.AgenticMessage](ctx, &TypedChatModelAgentConfig[*schema.AgenticMessage]{
+		Name:        "failover-stream-agent",
+		Description: "test failover stream",
+		Model:       m1,
+		ModelFailoverConfig: &TypedModelFailoverConfig[*schema.AgenticMessage]{
+			MaxRetries: 1,
+			ShouldFailover: func(_ context.Context, _ *schema.AgenticMessage, err error) bool {
+				return err != nil
+			},
+			GetFailoverModel: func(_ context.Context, failoverCtx *TypedFailoverContext[*schema.AgenticMessage]) (model.BaseModel[*schema.AgenticMessage], []*schema.AgenticMessage, error) {
+				capturedLastOutput = failoverCtx.LastOutputMessage
+				return m2, nil, nil
+			},
+		},
+	})
+	require.NoError(t, err)
+
+	runner := NewTypedRunner[*schema.AgenticMessage](TypedRunnerConfig[*schema.AgenticMessage]{
+		Agent:          agent,
+		EnableStreaming: true,
+	})
+	iter := runner.Run(ctx, []*schema.AgenticMessage{schema.UserAgenticMessage("hello")})
+
+	var lastMsg *schema.AgenticMessage
+	for {
+		ev, ok := iter.Next()
+		if !ok {
+			break
+		}
+		if ev.Err != nil {
+			var willRetry *WillRetryError
+			if errors.As(ev.Err, &willRetry) {
+				continue
+			}
+			t.Fatalf("unexpected error: %v", ev.Err)
+		}
+		if ev.Output != nil && ev.Output.MessageOutput != nil {
+			if ev.Output.MessageOutput.IsStreaming && ev.Output.MessageOutput.MessageStream != nil {
+				sr := ev.Output.MessageOutput.MessageStream
+				for {
+					chunk, err := sr.Recv()
+					if err != nil {
+						break
+					}
+					lastMsg = chunk
+				}
+			} else if ev.Output.MessageOutput.Message != nil {
+				lastMsg = ev.Output.MessageOutput.Message
+			}
+		}
+	}
+
+	require.NotNil(t, lastMsg, "should have received final stream from m2")
+	assert.Contains(t, agenticTextContent(lastMsg), "failover stream ok")
+	assert.Equal(t, int32(1), atomic.LoadInt32(&m1Calls))
+	assert.Equal(t, int32(1), atomic.LoadInt32(&m2Calls))
+	assert.NotNil(t, capturedLastOutput, "failoverCtx.LastOutputMessage should contain partial stream from m1")
 }

--- a/adk/agentic_test.go
+++ b/adk/agentic_test.go
@@ -1567,12 +1567,12 @@ func TestAgenticFailoverGenerate(t *testing.T) {
 		Name:        "failover-gen-agent",
 		Description: "test failover generate",
 		Model:       m1,
-		ModelFailoverConfig: &TypedModelFailoverConfig[*schema.AgenticMessage]{
+		ModelFailoverConfig: &ModelFailoverConfig[*schema.AgenticMessage]{
 			MaxRetries: 1,
 			ShouldFailover: func(_ context.Context, _ *schema.AgenticMessage, err error) bool {
 				return err != nil
 			},
-			GetFailoverModel: func(_ context.Context, failoverCtx *TypedFailoverContext[*schema.AgenticMessage]) (model.BaseModel[*schema.AgenticMessage], []*schema.AgenticMessage, error) {
+			GetFailoverModel: func(_ context.Context, failoverCtx *FailoverContext[*schema.AgenticMessage]) (model.BaseModel[*schema.AgenticMessage], []*schema.AgenticMessage, error) {
 				assert.Equal(t, uint(1), failoverCtx.FailoverAttempt)
 				assert.Nil(t, failoverCtx.LastOutputMessage, "LastOutputMessage should be nil when Generate returns error")
 				assert.ErrorIs(t, failoverCtx.LastErr, m1Err)
@@ -1625,12 +1625,12 @@ func TestAgenticFailoverStream_MidStreamError(t *testing.T) {
 		Name:        "failover-stream-agent",
 		Description: "test failover stream",
 		Model:       m1,
-		ModelFailoverConfig: &TypedModelFailoverConfig[*schema.AgenticMessage]{
+		ModelFailoverConfig: &ModelFailoverConfig[*schema.AgenticMessage]{
 			MaxRetries: 1,
 			ShouldFailover: func(_ context.Context, _ *schema.AgenticMessage, err error) bool {
 				return err != nil
 			},
-			GetFailoverModel: func(_ context.Context, failoverCtx *TypedFailoverContext[*schema.AgenticMessage]) (model.BaseModel[*schema.AgenticMessage], []*schema.AgenticMessage, error) {
+			GetFailoverModel: func(_ context.Context, failoverCtx *FailoverContext[*schema.AgenticMessage]) (model.BaseModel[*schema.AgenticMessage], []*schema.AgenticMessage, error) {
 				capturedLastOutput = failoverCtx.LastOutputMessage
 				return m2, nil, nil
 			},

--- a/adk/callback.go
+++ b/adk/callback.go
@@ -43,7 +43,7 @@ type AgentCallbackOutput struct {
 	Events *AsyncIterator[*AgentEvent]
 }
 
-func copyTypedEventIterator[M messageType](iter *AsyncIterator[*TypedAgentEvent[M]], n int) []*AsyncIterator[*TypedAgentEvent[M]] {
+func copyTypedEventIterator[M MessageType](iter *AsyncIterator[*TypedAgentEvent[M]], n int) []*AsyncIterator[*TypedAgentEvent[M]] {
 	if n <= 0 {
 		return nil
 	}
@@ -136,7 +136,7 @@ func getAgentType(agent Agent) string {
 
 // TypedAgentCallbackInput represents the input passed to typed agent callbacks during OnStart.
 // Use ConvTypedCallbackInput to safely convert from callbacks.CallbackInput.
-type TypedAgentCallbackInput[M messageType] struct {
+type TypedAgentCallbackInput[M MessageType] struct {
 	// Input contains the agent input for a new run. Nil when resuming.
 	Input *TypedAgentInput[M]
 	// ResumeInfo contains resume information when resuming from an interrupt. Nil for new runs.
@@ -148,14 +148,14 @@ type TypedAgentCallbackInput[M messageType] struct {
 //
 // Important: The Events iterator should be consumed asynchronously to avoid blocking
 // the agent execution. Each callback handler receives an independent copy of the iterator.
-type TypedAgentCallbackOutput[M messageType] struct {
+type TypedAgentCallbackOutput[M MessageType] struct {
 	// Events provides a stream of agent events. Each handler receives its own copy.
 	Events *AsyncIterator[*TypedAgentEvent[M]]
 }
 
 // ConvTypedCallbackInput converts a callbacks.CallbackInput to *TypedAgentCallbackInput[M].
 // Returns nil if the input is not of the expected type.
-func ConvTypedCallbackInput[M messageType](input callbacks.CallbackInput) *TypedAgentCallbackInput[M] {
+func ConvTypedCallbackInput[M MessageType](input callbacks.CallbackInput) *TypedAgentCallbackInput[M] {
 	if v, ok := input.(*TypedAgentCallbackInput[M]); ok {
 		return v
 	}
@@ -164,14 +164,14 @@ func ConvTypedCallbackInput[M messageType](input callbacks.CallbackInput) *Typed
 
 // ConvTypedCallbackOutput converts a callbacks.CallbackOutput to *TypedAgentCallbackOutput[M].
 // Returns nil if the output is not of the expected type.
-func ConvTypedCallbackOutput[M messageType](output callbacks.CallbackOutput) *TypedAgentCallbackOutput[M] {
+func ConvTypedCallbackOutput[M MessageType](output callbacks.CallbackOutput) *TypedAgentCallbackOutput[M] {
 	if v, ok := output.(*TypedAgentCallbackOutput[M]); ok {
 		return v
 	}
 	return nil
 }
 
-func copyTypedCallbackOutput[M messageType](out *TypedAgentCallbackOutput[M], n int) []*TypedAgentCallbackOutput[M] {
+func copyTypedCallbackOutput[M MessageType](out *TypedAgentCallbackOutput[M], n int) []*TypedAgentCallbackOutput[M] {
 	if out == nil || out.Events == nil {
 		result := make([]*TypedAgentCallbackOutput[M], n)
 		for i := 0; i < n; i++ {

--- a/adk/cancel.go
+++ b/adk/cancel.go
@@ -812,7 +812,7 @@ func (cc *cancelContext) buildCancelFunc() AgentCancelFunc {
 // were passed through unconverted, markDone would transition stateCancelling→stateDone
 // before the Runner goroutine could call createAndMarkCancelHandled, causing it
 // to fail the CAS.
-func wrapIterWithCancelCtx[M messageType](iter *AsyncIterator[*TypedAgentEvent[M]], cancelCtx *cancelContext) *AsyncIterator[*TypedAgentEvent[M]] {
+func wrapIterWithCancelCtx[M MessageType](iter *AsyncIterator[*TypedAgentEvent[M]], cancelCtx *cancelContext) *AsyncIterator[*TypedAgentEvent[M]] {
 	if cancelCtx == nil {
 		return iter
 	}
@@ -848,7 +848,7 @@ func wrapIterWithCancelCtx[M messageType](iter *AsyncIterator[*TypedAgentEvent[M
 // by a dedicated node after the ChatModel in the compose graph).
 // Stream: pipes chunks through a goroutine that selects on immediateChan for
 // CancelImmediate abort.
-type typedCancelMonitoredModel[M messageType] struct {
+type typedCancelMonitoredModel[M MessageType] struct {
 	inner         model.BaseModel[M]
 	cancelContext *cancelContext
 }

--- a/adk/chatmodel.go
+++ b/adk/chatmodel.go
@@ -421,7 +421,7 @@ type TypedChatModelAgentConfig[M MessageType] struct {
 	// and on failure, call GetFailoverModel to select alternate models.
 	// Model field is still required as it serves as the initial model.
 	// Optional. If nil, no failover will be performed.
-	ModelFailoverConfig *TypedModelFailoverConfig[M]
+	ModelFailoverConfig *ModelFailoverConfig[M]
 }
 
 type ChatModelAgentConfig = TypedChatModelAgentConfig[*schema.Message]
@@ -456,7 +456,7 @@ type TypedChatModelAgent[M MessageType] struct {
 	middlewares []AgentMiddleware
 
 	modelRetryConfig    *TypedModelRetryConfig[M]
-	modelFailoverConfig *TypedModelFailoverConfig[M]
+	modelFailoverConfig *ModelFailoverConfig[M]
 
 	once   sync.Once
 	run    typedRunFunc[M]
@@ -1086,7 +1086,7 @@ func (a *TypedChatModelAgent[M]) buildMessageReActRunFunc(ctx context.Context, b
 			handlers:       msgHandlers,
 			middlewares:    a.middlewares,
 			retryConfig:    any(a.modelRetryConfig).(*ModelRetryConfig),
-			failoverConfig: any(a.modelFailoverConfig).(*ModelFailoverConfig),
+			failoverConfig: any(a.modelFailoverConfig).(*ModelFailoverConfig[*schema.Message]),
 			toolInfos:      bc.toolInfos,
 		},
 		toolsReturnDirectly: bc.returnDirectly,

--- a/adk/chatmodel.go
+++ b/adk/chatmodel.go
@@ -414,14 +414,14 @@ type TypedChatModelAgentConfig[M messageType] struct {
 	// When set, the agent will automatically retry failed ChatModel calls
 	// based on the configured policy.
 	// Optional. If nil, no retry will be performed.
-	ModelRetryConfig *ModelRetryConfig
+	ModelRetryConfig *TypedModelRetryConfig[M]
 
 	// ModelFailoverConfig configures failover behavior for the ChatModel.
 	// When set, the agent will first try the last successful model (initially the configured Model),
 	// and on failure, call GetFailoverModel to select alternate models.
 	// Model field is still required as it serves as the initial model.
 	// Optional. If nil, no failover will be performed.
-	ModelFailoverConfig *ModelFailoverConfig
+	ModelFailoverConfig *TypedModelFailoverConfig[M]
 }
 
 type ChatModelAgentConfig = TypedChatModelAgentConfig[*schema.Message]
@@ -455,8 +455,8 @@ type TypedChatModelAgent[M messageType] struct {
 	handlers    []TypedChatModelAgentMiddleware[M]
 	middlewares []AgentMiddleware
 
-	modelRetryConfig    *ModelRetryConfig
-	modelFailoverConfig *ModelFailoverConfig
+	modelRetryConfig    *TypedModelRetryConfig[M]
+	modelFailoverConfig *TypedModelFailoverConfig[M]
 
 	once   sync.Once
 	run    typedRunFunc[M]
@@ -1085,8 +1085,8 @@ func (a *TypedChatModelAgent[M]) buildMessageReActRunFunc(ctx context.Context, b
 		modelWrapperConf: &modelWrapperConfig{
 			handlers:       msgHandlers,
 			middlewares:    a.middlewares,
-			retryConfig:    a.modelRetryConfig,
-			failoverConfig: a.modelFailoverConfig,
+			retryConfig:    any(a.modelRetryConfig).(*ModelRetryConfig),
+			failoverConfig: any(a.modelFailoverConfig).(*ModelFailoverConfig),
 			toolInfos:      bc.toolInfos,
 		},
 		toolsReturnDirectly: bc.returnDirectly,
@@ -1216,7 +1216,7 @@ func (a *TypedChatModelAgent[M]) buildAgenticReActRunFunc(ctx context.Context, b
 		modelWrapperConf: &typedModelWrapperConfig[*schema.AgenticMessage]{
 			handlers:    agenticHandlers,
 			middlewares: a.middlewares,
-			retryConfig: a.modelRetryConfig,
+			retryConfig: any(a.modelRetryConfig).(*TypedModelRetryConfig[*schema.AgenticMessage]),
 			toolInfos:   bc.toolInfos,
 		},
 		toolsReturnDirectly: bc.returnDirectly,

--- a/adk/chatmodel.go
+++ b/adk/chatmodel.go
@@ -42,7 +42,7 @@ import (
 var _ ResumableAgent = &TypedChatModelAgent[*schema.Message]{}
 var _ TypedResumableAgent[*schema.AgenticMessage] = &TypedChatModelAgent[*schema.AgenticMessage]{}
 
-type typedChatModelAgentExecCtx[M messageType] struct {
+type typedChatModelAgentExecCtx[M MessageType] struct {
 	runtimeReturnDirectly map[string]bool
 	generator             *AsyncGenerator[*TypedAgentEvent[M]]
 	cancelCtx             *cancelContext
@@ -70,13 +70,13 @@ func (e *typedChatModelAgentExecCtx[M]) send(event *TypedAgentEvent[M]) {
 
 type chatModelAgentExecCtx = typedChatModelAgentExecCtx[*schema.Message]
 
-type typedChatModelAgentExecCtxKey[M messageType] struct{}
+type typedChatModelAgentExecCtxKey[M MessageType] struct{}
 
-func withTypedChatModelAgentExecCtx[M messageType](ctx context.Context, execCtx *typedChatModelAgentExecCtx[M]) context.Context {
+func withTypedChatModelAgentExecCtx[M MessageType](ctx context.Context, execCtx *typedChatModelAgentExecCtx[M]) context.Context {
 	return context.WithValue(ctx, typedChatModelAgentExecCtxKey[M]{}, execCtx)
 }
 
-func getTypedChatModelAgentExecCtx[M messageType](ctx context.Context) *typedChatModelAgentExecCtx[M] {
+func getTypedChatModelAgentExecCtx[M MessageType](ctx context.Context) *typedChatModelAgentExecCtx[M] {
 	if v := ctx.Value(typedChatModelAgentExecCtxKey[M]{}); v != nil {
 		return v.(*typedChatModelAgentExecCtx[M])
 	}
@@ -160,7 +160,7 @@ type ToolsConfig struct {
 // messages ([]M). This is the primary customization point for controlling what the model sees.
 // The default implementation prepends a system message (if instruction is non-empty),
 // followed by the user's input messages.
-type TypedGenModelInput[M messageType] func(ctx context.Context, instruction string, input *TypedAgentInput[M]) ([]M, error)
+type TypedGenModelInput[M MessageType] func(ctx context.Context, instruction string, input *TypedAgentInput[M]) ([]M, error)
 
 // GenModelInput transforms agent instructions and input into a format suitable for the model.
 type GenModelInput = TypedGenModelInput[*schema.Message]
@@ -193,7 +193,7 @@ func defaultGenModelInput(ctx context.Context, instruction string, input *AgentI
 	return msgs, nil
 }
 
-func newDefaultGenModelInput[M messageType]() TypedGenModelInput[M] {
+func newDefaultGenModelInput[M MessageType]() TypedGenModelInput[M] {
 	var zero M
 	switch any(zero).(type) {
 	case *schema.Message:
@@ -208,13 +208,13 @@ func newDefaultGenModelInput[M messageType]() TypedGenModelInput[M] {
 			return msgs, nil
 		})).(TypedGenModelInput[M])
 	default:
-		panic("unreachable: unknown messageType")
+		panic("unreachable: unknown MessageType")
 	}
 }
 
 // TypedChatModelAgentState represents the state of a chat model agent during conversation.
 // This is the primary state type for both TypedChatModelAgentMiddleware and AgentMiddleware callbacks.
-type TypedChatModelAgentState[M messageType] struct {
+type TypedChatModelAgentState[M MessageType] struct {
 	// Messages contains all messages in the current conversation session.
 	Messages []M
 
@@ -266,7 +266,7 @@ type AgentMiddleware struct {
 }
 
 // TypedChatModelAgentConfig is the generic configuration for ChatModelAgent.
-type TypedChatModelAgentConfig[M messageType] struct {
+type TypedChatModelAgentConfig[M MessageType] struct {
 	// Name of the agent. Better be unique across all agents.
 	// Optional. If empty, the agent can still run standalone but cannot be used as
 	// a sub-agent tool via NewAgentTool (which requires a non-empty Name).
@@ -432,7 +432,7 @@ type ChatModelAgentConfig = TypedChatModelAgentConfig[*schema.Message]
 // For M = *schema.AgenticMessage, a single-shot chain is used since agentic models
 // handle tool calling internally. Cancel monitoring and retry on the model stream
 // are not yet supported for agentic models.
-type TypedChatModelAgent[M messageType] struct {
+type TypedChatModelAgent[M MessageType] struct {
 	name        string
 	description string
 	instruction string
@@ -467,7 +467,7 @@ type TypedChatModelAgent[M messageType] struct {
 type ChatModelAgent = TypedChatModelAgent[*schema.Message]
 
 // typedRunParams holds the parameters for a typedRunFunc invocation.
-type typedRunParams[M messageType] struct {
+type typedRunParams[M MessageType] struct {
 	input          *TypedAgentInput[M]
 	generator      *AsyncGenerator[*TypedAgentEvent[M]]
 	store          *bridgeStore
@@ -480,7 +480,7 @@ type typedRunParams[M messageType] struct {
 	afterToolCallsHook func(ctx context.Context) error
 }
 
-type typedRunFunc[M messageType] func(ctx context.Context, p *typedRunParams[M])
+type typedRunFunc[M MessageType] func(ctx context.Context, p *typedRunParams[M])
 
 // NewChatModelAgent creates a new ChatModelAgent with the given config.
 func NewChatModelAgent(ctx context.Context, config *ChatModelAgentConfig) (*ChatModelAgent, error) {
@@ -488,7 +488,7 @@ func NewChatModelAgent(ctx context.Context, config *ChatModelAgentConfig) (*Chat
 }
 
 // NewTypedChatModelAgent creates a new TypedChatModelAgent with the given config.
-func NewTypedChatModelAgent[M messageType](ctx context.Context, config *TypedChatModelAgentConfig[M]) (*TypedChatModelAgent[M], error) {
+func NewTypedChatModelAgent[M MessageType](ctx context.Context, config *TypedChatModelAgentConfig[M]) (*TypedChatModelAgent[M], error) {
 	if config.ModelFailoverConfig != nil {
 		if config.ModelFailoverConfig.GetFailoverModel == nil {
 			return nil, errors.New("ModelFailoverConfig.GetFailoverModel is required when ModelFailoverConfig is set")
@@ -732,7 +732,7 @@ func init() {
 	schema.RegisterName[*ChatModelAgentInterruptInfo]("_eino_adk_chat_model_agent_interrupt_info")
 }
 
-func extractTextContent[M messageType](msg M) string {
+func extractTextContent[M MessageType](msg M) string {
 	switch v := any(msg).(type) {
 	case *schema.Message:
 		return v.Content
@@ -749,7 +749,7 @@ func extractTextContent[M messageType](msg M) string {
 	}
 }
 
-func setOutputToSession[M messageType](ctx context.Context, msg M, msgStream *schema.StreamReader[M], outputKey string) error {
+func setOutputToSession[M MessageType](ctx context.Context, msg M, msgStream *schema.StreamReader[M], outputKey string) error {
 	if !isNilMessage(msg) {
 		AddSessionValue(ctx, outputKey, extractTextContent(msg))
 		return nil
@@ -764,7 +764,7 @@ func setOutputToSession[M messageType](ctx context.Context, msg M, msgStream *sc
 	return nil
 }
 
-func typedErrFunc[M messageType](err error) typedRunFunc[M] {
+func typedErrFunc[M MessageType](err error) typedRunFunc[M] {
 	return func(ctx context.Context, p *typedRunParams[M]) {
 		p.generator.Send(&TypedAgentEvent[M]{Err: err})
 	}
@@ -945,12 +945,12 @@ func (a *TypedChatModelAgent[M]) handleRunFuncError(
 	generator.Send(&TypedAgentEvent[M]{Err: err})
 }
 
-type typedNoToolsInput[M messageType] struct {
+type typedNoToolsInput[M MessageType] struct {
 	input       *TypedAgentInput[M]
 	instruction string
 }
 
-func appendModelToChain[I, O any, M messageType](chain *compose.Chain[I, O], m model.BaseModel[M]) {
+func appendModelToChain[I, O any, M MessageType](chain *compose.Chain[I, O], m model.BaseModel[M]) {
 	var zero M
 	switch any(zero).(type) {
 	case *schema.Message:

--- a/adk/chatmodel_retry_test.go
+++ b/adk/chatmodel_retry_test.go
@@ -3083,3 +3083,134 @@ func TestAttack_ShouldRetry_Stream_MidStreamError_VerdictDoubleRead(t *testing.T
 		t.Fatal("goroutine leak: onEOF blocked on signal.ch after errWrapper already drained the verdict")
 	}
 }
+
+type rejectReasonTestModel struct {
+	streamFn func(ctx context.Context, input []*schema.Message, opts ...model.Option) (*schema.StreamReader[*schema.Message], error)
+}
+
+func (m *rejectReasonTestModel) Generate(_ context.Context, _ []*schema.Message, _ ...model.Option) (*schema.Message, error) {
+	return schema.AssistantMessage("generated", nil), nil
+}
+
+func (m *rejectReasonTestModel) Stream(ctx context.Context, input []*schema.Message, opts ...model.Option) (*schema.StreamReader[*schema.Message], error) {
+	return m.streamFn(ctx, input, opts...)
+}
+
+func TestRejectReason_StreamPath(t *testing.T) {
+	ctx := context.Background()
+
+	type rejectInfo struct {
+		Reason  string
+		Attempt int
+	}
+
+	streamErr := errors.New("bad output")
+	var streamCallCount int32
+
+	m := &rejectReasonTestModel{
+		streamFn: func(_ context.Context, _ []*schema.Message, _ ...model.Option) (*schema.StreamReader[*schema.Message], error) {
+			n := atomic.AddInt32(&streamCallCount, 1)
+			if n == 1 {
+				return streamWithMidError(
+					[]*schema.Message{schema.AssistantMessage("rejected chunk", nil)},
+					streamErr,
+				), nil
+			}
+			sr, sw := schema.Pipe[*schema.Message](1)
+			go func() {
+				defer sw.Close()
+				sw.Send(schema.AssistantMessage("accepted", nil), nil)
+			}()
+			return sr, nil
+		},
+	}
+
+	agent, err := NewChatModelAgent(ctx, &ChatModelAgentConfig{
+		Name:        "reject-reason-agent",
+		Description: "test reject reason",
+		Instruction: "test",
+		Model:       m,
+		ModelRetryConfig: &ModelRetryConfig{
+			MaxRetries: 1,
+			ShouldRetry: func(_ context.Context, retryCtx *RetryContext) *RetryDecision {
+				if retryCtx.Err != nil {
+					return &RetryDecision{
+						Retry: true,
+						RejectReason: rejectInfo{
+							Reason:  "output quality too low",
+							Attempt: retryCtx.RetryAttempt,
+						},
+					}
+				}
+				return nil
+			},
+			BackoffFunc: func(_ context.Context, _ int) time.Duration { return time.Millisecond },
+		},
+	})
+	require.NoError(t, err)
+
+	input := &AgentInput{
+		Messages:       []Message{schema.UserMessage("hello")},
+		EnableStreaming: true,
+	}
+	ctx, _ = initRunCtx(ctx, agent.Name(ctx), input)
+	iter := agent.Run(ctx, input)
+
+	var capturedRejectReasons []any
+	var finalContent string
+	for {
+		ev, ok := iter.Next()
+		if !ok {
+			break
+		}
+		if ev.Err != nil {
+			continue
+		}
+		if ev.Output != nil && ev.Output.MessageOutput != nil && ev.Output.MessageOutput.IsStreaming {
+			sr := ev.Output.MessageOutput.MessageStream
+			for {
+				chunk, recvErr := sr.Recv()
+				if recvErr != nil {
+					var willRetry *WillRetryError
+					if errors.As(recvErr, &willRetry) {
+						capturedRejectReasons = append(capturedRejectReasons, willRetry.RejectReason())
+					}
+					break
+				}
+				if chunk != nil {
+					finalContent = chunk.Content
+				}
+			}
+		}
+	}
+
+	assert.Contains(t, finalContent, "accepted")
+	require.NotEmpty(t, capturedRejectReasons, "should have at least one WillRetryError with RejectReason from stream Recv()")
+	for _, reason := range capturedRejectReasons {
+		require.NotNil(t, reason)
+		ri, ok := reason.(rejectInfo)
+		require.True(t, ok, "RejectReason should be rejectInfo type, got %T", reason)
+		assert.Equal(t, "output quality too low", ri.Reason)
+		assert.Equal(t, 1, ri.Attempt)
+	}
+}
+
+func TestWillRetryError_RejectReason(t *testing.T) {
+	t.Run("nil when not set", func(t *testing.T) {
+		wre := &WillRetryError{ErrStr: "test", RetryAttempt: 1, err: errors.New("test")}
+		assert.Nil(t, wre.RejectReason(), "RejectReason should be nil when not set")
+	})
+
+	t.Run("returns value when set", func(t *testing.T) {
+		reason := map[string]string{"key": "value"}
+		wre := &WillRetryError{
+			ErrStr:       "rejected",
+			RetryAttempt: 2,
+			rejectReason: reason,
+			err:          errors.New("inner"),
+		}
+		assert.Equal(t, reason, wre.RejectReason())
+		assert.Equal(t, "rejected", wre.Error())
+		assert.Equal(t, 2, wre.RetryAttempt)
+	})
+}

--- a/adk/chatmodel_retry_test.go
+++ b/adk/chatmodel_retry_test.go
@@ -3197,20 +3197,20 @@ func TestRejectReason_StreamPath(t *testing.T) {
 
 func TestWillRetryError_RejectReason(t *testing.T) {
 	t.Run("nil when not set", func(t *testing.T) {
-		wre := &WillRetryError{ErrStr: "test", RetryAttempt: 1, err: errors.New("test")}
-		assert.Nil(t, wre.RejectReason(), "RejectReason should be nil when not set")
+		wrErr := &WillRetryError{ErrStr: "test", RetryAttempt: 1, err: errors.New("test")}
+		assert.Nil(t, wrErr.RejectReason(), "RejectReason should be nil when not set")
 	})
 
 	t.Run("returns value when set", func(t *testing.T) {
 		reason := map[string]string{"key": "value"}
-		wre := &WillRetryError{
+		wrErr := &WillRetryError{
 			ErrStr:       "rejected",
 			RetryAttempt: 2,
 			rejectReason: reason,
 			err:          errors.New("inner"),
 		}
-		assert.Equal(t, reason, wre.RejectReason())
-		assert.Equal(t, "rejected", wre.Error())
-		assert.Equal(t, 2, wre.RetryAttempt)
+		assert.Equal(t, reason, wrErr.RejectReason())
+		assert.Equal(t, "rejected", wrErr.Error())
+		assert.Equal(t, 2, wrErr.RetryAttempt)
 	})
 }

--- a/adk/chatmodel_retry_test.go
+++ b/adk/chatmodel_retry_test.go
@@ -3007,7 +3007,7 @@ func TestAttack_ShouldRetry_ConcatMessagesFails_EmptyStream(t *testing.T) {
 	}
 
 	require.NotNil(t, capturedCtx)
-	assert.Nil(t, capturedCtx.OutputMessage, "empty stream should have nil OutputMessage")
+	assert.NotNil(t, capturedCtx.OutputMessage, "empty stream should have non-nil OutputMessage from ConcatMessages")
 	assert.Nil(t, capturedCtx.Err, "empty stream should have nil Err")
 }
 

--- a/adk/chatmodel_test.go
+++ b/adk/chatmodel_test.go
@@ -2077,7 +2077,7 @@ func TestNewChatModelAgent_FailoverConfigValidation(t *testing.T) {
 			Name:        "TestAgent",
 			Description: "test",
 			Model:       cm,
-			ModelFailoverConfig: &ModelFailoverConfig{
+			ModelFailoverConfig: &ModelFailoverConfig[*schema.Message]{
 				ShouldFailover: func(context.Context, *schema.Message, error) bool { return true },
 			},
 		})
@@ -2090,8 +2090,8 @@ func TestNewChatModelAgent_FailoverConfigValidation(t *testing.T) {
 			Name:        "TestAgent",
 			Description: "test",
 			Model:       cm,
-			ModelFailoverConfig: &ModelFailoverConfig{
-				GetFailoverModel: func(_ context.Context, _ *FailoverContext) (model.BaseChatModel, []*schema.Message, error) {
+			ModelFailoverConfig: &ModelFailoverConfig[*schema.Message]{
+				GetFailoverModel: func(_ context.Context, _ *FailoverContext[*schema.Message]) (model.BaseChatModel, []*schema.Message, error) {
 					return cm, nil, nil
 				},
 			},

--- a/adk/failover_chatmodel.go
+++ b/adk/failover_chatmodel.go
@@ -123,18 +123,18 @@ func (m *typedFailoverProxyModel[M]) GetType() string {
 
 type failoverProxyModel = typedFailoverProxyModel[*schema.Message]
 
-// FailoverContext contains context information during failover process.
-type FailoverContext struct {
+// TypedFailoverContext contains context information during failover process.
+type TypedFailoverContext[M messageType] struct {
 	// FailoverAttempt is the current failover attempt number, starting from 1.
 	FailoverAttempt uint
 
 	// InputMessages is the original input messages before any transformation.
-	InputMessages []*schema.Message
+	InputMessages []M
 
 	// LastOutputMessage is the output message from the last failed attempt.
 	// May be nil if no output was produced. For streaming, this may be a partial message
 	// already received before the stream error.
-	LastOutputMessage *schema.Message
+	LastOutputMessage M
 
 	// LastErr is the error from the last failed attempt that triggered this failover.
 	//
@@ -144,10 +144,13 @@ type FailoverContext struct {
 	LastErr error
 }
 
-// ModelFailoverConfig configures failover behavior for ChatModel.
+// FailoverContext is the default failover context type using *schema.Message.
+type FailoverContext = TypedFailoverContext[*schema.Message]
+
+// TypedModelFailoverConfig configures failover behavior for ChatModel.
 // When configured, each ChatModel call first tries the last successful model (initially the configured Model),
 // and if that fails, calls GetFailoverModel to select alternate models.
-type ModelFailoverConfig struct {
+type TypedModelFailoverConfig[M messageType] struct {
 	// MaxRetries specifies the maximum number of failover attempts.
 	//
 	// When failover is triggered, GetFailoverModel will be called up to MaxRetries times
@@ -162,24 +165,19 @@ type ModelFailoverConfig struct {
 	MaxRetries uint
 
 	// ShouldFailover determines whether to fail over to the next model when an error occurs.
-	// It receives the output message (may be nil if no output is available) and the error (non-nil on failure).
+	// It receives the output message (may be nil/zero if no output is available) and the error (non-nil on failure).
 	// For streaming errors, outputMessage can carry a partial message accumulated before the error.
 	//
 	// Note: When ModelRetryConfig is also configured, outputErr will be a *RetryExhaustedError
 	// (if retries were exhausted) rather than the original model error. Use errors.As to extract
-	// the RetryExhaustedError and access RetryExhaustedError.LastErr for the original error:
-	//
-	//   var retryErr *adk.RetryExhaustedError
-	//   if errors.As(outputErr, &retryErr) {
-	//       // retryErr.LastErr contains the original model error
-	//   }
+	// the RetryExhaustedError and access RetryExhaustedError.LastErr for the original error.
 	//
 	// Note: When the context itself is cancelled (ctx.Err() != nil), failover will stop immediately
 	// regardless of this function. However, if the model returns context.Canceled or context.DeadlineExceeded
 	// as an error while the context is still active, this function will still be called.
 	// Should not be nil when ModelFailoverConfig is set.
 	// Return true to fail over to the next model, false to stop and return the current result/error.
-	ShouldFailover func(ctx context.Context, outputMessage *schema.Message, outputErr error) bool
+	ShouldFailover func(ctx context.Context, outputMessage M, outputErr error) bool
 
 	// GetFailoverModel is called when a model call fails and ShouldFailover returns true.
 	// It selects the next model to use for the failover attempt and optionally transforms input messages.
@@ -189,9 +187,12 @@ type ModelFailoverConfig struct {
 	//   - failoverModelInputMessages: The transformed input messages for the failover model. If nil, will use original input.
 	//   - failoverErr: If non-nil, failover stops and this error is returned.
 	// Should not be nil when ModelFailoverConfig is set via ChatModelAgentConfig.
-	GetFailoverModel func(ctx context.Context, failoverCtx *FailoverContext) (
-		failoverModel model.BaseChatModel, failoverModelInputMessages []*schema.Message, failoverErr error)
+	GetFailoverModel func(ctx context.Context, failoverCtx *TypedFailoverContext[M]) (
+		failoverModel model.BaseModel[M], failoverModelInputMessages []M, failoverErr error)
 }
+
+// ModelFailoverConfig is the default failover config type using *schema.Message.
+type ModelFailoverConfig = TypedModelFailoverConfig[*schema.Message]
 
 func typedGetFailoverLastSuccessModel[M messageType](ctx context.Context) model.BaseModel[M] {
 	execCtx := getTypedChatModelAgentExecCtx[M](ctx)
@@ -208,13 +209,13 @@ func typedSetFailoverLastSuccessModel[M messageType](ctx context.Context, m mode
 }
 
 type typedFailoverModelWrapper[M messageType] struct {
-	config *ModelFailoverConfig
+	config *TypedModelFailoverConfig[M]
 	inner  model.BaseModel[M]
 }
 
 type failoverModelWrapper = typedFailoverModelWrapper[*schema.Message]
 
-func newTypedFailoverModelWrapper[M messageType](inner model.BaseModel[M], config *ModelFailoverConfig) *typedFailoverModelWrapper[M] {
+func newTypedFailoverModelWrapper[M messageType](inner model.BaseModel[M], config *TypedModelFailoverConfig[M]) *typedFailoverModelWrapper[M] {
 	return &typedFailoverModelWrapper[M]{
 		config: config,
 		inner:  inner,
@@ -233,32 +234,18 @@ func (f *typedFailoverModelWrapper[M]) needFailover(ctx context.Context, outputM
 	}
 
 	// ShouldFailover is validated at agent construction; nil here indicates a programmer error.
-	schemaMsg, _ := any(outputMessage).(*schema.Message)
-	return f.config.ShouldFailover(ctx, schemaMsg, outputErr)
+	return f.config.ShouldFailover(ctx, outputMessage, outputErr)
 }
 
-func (f *typedFailoverModelWrapper[M]) getFailoverModel(ctx context.Context, failoverCtx *FailoverContext) (model.BaseModel[M], []M, error) {
-	chatModel, msgs, err := f.config.GetFailoverModel(ctx, failoverCtx)
+func (f *typedFailoverModelWrapper[M]) getFailoverModel(ctx context.Context, failoverCtx *TypedFailoverContext[M]) (model.BaseModel[M], []M, error) {
+	currentModel, msgs, err := f.config.GetFailoverModel(ctx, failoverCtx)
 	if err != nil {
 		return nil, nil, err
 	}
-	if chatModel == nil {
+	if currentModel == nil {
 		return nil, nil, nil
 	}
-
-	typedModel, ok := any(chatModel).(model.BaseModel[M])
-	if !ok {
-		return nil, nil, fmt.Errorf("failover GetFailoverModel returned model of type %T, expected model.BaseModel[%T]", chatModel, *new(M))
-	}
-
-	var typedMsgs []M
-	if msgs != nil {
-		if m, ok := any(msgs).([]M); ok {
-			typedMsgs = m
-		}
-	}
-
-	return typedModel, typedMsgs, nil
+	return currentModel, msgs, nil
 }
 
 func (f *typedFailoverModelWrapper[M]) Generate(ctx context.Context, input []M, opts ...model.Option) (M, error) {
@@ -300,12 +287,10 @@ func (f *typedFailoverModelWrapper[M]) Generate(ctx context.Context, input []M, 
 			return zero, err
 		}
 
-		inputMsgs, _ := any(input).([]*schema.Message)
-		lastOutputMsg, _ := any(lastOutputMessage).(*schema.Message)
-		failoverCtx := &FailoverContext{
+		failoverCtx := &TypedFailoverContext[M]{
 			FailoverAttempt:   attempt,
-			InputMessages:     inputMsgs,
-			LastOutputMessage: lastOutputMsg,
+			InputMessages:     input,
+			LastOutputMessage: lastOutputMessage,
 			LastErr:           lastErr,
 		}
 
@@ -398,12 +383,10 @@ func (f *typedFailoverModelWrapper[M]) Stream(ctx context.Context, input []M, op
 			return nil, err
 		}
 
-		inputMsgs2, _ := any(input).([]*schema.Message)
-		lastOutputMsg2, _ := any(lastOutputMessage).(*schema.Message)
-		failoverCtx := &FailoverContext{
+		failoverCtx := &TypedFailoverContext[M]{
 			FailoverAttempt:   attempt,
-			InputMessages:     inputMsgs2,
-			LastOutputMessage: lastOutputMsg2,
+			InputMessages:     input,
+			LastOutputMessage: lastOutputMessage,
 			LastErr:           lastErr,
 		}
 
@@ -493,6 +476,9 @@ func typedConsumeStream[M messageType](stream *schema.StreamReader[M]) (M, error
 				break
 			}
 			if err != nil {
+				if len(chunks) == 0 {
+					return zero, err
+				}
 				msg, _ := schema.ConcatMessages(chunks)
 				if msg != nil {
 					return any(msg).(M), err
@@ -500,6 +486,9 @@ func typedConsumeStream[M messageType](stream *schema.StreamReader[M]) (M, error
 				return zero, err
 			}
 			chunks = append(chunks, chunk)
+		}
+		if len(chunks) == 0 {
+			return zero, nil
 		}
 		msg, _ := schema.ConcatMessages(chunks)
 		if msg != nil {
@@ -514,6 +503,9 @@ func typedConsumeStream[M messageType](stream *schema.StreamReader[M]) (M, error
 				break
 			}
 			if err != nil {
+				if len(chunks) == 0 {
+					return zero, err
+				}
 				msg, _ := schema.ConcatAgenticMessages(chunks)
 				if msg != nil {
 					return any(msg).(M), err
@@ -521,6 +513,9 @@ func typedConsumeStream[M messageType](stream *schema.StreamReader[M]) (M, error
 				return zero, err
 			}
 			chunks = append(chunks, chunk)
+		}
+		if len(chunks) == 0 {
+			return zero, nil
 		}
 		msg, _ := schema.ConcatAgenticMessages(chunks)
 		if msg != nil {

--- a/adk/failover_chatmodel.go
+++ b/adk/failover_chatmodel.go
@@ -31,11 +31,11 @@ import (
 
 type failoverCurrentModelKey struct{}
 
-func typedSetFailoverCurrentModel[M messageType](ctx context.Context, currentModel model.BaseModel[M]) context.Context {
+func typedSetFailoverCurrentModel[M MessageType](ctx context.Context, currentModel model.BaseModel[M]) context.Context {
 	return context.WithValue(ctx, failoverCurrentModelKey{}, currentModel)
 }
 
-func typedGetFailoverCurrentModel[M messageType](ctx context.Context) (model.BaseModel[M], bool) {
+func typedGetFailoverCurrentModel[M MessageType](ctx context.Context) (model.BaseModel[M], bool) {
 	m, ok := ctx.Value(failoverCurrentModelKey{}).(model.BaseModel[M])
 	return m, ok
 }
@@ -56,7 +56,7 @@ func getFailoverHasMoreAttempts(ctx context.Context) bool {
 	return v
 }
 
-type typedFailoverProxyModel[M messageType] struct {
+type typedFailoverProxyModel[M MessageType] struct {
 }
 
 func (m *typedFailoverProxyModel[M]) prepareCallbacks(ctx context.Context) (context.Context, model.BaseModel[M], error) {
@@ -124,7 +124,7 @@ func (m *typedFailoverProxyModel[M]) GetType() string {
 type failoverProxyModel = typedFailoverProxyModel[*schema.Message]
 
 // TypedFailoverContext contains context information during failover process.
-type TypedFailoverContext[M messageType] struct {
+type TypedFailoverContext[M MessageType] struct {
 	// FailoverAttempt is the current failover attempt number, starting from 1.
 	FailoverAttempt uint
 
@@ -150,7 +150,7 @@ type FailoverContext = TypedFailoverContext[*schema.Message]
 // TypedModelFailoverConfig configures failover behavior for ChatModel.
 // When configured, each ChatModel call first tries the last successful model (initially the configured Model),
 // and if that fails, calls GetFailoverModel to select alternate models.
-type TypedModelFailoverConfig[M messageType] struct {
+type TypedModelFailoverConfig[M MessageType] struct {
 	// MaxRetries specifies the maximum number of failover attempts.
 	//
 	// When failover is triggered, GetFailoverModel will be called up to MaxRetries times
@@ -194,7 +194,7 @@ type TypedModelFailoverConfig[M messageType] struct {
 // ModelFailoverConfig is the default failover config type using *schema.Message.
 type ModelFailoverConfig = TypedModelFailoverConfig[*schema.Message]
 
-func typedGetFailoverLastSuccessModel[M messageType](ctx context.Context) model.BaseModel[M] {
+func typedGetFailoverLastSuccessModel[M MessageType](ctx context.Context) model.BaseModel[M] {
 	execCtx := getTypedChatModelAgentExecCtx[M](ctx)
 	if execCtx == nil {
 		return nil
@@ -202,20 +202,20 @@ func typedGetFailoverLastSuccessModel[M messageType](ctx context.Context) model.
 	return execCtx.failoverLastSuccessModel
 }
 
-func typedSetFailoverLastSuccessModel[M messageType](ctx context.Context, m model.BaseModel[M]) {
+func typedSetFailoverLastSuccessModel[M MessageType](ctx context.Context, m model.BaseModel[M]) {
 	if execCtx := getTypedChatModelAgentExecCtx[M](ctx); execCtx != nil {
 		execCtx.failoverLastSuccessModel = m
 	}
 }
 
-type typedFailoverModelWrapper[M messageType] struct {
+type typedFailoverModelWrapper[M MessageType] struct {
 	config *TypedModelFailoverConfig[M]
 	inner  model.BaseModel[M]
 }
 
 type failoverModelWrapper = typedFailoverModelWrapper[*schema.Message]
 
-func newTypedFailoverModelWrapper[M messageType](inner model.BaseModel[M], config *TypedModelFailoverConfig[M]) *typedFailoverModelWrapper[M] {
+func newTypedFailoverModelWrapper[M MessageType](inner model.BaseModel[M], config *TypedModelFailoverConfig[M]) *typedFailoverModelWrapper[M] {
 	return &typedFailoverModelWrapper[M]{
 		config: config,
 		inner:  inner,
@@ -463,7 +463,7 @@ func (f *typedFailoverModelWrapper[M]) Stream(ctx context.Context, input []M, op
 	return nil, lastErr
 }
 
-func typedConsumeStream[M messageType](stream *schema.StreamReader[M]) (M, error) {
+func typedConsumeStream[M MessageType](stream *schema.StreamReader[M]) (M, error) {
 	var zero M
 	defer stream.Close()
 
@@ -476,9 +476,6 @@ func typedConsumeStream[M messageType](stream *schema.StreamReader[M]) (M, error
 				break
 			}
 			if err != nil {
-				if len(chunks) == 0 {
-					return zero, err
-				}
 				msg, _ := schema.ConcatMessages(chunks)
 				if msg != nil {
 					return any(msg).(M), err
@@ -486,9 +483,6 @@ func typedConsumeStream[M messageType](stream *schema.StreamReader[M]) (M, error
 				return zero, err
 			}
 			chunks = append(chunks, chunk)
-		}
-		if len(chunks) == 0 {
-			return zero, nil
 		}
 		msg, _ := schema.ConcatMessages(chunks)
 		if msg != nil {
@@ -503,9 +497,6 @@ func typedConsumeStream[M messageType](stream *schema.StreamReader[M]) (M, error
 				break
 			}
 			if err != nil {
-				if len(chunks) == 0 {
-					return zero, err
-				}
 				msg, _ := schema.ConcatAgenticMessages(chunks)
 				if msg != nil {
 					return any(msg).(M), err
@@ -514,15 +505,12 @@ func typedConsumeStream[M messageType](stream *schema.StreamReader[M]) (M, error
 			}
 			chunks = append(chunks, chunk)
 		}
-		if len(chunks) == 0 {
-			return zero, nil
-		}
 		msg, _ := schema.ConcatAgenticMessages(chunks)
 		if msg != nil {
 			return any(msg).(M), nil
 		}
 		return zero, nil
 	default:
-		panic("unreachable: unknown messageType")
+		panic("unreachable: unknown MessageType")
 	}
 }

--- a/adk/failover_chatmodel.go
+++ b/adk/failover_chatmodel.go
@@ -123,8 +123,8 @@ func (m *typedFailoverProxyModel[M]) GetType() string {
 
 type failoverProxyModel = typedFailoverProxyModel[*schema.Message]
 
-// TypedFailoverContext contains context information during failover process.
-type TypedFailoverContext[M MessageType] struct {
+// FailoverContext contains context information during failover process.
+type FailoverContext[M MessageType] struct {
 	// FailoverAttempt is the current failover attempt number, starting from 1.
 	FailoverAttempt uint
 
@@ -144,13 +144,10 @@ type TypedFailoverContext[M MessageType] struct {
 	LastErr error
 }
 
-// FailoverContext is the default failover context type using *schema.Message.
-type FailoverContext = TypedFailoverContext[*schema.Message]
-
-// TypedModelFailoverConfig configures failover behavior for ChatModel.
+// ModelFailoverConfig configures failover behavior for ChatModel.
 // When configured, each ChatModel call first tries the last successful model (initially the configured Model),
 // and if that fails, calls GetFailoverModel to select alternate models.
-type TypedModelFailoverConfig[M MessageType] struct {
+type ModelFailoverConfig[M MessageType] struct {
 	// MaxRetries specifies the maximum number of failover attempts.
 	//
 	// When failover is triggered, GetFailoverModel will be called up to MaxRetries times
@@ -187,12 +184,9 @@ type TypedModelFailoverConfig[M MessageType] struct {
 	//   - failoverModelInputMessages: The transformed input messages for the failover model. If nil, will use original input.
 	//   - failoverErr: If non-nil, failover stops and this error is returned.
 	// Should not be nil when ModelFailoverConfig is set via ChatModelAgentConfig.
-	GetFailoverModel func(ctx context.Context, failoverCtx *TypedFailoverContext[M]) (
+	GetFailoverModel func(ctx context.Context, failoverCtx *FailoverContext[M]) (
 		failoverModel model.BaseModel[M], failoverModelInputMessages []M, failoverErr error)
 }
-
-// ModelFailoverConfig is the default failover config type using *schema.Message.
-type ModelFailoverConfig = TypedModelFailoverConfig[*schema.Message]
 
 func typedGetFailoverLastSuccessModel[M MessageType](ctx context.Context) model.BaseModel[M] {
 	execCtx := getTypedChatModelAgentExecCtx[M](ctx)
@@ -208,21 +202,19 @@ func typedSetFailoverLastSuccessModel[M MessageType](ctx context.Context, m mode
 	}
 }
 
-type typedFailoverModelWrapper[M MessageType] struct {
-	config *TypedModelFailoverConfig[M]
+type failoverModelWrapper[M MessageType] struct {
+	config *ModelFailoverConfig[M]
 	inner  model.BaseModel[M]
 }
 
-type failoverModelWrapper = typedFailoverModelWrapper[*schema.Message]
-
-func newTypedFailoverModelWrapper[M MessageType](inner model.BaseModel[M], config *TypedModelFailoverConfig[M]) *typedFailoverModelWrapper[M] {
-	return &typedFailoverModelWrapper[M]{
+func newFailoverModelWrapper[M MessageType](inner model.BaseModel[M], config *ModelFailoverConfig[M]) *failoverModelWrapper[M] {
+	return &failoverModelWrapper[M]{
 		config: config,
 		inner:  inner,
 	}
 }
 
-func (f *typedFailoverModelWrapper[M]) needFailover(ctx context.Context, outputMessage M, outputErr error) bool {
+func (f *failoverModelWrapper[M]) needFailover(ctx context.Context, outputMessage M, outputErr error) bool {
 	if ctx.Err() != nil {
 		return false
 	}
@@ -237,7 +229,7 @@ func (f *typedFailoverModelWrapper[M]) needFailover(ctx context.Context, outputM
 	return f.config.ShouldFailover(ctx, outputMessage, outputErr)
 }
 
-func (f *typedFailoverModelWrapper[M]) getFailoverModel(ctx context.Context, failoverCtx *TypedFailoverContext[M]) (model.BaseModel[M], []M, error) {
+func (f *failoverModelWrapper[M]) getFailoverModel(ctx context.Context, failoverCtx *FailoverContext[M]) (model.BaseModel[M], []M, error) {
 	currentModel, msgs, err := f.config.GetFailoverModel(ctx, failoverCtx)
 	if err != nil {
 		return nil, nil, err
@@ -248,7 +240,7 @@ func (f *typedFailoverModelWrapper[M]) getFailoverModel(ctx context.Context, fai
 	return currentModel, msgs, nil
 }
 
-func (f *typedFailoverModelWrapper[M]) Generate(ctx context.Context, input []M, opts ...model.Option) (M, error) {
+func (f *failoverModelWrapper[M]) Generate(ctx context.Context, input []M, opts ...model.Option) (M, error) {
 	// Defensive: GetFailoverModel is validated non-nil at agent construction.
 	if f.config.GetFailoverModel == nil {
 		return f.inner.Generate(ctx, input, opts...)
@@ -287,7 +279,7 @@ func (f *typedFailoverModelWrapper[M]) Generate(ctx context.Context, input []M, 
 			return zero, err
 		}
 
-		failoverCtx := &TypedFailoverContext[M]{
+		failoverCtx := &FailoverContext[M]{
 			FailoverAttempt:   attempt,
 			InputMessages:     input,
 			LastOutputMessage: lastOutputMessage,
@@ -331,7 +323,7 @@ func (f *typedFailoverModelWrapper[M]) Generate(ctx context.Context, input []M, 
 	return lastOutputMessage, lastErr
 }
 
-func (f *typedFailoverModelWrapper[M]) Stream(ctx context.Context, input []M, opts ...model.Option) (
+func (f *failoverModelWrapper[M]) Stream(ctx context.Context, input []M, opts ...model.Option) (
 	*schema.StreamReader[M], error) {
 	// Defensive: GetFailoverModel is validated non-nil at agent construction.
 	if f.config.GetFailoverModel == nil {
@@ -383,7 +375,7 @@ func (f *typedFailoverModelWrapper[M]) Stream(ctx context.Context, input []M, op
 			return nil, err
 		}
 
-		failoverCtx := &TypedFailoverContext[M]{
+		failoverCtx := &FailoverContext[M]{
 			FailoverAttempt:   attempt,
 			InputMessages:     input,
 			LastOutputMessage: lastOutputMessage,

--- a/adk/failover_chatmodel_test.go
+++ b/adk/failover_chatmodel_test.go
@@ -23,6 +23,7 @@ import (
 	"sync/atomic"
 	"testing"
 
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
 	"github.com/cloudwego/eino/components/model"
@@ -696,4 +697,46 @@ func TestFailoverModelWrapper_Stream(t *testing.T) {
 		require.Equal(t, int32(0), atomic.LoadInt32(&m2Calls))
 		require.Equal(t, int32(0), atomic.LoadInt32(&shouldCalls))
 	})
+}
+
+func TestTypedConsumeStream_EmptyAgenticStream(t *testing.T) {
+	sr, sw := schema.Pipe[*schema.AgenticMessage](1)
+	sw.Close()
+
+	msg, err := typedConsumeStream(sr)
+	assert.Nil(t, err, "empty stream should not return error")
+	assert.Nil(t, msg, "empty stream should return nil message, not a zero-value struct")
+}
+
+func TestTypedConsumeStream_AgenticMidStreamError(t *testing.T) {
+	midErr := errors.New("mid-stream failure")
+	sr := streamWithMidErrorAgentic(
+		[]*schema.AgenticMessage{agenticChunk("chunk1"), agenticChunk("chunk2")},
+		midErr,
+	)
+
+	msg, err := typedConsumeStream(sr)
+	assert.ErrorIs(t, err, midErr, "should return the mid-stream error")
+	assert.NotNil(t, msg, "should return concatenated partial message from received chunks")
+}
+
+func streamWithMidErrorAgentic(chunks []*schema.AgenticMessage, err error) *schema.StreamReader[*schema.AgenticMessage] {
+	sr, sw := schema.Pipe[*schema.AgenticMessage](len(chunks) + 1)
+	go func() {
+		defer sw.Close()
+		for _, c := range chunks {
+			sw.Send(c, nil)
+		}
+		sw.Send(nil, err)
+	}()
+	return sr
+}
+
+func agenticChunk(text string) *schema.AgenticMessage {
+	return &schema.AgenticMessage{
+		Role: schema.AgenticRoleTypeAssistant,
+		ContentBlocks: []*schema.ContentBlock{
+			schema.NewContentBlock(&schema.AssistantGenText{Text: text}),
+		},
+	}
 }

--- a/adk/failover_chatmodel_test.go
+++ b/adk/failover_chatmodel_test.go
@@ -705,7 +705,7 @@ func TestTypedConsumeStream_EmptyAgenticStream(t *testing.T) {
 
 	msg, err := typedConsumeStream(sr)
 	assert.Nil(t, err, "empty stream should not return error")
-	assert.Nil(t, msg, "empty stream should return nil message, not a zero-value struct")
+	assert.NotNil(t, msg, "empty stream should return non-nil message from ConcatAgenticMessages")
 }
 
 func TestTypedConsumeStream_AgenticMidStreamError(t *testing.T) {

--- a/adk/failover_chatmodel_test.go
+++ b/adk/failover_chatmodel_test.go
@@ -170,7 +170,7 @@ func TestFailoverModelWrapper_Generate(t *testing.T) {
 				return schema.StreamReaderFromArray([]*schema.Message{schema.AssistantMessage("inner", nil)}), nil
 			},
 		}
-		w := newTypedFailoverModelWrapper[*schema.Message](inner, &ModelFailoverConfig{
+		w := newFailoverModelWrapper[*schema.Message](inner, &ModelFailoverConfig[*schema.Message]{
 			MaxRetries:       2,
 			ShouldFailover:   func(context.Context, *schema.Message, error) bool { return true },
 			GetFailoverModel: nil,
@@ -208,19 +208,19 @@ func TestFailoverModelWrapper_Generate(t *testing.T) {
 			},
 		}
 
-		cfg := &ModelFailoverConfig{
+		cfg := &ModelFailoverConfig[*schema.Message]{
 			MaxRetries: 1,
 			ShouldFailover: func(_ context.Context, _ *schema.Message, err error) bool {
 				atomic.AddInt32(&shouldCalls, 1)
 				return errors.Is(err, wantErr)
 			},
-			GetFailoverModel: func(_ context.Context, failoverCtx *FailoverContext) (model.BaseChatModel, []*schema.Message, error) {
+			GetFailoverModel: func(_ context.Context, failoverCtx *FailoverContext[*schema.Message]) (model.BaseChatModel, []*schema.Message, error) {
 				require.Equal(t, uint(1), failoverCtx.FailoverAttempt)
 				return m2, nil, nil
 			},
 		}
 
-		w := newTypedFailoverModelWrapper[*schema.Message](&failoverProxyModel{}, cfg)
+		w := newFailoverModelWrapper[*schema.Message](&failoverProxyModel{}, cfg)
 		ctx := withTypedChatModelAgentExecCtx[*schema.Message](context.Background(), &chatModelAgentExecCtx{
 			failoverLastSuccessModel: m1,
 		})
@@ -244,19 +244,19 @@ func TestFailoverModelWrapper_Generate(t *testing.T) {
 			},
 		}
 
-		cfg := &ModelFailoverConfig{
+		cfg := &ModelFailoverConfig[*schema.Message]{
 			MaxRetries: 5,
 			ShouldFailover: func(_ context.Context, _ *schema.Message, err error) bool {
 				atomic.AddInt32(&shouldCalls, 1)
 				// User decides to stop on canceled error
 				return !errors.Is(err, context.Canceled)
 			},
-			GetFailoverModel: func(_ context.Context, _ *FailoverContext) (model.BaseChatModel, []*schema.Message, error) {
+			GetFailoverModel: func(_ context.Context, _ *FailoverContext[*schema.Message]) (model.BaseChatModel, []*schema.Message, error) {
 				return m1, nil, nil
 			},
 		}
 
-		w := newTypedFailoverModelWrapper[*schema.Message](&failoverProxyModel{}, cfg)
+		w := newFailoverModelWrapper[*schema.Message](&failoverProxyModel{}, cfg)
 		ctx := withTypedChatModelAgentExecCtx[*schema.Message](context.Background(), &chatModelAgentExecCtx{
 			failoverLastSuccessModel: m1,
 		})
@@ -280,30 +280,30 @@ func TestFailoverModelWrapper_Generate(t *testing.T) {
 			},
 		}
 
-		cfg := &ModelFailoverConfig{
+		cfg := &ModelFailoverConfig[*schema.Message]{
 			MaxRetries:     3,
 			ShouldFailover: func(context.Context, *schema.Message, error) bool { return true },
-			GetFailoverModel: func(_ context.Context, _ *FailoverContext) (model.BaseChatModel, []*schema.Message, error) {
+			GetFailoverModel: func(_ context.Context, _ *FailoverContext[*schema.Message]) (model.BaseChatModel, []*schema.Message, error) {
 				return nil, nil, wantErr
 			},
 		}
 
-		w := newTypedFailoverModelWrapper[*schema.Message](inner, cfg)
+		w := newFailoverModelWrapper[*schema.Message](inner, cfg)
 		_, err := w.Generate(context.Background(), []*schema.Message{schema.UserMessage("hi")})
 		require.ErrorIs(t, err, wantErr)
 		require.Equal(t, int32(0), atomic.LoadInt32(&called))
 	})
 
 	t.Run("stops when GetFailoverModel returns nil model", func(t *testing.T) {
-		cfg := &ModelFailoverConfig{
+		cfg := &ModelFailoverConfig[*schema.Message]{
 			MaxRetries:     1,
 			ShouldFailover: func(context.Context, *schema.Message, error) bool { return true },
-			GetFailoverModel: func(_ context.Context, _ *FailoverContext) (model.BaseChatModel, []*schema.Message, error) {
+			GetFailoverModel: func(_ context.Context, _ *FailoverContext[*schema.Message]) (model.BaseChatModel, []*schema.Message, error) {
 				return nil, nil, nil
 			},
 		}
 
-		w := newTypedFailoverModelWrapper[*schema.Message](&failoverProxyModel{}, cfg)
+		w := newFailoverModelWrapper[*schema.Message](&failoverProxyModel{}, cfg)
 		msg, err := w.Generate(context.Background(), []*schema.Message{schema.UserMessage("hi")})
 		require.Nil(t, msg)
 		require.Error(t, err)
@@ -331,18 +331,18 @@ func TestFailoverModelWrapper_Stream(t *testing.T) {
 			},
 		}
 
-		cfg := &ModelFailoverConfig{
+		cfg := &ModelFailoverConfig[*schema.Message]{
 			MaxRetries: 0,
 			ShouldFailover: func(context.Context, *schema.Message, error) bool {
 				atomic.AddInt32(&shouldCalls, 1)
 				return false
 			},
-			GetFailoverModel: func(_ context.Context, _ *FailoverContext) (model.BaseChatModel, []*schema.Message, error) {
+			GetFailoverModel: func(_ context.Context, _ *FailoverContext[*schema.Message]) (model.BaseChatModel, []*schema.Message, error) {
 				return m1, nil, nil
 			},
 		}
 
-		w := newTypedFailoverModelWrapper[*schema.Message](&failoverProxyModel{}, cfg)
+		w := newFailoverModelWrapper[*schema.Message](&failoverProxyModel{}, cfg)
 		ctx := withTypedChatModelAgentExecCtx[*schema.Message](context.Background(), &chatModelAgentExecCtx{
 			failoverLastSuccessModel: m1,
 		})
@@ -383,19 +383,19 @@ func TestFailoverModelWrapper_Stream(t *testing.T) {
 			},
 		}
 
-		cfg := &ModelFailoverConfig{
+		cfg := &ModelFailoverConfig[*schema.Message]{
 			MaxRetries: 1,
 			ShouldFailover: func(_ context.Context, _ *schema.Message, err error) bool {
 				atomic.AddInt32(&shouldCalls, 1)
 				return errors.Is(err, wantErr)
 			},
-			GetFailoverModel: func(_ context.Context, failoverCtx *FailoverContext) (model.BaseChatModel, []*schema.Message, error) {
+			GetFailoverModel: func(_ context.Context, failoverCtx *FailoverContext[*schema.Message]) (model.BaseChatModel, []*schema.Message, error) {
 				require.Equal(t, uint(1), failoverCtx.FailoverAttempt)
 				return m2, nil, nil
 			},
 		}
 
-		w := newTypedFailoverModelWrapper[*schema.Message](&failoverProxyModel{}, cfg)
+		w := newFailoverModelWrapper[*schema.Message](&failoverProxyModel{}, cfg)
 		ctx := withTypedChatModelAgentExecCtx[*schema.Message](context.Background(), &chatModelAgentExecCtx{
 			failoverLastSuccessModel: m1,
 		})
@@ -441,7 +441,7 @@ func TestFailoverModelWrapper_Stream(t *testing.T) {
 			},
 		}
 
-		cfg := &ModelFailoverConfig{
+		cfg := &ModelFailoverConfig[*schema.Message]{
 			MaxRetries: 1,
 			ShouldFailover: func(_ context.Context, out *schema.Message, err error) bool {
 				atomic.AddInt32(&shouldCalls, 1)
@@ -450,13 +450,13 @@ func TestFailoverModelWrapper_Stream(t *testing.T) {
 				}
 				return errors.Is(err, streamErr)
 			},
-			GetFailoverModel: func(_ context.Context, failoverCtx *FailoverContext) (model.BaseChatModel, []*schema.Message, error) {
+			GetFailoverModel: func(_ context.Context, failoverCtx *FailoverContext[*schema.Message]) (model.BaseChatModel, []*schema.Message, error) {
 				require.Equal(t, uint(1), failoverCtx.FailoverAttempt)
 				return m2, nil, nil
 			},
 		}
 
-		w := newTypedFailoverModelWrapper[*schema.Message](&failoverProxyModel{}, cfg)
+		w := newFailoverModelWrapper[*schema.Message](&failoverProxyModel{}, cfg)
 		ctx := withTypedChatModelAgentExecCtx[*schema.Message](context.Background(), &chatModelAgentExecCtx{
 			failoverLastSuccessModel: m1,
 		})
@@ -484,17 +484,17 @@ func TestFailoverModelWrapper_Stream(t *testing.T) {
 			},
 		}
 
-		cfg := &ModelFailoverConfig{
+		cfg := &ModelFailoverConfig[*schema.Message]{
 			MaxRetries: 3,
 			ShouldFailover: func(context.Context, *schema.Message, error) bool {
 				return false
 			},
-			GetFailoverModel: func(_ context.Context, _ *FailoverContext) (model.BaseChatModel, []*schema.Message, error) {
+			GetFailoverModel: func(_ context.Context, _ *FailoverContext[*schema.Message]) (model.BaseChatModel, []*schema.Message, error) {
 				return m1, nil, nil
 			},
 		}
 
-		w := newTypedFailoverModelWrapper[*schema.Message](&failoverProxyModel{}, cfg)
+		w := newFailoverModelWrapper[*schema.Message](&failoverProxyModel{}, cfg)
 		ctx := withTypedChatModelAgentExecCtx[*schema.Message](context.Background(), &chatModelAgentExecCtx{
 			failoverLastSuccessModel: m1,
 		})
@@ -515,19 +515,19 @@ func TestFailoverModelWrapper_Stream(t *testing.T) {
 			},
 		}
 
-		cfg := &ModelFailoverConfig{
+		cfg := &ModelFailoverConfig[*schema.Message]{
 			MaxRetries: 3,
 			ShouldFailover: func(_ context.Context, _ *schema.Message, err error) bool {
 				atomic.AddInt32(&shouldCalls, 1)
 				// User decides to stop on canceled error
 				return !errors.Is(err, context.Canceled)
 			},
-			GetFailoverModel: func(_ context.Context, _ *FailoverContext) (model.BaseChatModel, []*schema.Message, error) {
+			GetFailoverModel: func(_ context.Context, _ *FailoverContext[*schema.Message]) (model.BaseChatModel, []*schema.Message, error) {
 				return m1, nil, nil
 			},
 		}
 
-		w := newTypedFailoverModelWrapper[*schema.Message](&failoverProxyModel{}, cfg)
+		w := newFailoverModelWrapper[*schema.Message](&failoverProxyModel{}, cfg)
 		ctx := withTypedChatModelAgentExecCtx[*schema.Message](context.Background(), &chatModelAgentExecCtx{
 			failoverLastSuccessModel: m1,
 		})
@@ -554,19 +554,19 @@ func TestFailoverModelWrapper_Stream(t *testing.T) {
 			},
 		}
 
-		cfg := &ModelFailoverConfig{
+		cfg := &ModelFailoverConfig[*schema.Message]{
 			MaxRetries: 3,
 			ShouldFailover: func(_ context.Context, _ *schema.Message, err error) bool {
 				atomic.AddInt32(&shouldCalls, 1)
 				require.ErrorIs(t, err, wantErr)
 				return false
 			},
-			GetFailoverModel: func(_ context.Context, _ *FailoverContext) (model.BaseChatModel, []*schema.Message, error) {
+			GetFailoverModel: func(_ context.Context, _ *FailoverContext[*schema.Message]) (model.BaseChatModel, []*schema.Message, error) {
 				return m1, nil, nil
 			},
 		}
 
-		w := newTypedFailoverModelWrapper[*schema.Message](&failoverProxyModel{}, cfg)
+		w := newFailoverModelWrapper[*schema.Message](&failoverProxyModel{}, cfg)
 		ctx := withTypedChatModelAgentExecCtx[*schema.Message](context.Background(), &chatModelAgentExecCtx{
 			failoverLastSuccessModel: m1,
 		})
@@ -578,15 +578,15 @@ func TestFailoverModelWrapper_Stream(t *testing.T) {
 	})
 
 	t.Run("stops when GetFailoverModel returns nil model", func(t *testing.T) {
-		cfg := &ModelFailoverConfig{
+		cfg := &ModelFailoverConfig[*schema.Message]{
 			MaxRetries:     1,
 			ShouldFailover: func(context.Context, *schema.Message, error) bool { return true },
-			GetFailoverModel: func(_ context.Context, _ *FailoverContext) (model.BaseChatModel, []*schema.Message, error) {
+			GetFailoverModel: func(_ context.Context, _ *FailoverContext[*schema.Message]) (model.BaseChatModel, []*schema.Message, error) {
 				return nil, nil, nil
 			},
 		}
 
-		w := newTypedFailoverModelWrapper[*schema.Message](&failoverProxyModel{}, cfg)
+		w := newFailoverModelWrapper[*schema.Message](&failoverProxyModel{}, cfg)
 		sr, err := w.Stream(context.Background(), []*schema.Message{schema.UserMessage("hi")})
 		require.Nil(t, sr)
 		require.Error(t, err)
@@ -607,15 +607,15 @@ func TestFailoverModelWrapper_Stream(t *testing.T) {
 			},
 		}
 
-		cfg := &ModelFailoverConfig{
+		cfg := &ModelFailoverConfig[*schema.Message]{
 			MaxRetries:     3,
 			ShouldFailover: func(context.Context, *schema.Message, error) bool { return true },
-			GetFailoverModel: func(_ context.Context, _ *FailoverContext) (model.BaseChatModel, []*schema.Message, error) {
+			GetFailoverModel: func(_ context.Context, _ *FailoverContext[*schema.Message]) (model.BaseChatModel, []*schema.Message, error) {
 				return nil, nil, wantErr
 			},
 		}
 
-		w := newTypedFailoverModelWrapper[*schema.Message](inner, cfg)
+		w := newFailoverModelWrapper[*schema.Message](inner, cfg)
 		sr, err := w.Stream(context.Background(), []*schema.Message{schema.UserMessage("hi")})
 		require.Nil(t, sr)
 		require.ErrorIs(t, err, wantErr)
@@ -656,19 +656,19 @@ func TestFailoverModelWrapper_Stream(t *testing.T) {
 			},
 		}
 
-		cfg := &ModelFailoverConfig{
+		cfg := &ModelFailoverConfig[*schema.Message]{
 			MaxRetries: 1,
 			ShouldFailover: func(context.Context, *schema.Message, error) bool {
 				atomic.AddInt32(&shouldCalls, 1)
 				return true
 			},
-			GetFailoverModel: func(_ context.Context, failoverCtx *FailoverContext) (model.BaseChatModel, []*schema.Message, error) {
+			GetFailoverModel: func(_ context.Context, failoverCtx *FailoverContext[*schema.Message]) (model.BaseChatModel, []*schema.Message, error) {
 				require.Equal(t, uint(1), failoverCtx.FailoverAttempt)
 				return m2, nil, nil
 			},
 		}
 
-		w := newTypedFailoverModelWrapper[*schema.Message](&failoverProxyModel{}, cfg)
+		w := newFailoverModelWrapper[*schema.Message](&failoverProxyModel{}, cfg)
 		baseCtx := withTypedChatModelAgentExecCtx[*schema.Message](context.Background(), &chatModelAgentExecCtx{
 			failoverLastSuccessModel: m1,
 		})

--- a/adk/flow.go
+++ b/adk/flow.go
@@ -622,20 +622,20 @@ func wrapIterWithOnEnd(ctx context.Context, iter *AsyncIterator[*AgentEvent]) *A
 // flowAgent (the *schema.Message path).
 // ---------------------------------------------------------------------------
 
-type typedFlowAgent[M messageType] struct {
+type typedFlowAgent[M MessageType] struct {
 	TypedAgent[M]
 
 	checkPointStore compose.CheckPointStore
 }
 
-func toTypedFlowAgent[M messageType](agent TypedAgent[M]) *typedFlowAgent[M] {
+func toTypedFlowAgent[M MessageType](agent TypedAgent[M]) *typedFlowAgent[M] {
 	if fa, ok := agent.(*typedFlowAgent[M]); ok {
 		return fa
 	}
 	return &typedFlowAgent[M]{TypedAgent: agent}
 }
 
-func getTypedAgentType[M messageType](agent TypedAgent[M]) string {
+func getTypedAgentType[M MessageType](agent TypedAgent[M]) string {
 	if msgAgent, ok := any(agent).(Agent); ok {
 		return getAgentType(msgAgent)
 	}
@@ -799,11 +799,11 @@ func genAgenticErrorIter(err error) *AsyncIterator[*TypedAgentEvent[*schema.Agen
 	return iter
 }
 
-func typedWrapIterWithOnEnd[M messageType](ctx context.Context, iter *AsyncIterator[*TypedAgentEvent[M]]) *AsyncIterator[*TypedAgentEvent[M]] {
+func typedWrapIterWithOnEnd[M MessageType](ctx context.Context, iter *AsyncIterator[*TypedAgentEvent[M]]) *AsyncIterator[*TypedAgentEvent[M]] {
 	agenticIter := any(iter).(*AsyncIterator[*TypedAgentEvent[*schema.AgenticMessage]])
 	return any(wrapAgenticIterWithOnEnd(ctx, agenticIter)).(*AsyncIterator[*TypedAgentEvent[M]])
 }
 
-func typedErrorIterWithOnEnd[M messageType](ctx context.Context, err error) *AsyncIterator[*TypedAgentEvent[M]] {
+func typedErrorIterWithOnEnd[M MessageType](ctx context.Context, err error) *AsyncIterator[*TypedAgentEvent[M]] {
 	return typedWrapIterWithOnEnd[M](ctx, typedErrorIter[M](err))
 }

--- a/adk/handler.go
+++ b/adk/handler.go
@@ -53,8 +53,8 @@ type ToolCallsContext struct {
 	ToolCalls []ToolContext
 }
 
-// ModelContext contains context information passed to WrapModel.
-type ModelContext struct {
+// TypedModelContext contains context information passed to WrapModel.
+type TypedModelContext[M messageType] struct {
 	// Tools contains the current tool list configured for the agent.
 	// This is populated at request time with the tools that will be sent to the model.
 	//
@@ -66,16 +66,19 @@ type ModelContext struct {
 	// ModelRetryConfig contains the retry configuration for the model.
 	// This is populated at request time from the agent's ModelRetryConfig.
 	// Used by EventSenderModelWrapper to wrap stream errors appropriately.
-	ModelRetryConfig *ModelRetryConfig
+	ModelRetryConfig *TypedModelRetryConfig[M]
 
 	// ModelFailoverConfig contains the failover configuration for the model.
 	// This is populated at request time from the agent's ModelFailoverConfig.
 	// Used by EventSenderModelWrapper to wrap stream errors so that failed failover
 	// attempts are skipped (not treated as fatal) by the flow event processor.
-	ModelFailoverConfig *ModelFailoverConfig
+	ModelFailoverConfig *TypedModelFailoverConfig[M]
 
 	cancelContext *cancelContext
 }
+
+// ModelContext is the default model context type using *schema.Message.
+type ModelContext = TypedModelContext[*schema.Message]
 
 // ChatModelAgentContext contains runtime information passed to handlers before each ChatModelAgent run.
 // Handlers can modify Instruction, Tools, and ReturnDirectly to customize agent behavior.
@@ -149,7 +152,7 @@ type TypedChatModelAgentMiddleware[M messageType] interface {
 	//
 	// This is the recommended place to modify messages and tools before a model call.
 	// Changes here are persisted in state and reflected in subsequent iterations.
-	BeforeModelRewriteState(ctx context.Context, state *TypedChatModelAgentState[M], mc *ModelContext) (context.Context, *TypedChatModelAgentState[M], error)
+	BeforeModelRewriteState(ctx context.Context, state *TypedChatModelAgentState[M], mc *TypedModelContext[M]) (context.Context, *TypedChatModelAgentState[M], error)
 
 	// AfterModelRewriteState is called after each model invocation.
 	// The input state includes the model's response as the last message.
@@ -159,7 +162,7 @@ type TypedChatModelAgentMiddleware[M messageType] interface {
 	//   - Messages: the conversation history including the model's response
 	//   - ToolInfos: the tool list that was sent to the model
 	//   - DeferredToolInfos: tools for server-side search (nil if unused)
-	AfterModelRewriteState(ctx context.Context, state *TypedChatModelAgentState[M], mc *ModelContext) (context.Context, *TypedChatModelAgentState[M], error)
+	AfterModelRewriteState(ctx context.Context, state *TypedChatModelAgentState[M], mc *TypedModelContext[M]) (context.Context, *TypedChatModelAgentState[M], error)
 
 	// WrapInvokableToolCall wraps a tool's synchronous execution with custom behavior.
 	// Return the input endpoint unchanged and nil error if no wrapping is needed.
@@ -232,7 +235,7 @@ type TypedChatModelAgentMiddleware[M messageType] interface {
 	//
 	// The mc parameter provides read-only context about the current model call:
 	//   - Tools: The tool infos that will be sent to the model (Deprecated: read state.ToolInfos instead)
-	WrapModel(ctx context.Context, m model.BaseModel[M], mc *ModelContext) (model.BaseModel[M], error)
+	WrapModel(ctx context.Context, m model.BaseModel[M], mc *TypedModelContext[M]) (model.BaseModel[M], error)
 }
 
 // ChatModelAgentMiddleware is the default middleware type using *schema.Message.
@@ -273,7 +276,7 @@ func (b *TypedBaseChatModelAgentMiddleware[M]) WrapEnhancedStreamableToolCall(_ 
 	return endpoint, nil
 }
 
-func (b *TypedBaseChatModelAgentMiddleware[M]) WrapModel(_ context.Context, m model.BaseModel[M], _ *ModelContext) (model.BaseModel[M], error) {
+func (b *TypedBaseChatModelAgentMiddleware[M]) WrapModel(_ context.Context, m model.BaseModel[M], _ *TypedModelContext[M]) (model.BaseModel[M], error) {
 	return m, nil
 }
 
@@ -281,11 +284,11 @@ func (b *TypedBaseChatModelAgentMiddleware[M]) BeforeAgent(ctx context.Context, 
 	return ctx, runCtx, nil
 }
 
-func (b *TypedBaseChatModelAgentMiddleware[M]) BeforeModelRewriteState(ctx context.Context, state *TypedChatModelAgentState[M], mc *ModelContext) (context.Context, *TypedChatModelAgentState[M], error) {
+func (b *TypedBaseChatModelAgentMiddleware[M]) BeforeModelRewriteState(ctx context.Context, state *TypedChatModelAgentState[M], mc *TypedModelContext[M]) (context.Context, *TypedChatModelAgentState[M], error) {
 	return ctx, state, nil
 }
 
-func (b *TypedBaseChatModelAgentMiddleware[M]) AfterModelRewriteState(ctx context.Context, state *TypedChatModelAgentState[M], mc *ModelContext) (context.Context, *TypedChatModelAgentState[M], error) {
+func (b *TypedBaseChatModelAgentMiddleware[M]) AfterModelRewriteState(ctx context.Context, state *TypedChatModelAgentState[M], mc *TypedModelContext[M]) (context.Context, *TypedChatModelAgentState[M], error) {
 	return ctx, state, nil
 }
 

--- a/adk/handler.go
+++ b/adk/handler.go
@@ -54,7 +54,7 @@ type ToolCallsContext struct {
 }
 
 // TypedModelContext contains context information passed to WrapModel.
-type TypedModelContext[M messageType] struct {
+type TypedModelContext[M MessageType] struct {
 	// Tools contains the current tool list configured for the agent.
 	// This is populated at request time with the tools that will be sent to the model.
 	//
@@ -136,7 +136,7 @@ type ChatModelAgentContext struct {
 //
 // Use *TypedBaseChatModelAgentMiddleware as an embedded struct to provide default no-op
 // implementations for all methods.
-type TypedChatModelAgentMiddleware[M messageType] interface {
+type TypedChatModelAgentMiddleware[M MessageType] interface {
 	// BeforeAgent is called before each agent run, allowing modification of
 	// the agent's instruction and tools configuration.
 	BeforeAgent(ctx context.Context, runCtx *ChatModelAgentContext) (context.Context, *ChatModelAgentContext, error)
@@ -242,7 +242,7 @@ type TypedChatModelAgentMiddleware[M messageType] interface {
 // See TypedChatModelAgentMiddleware for full documentation.
 type ChatModelAgentMiddleware = TypedChatModelAgentMiddleware[*schema.Message]
 
-type TypedBaseChatModelAgentMiddleware[M messageType] struct{}
+type TypedBaseChatModelAgentMiddleware[M MessageType] struct{}
 
 // BaseChatModelAgentMiddleware provides default no-op implementations for ChatModelAgentMiddleware.
 // Embed *BaseChatModelAgentMiddleware in custom handlers to only override the methods you need.
@@ -381,7 +381,7 @@ func DeleteRunLocalValue(ctx context.Context, key string) error {
 //
 // This function can only be called from within a TypedChatModelAgentMiddleware during agent execution.
 // Returns an error if called outside of an agent execution context.
-func TypedSendEvent[M messageType](ctx context.Context, event *TypedAgentEvent[M]) error {
+func TypedSendEvent[M MessageType](ctx context.Context, event *TypedAgentEvent[M]) error {
 	execCtx := getTypedChatModelAgentExecCtx[M](ctx)
 	if execCtx == nil || execCtx.generator == nil {
 		return fmt.Errorf("TypedSendEvent failed: must be called within a ChatModelAgent Run() or Resume() execution context")

--- a/adk/handler.go
+++ b/adk/handler.go
@@ -72,7 +72,7 @@ type TypedModelContext[M MessageType] struct {
 	// This is populated at request time from the agent's ModelFailoverConfig.
 	// Used by EventSenderModelWrapper to wrap stream errors so that failed failover
 	// attempts are skipped (not treated as fatal) by the flow event processor.
-	ModelFailoverConfig *TypedModelFailoverConfig[M]
+	ModelFailoverConfig *ModelFailoverConfig[M]
 
 	cancelContext *cancelContext
 }

--- a/adk/instruction.go
+++ b/adk/instruction.go
@@ -45,7 +45,7 @@ When transferring: OUTPUT ONLY THE FUNCTION CALL`
 	agentDescriptionTplChinese = "\n- Agent 名字: %s\n  Agent 描述: %s"
 )
 
-func genTransferToAgentInstruction[M messageType](ctx context.Context, agents []TypedAgent[M]) string {
+func genTransferToAgentInstruction[M MessageType](ctx context.Context, agents []TypedAgent[M]) string {
 	tpl := internal.SelectPrompt(internal.I18nPrompts{
 		English: agentDescriptionTpl,
 		Chinese: agentDescriptionTplChinese,

--- a/adk/interface.go
+++ b/adk/interface.go
@@ -36,11 +36,11 @@ const ComponentOfAgent components.Component = "Agent"
 // that use *schema.AgenticMessage in callbacks.
 const ComponentOfAgenticAgent components.Component = "AgenticAgent"
 
-// messageType is the sealed type constraint for message types used in ADK.
+// MessageType is the sealed type constraint for message types used in ADK.
 // Only *schema.Message and *schema.AgenticMessage satisfy this constraint.
 // External packages cannot add new types to this union; all generic functions
 // in ADK use exhaustive type switches on these two types.
-type messageType interface {
+type MessageType interface {
 	*schema.Message | *schema.AgenticMessage
 }
 
@@ -53,7 +53,7 @@ type AgenticMessageStream = *schema.StreamReader[AgenticMessage]
 // isNilMessage checks whether a generic message value is nil.
 // Direct `msg == nil` does not compile for generic pointer types in Go;
 // the canonical workaround is to compare through the `any` interface.
-func isNilMessage[M messageType](msg M) bool {
+func isNilMessage[M MessageType](msg M) bool {
 	var zero M
 	return any(msg) == any(zero)
 }
@@ -70,7 +70,7 @@ func isNilMessage[M messageType](msg M) bool {
 // For *schema.Message events, Role and ToolName exist independently of the inner
 // Message because in streaming mode (IsStreaming=true, Message=nil), the message
 // has not materialized yet and the consumer needs metadata without consuming the stream.
-type TypedMessageVariant[M messageType] struct {
+type TypedMessageVariant[M MessageType] struct {
 	IsStreaming bool
 
 	Message       M
@@ -244,7 +244,7 @@ func gobDecodeAgenticMessageVariant(mv *TypedMessageVariant[*schema.AgenticMessa
 }
 
 // typedEventFromMessage creates a TypedAgentEvent containing the given message and optional stream.
-func typedEventFromMessage[M messageType](msg M, msgStream *schema.StreamReader[M],
+func typedEventFromMessage[M MessageType](msg M, msgStream *schema.StreamReader[M],
 	role schema.RoleType, toolName string) *TypedAgentEvent[M] {
 	return &TypedAgentEvent[M]{
 		Output: &TypedAgentOutput[M]{
@@ -262,7 +262,7 @@ func typedEventFromMessage[M messageType](msg M, msgStream *schema.StreamReader[
 // typedModelOutputEvent creates a model-output event for the generic path.
 // For *schema.Message, Role is set to schema.Assistant.
 // For *schema.AgenticMessage, AgenticRole is set to schema.AgenticRoleTypeAssistant.
-func typedModelOutputEvent[M messageType](msg M, msgStream *schema.StreamReader[M]) *TypedAgentEvent[M] {
+func typedModelOutputEvent[M MessageType](msg M, msgStream *schema.StreamReader[M]) *TypedAgentEvent[M] {
 	var role schema.RoleType
 	var agenticRole schema.AgenticRoleType
 	var zero M
@@ -317,7 +317,7 @@ type TransferToAgentAction struct {
 	DestAgentName string
 }
 
-type TypedAgentOutput[M messageType] struct {
+type TypedAgentOutput[M MessageType] struct {
 	MessageOutput *TypedMessageVariant[M]
 
 	CustomizedOutput any
@@ -416,7 +416,7 @@ type runStepSerialization struct {
 
 // TypedAgentEvent represents a single event emitted during agent execution.
 // CheckpointSchema: persisted via serialization.RunCtx (gob).
-type TypedAgentEvent[M messageType] struct {
+type TypedAgentEvent[M MessageType] struct {
 	AgentName string
 
 	// RunPath represents the execution path from root agent to the current event source.
@@ -437,7 +437,7 @@ type TypedAgentEvent[M messageType] struct {
 // AgentEvent is the default event type using *schema.Message.
 type AgentEvent = TypedAgentEvent[*schema.Message]
 
-type TypedAgentInput[M messageType] struct {
+type TypedAgentInput[M MessageType] struct {
 	Messages        []M
 	EnableStreaming bool
 }
@@ -450,7 +450,7 @@ type AgentInput = TypedAgentInput[*schema.Message]
 // orchestration, cancel monitoring, retry, flowAgent).
 // For M = *schema.AgenticMessage, single-agent execution works but cancel
 // monitoring on the model stream and retry are not yet wired.
-type TypedAgent[M messageType] interface {
+type TypedAgent[M MessageType] interface {
 	Name(ctx context.Context) string
 	Description(ctx context.Context) string
 
@@ -478,7 +478,7 @@ type OnSubAgents interface {
 	OnDisallowTransferToParent(ctx context.Context) error
 }
 
-type TypedResumableAgent[M messageType] interface {
+type TypedResumableAgent[M MessageType] interface {
 	TypedAgent[M]
 
 	Resume(ctx context.Context, info *ResumeInfo, opts ...AgentRunOption) *AsyncIterator[*TypedAgentEvent[M]]
@@ -486,7 +486,7 @@ type TypedResumableAgent[M messageType] interface {
 
 type ResumableAgent = TypedResumableAgent[*schema.Message]
 
-func concatMessageStream[M messageType](stream *schema.StreamReader[M]) (M, error) {
+func concatMessageStream[M MessageType](stream *schema.StreamReader[M]) (M, error) {
 	var zero M
 	switch s := any(stream).(type) {
 	case *schema.StreamReader[*schema.Message]:
@@ -514,6 +514,6 @@ func concatMessageStream[M messageType](stream *schema.StreamReader[M]) (M, erro
 		}
 		return any(result).(M), nil
 	default:
-		panic("unreachable: unknown messageType")
+		panic("unreachable: unknown MessageType")
 	}
 }

--- a/adk/interrupt.go
+++ b/adk/interrupt.go
@@ -56,7 +56,7 @@ type InterruptInfo struct {
 
 // TypedInterrupt creates a typed interrupt event that pauses execution to request external input.
 // It is the generic counterpart of Interrupt; see Interrupt for full documentation.
-func TypedInterrupt[M messageType](ctx context.Context, info any) *TypedAgentEvent[M] {
+func TypedInterrupt[M MessageType](ctx context.Context, info any) *TypedAgentEvent[M] {
 	var rp []RunStep
 	rCtx := getRunCtx(ctx)
 	if rCtx != nil {
@@ -91,7 +91,7 @@ func Interrupt(ctx context.Context, info any) *AgentEvent {
 
 // TypedStatefulInterrupt creates a typed interrupt event that also saves the agent's internal state.
 // It is the generic counterpart of StatefulInterrupt; see StatefulInterrupt for full documentation.
-func TypedStatefulInterrupt[M messageType](ctx context.Context, info any, state any) *TypedAgentEvent[M] {
+func TypedStatefulInterrupt[M MessageType](ctx context.Context, info any, state any) *TypedAgentEvent[M] {
 	var rp []RunStep
 	rCtx := getRunCtx(ctx)
 	if rCtx != nil {
@@ -126,7 +126,7 @@ func StatefulInterrupt(ctx context.Context, info any, state any) *AgentEvent {
 
 // TypedCompositeInterrupt creates a typed interrupt event that aggregates sub-interrupt signals.
 // It is the generic counterpart of CompositeInterrupt; see CompositeInterrupt for full documentation.
-func TypedCompositeInterrupt[M messageType](ctx context.Context, info any, state any,
+func TypedCompositeInterrupt[M MessageType](ctx context.Context, info any, state any,
 	subInterruptSignals ...*InterruptSignal) *TypedAgentEvent[M] {
 	var rp []RunStep
 	rCtx := getRunCtx(ctx)

--- a/adk/middlewares/filesystem/filesystem.go
+++ b/adk/middlewares/filesystem/filesystem.go
@@ -341,6 +341,38 @@ func (c *MiddlewareConfig) mergeToolConfigWithDesc(
 	return toolConfig
 }
 
+// NewTyped constructs and returns the filesystem middleware as a TypedChatModelAgentMiddleware[M].
+//
+// This is the generic constructor that supports both *schema.Message and *schema.AgenticMessage.
+// It returns a TypedChatModelAgentMiddleware[M] which provides:
+//   - Better context propagation through WrapInvokableToolCall and WrapStreamableToolCall methods
+//   - BeforeAgent hook for modifying agent instruction and tools at runtime
+//   - More flexible extension points compared to the struct-based AgentMiddleware
+//
+// The middleware provides filesystem tools (ls, read_file, write_file, edit_file, glob, grep)
+// and optionally an execute tool if the Backend implements ShellBackend or StreamingShellBackend.
+func NewTyped[M adk.MessageType](ctx context.Context, config *MiddlewareConfig) (adk.TypedChatModelAgentMiddleware[M], error) {
+	err := config.Validate()
+	if err != nil {
+		return nil, err
+	}
+	ts, err := getFilesystemTools(ctx, config)
+	if err != nil {
+		return nil, err
+	}
+	var systemPrompt string
+	if config.CustomSystemPrompt != nil {
+		systemPrompt = *config.CustomSystemPrompt
+	}
+
+	m := &typedFilesystemMiddleware[M]{
+		additionalInstruction: systemPrompt,
+		additionalTools:       ts,
+	}
+
+	return m, nil
+}
+
 // New constructs and returns the filesystem middleware as a ChatModelAgentMiddleware.
 //
 // This is the recommended constructor for new code. It returns a ChatModelAgentMiddleware which provides:
@@ -361,34 +393,16 @@ func (c *MiddlewareConfig) mergeToolConfigWithDesc(
 //	    Handlers: []adk.ChatModelAgentMiddleware{middleware},
 //	})
 func New(ctx context.Context, config *MiddlewareConfig) (adk.ChatModelAgentMiddleware, error) {
-	err := config.Validate()
-	if err != nil {
-		return nil, err
-	}
-	ts, err := getFilesystemTools(ctx, config)
-	if err != nil {
-		return nil, err
-	}
-	var systemPrompt string
-	if config.CustomSystemPrompt != nil {
-		systemPrompt = *config.CustomSystemPrompt
-	}
-
-	m := &filesystemMiddleware{
-		additionalInstruction: systemPrompt,
-		additionalTools:       ts,
-	}
-
-	return m, nil
+	return NewTyped[*schema.Message](ctx, config)
 }
 
-type filesystemMiddleware struct {
-	adk.BaseChatModelAgentMiddleware
+type typedFilesystemMiddleware[M adk.MessageType] struct {
+	*adk.TypedBaseChatModelAgentMiddleware[M]
 	additionalInstruction string
 	additionalTools       []tool.BaseTool
 }
 
-func (m *filesystemMiddleware) BeforeAgent(ctx context.Context, runCtx *adk.ChatModelAgentContext) (context.Context, *adk.ChatModelAgentContext, error) {
+func (m *typedFilesystemMiddleware[M]) BeforeAgent(ctx context.Context, runCtx *adk.ChatModelAgentContext) (context.Context, *adk.ChatModelAgentContext, error) {
 	if runCtx == nil {
 		return ctx, runCtx, nil
 	}

--- a/adk/middlewares/filesystem/filesystem_test.go
+++ b/adk/middlewares/filesystem/filesystem_test.go
@@ -677,7 +677,7 @@ func TestNew(t *testing.T) {
 		assert.NoError(t, err)
 		assert.NotNil(t, m)
 
-		fm, ok := m.(*filesystemMiddleware)
+		fm, ok := m.(*typedFilesystemMiddleware[*schema.Message])
 		assert.True(t, ok)
 		assert.Len(t, fm.additionalTools, 6)
 	})
@@ -690,7 +690,7 @@ func TestNew(t *testing.T) {
 		})
 		assert.NoError(t, err)
 
-		fm, ok := m.(*filesystemMiddleware)
+		fm, ok := m.(*typedFilesystemMiddleware[*schema.Message])
 		assert.True(t, ok)
 		assert.Equal(t, customPrompt, fm.additionalInstruction)
 	})
@@ -703,7 +703,7 @@ func TestNew(t *testing.T) {
 		m, err := New(ctx, &MiddlewareConfig{Backend: shellBackend, Shell: shellBackend})
 		assert.NoError(t, err)
 
-		fm, ok := m.(*filesystemMiddleware)
+		fm, ok := m.(*typedFilesystemMiddleware[*schema.Message])
 		assert.True(t, ok)
 		assert.Len(t, fm.additionalTools, 7)
 	})
@@ -1033,7 +1033,7 @@ func TestCustomToolNames(t *testing.T) {
 		})
 		assert.NoError(t, err)
 
-		fm, ok := m.(*filesystemMiddleware)
+		fm, ok := m.(*typedFilesystemMiddleware[*schema.Message])
 		assert.True(t, ok)
 
 		toolNames := make(map[string]bool)
@@ -1959,7 +1959,7 @@ func TestNew_StreamingShell(t *testing.T) {
 		})
 		assert.NoError(t, err)
 
-		fm, ok := m.(*filesystemMiddleware)
+		fm, ok := m.(*typedFilesystemMiddleware[*schema.Message])
 		assert.True(t, ok)
 		assert.Len(t, fm.additionalTools, 7)
 	})

--- a/adk/prebuilt/deep/deep.go
+++ b/adk/prebuilt/deep/deep.go
@@ -37,8 +37,11 @@ func init() {
 	schema.RegisterName[[]TODO]("_eino_adk_prebuilt_deep_todo_slice")
 }
 
-// Config defines the configuration for creating a DeepAgent.
-type Config struct {
+// TypedConfig defines the configuration for creating a DeepAgent parameterized by message type.
+// An Agentic DeepAgent (M = *schema.AgenticMessage) only supports Agentic sub-agents,
+// and a standard DeepAgent (M = *schema.Message) only supports standard sub-agents.
+// This is enforced by the type system through the SubAgents field.
+type TypedConfig[M messageType] struct {
 	// Name is the identifier for the Deep agent.
 	Name string
 	// Description provides a brief explanation of the agent's purpose.
@@ -47,13 +50,14 @@ type Config struct {
 	// ChatModel is the model used by DeepAgent for reasoning and task execution.
 	// If the agent uses any tools, this model must support the model.WithTools call option,
 	// as that's how the agent configures the model with tool information.
-	ChatModel model.BaseChatModel
+	ChatModel model.BaseModel[M]
 	// Instruction contains the system prompt that guides the agent's behavior.
 	// When empty, a built-in default system prompt will be used, which includes general assistant
 	// behavior guidelines, security policies, coding style guidelines, and tool usage policies.
 	Instruction string
 	// SubAgents are specialized agents that can be invoked by the agent.
-	SubAgents []adk.Agent
+	// For M = *schema.AgenticMessage, only agentic sub-agents are accepted.
+	SubAgents []adk.TypedAgent[M]
 	// ToolsConfig provides the tools and tool-calling configurations available for the agent to invoke.
 	ToolsConfig adk.ToolsConfig
 	// MaxIteration limits the maximum number of reasoning iterations the agent can perform.
@@ -78,7 +82,7 @@ type Config struct {
 	WithoutGeneralSubAgent bool
 	// TaskToolDescriptionGenerator allows customizing the description for the task tool.
 	// If provided, this function generates the tool description based on available subagents.
-	TaskToolDescriptionGenerator func(ctx context.Context, availableAgents []adk.Agent) (string, error)
+	TaskToolDescriptionGenerator func(ctx context.Context, availableAgents []adk.TypedAgent[M]) (string, error)
 
 	Middlewares []adk.AgentMiddleware
 
@@ -90,24 +94,27 @@ type Config struct {
 	//
 	// Handlers are processed after Middlewares, in registration order.
 	// See adk.ChatModelAgentMiddleware documentation for when to use Handlers vs Middlewares.
-	Handlers []adk.ChatModelAgentMiddleware
+	Handlers []adk.TypedChatModelAgentMiddleware[M]
 
-	ModelRetryConfig *adk.ModelRetryConfig
+	ModelRetryConfig *adk.TypedModelRetryConfig[M]
 	// ModelFailoverConfig configures failover behavior for the ChatModel.
 	// When set, the agent will automatically fail over to alternative models on errors.
 	// This config is also propagated to the general sub-agent.
-	ModelFailoverConfig *adk.ModelFailoverConfig
+	ModelFailoverConfig *adk.TypedModelFailoverConfig[M]
 
 	// OutputKey stores the agent's response in the session.
 	// Optional. When set, stores output via AddSessionValue(ctx, outputKey, msg.Content).
 	OutputKey string
 }
 
-// New creates a new Deep agent instance with the provided configuration.
+// Config defines the configuration for creating a standard DeepAgent.
+type Config = TypedConfig[*schema.Message]
+
+// NewTyped creates a new typed Deep agent instance with the provided configuration.
 // This function initializes built-in tools, creates a task tool for subagent orchestration,
-// and returns a fully configured ChatModelAgent ready for execution.
-func New(ctx context.Context, cfg *Config) (adk.ResumableAgent, error) {
-	handlers, err := buildBuiltinAgentMiddlewares(ctx, cfg)
+// and returns a fully configured TypedChatModelAgent ready for execution.
+func NewTyped[M messageType](ctx context.Context, cfg *TypedConfig[M]) (adk.TypedResumableAgent[M], error) {
+	handlers, err := buildTypedBuiltinAgentMiddlewares[M](ctx, cfg)
 	if err != nil {
 		return nil, err
 	}
@@ -121,7 +128,7 @@ func New(ctx context.Context, cfg *Config) (adk.ResumableAgent, error) {
 	}
 
 	if !cfg.WithoutGeneralSubAgent || len(cfg.SubAgents) > 0 {
-		tt, err := newTaskToolMiddleware(
+		tt, err := typedTaskToolMiddleware(
 			ctx,
 			cfg.TaskToolDescriptionGenerator,
 			cfg.SubAgents,
@@ -141,7 +148,7 @@ func New(ctx context.Context, cfg *Config) (adk.ResumableAgent, error) {
 		handlers = append(handlers, tt)
 	}
 
-	return adk.NewChatModelAgent(ctx, &adk.ChatModelAgentConfig{
+	return adk.NewTypedChatModelAgent[M](ctx, &adk.TypedChatModelAgentConfig[M]{
 		Name:          cfg.Name,
 		Description:   cfg.Description,
 		Instruction:   instruction,
@@ -151,29 +158,62 @@ func New(ctx context.Context, cfg *Config) (adk.ResumableAgent, error) {
 		Middlewares:   cfg.Middlewares,
 		Handlers:      append(handlers, cfg.Handlers...),
 
-		GenModelInput:       genModelInput,
+		GenModelInput:       typedGenModelInput[M],
 		ModelRetryConfig:    cfg.ModelRetryConfig,
 		ModelFailoverConfig: cfg.ModelFailoverConfig,
 		OutputKey:           cfg.OutputKey,
 	})
 }
 
-func genModelInput(ctx context.Context, instruction string, input *adk.AgentInput) ([]*schema.Message, error) {
-	msgs := make([]*schema.Message, 0, len(input.Messages)+1)
-
-	if instruction != "" {
-		msgs = append(msgs, schema.SystemMessage(instruction))
-	}
-
-	msgs = append(msgs, input.Messages...)
-
-	return msgs, nil
+// New creates a new Deep agent instance with the provided configuration.
+// This function initializes built-in tools, creates a task tool for subagent orchestration,
+// and returns a fully configured ChatModelAgent ready for execution.
+func New(ctx context.Context, cfg *Config) (adk.ResumableAgent, error) {
+	return NewTyped[*schema.Message](ctx, cfg)
 }
 
-func buildBuiltinAgentMiddlewares(ctx context.Context, cfg *Config) ([]adk.ChatModelAgentMiddleware, error) {
-	var ms []adk.ChatModelAgentMiddleware
+func typedGenModelInput[M messageType](ctx context.Context, instruction string, input *adk.TypedAgentInput[M]) ([]M, error) {
+	var zero M
+	switch any(zero).(type) {
+	case *schema.Message:
+		msgs := make([]*schema.Message, 0, len(input.Messages)+1)
+		if instruction != "" {
+			msgs = append(msgs, schema.SystemMessage(instruction))
+		}
+		// Type assertion is safe here because M = *schema.Message.
+		for _, m := range input.Messages {
+			msgs = append(msgs, any(m).(*schema.Message))
+		}
+		result := make([]M, len(msgs))
+		for i, m := range msgs {
+			result[i] = any(m).(M)
+		}
+		return result, nil
+	case *schema.AgenticMessage:
+		msgs := make([]*schema.AgenticMessage, 0, len(input.Messages)+1)
+		if instruction != "" {
+			msgs = append(msgs, schema.SystemAgenticMessage(instruction))
+		}
+		for _, m := range input.Messages {
+			msgs = append(msgs, any(m).(*schema.AgenticMessage))
+		}
+		result := make([]M, len(msgs))
+		for i, m := range msgs {
+			result[i] = any(m).(M)
+		}
+		return result, nil
+	}
+	panic("unreachable")
+}
+
+func genModelInput(ctx context.Context, instruction string, input *adk.AgentInput) ([]*schema.Message, error) {
+	return typedGenModelInput[*schema.Message](ctx, instruction, input)
+}
+
+func buildTypedBuiltinAgentMiddlewares[M messageType](ctx context.Context, cfg *TypedConfig[M]) ([]adk.TypedChatModelAgentMiddleware[M], error) {
+	var ms []adk.TypedChatModelAgentMiddleware[M]
 	if !cfg.WithoutWriteTodos {
-		t, err := newWriteTodos()
+		t, err := typedNewWriteTodos[M]()
 		if err != nil {
 			return nil, err
 		}
@@ -189,10 +229,14 @@ func buildBuiltinAgentMiddlewares(ctx context.Context, cfg *Config) ([]adk.ChatM
 		if err != nil {
 			return nil, err
 		}
-		ms = append(ms, fm)
+		ms = append(ms, adaptMiddleware[M](fm))
 	}
 
 	return ms, nil
+}
+
+func buildBuiltinAgentMiddlewares(ctx context.Context, cfg *Config) ([]adk.ChatModelAgentMiddleware, error) {
+	return buildTypedBuiltinAgentMiddlewares[*schema.Message](ctx, cfg)
 }
 
 type TODO struct {
@@ -205,7 +249,7 @@ type writeTodosArguments struct {
 	Todos []TODO `json:"todos"`
 }
 
-func newWriteTodos() (adk.ChatModelAgentMiddleware, error) {
+func typedNewWriteTodos[M messageType]() (adk.TypedChatModelAgentMiddleware[M], error) {
 	toolDesc := internal.SelectPrompt(internal.I18nPrompts{
 		English: writeTodosToolDescription,
 		Chinese: writeTodosToolDescriptionChinese,
@@ -227,5 +271,9 @@ func newWriteTodos() (adk.ChatModelAgentMiddleware, error) {
 		return nil, err
 	}
 
-	return buildAppendPromptTool("", t), nil
+	return typedBuildAppendPromptTool[M]("", t), nil
+}
+
+func newWriteTodos() (adk.ChatModelAgentMiddleware, error) {
+	return typedNewWriteTodos[*schema.Message]()
 }

--- a/adk/prebuilt/deep/deep.go
+++ b/adk/prebuilt/deep/deep.go
@@ -100,7 +100,7 @@ type TypedConfig[M adk.MessageType] struct {
 	// ModelFailoverConfig configures failover behavior for the ChatModel.
 	// When set, the agent will automatically fail over to alternative models on errors.
 	// This config is also propagated to the general sub-agent.
-	ModelFailoverConfig *adk.TypedModelFailoverConfig[M]
+	ModelFailoverConfig *adk.ModelFailoverConfig[M]
 
 	// OutputKey stores the agent's response in the session.
 	// Optional. When set, stores output via AddSessionValue(ctx, outputKey, msg.Content).

--- a/adk/prebuilt/deep/deep.go
+++ b/adk/prebuilt/deep/deep.go
@@ -41,7 +41,7 @@ func init() {
 // An Agentic DeepAgent (M = *schema.AgenticMessage) only supports Agentic sub-agents,
 // and a standard DeepAgent (M = *schema.Message) only supports standard sub-agents.
 // This is enforced by the type system through the SubAgents field.
-type TypedConfig[M messageType] struct {
+type TypedConfig[M adk.MessageType] struct {
 	// Name is the identifier for the Deep agent.
 	Name string
 	// Description provides a brief explanation of the agent's purpose.
@@ -113,8 +113,8 @@ type Config = TypedConfig[*schema.Message]
 // NewTyped creates a new typed Deep agent instance with the provided configuration.
 // This function initializes built-in tools, creates a task tool for subagent orchestration,
 // and returns a fully configured TypedChatModelAgent ready for execution.
-func NewTyped[M messageType](ctx context.Context, cfg *TypedConfig[M]) (adk.TypedResumableAgent[M], error) {
-	handlers, err := buildTypedBuiltinAgentMiddlewares[M](ctx, cfg)
+func NewTyped[M adk.MessageType](ctx context.Context, cfg *TypedConfig[M]) (adk.TypedResumableAgent[M], error) {
+	handlers, err := buildTypedBuiltinAgentMiddlewares(ctx, cfg)
 	if err != nil {
 		return nil, err
 	}
@@ -172,7 +172,7 @@ func New(ctx context.Context, cfg *Config) (adk.ResumableAgent, error) {
 	return NewTyped[*schema.Message](ctx, cfg)
 }
 
-func typedGenModelInput[M messageType](ctx context.Context, instruction string, input *adk.TypedAgentInput[M]) ([]M, error) {
+func typedGenModelInput[M adk.MessageType](_ context.Context, instruction string, input *adk.TypedAgentInput[M]) ([]M, error) {
 	var zero M
 	switch any(zero).(type) {
 	case *schema.Message:
@@ -206,11 +206,7 @@ func typedGenModelInput[M messageType](ctx context.Context, instruction string, 
 	panic("unreachable")
 }
 
-func genModelInput(ctx context.Context, instruction string, input *adk.AgentInput) ([]*schema.Message, error) {
-	return typedGenModelInput[*schema.Message](ctx, instruction, input)
-}
-
-func buildTypedBuiltinAgentMiddlewares[M messageType](ctx context.Context, cfg *TypedConfig[M]) ([]adk.TypedChatModelAgentMiddleware[M], error) {
+func buildTypedBuiltinAgentMiddlewares[M adk.MessageType](ctx context.Context, cfg *TypedConfig[M]) ([]adk.TypedChatModelAgentMiddleware[M], error) {
 	var ms []adk.TypedChatModelAgentMiddleware[M]
 	if !cfg.WithoutWriteTodos {
 		t, err := typedNewWriteTodos[M]()
@@ -221,7 +217,7 @@ func buildTypedBuiltinAgentMiddlewares[M messageType](ctx context.Context, cfg *
 	}
 
 	if cfg.Backend != nil || cfg.Shell != nil || cfg.StreamingShell != nil {
-		fm, err := filesystem2.New(ctx, &filesystem2.MiddlewareConfig{
+		fm, err := filesystem2.NewTyped[M](ctx, &filesystem2.MiddlewareConfig{
 			Backend:        cfg.Backend,
 			Shell:          cfg.Shell,
 			StreamingShell: cfg.StreamingShell,
@@ -229,14 +225,10 @@ func buildTypedBuiltinAgentMiddlewares[M messageType](ctx context.Context, cfg *
 		if err != nil {
 			return nil, err
 		}
-		ms = append(ms, adaptMiddleware[M](fm))
+		ms = append(ms, fm)
 	}
 
 	return ms, nil
-}
-
-func buildBuiltinAgentMiddlewares(ctx context.Context, cfg *Config) ([]adk.ChatModelAgentMiddleware, error) {
-	return buildTypedBuiltinAgentMiddlewares[*schema.Message](ctx, cfg)
 }
 
 type TODO struct {
@@ -249,7 +241,7 @@ type writeTodosArguments struct {
 	Todos []TODO `json:"todos"`
 }
 
-func typedNewWriteTodos[M messageType]() (adk.TypedChatModelAgentMiddleware[M], error) {
+func typedNewWriteTodos[M adk.MessageType]() (adk.TypedChatModelAgentMiddleware[M], error) {
 	toolDesc := internal.SelectPrompt(internal.I18nPrompts{
 		English: writeTodosToolDescription,
 		Chinese: writeTodosToolDescriptionChinese,
@@ -272,8 +264,4 @@ func typedNewWriteTodos[M messageType]() (adk.TypedChatModelAgentMiddleware[M], 
 	}
 
 	return typedBuildAppendPromptTool[M]("", t), nil
-}
-
-func newWriteTodos() (adk.ChatModelAgentMiddleware, error) {
-	return typedNewWriteTodos[*schema.Message]()
 }

--- a/adk/prebuilt/deep/deep_test.go
+++ b/adk/prebuilt/deep/deep_test.go
@@ -42,7 +42,7 @@ func TestGenModelInput(t *testing.T) {
 			},
 		}
 
-		msgs, err := genModelInput(ctx, "You are a helpful assistant", input)
+		msgs, err := typedGenModelInput[*schema.Message](ctx, "You are a helpful assistant", input)
 		assert.NoError(t, err)
 		assert.Len(t, msgs, 2)
 		assert.Equal(t, schema.System, msgs[0].Role)
@@ -58,7 +58,7 @@ func TestGenModelInput(t *testing.T) {
 			},
 		}
 
-		msgs, err := genModelInput(ctx, "", input)
+		msgs, err := typedGenModelInput[*schema.Message](ctx, "", input)
 		assert.NoError(t, err)
 		assert.Len(t, msgs, 1)
 		assert.Equal(t, schema.User, msgs[0].Role)
@@ -67,10 +67,10 @@ func TestGenModelInput(t *testing.T) {
 }
 
 func TestWriteTodos(t *testing.T) {
-	m, err := buildBuiltinAgentMiddlewares(context.Background(), &Config{WithoutWriteTodos: false})
+	m, err := buildTypedBuiltinAgentMiddlewares[*schema.Message](context.Background(), &Config{WithoutWriteTodos: false})
 	assert.NoError(t, err)
 
-	wt := m[0].(*appendPromptTool).t.(tool.InvokableTool)
+	wt := m[0].(*typedAppendPromptTool[*schema.Message]).t.(tool.InvokableTool)
 
 	todos := `[{"content":"content1","activeForm":"","status":"pending"},{"content":"content2","activeForm":"","status":"pending"}]`
 	args := fmt.Sprintf(`{"todos": %s}`, todos)
@@ -202,7 +202,7 @@ type spyStreamingSubAgent struct {
 
 func (s *spyStreamingSubAgent) Name(context.Context) string        { return "spy-streaming-subagent" }
 func (s *spyStreamingSubAgent) Description(context.Context) string { return "spy" }
-func (s *spyStreamingSubAgent) Run(ctx context.Context, input *adk.AgentInput, _ ...adk.AgentRunOption) *adk.AsyncIterator[*adk.AgentEvent] {
+func (s *spyStreamingSubAgent) Run(_ context.Context, input *adk.AgentInput, _ ...adk.AgentRunOption) *adk.AsyncIterator[*adk.AgentEvent] {
 	if input != nil {
 		s.seenEnableStreaming = input.EnableStreaming
 	}

--- a/adk/prebuilt/deep/task_tool.go
+++ b/adk/prebuilt/deep/task_tool.go
@@ -32,6 +32,32 @@ import (
 	"github.com/cloudwego/eino/schema"
 )
 
+func typedTaskToolMiddleware[M messageType](
+	ctx context.Context,
+	taskToolDescriptionGenerator func(ctx context.Context, subAgents []adk.TypedAgent[M]) (string, error),
+	subAgents []adk.TypedAgent[M],
+
+	withoutGeneralSubAgent bool,
+	cm model.BaseModel[M],
+	instruction string,
+	toolsConfig adk.ToolsConfig,
+	maxIteration int,
+	middlewares []adk.AgentMiddleware,
+	handlers []adk.TypedChatModelAgentMiddleware[M],
+	modelFailoverConfig *adk.TypedModelFailoverConfig[M],
+) (adk.TypedChatModelAgentMiddleware[M], error) {
+	t, err := typedNewTaskTool(ctx, taskToolDescriptionGenerator, subAgents, withoutGeneralSubAgent, cm, instruction, toolsConfig, maxIteration, middlewares, handlers, modelFailoverConfig)
+	if err != nil {
+		return nil, err
+	}
+	prompt := internal.SelectPrompt(internal.I18nPrompts{
+		English: taskPrompt,
+		Chinese: taskPromptChinese,
+	})
+
+	return typedBuildAppendPromptTool[M](prompt, t), nil
+}
+
 func newTaskToolMiddleware(
 	ctx context.Context,
 	taskToolDescriptionGenerator func(ctx context.Context, subAgents []adk.Agent) (string, error),
@@ -47,16 +73,72 @@ func newTaskToolMiddleware(
 	handlers []adk.ChatModelAgentMiddleware,
 	modelFailoverConfig *adk.ModelFailoverConfig,
 ) (adk.ChatModelAgentMiddleware, error) {
-	t, err := newTaskTool(ctx, taskToolDescriptionGenerator, subAgents, withoutGeneralSubAgent, cm, instruction, toolsConfig, maxIteration, middlewares, handlers, modelFailoverConfig)
-	if err != nil {
-		return nil, err
-	}
-	prompt := internal.SelectPrompt(internal.I18nPrompts{
-		English: taskPrompt,
-		Chinese: taskPromptChinese,
-	})
+	return typedTaskToolMiddleware[*schema.Message](ctx, taskToolDescriptionGenerator, subAgents, withoutGeneralSubAgent, cm, instruction, toolsConfig, maxIteration, middlewares, handlers, modelFailoverConfig)
+}
 
-	return buildAppendPromptTool(prompt, t), nil
+func typedNewTaskTool[M messageType](
+	ctx context.Context,
+	taskToolDescriptionGenerator func(ctx context.Context, subAgents []adk.TypedAgent[M]) (string, error),
+	subAgents []adk.TypedAgent[M],
+
+	withoutGeneralSubAgent bool,
+	cm model.BaseModel[M],
+	instruction string,
+	toolsConfig adk.ToolsConfig,
+	maxIteration int,
+	middlewares []adk.AgentMiddleware,
+	handlers []adk.TypedChatModelAgentMiddleware[M],
+	modelFailoverConfig *adk.TypedModelFailoverConfig[M],
+) (tool.InvokableTool, error) {
+	t := &typedTaskTool[M]{
+		subAgents:     map[string]tool.InvokableTool{},
+		subAgentSlice: subAgents,
+		descGen:       typedDefaultTaskToolDescription[M],
+	}
+
+	if taskToolDescriptionGenerator != nil {
+		t.descGen = taskToolDescriptionGenerator
+	}
+
+	if !withoutGeneralSubAgent {
+		agentDesc := internal.SelectPrompt(internal.I18nPrompts{
+			English: generalAgentDescription,
+			Chinese: generalAgentDescriptionChinese,
+		})
+		generalAgent, err := adk.NewTypedChatModelAgent[M](ctx, &adk.TypedChatModelAgentConfig[M]{
+			Name:                generalAgentName,
+			Description:         agentDesc,
+			Instruction:         instruction,
+			Model:               cm,
+			ToolsConfig:         toolsConfig,
+			MaxIterations:       maxIteration,
+			Middlewares:         middlewares,
+			Handlers:            handlers,
+			GenModelInput:       typedGenModelInput[M],
+			ModelFailoverConfig: modelFailoverConfig,
+		})
+		if err != nil {
+			return nil, err
+		}
+
+		it, err := assertAgentTool(adk.NewTypedAgentTool[M](ctx, generalAgent))
+		if err != nil {
+			return nil, err
+		}
+		t.subAgents[generalAgent.Name(ctx)] = it
+		t.subAgentSlice = append(t.subAgentSlice, generalAgent)
+	}
+
+	for _, a := range subAgents {
+		name := a.Name(ctx)
+		it, err := assertAgentTool(adk.NewTypedAgentTool[M](ctx, a))
+		if err != nil {
+			return nil, err
+		}
+		t.subAgents[name] = it
+	}
+
+	return t, nil
 }
 
 func newTaskTool(
@@ -74,64 +156,18 @@ func newTaskTool(
 	handlers []adk.ChatModelAgentMiddleware,
 	modelFailoverConfig *adk.ModelFailoverConfig,
 ) (tool.InvokableTool, error) {
-	t := &taskTool{
-		subAgents:     map[string]tool.InvokableTool{},
-		subAgentSlice: subAgents,
-		descGen:       defaultTaskToolDescription,
-	}
-
-	if taskToolDescriptionGenerator != nil {
-		t.descGen = taskToolDescriptionGenerator
-	}
-
-	if !withoutGeneralSubAgent {
-		agentDesc := internal.SelectPrompt(internal.I18nPrompts{
-			English: generalAgentDescription,
-			Chinese: generalAgentDescriptionChinese,
-		})
-		generalAgent, err := adk.NewChatModelAgent(ctx, &adk.ChatModelAgentConfig{
-			Name:                generalAgentName,
-			Description:         agentDesc,
-			Instruction:         Instruction,
-			Model:               Model,
-			ToolsConfig:         ToolsConfig,
-			MaxIterations:       MaxIteration,
-			Middlewares:         middlewares,
-			Handlers:            handlers,
-			GenModelInput:       genModelInput,
-			ModelFailoverConfig: modelFailoverConfig,
-		})
-		if err != nil {
-			return nil, err
-		}
-
-		it, err := assertAgentTool(adk.NewAgentTool(ctx, generalAgent))
-		if err != nil {
-			return nil, err
-		}
-		t.subAgents[generalAgent.Name(ctx)] = it
-		t.subAgentSlice = append(t.subAgentSlice, generalAgent)
-	}
-
-	for _, a := range subAgents {
-		name := a.Name(ctx)
-		it, err := assertAgentTool(adk.NewAgentTool(ctx, a))
-		if err != nil {
-			return nil, err
-		}
-		t.subAgents[name] = it
-	}
-
-	return t, nil
+	return typedNewTaskTool[*schema.Message](ctx, taskToolDescriptionGenerator, subAgents, withoutGeneralSubAgent, Model, Instruction, ToolsConfig, MaxIteration, middlewares, handlers, modelFailoverConfig)
 }
 
-type taskTool struct {
+type typedTaskTool[M messageType] struct {
 	subAgents     map[string]tool.InvokableTool
-	subAgentSlice []adk.Agent
-	descGen       func(ctx context.Context, subAgents []adk.Agent) (string, error)
+	subAgentSlice []adk.TypedAgent[M]
+	descGen       func(ctx context.Context, subAgents []adk.TypedAgent[M]) (string, error)
 }
 
-func (t *taskTool) Info(ctx context.Context) (*schema.ToolInfo, error) {
+type taskTool = typedTaskTool[*schema.Message]
+
+func (t *typedTaskTool[M]) Info(ctx context.Context) (*schema.ToolInfo, error) {
 	desc, err := t.descGen(ctx, t.subAgentSlice)
 	if err != nil {
 		return nil, err
@@ -155,7 +191,7 @@ type taskToolArgument struct {
 	Description  string `json:"description"`
 }
 
-func (t *taskTool) InvokableRun(ctx context.Context, argumentsInJSON string, opts ...tool.Option) (string, error) {
+func (t *typedTaskTool[M]) InvokableRun(ctx context.Context, argumentsInJSON string, opts ...tool.Option) (string, error) {
 	input := &taskToolArgument{}
 	err := json.Unmarshal([]byte(argumentsInJSON), input)
 	if err != nil {
@@ -176,7 +212,7 @@ func (t *taskTool) InvokableRun(ctx context.Context, argumentsInJSON string, opt
 	return a.InvokableRun(ctx, params, opts...)
 }
 
-func defaultTaskToolDescription(ctx context.Context, subAgents []adk.Agent) (string, error) {
+func typedDefaultTaskToolDescription[M messageType](ctx context.Context, subAgents []adk.TypedAgent[M]) (string, error) {
 	subAgentsDescBuilder := strings.Builder{}
 	for _, a := range subAgents {
 		name := a.Name(ctx)
@@ -190,4 +226,8 @@ func defaultTaskToolDescription(ctx context.Context, subAgents []adk.Agent) (str
 	return pyfmt.Fmt(toolDesc, map[string]any{
 		"other_agents": subAgentsDescBuilder.String(),
 	})
+}
+
+func defaultTaskToolDescription(ctx context.Context, subAgents []adk.Agent) (string, error) {
+	return typedDefaultTaskToolDescription[*schema.Message](ctx, subAgents)
 }

--- a/adk/prebuilt/deep/task_tool.go
+++ b/adk/prebuilt/deep/task_tool.go
@@ -44,7 +44,7 @@ func typedTaskToolMiddleware[M adk.MessageType](
 	maxIteration int,
 	middlewares []adk.AgentMiddleware,
 	handlers []adk.TypedChatModelAgentMiddleware[M],
-	modelFailoverConfig *adk.TypedModelFailoverConfig[M],
+	modelFailoverConfig *adk.ModelFailoverConfig[M],
 ) (adk.TypedChatModelAgentMiddleware[M], error) {
 	t, err := typedNewTaskTool(ctx, taskToolDescriptionGenerator, subAgents, withoutGeneralSubAgent, cm, instruction, toolsConfig, maxIteration, middlewares, handlers, modelFailoverConfig)
 	if err != nil {
@@ -70,7 +70,7 @@ func typedNewTaskTool[M adk.MessageType](
 	maxIteration int,
 	middlewares []adk.AgentMiddleware,
 	handlers []adk.TypedChatModelAgentMiddleware[M],
-	modelFailoverConfig *adk.TypedModelFailoverConfig[M],
+	modelFailoverConfig *adk.ModelFailoverConfig[M],
 ) (tool.InvokableTool, error) {
 	t := &typedTaskTool[M]{
 		subAgents:     map[string]tool.InvokableTool{},

--- a/adk/prebuilt/deep/task_tool.go
+++ b/adk/prebuilt/deep/task_tool.go
@@ -32,7 +32,7 @@ import (
 	"github.com/cloudwego/eino/schema"
 )
 
-func typedTaskToolMiddleware[M messageType](
+func typedTaskToolMiddleware[M adk.MessageType](
 	ctx context.Context,
 	taskToolDescriptionGenerator func(ctx context.Context, subAgents []adk.TypedAgent[M]) (string, error),
 	subAgents []adk.TypedAgent[M],
@@ -58,25 +58,7 @@ func typedTaskToolMiddleware[M messageType](
 	return typedBuildAppendPromptTool[M](prompt, t), nil
 }
 
-func newTaskToolMiddleware(
-	ctx context.Context,
-	taskToolDescriptionGenerator func(ctx context.Context, subAgents []adk.Agent) (string, error),
-	subAgents []adk.Agent,
-
-	withoutGeneralSubAgent bool,
-	// cm is the chat model. Tools are configured via model.WithTools call option.
-	cm model.BaseChatModel,
-	instruction string,
-	toolsConfig adk.ToolsConfig,
-	maxIteration int,
-	middlewares []adk.AgentMiddleware,
-	handlers []adk.ChatModelAgentMiddleware,
-	modelFailoverConfig *adk.ModelFailoverConfig,
-) (adk.ChatModelAgentMiddleware, error) {
-	return typedTaskToolMiddleware[*schema.Message](ctx, taskToolDescriptionGenerator, subAgents, withoutGeneralSubAgent, cm, instruction, toolsConfig, maxIteration, middlewares, handlers, modelFailoverConfig)
-}
-
-func typedNewTaskTool[M messageType](
+func typedNewTaskTool[M adk.MessageType](
 	ctx context.Context,
 	taskToolDescriptionGenerator func(ctx context.Context, subAgents []adk.TypedAgent[M]) (string, error),
 	subAgents []adk.TypedAgent[M],
@@ -141,31 +123,11 @@ func typedNewTaskTool[M messageType](
 	return t, nil
 }
 
-func newTaskTool(
-	ctx context.Context,
-	taskToolDescriptionGenerator func(ctx context.Context, subAgents []adk.Agent) (string, error),
-	subAgents []adk.Agent,
-
-	withoutGeneralSubAgent bool,
-	// Model is the chat model. Tools are configured via model.WithTools call option.
-	Model model.BaseChatModel,
-	Instruction string,
-	ToolsConfig adk.ToolsConfig,
-	MaxIteration int,
-	middlewares []adk.AgentMiddleware,
-	handlers []adk.ChatModelAgentMiddleware,
-	modelFailoverConfig *adk.ModelFailoverConfig,
-) (tool.InvokableTool, error) {
-	return typedNewTaskTool[*schema.Message](ctx, taskToolDescriptionGenerator, subAgents, withoutGeneralSubAgent, Model, Instruction, ToolsConfig, MaxIteration, middlewares, handlers, modelFailoverConfig)
-}
-
-type typedTaskTool[M messageType] struct {
+type typedTaskTool[M adk.MessageType] struct {
 	subAgents     map[string]tool.InvokableTool
 	subAgentSlice []adk.TypedAgent[M]
 	descGen       func(ctx context.Context, subAgents []adk.TypedAgent[M]) (string, error)
 }
-
-type taskTool = typedTaskTool[*schema.Message]
 
 func (t *typedTaskTool[M]) Info(ctx context.Context) (*schema.ToolInfo, error) {
 	desc, err := t.descGen(ctx, t.subAgentSlice)
@@ -212,7 +174,7 @@ func (t *typedTaskTool[M]) InvokableRun(ctx context.Context, argumentsInJSON str
 	return a.InvokableRun(ctx, params, opts...)
 }
 
-func typedDefaultTaskToolDescription[M messageType](ctx context.Context, subAgents []adk.TypedAgent[M]) (string, error) {
+func typedDefaultTaskToolDescription[M adk.MessageType](ctx context.Context, subAgents []adk.TypedAgent[M]) (string, error) {
 	subAgentsDescBuilder := strings.Builder{}
 	for _, a := range subAgents {
 		name := a.Name(ctx)
@@ -226,8 +188,4 @@ func typedDefaultTaskToolDescription[M messageType](ctx context.Context, subAgen
 	return pyfmt.Fmt(toolDesc, map[string]any{
 		"other_agents": subAgentsDescBuilder.String(),
 	})
-}
-
-func defaultTaskToolDescription(ctx context.Context, subAgents []adk.Agent) (string, error) {
-	return typedDefaultTaskToolDescription[*schema.Message](ctx, subAgents)
 }

--- a/adk/prebuilt/deep/task_tool_test.go
+++ b/adk/prebuilt/deep/task_tool_test.go
@@ -30,7 +30,7 @@ func TestTaskTool(t *testing.T) {
 	a1 := &myAgent{name: "1", desc: "desc of my agent 1"}
 	a2 := &myAgent{name: "2", desc: "desc of my agent 2"}
 	ctx := context.Background()
-	tt, err := newTaskTool(
+	tt, err := typedNewTaskTool[*schema.Message](
 		ctx,
 		nil,
 		[]adk.Agent{a1, a2},
@@ -62,15 +62,15 @@ type myAgent struct {
 	desc string
 }
 
-func (m *myAgent) Name(ctx context.Context) string {
+func (m *myAgent) Name(_ context.Context) string {
 	return m.name
 }
 
-func (m *myAgent) Description(ctx context.Context) string {
+func (m *myAgent) Description(_ context.Context) string {
 	return m.desc
 }
 
-func (m *myAgent) Run(ctx context.Context, input *adk.AgentInput, options ...adk.AgentRunOption) *adk.AsyncIterator[*adk.AgentEvent] {
+func (m *myAgent) Run(_ context.Context, _ *adk.AgentInput, _ ...adk.AgentRunOption) *adk.AsyncIterator[*adk.AgentEvent] {
 	iter, gen := adk.NewAsyncIteratorPair[*adk.AgentEvent]()
 	gen.Send(adk.EventFromMessage(schema.UserMessage(m.desc), nil, schema.User, ""))
 	gen.Close()

--- a/adk/prebuilt/deep/types.go
+++ b/adk/prebuilt/deep/types.go
@@ -22,19 +22,12 @@ import (
 
 	"github.com/cloudwego/eino/adk"
 	"github.com/cloudwego/eino/components/tool"
-	"github.com/cloudwego/eino/schema"
 )
 
 const (
 	generalAgentName = "general-purpose"
 	taskToolName     = "task"
 )
-
-// messageType is the sealed type constraint for message types in the deep package.
-// This mirrors the unexported constraint in the adk package.
-type messageType interface {
-	*schema.Message | *schema.AgenticMessage
-}
 
 const (
 	SessionKeyTodos = "deep_agent_session_key_todos"
@@ -48,7 +41,7 @@ func assertAgentTool(t tool.BaseTool) (tool.InvokableTool, error) {
 	return it, nil
 }
 
-func typedBuildAppendPromptTool[M messageType](prompt string, t tool.BaseTool) adk.TypedChatModelAgentMiddleware[M] {
+func typedBuildAppendPromptTool[M adk.MessageType](prompt string, t tool.BaseTool) adk.TypedChatModelAgentMiddleware[M] {
 	return &typedAppendPromptTool[M]{
 		TypedBaseChatModelAgentMiddleware: &adk.TypedBaseChatModelAgentMiddleware[M]{},
 		t:                                 t,
@@ -56,17 +49,11 @@ func typedBuildAppendPromptTool[M messageType](prompt string, t tool.BaseTool) a
 	}
 }
 
-func buildAppendPromptTool(prompt string, t tool.BaseTool) adk.ChatModelAgentMiddleware {
-	return typedBuildAppendPromptTool[*schema.Message](prompt, t)
-}
-
-type typedAppendPromptTool[M messageType] struct {
+type typedAppendPromptTool[M adk.MessageType] struct {
 	*adk.TypedBaseChatModelAgentMiddleware[M]
 	t      tool.BaseTool
 	prompt string
 }
-
-type appendPromptTool = typedAppendPromptTool[*schema.Message]
 
 func (w *typedAppendPromptTool[M]) BeforeAgent(ctx context.Context, runCtx *adk.ChatModelAgentContext) (context.Context, *adk.ChatModelAgentContext, error) {
 	nRunCtx := *runCtx
@@ -75,42 +62,4 @@ func (w *typedAppendPromptTool[M]) BeforeAgent(ctx context.Context, runCtx *adk.
 		nRunCtx.Tools = append(nRunCtx.Tools, w.t)
 	}
 	return ctx, &nRunCtx, nil
-}
-
-type middlewareAdapter[M messageType] struct {
-	*adk.TypedBaseChatModelAgentMiddleware[M]
-	inner adk.ChatModelAgentMiddleware
-}
-
-func (a *middlewareAdapter[M]) BeforeAgent(ctx context.Context, runCtx *adk.ChatModelAgentContext) (context.Context, *adk.ChatModelAgentContext, error) {
-	return a.inner.BeforeAgent(ctx, runCtx)
-}
-
-func (a *middlewareAdapter[M]) WrapInvokableToolCall(ctx context.Context, endpoint adk.InvokableToolCallEndpoint, tCtx *adk.ToolContext) (adk.InvokableToolCallEndpoint, error) {
-	return a.inner.WrapInvokableToolCall(ctx, endpoint, tCtx)
-}
-
-func (a *middlewareAdapter[M]) WrapStreamableToolCall(ctx context.Context, endpoint adk.StreamableToolCallEndpoint, tCtx *adk.ToolContext) (adk.StreamableToolCallEndpoint, error) {
-	return a.inner.WrapStreamableToolCall(ctx, endpoint, tCtx)
-}
-
-func (a *middlewareAdapter[M]) WrapEnhancedInvokableToolCall(ctx context.Context, endpoint adk.EnhancedInvokableToolCallEndpoint, tCtx *adk.ToolContext) (adk.EnhancedInvokableToolCallEndpoint, error) {
-	return a.inner.WrapEnhancedInvokableToolCall(ctx, endpoint, tCtx)
-}
-
-func (a *middlewareAdapter[M]) WrapEnhancedStreamableToolCall(ctx context.Context, endpoint adk.EnhancedStreamableToolCallEndpoint, tCtx *adk.ToolContext) (adk.EnhancedStreamableToolCallEndpoint, error) {
-	return a.inner.WrapEnhancedStreamableToolCall(ctx, endpoint, tCtx)
-}
-
-func adaptMiddleware[M messageType](m adk.ChatModelAgentMiddleware) adk.TypedChatModelAgentMiddleware[M] {
-	var zero M
-	switch any(zero).(type) {
-	case *schema.Message:
-		return any(m).(adk.TypedChatModelAgentMiddleware[M])
-	default:
-		return &middlewareAdapter[M]{
-			TypedBaseChatModelAgentMiddleware: &adk.TypedBaseChatModelAgentMiddleware[M]{},
-			inner:                             m,
-		}
-	}
 }

--- a/adk/prebuilt/deep/types.go
+++ b/adk/prebuilt/deep/types.go
@@ -22,12 +22,19 @@ import (
 
 	"github.com/cloudwego/eino/adk"
 	"github.com/cloudwego/eino/components/tool"
+	"github.com/cloudwego/eino/schema"
 )
 
 const (
 	generalAgentName = "general-purpose"
 	taskToolName     = "task"
 )
+
+// messageType is the sealed type constraint for message types in the deep package.
+// This mirrors the unexported constraint in the adk package.
+type messageType interface {
+	*schema.Message | *schema.AgenticMessage
+}
 
 const (
 	SessionKeyTodos = "deep_agent_session_key_todos"
@@ -41,25 +48,69 @@ func assertAgentTool(t tool.BaseTool) (tool.InvokableTool, error) {
 	return it, nil
 }
 
-func buildAppendPromptTool(prompt string, t tool.BaseTool) adk.ChatModelAgentMiddleware {
-	return &appendPromptTool{
-		BaseChatModelAgentMiddleware: &adk.BaseChatModelAgentMiddleware{},
-		t:                            t,
-		prompt:                       prompt,
+func typedBuildAppendPromptTool[M messageType](prompt string, t tool.BaseTool) adk.TypedChatModelAgentMiddleware[M] {
+	return &typedAppendPromptTool[M]{
+		TypedBaseChatModelAgentMiddleware: &adk.TypedBaseChatModelAgentMiddleware[M]{},
+		t:                                 t,
+		prompt:                            prompt,
 	}
 }
 
-type appendPromptTool struct {
-	*adk.BaseChatModelAgentMiddleware
+func buildAppendPromptTool(prompt string, t tool.BaseTool) adk.ChatModelAgentMiddleware {
+	return typedBuildAppendPromptTool[*schema.Message](prompt, t)
+}
+
+type typedAppendPromptTool[M messageType] struct {
+	*adk.TypedBaseChatModelAgentMiddleware[M]
 	t      tool.BaseTool
 	prompt string
 }
 
-func (w *appendPromptTool) BeforeAgent(ctx context.Context, runCtx *adk.ChatModelAgentContext) (context.Context, *adk.ChatModelAgentContext, error) {
+type appendPromptTool = typedAppendPromptTool[*schema.Message]
+
+func (w *typedAppendPromptTool[M]) BeforeAgent(ctx context.Context, runCtx *adk.ChatModelAgentContext) (context.Context, *adk.ChatModelAgentContext, error) {
 	nRunCtx := *runCtx
 	nRunCtx.Instruction += w.prompt
 	if w.t != nil {
 		nRunCtx.Tools = append(nRunCtx.Tools, w.t)
 	}
 	return ctx, &nRunCtx, nil
+}
+
+type middlewareAdapter[M messageType] struct {
+	*adk.TypedBaseChatModelAgentMiddleware[M]
+	inner adk.ChatModelAgentMiddleware
+}
+
+func (a *middlewareAdapter[M]) BeforeAgent(ctx context.Context, runCtx *adk.ChatModelAgentContext) (context.Context, *adk.ChatModelAgentContext, error) {
+	return a.inner.BeforeAgent(ctx, runCtx)
+}
+
+func (a *middlewareAdapter[M]) WrapInvokableToolCall(ctx context.Context, endpoint adk.InvokableToolCallEndpoint, tCtx *adk.ToolContext) (adk.InvokableToolCallEndpoint, error) {
+	return a.inner.WrapInvokableToolCall(ctx, endpoint, tCtx)
+}
+
+func (a *middlewareAdapter[M]) WrapStreamableToolCall(ctx context.Context, endpoint adk.StreamableToolCallEndpoint, tCtx *adk.ToolContext) (adk.StreamableToolCallEndpoint, error) {
+	return a.inner.WrapStreamableToolCall(ctx, endpoint, tCtx)
+}
+
+func (a *middlewareAdapter[M]) WrapEnhancedInvokableToolCall(ctx context.Context, endpoint adk.EnhancedInvokableToolCallEndpoint, tCtx *adk.ToolContext) (adk.EnhancedInvokableToolCallEndpoint, error) {
+	return a.inner.WrapEnhancedInvokableToolCall(ctx, endpoint, tCtx)
+}
+
+func (a *middlewareAdapter[M]) WrapEnhancedStreamableToolCall(ctx context.Context, endpoint adk.EnhancedStreamableToolCallEndpoint, tCtx *adk.ToolContext) (adk.EnhancedStreamableToolCallEndpoint, error) {
+	return a.inner.WrapEnhancedStreamableToolCall(ctx, endpoint, tCtx)
+}
+
+func adaptMiddleware[M messageType](m adk.ChatModelAgentMiddleware) adk.TypedChatModelAgentMiddleware[M] {
+	var zero M
+	switch any(zero).(type) {
+	case *schema.Message:
+		return any(m).(adk.TypedChatModelAgentMiddleware[M])
+	default:
+		return &middlewareAdapter[M]{
+			TypedBaseChatModelAgentMiddleware: &adk.TypedBaseChatModelAgentMiddleware[M]{},
+			inner:                             m,
+		}
+	}
 }

--- a/adk/react.go
+++ b/adk/react.go
@@ -31,7 +31,7 @@ import (
 // ErrExceedMaxIterations indicates the agent reached the maximum iterations limit.
 var ErrExceedMaxIterations = errors.New("exceeds max iterations")
 
-type typedState[M messageType] struct {
+type typedState[M MessageType] struct {
 	Messages []M
 	Extra    map[string]any
 
@@ -258,7 +258,7 @@ type reactInput struct {
 	Messages []Message
 }
 
-type typedReactConfig[M messageType] struct {
+type typedReactConfig[M MessageType] struct {
 	model model.BaseModel[M]
 
 	toolsConfig      *compose.ToolsNodeConfig

--- a/adk/retry_chatmodel.go
+++ b/adk/retry_chatmodel.go
@@ -78,10 +78,7 @@ func (e *RetryExhaustedError) Unwrap() error {
 type WillRetryError struct {
 	ErrStr       string
 	RetryAttempt int
-	// OutputMessage is the model's output message from the attempt that triggered the retry, if any.
-	// May be nil if the model returned an error without producing a message.
-	OutputMessage *schema.Message
-	err           error
+	err          error
 }
 
 func (e *WillRetryError) Error() string {
@@ -96,7 +93,7 @@ func init() {
 	schema.RegisterName[*WillRetryError]("eino_adk_chatmodel_will_retry_error")
 }
 
-// RetryContext contains context information passed to ModelRetryConfig.ShouldRetry
+// TypedRetryContext contains context information passed to TypedModelRetryConfig.ShouldRetry
 // during a retry decision.
 //
 // State combinations for OutputMessage and Err:
@@ -105,13 +102,13 @@ func init() {
 //	OutputMessage == nil, Err != nil  → failed call (Generate error or Stream() error)
 //	OutputMessage != nil, Err != nil  → partial stream (chunks received before mid-stream error)
 //	OutputMessage == nil, Err == nil  → empty stream (zero chunks before EOF)
-type RetryContext struct {
+type TypedRetryContext[M messageType] struct {
 	// RetryAttempt is the current retry attempt number (1-based).
 	// For the first retry decision (after the initial call), this is 1.
 	RetryAttempt int
 
 	// InputMessages is the input messages that were sent to the model for the current attempt.
-	InputMessages []*schema.Message
+	InputMessages []M
 
 	// Options is the model options that were used for the current attempt.
 	Options []model.Option
@@ -124,7 +121,7 @@ type RetryContext struct {
 	// received before the error occurred.
 	// May be nil if the model returned an error without producing a message, or if the
 	// stream was empty (zero chunks before EOF).
-	OutputMessage *schema.Message
+	OutputMessage M
 
 	// Err is the error from the model call, if any.
 	// May be nil if the model produced a message without error.
@@ -132,8 +129,11 @@ type RetryContext struct {
 	Err error
 }
 
-// RetryDecision represents the decision made by ModelRetryConfig.ShouldRetry.
-type RetryDecision struct {
+// RetryContext is the default retry context type using *schema.Message.
+type RetryContext = TypedRetryContext[*schema.Message]
+
+// TypedRetryDecision represents the decision made by TypedModelRetryConfig.ShouldRetry.
+type TypedRetryDecision[M messageType] struct {
 	// Retry indicates whether the model call should be retried.
 	// If false, the model output (or error) is accepted as-is, unless RewriteError is set.
 	Retry bool
@@ -157,7 +157,7 @@ type RetryDecision struct {
 	//
 	// This enables advanced recovery strategies like context compression or message trimming.
 	// Only used when Retry is true. Ignored when Retry is false.
-	ModifiedInputMessages []*schema.Message
+	ModifiedInputMessages []M
 
 	// PersistModifiedInputMessages controls whether ModifiedInputMessages are written
 	// back to the agent's conversation history, affecting subsequent model calls in
@@ -192,9 +192,12 @@ type RetryDecision struct {
 	Backoff time.Duration
 }
 
-// ModelRetryConfig configures retry behavior for the ChatModel node.
+// RetryDecision is the default retry decision type using *schema.Message.
+type RetryDecision = TypedRetryDecision[*schema.Message]
+
+// TypedModelRetryConfig configures retry behavior for the ChatModel node.
 // It defines how the agent should handle transient failures when calling the ChatModel.
-type ModelRetryConfig struct {
+type TypedModelRetryConfig[M messageType] struct {
 	// MaxRetries specifies the maximum number of retry attempts.
 	// A value of 0 means no retries will be attempted.
 	// A value of 3 means up to 3 retry attempts (4 total calls including the initial attempt).
@@ -211,7 +214,7 @@ type ModelRetryConfig struct {
 	// Note: In streaming mode, the entire stream is consumed before ShouldRetry is called.
 	// The event stream is sent to the client in real time regardless; only the retry
 	// decision is deferred until the full response is available.
-	ShouldRetry func(ctx context.Context, retryCtx *RetryContext) *RetryDecision
+	ShouldRetry func(ctx context.Context, retryCtx *TypedRetryContext[M]) *TypedRetryDecision[M]
 
 	// Deprecated: Use ShouldRetry instead for richer retry control including message
 	// inspection, input modification, and option adjustment. When ShouldRetry is set,
@@ -226,6 +229,9 @@ type ModelRetryConfig struct {
 	// with random jitter (0-50% of delay) to prevent thundering herd.
 	BackoffFunc func(ctx context.Context, attempt int) time.Duration
 }
+
+// ModelRetryConfig is the default retry config type using *schema.Message.
+type ModelRetryConfig = TypedModelRetryConfig[*schema.Message]
 
 func defaultIsRetryAble(_ context.Context, err error) bool {
 	return err != nil
@@ -282,10 +288,9 @@ type retryVerdictSignal struct {
 }
 
 type retryVerdict struct {
-	WillRetry     bool
-	RetryAttempt  int
-	Err           error
-	OutputMessage *schema.Message
+	WillRetry    bool
+	RetryAttempt int
+	Err          error
 }
 
 // retryModelWrapper wraps a BaseChatModel with retry logic.
@@ -294,20 +299,16 @@ type retryVerdict struct {
 // callback injection) without re-running state management (BeforeModelRewriteState/AfterModelRewriteState).
 type typedRetryModelWrapper[M messageType] struct {
 	inner  model.BaseModel[M]
-	config *ModelRetryConfig
+	config *TypedModelRetryConfig[M]
 }
 
-func newTypedRetryModelWrapper[M messageType](inner model.BaseModel[M], config *ModelRetryConfig) *typedRetryModelWrapper[M] {
+func newTypedRetryModelWrapper[M messageType](inner model.BaseModel[M], config *TypedModelRetryConfig[M]) *typedRetryModelWrapper[M] {
 	return &typedRetryModelWrapper[M]{inner: inner, config: config}
 }
 
 func (r *typedRetryModelWrapper[M]) Generate(ctx context.Context, input []M, opts ...model.Option) (M, error) {
 	if r.config.ShouldRetry != nil {
-		// ShouldRetry is *schema.Message-specific (RetryContext.OutputMessage is *schema.Message).
-		msgR, _ := any(r).(*typedRetryModelWrapper[*schema.Message])
-		msgInput, _ := any(input).([]Message)
-		out, err := generateWithShouldRetry(msgR, ctx, msgInput, opts...)
-		return any(out).(M), err
+		return generateWithShouldRetry(r, ctx, input, opts...)
 	}
 	return r.generateLegacy(ctx, input, opts...)
 }
@@ -352,27 +353,27 @@ func (r *typedRetryModelWrapper[M]) generateLegacy(ctx context.Context, input []
 	return zero, &RetryExhaustedError{LastErr: lastErr, TotalRetries: r.config.MaxRetries}
 }
 
-func generateWithShouldRetry(r *typedRetryModelWrapper[*schema.Message], ctx context.Context, input []*schema.Message, opts ...model.Option) (*schema.Message, error) {
+func generateWithShouldRetry[M messageType](r *typedRetryModelWrapper[M], ctx context.Context, input []M, opts ...model.Option) (M, error) {
 	backoffFunc := r.config.BackoffFunc
 	if backoffFunc == nil {
 		backoffFunc = defaultBackoff
 	}
 
-	execCtx := getTypedChatModelAgentExecCtx[*schema.Message](ctx)
+	execCtx := getTypedChatModelAgentExecCtx[M](ctx)
 
 	currentInput := input
 	currentOpts := opts
 	var lastErr error
 
 	defer func() {
-		_ = compose.ProcessState(ctx, func(_ context.Context, st *State) error {
+		_ = compose.ProcessState(ctx, func(_ context.Context, st *typedState[M]) error {
 			st.setRetryAttempt(0)
 			return nil
 		})
 	}()
 
 	for attempt := 0; attempt <= r.config.MaxRetries; attempt++ {
-		_ = compose.ProcessState(ctx, func(_ context.Context, st *State) error {
+		_ = compose.ProcessState(ctx, func(_ context.Context, st *typedState[M]) error {
 			st.setRetryAttempt(attempt)
 			return nil
 		})
@@ -390,15 +391,17 @@ func generateWithShouldRetry(r *typedRetryModelWrapper[*schema.Message], ctx con
 
 		if err != nil {
 			if _, ok := compose.ExtractInterruptInfo(err); ok {
-				return nil, err
+				var zero M
+				return zero, err
 			}
 
 			if errors.Is(err, ErrStreamCanceled) {
-				return nil, err
+				var zero M
+				return zero, err
 			}
 		}
 
-		retryCtx := &RetryContext{
+		retryCtx := &TypedRetryContext[M]{
 			RetryAttempt:  attempt + 1,
 			InputMessages: currentInput,
 			Options:       currentOpts,
@@ -407,19 +410,20 @@ func generateWithShouldRetry(r *typedRetryModelWrapper[*schema.Message], ctx con
 		}
 		decision := r.config.ShouldRetry(ctx, retryCtx)
 		if decision == nil {
-			decision = &RetryDecision{}
+			decision = &TypedRetryDecision[M]{}
 		}
 
 		if !decision.Retry {
 			if decision.RewriteError != nil {
-				return nil, decision.RewriteError
+				var zero M
+				return zero, decision.RewriteError
 			}
 			if err != nil {
-				return nil, err
+				var zero M
+				return zero, err
 			}
 			if execCtx != nil && execCtx.generator != nil && out != nil {
-				msgCopy := *out
-				event := EventFromMessage(&msgCopy, nil, schema.Assistant, "")
+				event := typedModelOutputEvent[M](out, nil)
 				execCtx.send(event)
 			}
 			return out, nil
@@ -442,11 +446,13 @@ func generateWithShouldRetry(r *typedRetryModelWrapper[*schema.Message], ctx con
 		}
 
 		if err := r.contextAwareSleep(ctx, delay); err != nil {
-			return nil, err
+			var zero M
+			return zero, err
 		}
 	}
 
-	return nil, &RetryExhaustedError{LastErr: lastErr, TotalRetries: r.config.MaxRetries}
+	var zero M
+	return zero, &RetryExhaustedError{LastErr: lastErr, TotalRetries: r.config.MaxRetries}
 }
 
 func (r *typedRetryModelWrapper[M]) contextAwareSleep(ctx context.Context, delay time.Duration) error {
@@ -461,31 +467,8 @@ func (r *typedRetryModelWrapper[M]) contextAwareSleep(ctx context.Context, delay
 	}
 }
 
-func consumeStreamForMessage(stream *schema.StreamReader[*schema.Message]) (*schema.Message, error) {
-	defer stream.Close()
-	var chunks []*schema.Message
-	for {
-		chunk, err := stream.Recv()
-		if err == io.EOF {
-			if len(chunks) == 0 {
-				return nil, nil
-			}
-			msg, concatErr := schema.ConcatMessages(chunks)
-			return msg, concatErr
-		}
-		if err != nil {
-			if len(chunks) == 0 {
-				return nil, err
-			}
-			msg, _ := schema.ConcatMessages(chunks)
-			return msg, err
-		}
-		chunks = append(chunks, chunk)
-	}
-}
-
-func streamWithShouldRetry(r *typedRetryModelWrapper[*schema.Message], ctx context.Context, input []*schema.Message, opts ...model.Option) (
-	*schema.StreamReader[*schema.Message], error) {
+func streamWithShouldRetry[M messageType](r *typedRetryModelWrapper[M], ctx context.Context, input []M, opts ...model.Option) (
+	*schema.StreamReader[M], error) {
 
 	backoffFunc := r.config.BackoffFunc
 	if backoffFunc == nil {
@@ -493,13 +476,13 @@ func streamWithShouldRetry(r *typedRetryModelWrapper[*schema.Message], ctx conte
 	}
 
 	defer func() {
-		_ = compose.ProcessState(ctx, func(_ context.Context, st *State) error {
+		_ = compose.ProcessState(ctx, func(_ context.Context, st *typedState[M]) error {
 			st.setRetryAttempt(0)
 			return nil
 		})
 	}()
 
-	execCtx := getTypedChatModelAgentExecCtx[*schema.Message](ctx)
+	execCtx := getTypedChatModelAgentExecCtx[M](ctx)
 
 	currentInput := input
 	currentOpts := opts
@@ -522,7 +505,7 @@ func streamWithShouldRetry(r *typedRetryModelWrapper[*schema.Message], ctx conte
 	}()
 
 	for attempt := 0; attempt <= r.config.MaxRetries; attempt++ {
-		_ = compose.ProcessState(ctx, func(_ context.Context, st *State) error {
+		_ = compose.ProcessState(ctx, func(_ context.Context, st *typedState[M]) error {
 			st.setRetryAttempt(attempt)
 			return nil
 		})
@@ -551,7 +534,7 @@ func streamWithShouldRetry(r *typedRetryModelWrapper[*schema.Message], ctx conte
 				return nil, err
 			}
 
-			retryCtx := &RetryContext{
+			retryCtx := &TypedRetryContext[M]{
 				RetryAttempt:  attempt + 1,
 				InputMessages: currentInput,
 				Options:       currentOpts,
@@ -559,7 +542,7 @@ func streamWithShouldRetry(r *typedRetryModelWrapper[*schema.Message], ctx conte
 			}
 			decision := r.config.ShouldRetry(ctx, retryCtx)
 			if decision == nil {
-				decision = &RetryDecision{}
+				decision = &TypedRetryDecision[M]{}
 			}
 
 			if !decision.Retry {
@@ -592,7 +575,7 @@ func streamWithShouldRetry(r *typedRetryModelWrapper[*schema.Message], ctx conte
 		checkCopy := copies[0]
 		returnCopy := copies[1]
 
-		msg, streamErr := consumeStreamForMessage(checkCopy)
+		msg, streamErr := typedConsumeStream(checkCopy)
 
 		if errors.Is(streamErr, ErrStreamCanceled) {
 			signal.ch <- retryVerdict{WillRetry: false}
@@ -600,7 +583,7 @@ func streamWithShouldRetry(r *typedRetryModelWrapper[*schema.Message], ctx conte
 			return nil, streamErr
 		}
 
-		retryCtx := &RetryContext{
+		retryCtx := &TypedRetryContext[M]{
 			RetryAttempt:  attempt + 1,
 			InputMessages: currentInput,
 			Options:       currentOpts,
@@ -609,7 +592,7 @@ func streamWithShouldRetry(r *typedRetryModelWrapper[*schema.Message], ctx conte
 		}
 		decision := r.config.ShouldRetry(ctx, retryCtx)
 		if decision == nil {
-			decision = &RetryDecision{}
+			decision = &TypedRetryDecision[M]{}
 		}
 
 		if !decision.Retry {
@@ -631,10 +614,9 @@ func streamWithShouldRetry(r *typedRetryModelWrapper[*schema.Message], ctx conte
 			verdictErr = fmt.Errorf("model output rejected by ShouldRetry at attempt %d", attempt+1)
 		}
 		signal.ch <- retryVerdict{
-			WillRetry:     true,
-			RetryAttempt:  attempt,
-			Err:           verdictErr,
-			OutputMessage: msg,
+			WillRetry:    true,
+			RetryAttempt: attempt,
+			Err:          verdictErr,
 		}
 		returnCopy.Close()
 
@@ -655,12 +637,12 @@ func streamWithShouldRetry(r *typedRetryModelWrapper[*schema.Message], ctx conte
 	return nil, &RetryExhaustedError{LastErr: lastErr, TotalRetries: r.config.MaxRetries}
 }
 
-func applyDecisionForRetry(currentInput *[]*schema.Message, currentOpts *[]model.Option, ctx context.Context, decision *RetryDecision) {
+func applyDecisionForRetry[M messageType](currentInput *[]M, currentOpts *[]model.Option, ctx context.Context, decision *TypedRetryDecision[M]) {
 	if decision.ModifiedInputMessages != nil {
 		*currentInput = decision.ModifiedInputMessages
 		if decision.PersistModifiedInputMessages {
 			modifiedInput := *currentInput
-			_ = compose.ProcessState(ctx, func(_ context.Context, st *State) error {
+			_ = compose.ProcessState(ctx, func(_ context.Context, st *typedState[M]) error {
 				st.Messages = modifiedInput
 				return nil
 			})
@@ -678,14 +660,7 @@ func (r *typedRetryModelWrapper[M]) Stream(ctx context.Context, input []M, opts 
 	*schema.StreamReader[M], error) {
 
 	if r.config.ShouldRetry != nil {
-		// ShouldRetry is *schema.Message-specific (RetryContext.OutputMessage is *schema.Message).
-		msgR, _ := any(r).(*typedRetryModelWrapper[*schema.Message])
-		msgInput, _ := any(input).([]Message)
-		sr, err := streamWithShouldRetry(msgR, ctx, msgInput, opts...)
-		if err != nil {
-			return nil, err
-		}
-		return any(sr).(*schema.StreamReader[M]), nil
+		return streamWithShouldRetry(r, ctx, input, opts...)
 	}
 	return r.streamLegacy(ctx, input, opts...)
 }

--- a/adk/retry_chatmodel.go
+++ b/adk/retry_chatmodel.go
@@ -75,9 +75,13 @@ func (e *RetryExhaustedError) Unwrap() error {
 //     concrete error types. Since end-users only need the original error when the AgentEvent first
 //     occurs (not after restoring from checkpoint), skipping serialization is acceptable.
 //     After checkpoint restore, err will be nil and Unwrap() returns nil.
+//   - rejectReason (unexported): Stores a user-defined value set by the ShouldRetry callback
+//     via RetryDecision.RejectReason. This is runtime-only observability data — after checkpoint
+//     restore it will be nil. Unexported to avoid Gob serialization of arbitrary types.
 type WillRetryError struct {
 	ErrStr       string
 	RetryAttempt int
+	rejectReason any
 	err          error
 }
 
@@ -87,6 +91,12 @@ func (e *WillRetryError) Error() string {
 
 func (e *WillRetryError) Unwrap() error {
 	return e.err
+}
+
+// RejectReason returns the user-defined rejection reason set by the ShouldRetry callback
+// via RetryDecision.RejectReason. Returns nil if not set or after checkpoint restore.
+func (e *WillRetryError) RejectReason() any {
+	return e.rejectReason
 }
 
 func init() {
@@ -190,6 +200,18 @@ type TypedRetryDecision[M messageType] struct {
 	// the specific error or problematic message encountered.
 	// Only used when Retry is true. Ignored when Retry is false.
 	Backoff time.Duration
+
+	// RejectReason is an optional user-defined value describing why the output was rejected.
+	// When Retry is true and the rejected stream/message is observed downstream via
+	// AgentEvent, this value is attached to the WillRetryError emitted to the event stream.
+	// Consumers can retrieve it via WillRetryError.RejectReason().
+	//
+	// The ShouldRetry callback has full access to the model output (via retryCtx.OutputMessage)
+	// and error (via retryCtx.Err), so it can distill whatever information it wants into
+	// RejectReason — a string, a struct, the output message itself, or nil.
+	//
+	// Only used when Retry is true. Ignored when Retry is false.
+	RejectReason any
 }
 
 // RetryDecision is the default retry decision type using *schema.Message.
@@ -291,6 +313,7 @@ type retryVerdict struct {
 	WillRetry    bool
 	RetryAttempt int
 	Err          error
+	RejectReason any
 }
 
 // retryModelWrapper wraps a BaseChatModel with retry logic.
@@ -617,6 +640,7 @@ func streamWithShouldRetry[M messageType](r *typedRetryModelWrapper[M], ctx cont
 			WillRetry:    true,
 			RetryAttempt: attempt,
 			Err:          verdictErr,
+			RejectReason: decision.RejectReason,
 		}
 		returnCopy.Close()
 

--- a/adk/retry_chatmodel.go
+++ b/adk/retry_chatmodel.go
@@ -387,6 +387,7 @@ func generateWithShouldRetry[M messageType](r *typedRetryModelWrapper[M], ctx co
 	currentInput := input
 	currentOpts := opts
 	var lastErr error
+	var zero M
 
 	defer func() {
 		_ = compose.ProcessState(ctx, func(_ context.Context, st *typedState[M]) error {
@@ -414,12 +415,10 @@ func generateWithShouldRetry[M messageType](r *typedRetryModelWrapper[M], ctx co
 
 		if err != nil {
 			if _, ok := compose.ExtractInterruptInfo(err); ok {
-				var zero M
 				return zero, err
 			}
 
 			if errors.Is(err, ErrStreamCanceled) {
-				var zero M
 				return zero, err
 			}
 		}
@@ -438,11 +437,9 @@ func generateWithShouldRetry[M messageType](r *typedRetryModelWrapper[M], ctx co
 
 		if !decision.Retry {
 			if decision.RewriteError != nil {
-				var zero M
 				return zero, decision.RewriteError
 			}
 			if err != nil {
-				var zero M
 				return zero, err
 			}
 			if execCtx != nil && execCtx.generator != nil && out != nil {
@@ -469,12 +466,10 @@ func generateWithShouldRetry[M messageType](r *typedRetryModelWrapper[M], ctx co
 		}
 
 		if err := r.contextAwareSleep(ctx, delay); err != nil {
-			var zero M
 			return zero, err
 		}
 	}
 
-	var zero M
 	return zero, &RetryExhaustedError{LastErr: lastErr, TotalRetries: r.config.MaxRetries}
 }
 

--- a/adk/retry_chatmodel.go
+++ b/adk/retry_chatmodel.go
@@ -112,7 +112,7 @@ func init() {
 //	OutputMessage == nil, Err != nil  → failed call (Generate error or Stream() error)
 //	OutputMessage != nil, Err != nil  → partial stream (chunks received before mid-stream error)
 //	OutputMessage == nil, Err == nil  → empty stream (zero chunks before EOF)
-type TypedRetryContext[M messageType] struct {
+type TypedRetryContext[M MessageType] struct {
 	// RetryAttempt is the current retry attempt number (1-based).
 	// For the first retry decision (after the initial call), this is 1.
 	RetryAttempt int
@@ -143,7 +143,7 @@ type TypedRetryContext[M messageType] struct {
 type RetryContext = TypedRetryContext[*schema.Message]
 
 // TypedRetryDecision represents the decision made by TypedModelRetryConfig.ShouldRetry.
-type TypedRetryDecision[M messageType] struct {
+type TypedRetryDecision[M MessageType] struct {
 	// Retry indicates whether the model call should be retried.
 	// If false, the model output (or error) is accepted as-is, unless RewriteError is set.
 	Retry bool
@@ -219,7 +219,7 @@ type RetryDecision = TypedRetryDecision[*schema.Message]
 
 // TypedModelRetryConfig configures retry behavior for the ChatModel node.
 // It defines how the agent should handle transient failures when calling the ChatModel.
-type TypedModelRetryConfig[M messageType] struct {
+type TypedModelRetryConfig[M MessageType] struct {
 	// MaxRetries specifies the maximum number of retry attempts.
 	// A value of 0 means no retries will be attempted.
 	// A value of 3 means up to 3 retry attempts (4 total calls including the initial attempt).
@@ -320,12 +320,12 @@ type retryVerdict struct {
 // This is used inside the model wrapper chain, positioned between eventSenderModelWrapper
 // and stateModelWrapper, so that retry only affects the inner chain (event sending, user wrappers,
 // callback injection) without re-running state management (BeforeModelRewriteState/AfterModelRewriteState).
-type typedRetryModelWrapper[M messageType] struct {
+type typedRetryModelWrapper[M MessageType] struct {
 	inner  model.BaseModel[M]
 	config *TypedModelRetryConfig[M]
 }
 
-func newTypedRetryModelWrapper[M messageType](inner model.BaseModel[M], config *TypedModelRetryConfig[M]) *typedRetryModelWrapper[M] {
+func newTypedRetryModelWrapper[M MessageType](inner model.BaseModel[M], config *TypedModelRetryConfig[M]) *typedRetryModelWrapper[M] {
 	return &typedRetryModelWrapper[M]{inner: inner, config: config}
 }
 
@@ -376,7 +376,7 @@ func (r *typedRetryModelWrapper[M]) generateLegacy(ctx context.Context, input []
 	return zero, &RetryExhaustedError{LastErr: lastErr, TotalRetries: r.config.MaxRetries}
 }
 
-func generateWithShouldRetry[M messageType](r *typedRetryModelWrapper[M], ctx context.Context, input []M, opts ...model.Option) (M, error) {
+func generateWithShouldRetry[M MessageType](r *typedRetryModelWrapper[M], ctx context.Context, input []M, opts ...model.Option) (M, error) {
 	backoffFunc := r.config.BackoffFunc
 	if backoffFunc == nil {
 		backoffFunc = defaultBackoff
@@ -485,7 +485,7 @@ func (r *typedRetryModelWrapper[M]) contextAwareSleep(ctx context.Context, delay
 	}
 }
 
-func streamWithShouldRetry[M messageType](r *typedRetryModelWrapper[M], ctx context.Context, input []M, opts ...model.Option) (
+func streamWithShouldRetry[M MessageType](r *typedRetryModelWrapper[M], ctx context.Context, input []M, opts ...model.Option) (
 	*schema.StreamReader[M], error) {
 
 	backoffFunc := r.config.BackoffFunc
@@ -656,7 +656,7 @@ func streamWithShouldRetry[M messageType](r *typedRetryModelWrapper[M], ctx cont
 	return nil, &RetryExhaustedError{LastErr: lastErr, TotalRetries: r.config.MaxRetries}
 }
 
-func applyDecisionForRetry[M messageType](currentInput *[]M, currentOpts *[]model.Option, ctx context.Context, decision *TypedRetryDecision[M]) {
+func applyDecisionForRetry[M MessageType](currentInput *[]M, currentOpts *[]model.Option, ctx context.Context, decision *TypedRetryDecision[M]) {
 	if decision.ModifiedInputMessages != nil {
 		*currentInput = decision.ModifiedInputMessages
 		if decision.PersistModifiedInputMessages {

--- a/adk/runctx.go
+++ b/adk/runctx.go
@@ -69,7 +69,7 @@ type agentEventWrapper struct {
 	StreamErr error
 }
 
-type typedAgentEventWrapper[M messageType] struct {
+type typedAgentEventWrapper[M MessageType] struct {
 	event               *TypedAgentEvent[M]
 	mu                  sync.Mutex
 	concatenatedMessage M
@@ -79,7 +79,7 @@ type typedAgentEventWrapper[M messageType] struct {
 
 // typedAgentEventWrapperForGob is a gob-serializable representation of typedAgentEventWrapper.
 // We encode the event and TS separately to avoid the sync.Mutex and non-exported fields.
-type typedAgentEventWrapperForGob[M messageType] struct {
+type typedAgentEventWrapperForGob[M MessageType] struct {
 	Event *TypedAgentEvent[M]
 	TS    int64
 }
@@ -292,7 +292,7 @@ func (rs *runSession) getEvents() []*agentEventWrapper {
 	return finalEvents
 }
 
-func addTypedEvent[M messageType](session *runSession, event *TypedAgentEvent[M]) {
+func addTypedEvent[M MessageType](session *runSession, event *TypedAgentEvent[M]) {
 	var zero M
 	if _, ok := any(zero).(*schema.Message); ok {
 		session.addEvent(any(event).(*AgentEvent))
@@ -310,7 +310,7 @@ func addTypedEvent[M messageType](session *runSession, event *TypedAgentEvent[M]
 	*store = append(*store, wrapper)
 }
 
-func getTypedEvents[M messageType](session *runSession) []*typedAgentEventWrapper[M] {
+func getTypedEvents[M MessageType](session *runSession) []*typedAgentEventWrapper[M] {
 	var zero M
 	if _, ok := any(zero).(*schema.Message); ok {
 		events := session.getEvents()
@@ -446,7 +446,7 @@ func initRunCtx(ctx context.Context, agentName string, input *AgentInput) (conte
 	return setRunCtx(ctx, runCtx), runCtx
 }
 
-func initTypedRunCtx[M messageType](ctx context.Context, agentName string, input *TypedAgentInput[M]) (context.Context, *runContext) {
+func initTypedRunCtx[M MessageType](ctx context.Context, agentName string, input *TypedAgentInput[M]) (context.Context, *runContext) {
 	runCtx := getRunCtx(ctx)
 	if runCtx != nil {
 		runCtx = runCtx.deepCopy()
@@ -581,7 +581,7 @@ func ClearRunCtx(ctx context.Context) context.Context {
 	return context.WithValue(ctx, runCtxKey{}, nil)
 }
 
-func ctxWithNewTypedRunCtx[M messageType](ctx context.Context, input *TypedAgentInput[M], sharedParentSession bool) context.Context {
+func ctxWithNewTypedRunCtx[M MessageType](ctx context.Context, input *TypedAgentInput[M], sharedParentSession bool) context.Context {
 	var session *runSession
 	if sharedParentSession {
 		if parentSession := getSession(ctx); parentSession != nil {

--- a/adk/runner.go
+++ b/adk/runner.go
@@ -28,14 +28,14 @@ import (
 	"github.com/cloudwego/eino/schema"
 )
 
-func errorIterator[M messageType](err error) *AsyncIterator[*TypedAgentEvent[M]] {
+func errorIterator[M MessageType](err error) *AsyncIterator[*TypedAgentEvent[M]] {
 	iter, gen := NewAsyncIteratorPair[*TypedAgentEvent[M]]()
 	gen.Send(&TypedAgentEvent[M]{Err: err})
 	gen.Close()
 	return iter
 }
 
-func newUserMessage[M messageType](query string) (M, error) {
+func newUserMessage[M MessageType](query string) (M, error) {
 	var zero M
 	switch any(zero).(type) {
 	case *schema.Message:
@@ -52,7 +52,7 @@ func newUserMessage[M messageType](query string) (M, error) {
 //
 // Execution always goes through the flowAgent pipeline, which handles
 // multi-agent orchestration, callbacks, agent naming, run paths, and cancellation.
-type TypedRunner[M messageType] struct {
+type TypedRunner[M MessageType] struct {
 	a               TypedAgent[M]
 	enableStreaming bool
 	store           CheckPointStore
@@ -65,7 +65,7 @@ type CheckPointStore = core.CheckPointStore
 
 type CheckPointDeleter = core.CheckPointDeleter
 
-type TypedRunnerConfig[M messageType] struct {
+type TypedRunnerConfig[M MessageType] struct {
 	Agent           TypedAgent[M]
 	EnableStreaming bool
 
@@ -91,7 +91,7 @@ func NewRunner(_ context.Context, conf RunnerConfig) *Runner {
 }
 
 // NewTypedRunner creates a new TypedRunner with the given config.
-func NewTypedRunner[M messageType](conf TypedRunnerConfig[M]) *TypedRunner[M] {
+func NewTypedRunner[M MessageType](conf TypedRunnerConfig[M]) *TypedRunner[M] {
 	return &TypedRunner[M]{
 		enableStreaming: conf.EnableStreaming,
 		a:               conf.Agent,
@@ -153,7 +153,7 @@ func (r *TypedRunner[M]) resumeInternal(ctx context.Context, checkPointID string
 	return typedRunnerResumeInternalImpl(r.a, r.enableStreaming, r.store, ctx, checkPointID, resumeData, opts...)
 }
 
-func typedRunnerRunImpl[M messageType](a TypedAgent[M], enableStreaming bool, store CheckPointStore, ctx context.Context, messages []M, opts ...AgentRunOption) *AsyncIterator[*TypedAgentEvent[M]] {
+func typedRunnerRunImpl[M MessageType](a TypedAgent[M], enableStreaming bool, store CheckPointStore, ctx context.Context, messages []M, opts ...AgentRunOption) *AsyncIterator[*TypedAgentEvent[M]] {
 	o := getCommonOptions(nil, opts...)
 
 	input := &TypedAgentInput[M]{
@@ -202,7 +202,7 @@ func typedRunnerRunImpl[M messageType](a TypedAgent[M], enableStreaming bool, st
 	return niter
 }
 
-func typedRunnerResumeInternalImpl[M messageType](a TypedAgent[M], enableStreaming bool, store CheckPointStore, ctx context.Context, checkPointID string, resumeData map[string]any, //nolint:revive // argument-limit
+func typedRunnerResumeInternalImpl[M MessageType](a TypedAgent[M], enableStreaming bool, store CheckPointStore, ctx context.Context, checkPointID string, resumeData map[string]any, //nolint:revive // argument-limit
 	opts ...AgentRunOption) (*AsyncIterator[*TypedAgentEvent[M]], error) {
 	if store == nil {
 		return nil, fmt.Errorf("failed to resume: store is nil")
@@ -262,7 +262,7 @@ func typedRunnerResumeInternalImpl[M messageType](a TypedAgent[M], enableStreami
 	return niter, nil
 }
 
-func typedRunnerHandleIterImpl[M messageType](enableStreaming bool, store CheckPointStore, ctx context.Context, aIter *AsyncIterator[*TypedAgentEvent[M]], //nolint:revive // argument-limit
+func typedRunnerHandleIterImpl[M MessageType](enableStreaming bool, store CheckPointStore, ctx context.Context, aIter *AsyncIterator[*TypedAgentEvent[M]], //nolint:revive // argument-limit
 	gen *AsyncGenerator[*TypedAgentEvent[M]], checkPointID *string, cancelCtx *cancelContext) {
 	defer func() {
 		panicErr := recover()

--- a/adk/turn_loop.go
+++ b/adk/turn_loop.go
@@ -356,7 +356,7 @@ func (s *preemptSignal) drainAll() {
 }
 
 // TurnLoopConfig is the configuration for creating a TurnLoop.
-type TurnLoopConfig[T any, M messageType] struct {
+type TurnLoopConfig[T any, M MessageType] struct {
 	// GenInput receives the TurnLoop instance and all buffered items, and decides what to process.
 	// It returns which items to consume now vs keep for later turns.
 	// The loop parameter allows calling Push() or Stop() directly from within the callback.
@@ -430,7 +430,7 @@ type TurnLoopConfig[T any, M messageType] struct {
 }
 
 // GenInputResult contains the result of GenInput processing.
-type GenInputResult[T any, M messageType] struct {
+type GenInputResult[T any, M MessageType] struct {
 	// RunCtx, if non-nil, overrides the context for this turn's execution
 	// (PrepareAgent, agent run, OnAgentEvents).
 	//
@@ -464,7 +464,7 @@ type GenInputResult[T any, M messageType] struct {
 }
 
 // GenResumeResult contains the result of GenResume processing.
-type GenResumeResult[T any, M messageType] struct {
+type GenResumeResult[T any, M MessageType] struct {
 	// RunCtx, if non-nil, overrides the context for this resumed turn's execution
 	// (PrepareAgent, agent resume, OnAgentEvents).
 	RunCtx context.Context
@@ -489,7 +489,7 @@ type GenResumeResult[T any, M messageType] struct {
 	Remaining []T
 }
 
-type turnRunSpec[T any, M messageType] struct {
+type turnRunSpec[T any, M MessageType] struct {
 	runCtx       context.Context
 	input        *TypedAgentInput[M]
 	runOpts      []AgentRunOption
@@ -499,7 +499,7 @@ type turnRunSpec[T any, M messageType] struct {
 	resumeBytes  []byte
 }
 
-type turnPlan[T any, M messageType] struct {
+type turnPlan[T any, M MessageType] struct {
 	turnCtx   context.Context
 	remaining []T
 	spec      *turnRunSpec[T, M]
@@ -570,7 +570,7 @@ func (l *TurnLoop[T, M]) planTurn(
 
 // TurnLoopExitState is returned when TurnLoop exits, containing the exit reason
 // and any items that were not processed.
-type TurnLoopExitState[T any, M messageType] struct {
+type TurnLoopExitState[T any, M MessageType] struct {
 	// ExitReason indicates why the loop exited.
 	// nil means clean exit (Stop() was called without cancel options, or the
 	// agent completed normally before Stop took effect).
@@ -621,7 +621,7 @@ type TurnLoopExitState[T any, M messageType] struct {
 }
 
 // TurnContext provides per-turn context to the OnAgentEvents callback.
-type TurnContext[T any, M messageType] struct {
+type TurnContext[T any, M MessageType] struct {
 	// Loop is the TurnLoop instance, allowing Push() or Stop() calls.
 	Loop *TurnLoop[T, M]
 
@@ -672,7 +672,7 @@ type TurnContext[T any, M messageType] struct {
 //   - Wait: blocks until Run is called AND the loop exits. If Run is never
 //     called, Wait blocks forever (this is a programming error, analogous
 //     to reading from a channel that nobody writes to).
-type TurnLoop[T any, M messageType] struct {
+type TurnLoop[T any, M MessageType] struct {
 	config TurnLoopConfig[T, M]
 
 	buffer *turnBuffer[T]
@@ -973,7 +973,7 @@ func UntilIdleFor(duration time.Duration) StopOption {
 	}
 }
 
-type pushConfig[T any, M messageType] struct {
+type pushConfig[T any, M MessageType] struct {
 	preempt         bool
 	preemptDelay    time.Duration
 	agentCancelOpts []AgentCancelOption
@@ -981,7 +981,7 @@ type pushConfig[T any, M messageType] struct {
 }
 
 // PushOption is an option for Push().
-type PushOption[T any, M messageType] func(*pushConfig[T, M])
+type PushOption[T any, M MessageType] func(*pushConfig[T, M])
 
 // WithPreempt signals that the current agent turn should be cancelled at the
 // specified safePoint after pushing the new item. The loop cancels the current
@@ -1001,7 +1001,7 @@ type PushOption[T any, M messageType] func(*pushConfig[T, M])
 // passed to the same Push call, the last one wins.
 //
 // safePoint must not be zero; passing SafePoint(0) panics.
-func WithPreempt[T any, M messageType](safePoint SafePoint) PushOption[T, M] {
+func WithPreempt[T any, M MessageType](safePoint SafePoint) PushOption[T, M] {
 	if safePoint == 0 {
 		panic("adk: SafePoint must not be zero; use AfterToolCalls, AfterChatModel, or AnySafePoint")
 	}
@@ -1019,7 +1019,7 @@ func WithPreempt[T any, M messageType](safePoint SafePoint) PushOption[T, M] {
 // also receive the cancel signal and be torn down.
 //
 // safePoint must not be zero; passing SafePoint(0) panics.
-func WithPreemptTimeout[T any, M messageType](safePoint SafePoint, timeout time.Duration) PushOption[T, M] {
+func WithPreemptTimeout[T any, M MessageType](safePoint SafePoint, timeout time.Duration) PushOption[T, M] {
 	if safePoint == 0 {
 		panic("adk: SafePoint must not be zero; use AfterToolCalls, AfterChatModel, or AnySafePoint")
 	}
@@ -1038,7 +1038,7 @@ func WithPreemptTimeout[T any, M messageType](safePoint SafePoint, timeout time.
 // immediately, but the preemption signal will be delayed by the specified
 // duration. This allows the current agent to continue processing for a grace
 // period before being preempted.
-func WithPreemptDelay[T any, M messageType](delay time.Duration) PushOption[T, M] {
+func WithPreemptDelay[T any, M MessageType](delay time.Duration) PushOption[T, M] {
 	return func(cfg *pushConfig[T, M]) {
 		cfg.preemptDelay = delay
 	}
@@ -1063,13 +1063,13 @@ func WithPreemptDelay[T any, M messageType](delay time.Duration) PushOption[T, M
 //	    }
 //	    return nil // don't preempt high-priority work
 //	}))
-func WithPushStrategy[T any, M messageType](fn func(ctx context.Context, tc *TurnContext[T, M]) []PushOption[T, M]) PushOption[T, M] {
+func WithPushStrategy[T any, M MessageType](fn func(ctx context.Context, tc *TurnContext[T, M]) []PushOption[T, M]) PushOption[T, M] {
 	return func(cfg *pushConfig[T, M]) {
 		cfg.pushStrategy = fn
 	}
 }
 
-func defaultTurnLoopOnAgentEvents[T any, M messageType](_ context.Context, _ *TurnContext[T, M], events *AsyncIterator[*TypedAgentEvent[M]]) error {
+func defaultTurnLoopOnAgentEvents[T any, M MessageType](_ context.Context, _ *TurnContext[T, M], events *AsyncIterator[*TypedAgentEvent[M]]) error {
 	for {
 		event, ok := events.Next()
 		if !ok {
@@ -1088,7 +1088,7 @@ func defaultTurnLoopOnAgentEvents[T any, M messageType](_ context.Context, _ *Tu
 // Call Run to start the processing goroutine.
 //
 // NewTurnLoop panics if GenInput or PrepareAgent is nil.
-func NewTurnLoop[T any, M messageType](cfg TurnLoopConfig[T, M]) *TurnLoop[T, M] {
+func NewTurnLoop[T any, M MessageType](cfg TurnLoopConfig[T, M]) *TurnLoop[T, M] {
 	if cfg.GenInput == nil {
 		panic("adk: NewTurnLoop: GenInput is required")
 	}

--- a/adk/turn_loop_test.go
+++ b/adk/turn_loop_test.go
@@ -161,7 +161,7 @@ func (a *turnLoopStopModeProbeAgent) Run(ctx context.Context, input *AgentInput,
 	return iter
 }
 
-func newAndRunTurnLoop[T any, M messageType](ctx context.Context, cfg TurnLoopConfig[T, M]) *TurnLoop[T, M] {
+func newAndRunTurnLoop[T any, M MessageType](ctx context.Context, cfg TurnLoopConfig[T, M]) *TurnLoop[T, M] {
 	l := NewTurnLoop[T, M](cfg)
 	l.Run(ctx)
 	return l

--- a/adk/utils.go
+++ b/adk/utils.go
@@ -102,7 +102,7 @@ func GenTransferMessages(_ context.Context, destAgentName string) (Message, Mess
 	return assistantMessage, toolMessage
 }
 
-func typedSetAutomaticClose[M messageType](e *TypedAgentEvent[M]) {
+func typedSetAutomaticClose[M MessageType](e *TypedAgentEvent[M]) {
 	if e.Output == nil || e.Output.MessageOutput == nil || !e.Output.MessageOutput.IsStreaming {
 		return
 	}
@@ -119,7 +119,7 @@ func setAutomaticClose(e *AgentEvent) {
 // If the stream contains an error chunk, this function returns (nil, err) and
 // sets StreamErr to prevent re-consumption. The nil message ensures that
 // failed stream responses are not included in subsequent agents' context windows.
-func getMessageFromTypedWrappedEvent[M messageType](e *typedAgentEventWrapper[M]) (M, error) {
+func getMessageFromTypedWrappedEvent[M MessageType](e *typedAgentEventWrapper[M]) (M, error) {
 	var zero M
 	if e.event.Output == nil || e.event.Output.MessageOutput == nil {
 		return zero, nil
@@ -234,7 +234,7 @@ func (e *agentEventWrapper) consumeStream() {
 // NOTE: even if the event is copied, it's still not recommended to modify
 // the Message itself or Chunks of the MessageStream, as they are not copied.
 // NOTE: if you have CustomizedOutput or CustomizedAction, they are NOT copied.
-func copyTypedAgentEvent[M messageType](ae *TypedAgentEvent[M]) *TypedAgentEvent[M] {
+func copyTypedAgentEvent[M MessageType](ae *TypedAgentEvent[M]) *TypedAgentEvent[M] {
 	rp := make([]RunStep, len(ae.RunPath))
 	copy(rp, ae.RunPath)
 
@@ -275,7 +275,7 @@ func copyTypedAgentEvent[M messageType](ae *TypedAgentEvent[M]) *TypedAgentEvent
 }
 
 // TypedGetMessage extracts the message from a TypedAgentEvent, concatenating a stream if present.
-func TypedGetMessage[M messageType](e *TypedAgentEvent[M]) (M, *TypedAgentEvent[M], error) {
+func TypedGetMessage[M MessageType](e *TypedAgentEvent[M]) (M, *TypedAgentEvent[M], error) {
 	var zero M
 	if e.Output == nil || e.Output.MessageOutput == nil {
 		return zero, e, nil
@@ -300,7 +300,7 @@ func GetMessage(e *AgentEvent) (Message, *AgentEvent, error) {
 	return TypedGetMessage(e)
 }
 
-func typedErrorIter[M messageType](err error) *AsyncIterator[*TypedAgentEvent[M]] {
+func typedErrorIter[M MessageType](err error) *AsyncIterator[*TypedAgentEvent[M]] {
 	iterator, generator := NewAsyncIteratorPair[*TypedAgentEvent[M]]()
 	generator.Send(&TypedAgentEvent[M]{Err: err})
 	generator.Close()

--- a/adk/wrappers.go
+++ b/adk/wrappers.go
@@ -38,8 +38,8 @@ type typedStreamEndpoint[M messageType] func(ctx context.Context, input []M, opt
 type typedModelWrapperConfig[M messageType] struct {
 	handlers       []TypedChatModelAgentMiddleware[M]
 	middlewares    []AgentMiddleware
-	retryConfig    *ModelRetryConfig
-	failoverConfig *ModelFailoverConfig
+	retryConfig    *TypedModelRetryConfig[M]
+	failoverConfig *TypedModelFailoverConfig[M]
 	toolInfos      []*schema.ToolInfo
 	cancelContext  *cancelContext
 }
@@ -264,7 +264,7 @@ func NewEventSenderModelWrapper() ChatModelAgentMiddleware {
 	}
 }
 
-func (w *typedEventSenderModelWrapper[M]) WrapModel(_ context.Context, m model.BaseModel[M], mc *ModelContext) (model.BaseModel[M], error) {
+func (w *typedEventSenderModelWrapper[M]) WrapModel(_ context.Context, m model.BaseModel[M], mc *TypedModelContext[M]) (model.BaseModel[M], error) {
 	inner := m
 	if mc != nil && mc.cancelContext != nil {
 		inner = &typedCancelMonitoredModel[M]{
@@ -272,11 +272,11 @@ func (w *typedEventSenderModelWrapper[M]) WrapModel(_ context.Context, m model.B
 			cancelContext: mc.cancelContext,
 		}
 	}
-	var retryConfig *ModelRetryConfig
+	var retryConfig *TypedModelRetryConfig[M]
 	if mc != nil {
 		retryConfig = mc.ModelRetryConfig
 	}
-	var failoverConfig *ModelFailoverConfig
+	var failoverConfig *TypedModelFailoverConfig[M]
 	if mc != nil {
 		failoverConfig = mc.ModelFailoverConfig
 	}
@@ -285,8 +285,8 @@ func (w *typedEventSenderModelWrapper[M]) WrapModel(_ context.Context, m model.B
 
 type typedEventSenderModel[M messageType] struct {
 	inner               model.BaseModel[M]
-	modelRetryConfig    *ModelRetryConfig
-	modelFailoverConfig *ModelFailoverConfig
+	modelRetryConfig    *TypedModelRetryConfig[M]
+	modelFailoverConfig *TypedModelFailoverConfig[M]
 }
 
 func (m *typedEventSenderModel[M]) Generate(ctx context.Context, input []M, opts ...model.Option) (M, error) {
@@ -379,7 +379,7 @@ func (m *typedEventSenderModel[M]) buildStreamConvertOptions(ctx context.Context
 	var retryWrapper func(error) error
 	if m.modelRetryConfig != nil {
 		if m.modelRetryConfig.ShouldRetry != nil {
-			execCtx := getTypedChatModelAgentExecCtx[*schema.Message](ctx)
+			execCtx := getTypedChatModelAgentExecCtx[M](ctx)
 			signal := (*retryVerdictSignal)(nil)
 			if execCtx != nil {
 				signal = execCtx.retryVerdictSignal
@@ -400,10 +400,9 @@ func (m *typedEventSenderModel[M]) buildStreamConvertOptions(ctx context.Context
 					verdict := readVerdict()
 					if verdict.WillRetry {
 						return &WillRetryError{
-							ErrStr:        err.Error(),
-							RetryAttempt:  verdict.RetryAttempt,
-							OutputMessage: verdict.OutputMessage,
-							err:           err,
+							ErrStr:       err.Error(),
+							RetryAttempt: verdict.RetryAttempt,
+							err:          err,
 						}
 					}
 					return err
@@ -413,10 +412,9 @@ func (m *typedEventSenderModel[M]) buildStreamConvertOptions(ctx context.Context
 					verdict := readVerdict()
 					if verdict.WillRetry {
 						return nil, &WillRetryError{
-							ErrStr:        verdict.Err.Error(),
-							RetryAttempt:  verdict.RetryAttempt,
-							OutputMessage: verdict.OutputMessage,
-							err:           verdict.Err,
+							ErrStr:       verdict.Err.Error(),
+							RetryAttempt: verdict.RetryAttempt,
+							err:          verdict.Err,
 						}
 					}
 					return nil, io.EOF
@@ -682,8 +680,8 @@ type typedStateModelWrapper[M messageType] struct {
 	handlers            []TypedChatModelAgentMiddleware[M]
 	middlewares         []AgentMiddleware
 	toolInfos           []*schema.ToolInfo
-	modelRetryConfig    *ModelRetryConfig
-	modelFailoverConfig *ModelFailoverConfig
+	modelRetryConfig    *TypedModelRetryConfig[M]
+	modelFailoverConfig *TypedModelFailoverConfig[M]
 	cancelContext       *cancelContext
 }
 
@@ -722,7 +720,7 @@ func (w *typedStateModelWrapper[M]) wrapGenerateEndpoint(endpoint typedGenerateE
 		endpoint = func(ctx context.Context, input []M, opts ...model.Option) (M, error) {
 			baseOpts := &model.Options{Tools: baseToolInfos}
 			commonOpts := model.GetCommonOptions(baseOpts, opts...)
-			mc := &ModelContext{Tools: commonOpts.Tools, ModelRetryConfig: retryConfig, cancelContext: cc}
+			mc := &TypedModelContext[M]{Tools: commonOpts.Tools, ModelRetryConfig: retryConfig, cancelContext: cc}
 			wrappedModel, err := handler.WrapModel(ctx, &typedEndpointModel[M]{generate: innerEndpoint}, mc)
 			if err != nil {
 				var zero M
@@ -742,7 +740,7 @@ func (w *typedStateModelWrapper[M]) wrapGenerateEndpoint(endpoint typedGenerateE
 			if execCtx == nil || execCtx.generator == nil {
 				return innerEndpoint(ctx, input, opts...)
 			}
-			mc := &ModelContext{ModelRetryConfig: retryConfig, ModelFailoverConfig: failoverConfig, cancelContext: cc}
+			mc := &TypedModelContext[M]{ModelRetryConfig: retryConfig, ModelFailoverConfig: failoverConfig, cancelContext: cc}
 			wrappedModel, err := eventSender.WrapModel(ctx, &typedEndpointModel[M]{generate: innerEndpoint}, mc)
 			if err != nil {
 				var zero M
@@ -785,7 +783,7 @@ func (w *typedStateModelWrapper[M]) wrapStreamEndpoint(endpoint typedStreamEndpo
 		endpoint = func(ctx context.Context, input []M, opts ...model.Option) (*schema.StreamReader[M], error) {
 			baseOpts := &model.Options{Tools: baseToolInfos}
 			commonOpts := model.GetCommonOptions(baseOpts, opts...)
-			mc := &ModelContext{Tools: commonOpts.Tools, ModelRetryConfig: retryConfig, cancelContext: cc}
+			mc := &TypedModelContext[M]{Tools: commonOpts.Tools, ModelRetryConfig: retryConfig, cancelContext: cc}
 			wrappedModel, err := handler.WrapModel(ctx, &typedEndpointModel[M]{stream: innerEndpoint}, mc)
 			if err != nil {
 				return nil, err
@@ -804,7 +802,7 @@ func (w *typedStateModelWrapper[M]) wrapStreamEndpoint(endpoint typedStreamEndpo
 			if execCtx == nil || execCtx.generator == nil {
 				return innerEndpoint(ctx, input, opts...)
 			}
-			mc := &ModelContext{ModelRetryConfig: retryConfig, ModelFailoverConfig: failoverConfig, cancelContext: cc}
+			mc := &TypedModelContext[M]{ModelRetryConfig: retryConfig, ModelFailoverConfig: failoverConfig, cancelContext: cc}
 			wrappedModel, err := eventSender.WrapModel(ctx, &typedEndpointModel[M]{stream: innerEndpoint}, mc)
 			if err != nil {
 				return nil, err
@@ -877,7 +875,7 @@ func (w *typedStateModelWrapper[M]) Generate(ctx context.Context, input []M, opt
 
 	baseOpts := &model.Options{Tools: w.toolInfos}
 	commonOpts := model.GetCommonOptions(baseOpts, opts...)
-	mc := &ModelContext{Tools: commonOpts.Tools, ModelRetryConfig: w.modelRetryConfig, cancelContext: w.cancelContext}
+	mc := &TypedModelContext[M]{Tools: commonOpts.Tools, ModelRetryConfig: w.modelRetryConfig, cancelContext: w.cancelContext}
 	for _, handler := range w.handlers {
 		var err error
 		ctx, state, err = handler.BeforeModelRewriteState(ctx, state, mc)
@@ -1001,7 +999,7 @@ func (w *typedStateModelWrapper[M]) Stream(ctx context.Context, input []M, opts 
 
 	baseOpts := &model.Options{Tools: w.toolInfos}
 	commonOpts := model.GetCommonOptions(baseOpts, opts...)
-	mc := &ModelContext{Tools: commonOpts.Tools, ModelRetryConfig: w.modelRetryConfig, cancelContext: w.cancelContext}
+	mc := &TypedModelContext[M]{Tools: commonOpts.Tools, ModelRetryConfig: w.modelRetryConfig, cancelContext: w.cancelContext}
 	for _, handler := range w.handlers {
 		var err error
 		ctx, state, err = handler.BeforeModelRewriteState(ctx, state, mc)

--- a/adk/wrappers.go
+++ b/adk/wrappers.go
@@ -402,6 +402,7 @@ func (m *typedEventSenderModel[M]) buildStreamConvertOptions(ctx context.Context
 						return &WillRetryError{
 							ErrStr:       err.Error(),
 							RetryAttempt: verdict.RetryAttempt,
+							rejectReason: verdict.RejectReason,
 							err:          err,
 						}
 					}
@@ -414,6 +415,7 @@ func (m *typedEventSenderModel[M]) buildStreamConvertOptions(ctx context.Context
 						return nil, &WillRetryError{
 							ErrStr:       verdict.Err.Error(),
 							RetryAttempt: verdict.RetryAttempt,
+							rejectReason: verdict.RejectReason,
 							err:          verdict.Err,
 						}
 					}

--- a/adk/wrappers.go
+++ b/adk/wrappers.go
@@ -39,7 +39,7 @@ type typedModelWrapperConfig[M MessageType] struct {
 	handlers       []TypedChatModelAgentMiddleware[M]
 	middlewares    []AgentMiddleware
 	retryConfig    *TypedModelRetryConfig[M]
-	failoverConfig *TypedModelFailoverConfig[M]
+	failoverConfig *ModelFailoverConfig[M]
 	toolInfos      []*schema.ToolInfo
 	cancelContext  *cancelContext
 }
@@ -276,7 +276,7 @@ func (w *typedEventSenderModelWrapper[M]) WrapModel(_ context.Context, m model.B
 	if mc != nil {
 		retryConfig = mc.ModelRetryConfig
 	}
-	var failoverConfig *TypedModelFailoverConfig[M]
+	var failoverConfig *ModelFailoverConfig[M]
 	if mc != nil {
 		failoverConfig = mc.ModelFailoverConfig
 	}
@@ -286,7 +286,7 @@ func (w *typedEventSenderModelWrapper[M]) WrapModel(_ context.Context, m model.B
 type typedEventSenderModel[M MessageType] struct {
 	inner               model.BaseModel[M]
 	modelRetryConfig    *TypedModelRetryConfig[M]
-	modelFailoverConfig *TypedModelFailoverConfig[M]
+	modelFailoverConfig *ModelFailoverConfig[M]
 }
 
 func (m *typedEventSenderModel[M]) Generate(ctx context.Context, input []M, opts ...model.Option) (M, error) {
@@ -683,7 +683,7 @@ type typedStateModelWrapper[M MessageType] struct {
 	middlewares         []AgentMiddleware
 	toolInfos           []*schema.ToolInfo
 	modelRetryConfig    *TypedModelRetryConfig[M]
-	modelFailoverConfig *TypedModelFailoverConfig[M]
+	modelFailoverConfig *ModelFailoverConfig[M]
 	cancelContext       *cancelContext
 }
 
@@ -764,7 +764,7 @@ func (w *typedStateModelWrapper[M]) wrapGenerateEndpoint(endpoint typedGenerateE
 		config := w.modelFailoverConfig
 		innerEndpoint := endpoint
 		endpoint = func(ctx context.Context, input []M, opts ...model.Option) (M, error) {
-			failoverWrapper := newTypedFailoverModelWrapper[M](&typedEndpointModel[M]{generate: innerEndpoint}, config)
+			failoverWrapper := newFailoverModelWrapper[M](&typedEndpointModel[M]{generate: innerEndpoint}, config)
 			return failoverWrapper.Generate(ctx, input, opts...)
 		}
 	}
@@ -825,7 +825,7 @@ func (w *typedStateModelWrapper[M]) wrapStreamEndpoint(endpoint typedStreamEndpo
 		config := w.modelFailoverConfig
 		innerEndpoint := endpoint
 		endpoint = func(ctx context.Context, input []M, opts ...model.Option) (*schema.StreamReader[M], error) {
-			failoverWrapper := newTypedFailoverModelWrapper[M](&typedEndpointModel[M]{stream: innerEndpoint}, config)
+			failoverWrapper := newFailoverModelWrapper[M](&typedEndpointModel[M]{stream: innerEndpoint}, config)
 			return failoverWrapper.Stream(ctx, input, opts...)
 		}
 	}

--- a/adk/wrappers.go
+++ b/adk/wrappers.go
@@ -32,10 +32,10 @@ import (
 	"github.com/cloudwego/eino/schema"
 )
 
-type typedGenerateEndpoint[M messageType] func(ctx context.Context, input []M, opts ...model.Option) (M, error)
-type typedStreamEndpoint[M messageType] func(ctx context.Context, input []M, opts ...model.Option) (*schema.StreamReader[M], error)
+type typedGenerateEndpoint[M MessageType] func(ctx context.Context, input []M, opts ...model.Option) (M, error)
+type typedStreamEndpoint[M MessageType] func(ctx context.Context, input []M, opts ...model.Option) (*schema.StreamReader[M], error)
 
-type typedModelWrapperConfig[M messageType] struct {
+type typedModelWrapperConfig[M MessageType] struct {
 	handlers       []TypedChatModelAgentMiddleware[M]
 	middlewares    []AgentMiddleware
 	retryConfig    *TypedModelRetryConfig[M]
@@ -46,11 +46,11 @@ type typedModelWrapperConfig[M messageType] struct {
 
 type modelWrapperConfig = typedModelWrapperConfig[*schema.Message]
 
-func buildModelWrappers[M messageType](m model.BaseModel[M], config *typedModelWrapperConfig[M]) model.BaseModel[M] {
+func buildModelWrappers[M MessageType](m model.BaseModel[M], config *typedModelWrapperConfig[M]) model.BaseModel[M] {
 	return buildModelWrappersImpl(m, config)
 }
 
-func buildModelWrappersImpl[M messageType](m model.BaseModel[M], config *typedModelWrapperConfig[M]) model.BaseModel[M] {
+func buildModelWrappersImpl[M MessageType](m model.BaseModel[M], config *typedModelWrapperConfig[M]) model.BaseModel[M] {
 	var wrapped model.BaseModel[M] = m
 
 	if config.failoverConfig != nil {
@@ -75,13 +75,13 @@ func buildModelWrappersImpl[M messageType](m model.BaseModel[M], config *typedMo
 	return wrapped
 }
 
-type typedCallbackInjectionModelWrapper[M messageType] struct{}
+type typedCallbackInjectionModelWrapper[M MessageType] struct{}
 
 func (w typedCallbackInjectionModelWrapper[M]) wrapModel(m model.BaseModel[M]) model.BaseModel[M] {
 	return &typedCallbackInjectedModel[M]{inner: m}
 }
 
-type typedCallbackInjectedModel[M messageType] struct {
+type typedCallbackInjectedModel[M MessageType] struct {
 	inner model.BaseModel[M]
 }
 
@@ -108,7 +108,7 @@ func (m *typedCallbackInjectedModel[M]) Stream(ctx context.Context, input []M, o
 	return wrappedStream, nil
 }
 
-func handlersToToolMiddlewares[M messageType](handlers []TypedChatModelAgentMiddleware[M]) []compose.ToolMiddleware {
+func handlersToToolMiddlewares[M MessageType](handlers []TypedChatModelAgentMiddleware[M]) []compose.ToolMiddleware {
 	var middlewares []compose.ToolMiddleware
 	for i := len(handlers) - 1; i >= 0; i-- {
 		handler := handlers[i]
@@ -253,7 +253,7 @@ func handlersToToolMiddlewares[M messageType](handlers []TypedChatModelAgentMidd
 	return middlewares
 }
 
-type typedEventSenderModelWrapper[M messageType] struct {
+type typedEventSenderModelWrapper[M MessageType] struct {
 	*TypedBaseChatModelAgentMiddleware[M]
 }
 
@@ -283,7 +283,7 @@ func (w *typedEventSenderModelWrapper[M]) WrapModel(_ context.Context, m model.B
 	return &typedEventSenderModel[M]{inner: inner, modelRetryConfig: retryConfig, modelFailoverConfig: failoverConfig}, nil
 }
 
-type typedEventSenderModel[M messageType] struct {
+type typedEventSenderModel[M MessageType] struct {
 	inner               model.BaseModel[M]
 	modelRetryConfig    *TypedModelRetryConfig[M]
 	modelFailoverConfig *TypedModelFailoverConfig[M]
@@ -464,7 +464,7 @@ func (m *typedEventSenderModel[M]) buildStreamConvertOptions(ctx context.Context
 	return opts
 }
 
-func copyMessage[M messageType](msg M) M {
+func copyMessage[M MessageType](msg M) M {
 	switch v := any(msg).(type) {
 	case *schema.Message:
 		cp := *v
@@ -477,7 +477,7 @@ func copyMessage[M messageType](msg M) M {
 	}
 }
 
-func typedPopToolGenAction[M messageType](ctx context.Context, toolName string) *AgentAction {
+func typedPopToolGenAction[M MessageType](ctx context.Context, toolName string) *AgentAction {
 	toolCallID := compose.GetToolCallID(ctx)
 
 	var action *AgentAction
@@ -667,7 +667,7 @@ func (w *eventSenderToolWrapper) WrapEnhancedStreamableToolCall(_ context.Contex
 	}, nil
 }
 
-func hasUserEventSenderToolWrapper[M messageType](handlers []TypedChatModelAgentMiddleware[M]) bool {
+func hasUserEventSenderToolWrapper[M MessageType](handlers []TypedChatModelAgentMiddleware[M]) bool {
 	for _, handler := range handlers {
 		if _, ok := any(handler).(eventSenderToolWrapperMarker); ok {
 			return true
@@ -676,7 +676,7 @@ func hasUserEventSenderToolWrapper[M messageType](handlers []TypedChatModelAgent
 	return false
 }
 
-type typedStateModelWrapper[M messageType] struct {
+type typedStateModelWrapper[M MessageType] struct {
 	inner               model.BaseModel[M]
 	original            model.BaseModel[M]
 	handlers            []TypedChatModelAgentMiddleware[M]
@@ -1079,7 +1079,7 @@ func (w *typedStateModelWrapper[M]) Stream(ctx context.Context, input []M, opts 
 	return schema.StreamReaderFromArray([]M{state.Messages[len(state.Messages)-1]}), nil
 }
 
-type typedEndpointModel[M messageType] struct {
+type typedEndpointModel[M MessageType] struct {
 	generate typedGenerateEndpoint[M]
 	stream   typedStreamEndpoint[M]
 }

--- a/adk/wrappers_failover_test.go
+++ b/adk/wrappers_failover_test.go
@@ -190,9 +190,9 @@ func TestFailoverAcceptsAgenticAgent(t *testing.T) {
 		},
 	}
 
-	fallbackModel := &mockChatModelForAttack{
-		generateFn: func(ctx context.Context, input []*schema.Message, opts ...model.Option) (*schema.Message, error) {
-			return schema.AssistantMessage("fallback", nil), nil
+	fallbackModel := &mockAgenticModel{
+		generateFn: func(ctx context.Context, input []*schema.AgenticMessage, opts ...model.Option) (*schema.AgenticMessage, error) {
+			return agenticMsg("fallback"), nil
 		},
 	}
 
@@ -200,12 +200,12 @@ func TestFailoverAcceptsAgenticAgent(t *testing.T) {
 		Name:        "FailoverAgent",
 		Description: "Agent with failover config",
 		Model:       m,
-		ModelFailoverConfig: &ModelFailoverConfig{
+		ModelFailoverConfig: &TypedModelFailoverConfig[*schema.AgenticMessage]{
 			MaxRetries: 1,
-			ShouldFailover: func(ctx context.Context, outputMessage *schema.Message, outputErr error) bool {
+			ShouldFailover: func(ctx context.Context, outputMessage *schema.AgenticMessage, outputErr error) bool {
 				return true
 			},
-			GetFailoverModel: func(ctx context.Context, failoverCtx *FailoverContext) (model.BaseChatModel, []*schema.Message, error) {
+			GetFailoverModel: func(ctx context.Context, failoverCtx *TypedFailoverContext[*schema.AgenticMessage]) (model.BaseModel[*schema.AgenticMessage], []*schema.AgenticMessage, error) {
 				return fallbackModel, nil, nil
 			},
 		},

--- a/adk/wrappers_failover_test.go
+++ b/adk/wrappers_failover_test.go
@@ -40,10 +40,10 @@ func TestBuildModelWrappers_FailoverProxyInner(t *testing.T) {
 		},
 	}
 
-	failoverCfg := &ModelFailoverConfig{
+	failoverCfg := &ModelFailoverConfig[*schema.Message]{
 		MaxRetries:     0,
 		ShouldFailover: func(context.Context, *schema.Message, error) bool { return false },
-		GetFailoverModel: func(_ context.Context, _ *FailoverContext) (model.BaseChatModel, []*schema.Message, error) {
+		GetFailoverModel: func(_ context.Context, _ *FailoverContext[*schema.Message]) (model.BaseChatModel, []*schema.Message, error) {
 			return base, nil, nil
 		},
 	}
@@ -87,7 +87,7 @@ func TestStateModelWrapper_Generate_WithFailover(t *testing.T) {
 		},
 	}
 
-	failoverCfg := &ModelFailoverConfig{
+	failoverCfg := &ModelFailoverConfig[*schema.Message]{
 		MaxRetries: 1,
 		ShouldFailover: func(_ context.Context, out *schema.Message, err error) bool {
 			atomic.AddInt32(&shouldCalls, 1)
@@ -96,7 +96,7 @@ func TestStateModelWrapper_Generate_WithFailover(t *testing.T) {
 			require.Equal(t, "partial", out.Content)
 			return true
 		},
-		GetFailoverModel: func(_ context.Context, failoverCtx *FailoverContext) (model.BaseChatModel, []*schema.Message, error) {
+		GetFailoverModel: func(_ context.Context, failoverCtx *FailoverContext[*schema.Message]) (model.BaseChatModel, []*schema.Message, error) {
 			require.Equal(t, uint(1), failoverCtx.FailoverAttempt)
 			return m2, nil, nil
 		},
@@ -148,7 +148,7 @@ func TestStateModelWrapper_Stream_WithFailover(t *testing.T) {
 		},
 	}
 
-	failoverCfg := &ModelFailoverConfig{
+	failoverCfg := &ModelFailoverConfig[*schema.Message]{
 		MaxRetries: 1,
 		ShouldFailover: func(_ context.Context, out *schema.Message, err error) bool {
 			atomic.AddInt32(&shouldCalls, 1)
@@ -157,7 +157,7 @@ func TestStateModelWrapper_Stream_WithFailover(t *testing.T) {
 			require.Equal(t, "p1p2", out.Content)
 			return true
 		},
-		GetFailoverModel: func(_ context.Context, failoverCtx *FailoverContext) (model.BaseChatModel, []*schema.Message, error) {
+		GetFailoverModel: func(_ context.Context, failoverCtx *FailoverContext[*schema.Message]) (model.BaseChatModel, []*schema.Message, error) {
 			require.Equal(t, uint(1), failoverCtx.FailoverAttempt)
 			return m2, nil, nil
 		},
@@ -200,12 +200,12 @@ func TestFailoverAcceptsAgenticAgent(t *testing.T) {
 		Name:        "FailoverAgent",
 		Description: "Agent with failover config",
 		Model:       m,
-		ModelFailoverConfig: &TypedModelFailoverConfig[*schema.AgenticMessage]{
+		ModelFailoverConfig: &ModelFailoverConfig[*schema.AgenticMessage]{
 			MaxRetries: 1,
 			ShouldFailover: func(ctx context.Context, outputMessage *schema.AgenticMessage, outputErr error) bool {
 				return true
 			},
-			GetFailoverModel: func(ctx context.Context, failoverCtx *TypedFailoverContext[*schema.AgenticMessage]) (model.BaseModel[*schema.AgenticMessage], []*schema.AgenticMessage, error) {
+			GetFailoverModel: func(ctx context.Context, failoverCtx *FailoverContext[*schema.AgenticMessage]) (model.BaseModel[*schema.AgenticMessage], []*schema.AgenticMessage, error) {
 				return fallbackModel, nil, nil
 			},
 		},

--- a/adk/wrappers_retry_failover_test.go
+++ b/adk/wrappers_retry_failover_test.go
@@ -67,12 +67,12 @@ func TestRetryThenFailover(t *testing.T) {
 			BackoffFunc: func(_ context.Context, _ int) time.Duration { return 0 },
 		}
 
-		failoverCfg := &ModelFailoverConfig{
+		failoverCfg := &ModelFailoverConfig[*schema.Message]{
 			MaxRetries: 1,
 			ShouldFailover: func(_ context.Context, _ *schema.Message, err error) bool {
 				return err != nil
 			},
-			GetFailoverModel: func(_ context.Context, fc *FailoverContext) (model.BaseChatModel, []*schema.Message, error) {
+			GetFailoverModel: func(_ context.Context, fc *FailoverContext[*schema.Message]) (model.BaseChatModel, []*schema.Message, error) {
 				require.NotNil(t, fc.LastErr)
 				return m2, nil, nil
 			},
@@ -116,12 +116,12 @@ func TestRetryThenFailover(t *testing.T) {
 			BackoffFunc: func(_ context.Context, _ int) time.Duration { return 0 },
 		}
 
-		failoverCfg := &ModelFailoverConfig{
+		failoverCfg := &ModelFailoverConfig[*schema.Message]{
 			MaxRetries: 1,
 			ShouldFailover: func(_ context.Context, _ *schema.Message, err error) bool {
 				return err != nil
 			},
-			GetFailoverModel: func(_ context.Context, _ *FailoverContext) (model.BaseChatModel, []*schema.Message, error) {
+			GetFailoverModel: func(_ context.Context, _ *FailoverContext[*schema.Message]) (model.BaseChatModel, []*schema.Message, error) {
 				return m2, nil, nil
 			},
 		}
@@ -165,13 +165,13 @@ func TestRetryThenFailover(t *testing.T) {
 			BackoffFunc: func(_ context.Context, _ int) time.Duration { return 0 },
 		}
 
-		failoverCfg := &ModelFailoverConfig{
+		failoverCfg := &ModelFailoverConfig[*schema.Message]{
 			MaxRetries: 1,
 			ShouldFailover: func(_ context.Context, _ *schema.Message, err error) bool {
 				atomic.AddInt32(&failoverCalled, 1)
 				return true
 			},
-			GetFailoverModel: func(_ context.Context, _ *FailoverContext) (model.BaseChatModel, []*schema.Message, error) {
+			GetFailoverModel: func(_ context.Context, _ *FailoverContext[*schema.Message]) (model.BaseChatModel, []*schema.Message, error) {
 				t.Fatal("GetFailoverModel should not be called when retry succeeds")
 				return nil, nil, nil
 			},
@@ -218,12 +218,12 @@ func TestRetryThenFailover(t *testing.T) {
 			BackoffFunc: func(_ context.Context, _ int) time.Duration { return 0 },
 		}
 
-		failoverCfg := &ModelFailoverConfig{
+		failoverCfg := &ModelFailoverConfig[*schema.Message]{
 			MaxRetries: 1,
 			ShouldFailover: func(_ context.Context, _ *schema.Message, err error) bool {
 				return err != nil
 			},
-			GetFailoverModel: func(_ context.Context, _ *FailoverContext) (model.BaseChatModel, []*schema.Message, error) {
+			GetFailoverModel: func(_ context.Context, _ *FailoverContext[*schema.Message]) (model.BaseChatModel, []*schema.Message, error) {
 				return m2, nil, nil
 			},
 		}
@@ -267,12 +267,12 @@ func TestRetryThenFailover(t *testing.T) {
 			BackoffFunc: func(_ context.Context, _ int) time.Duration { return 0 },
 		}
 
-		failoverCfg := &ModelFailoverConfig{
+		failoverCfg := &ModelFailoverConfig[*schema.Message]{
 			MaxRetries: 1,
 			ShouldFailover: func(_ context.Context, _ *schema.Message, err error) bool {
 				return err != nil
 			},
-			GetFailoverModel: func(_ context.Context, fc *FailoverContext) (model.BaseChatModel, []*schema.Message, error) {
+			GetFailoverModel: func(_ context.Context, fc *FailoverContext[*schema.Message]) (model.BaseChatModel, []*schema.Message, error) {
 				require.NotNil(t, fc.LastErr)
 				return m2, nil, nil
 			},
@@ -322,12 +322,12 @@ func TestRetryThenFailover(t *testing.T) {
 			BackoffFunc: func(_ context.Context, _ int) time.Duration { return 0 },
 		}
 
-		failoverCfg := &ModelFailoverConfig{
+		failoverCfg := &ModelFailoverConfig[*schema.Message]{
 			MaxRetries: 1,
 			ShouldFailover: func(_ context.Context, _ *schema.Message, err error) bool {
 				return err != nil
 			},
-			GetFailoverModel: func(_ context.Context, _ *FailoverContext) (model.BaseChatModel, []*schema.Message, error) {
+			GetFailoverModel: func(_ context.Context, _ *FailoverContext[*schema.Message]) (model.BaseChatModel, []*schema.Message, error) {
 				return m2, nil, nil
 			},
 		}
@@ -376,12 +376,12 @@ func TestRetryThenFailover(t *testing.T) {
 			BackoffFunc: func(_ context.Context, _ int) time.Duration { return 0 },
 		}
 
-		failoverCfg := &ModelFailoverConfig{
+		failoverCfg := &ModelFailoverConfig[*schema.Message]{
 			MaxRetries: 1,
 			ShouldFailover: func(_ context.Context, _ *schema.Message, err error) bool {
 				return err != nil
 			},
-			GetFailoverModel: func(_ context.Context, _ *FailoverContext) (model.BaseChatModel, []*schema.Message, error) {
+			GetFailoverModel: func(_ context.Context, _ *FailoverContext[*schema.Message]) (model.BaseChatModel, []*schema.Message, error) {
 				return m2, nil, nil
 			},
 		}
@@ -428,12 +428,12 @@ func TestRetryThenFailover(t *testing.T) {
 			BackoffFunc: func(_ context.Context, _ int) time.Duration { return 0 },
 		}
 
-		failoverCfg := &ModelFailoverConfig{
+		failoverCfg := &ModelFailoverConfig[*schema.Message]{
 			MaxRetries: 1,
 			ShouldFailover: func(_ context.Context, _ *schema.Message, err error) bool {
 				return err != nil
 			},
-			GetFailoverModel: func(_ context.Context, _ *FailoverContext) (model.BaseChatModel, []*schema.Message, error) {
+			GetFailoverModel: func(_ context.Context, _ *FailoverContext[*schema.Message]) (model.BaseChatModel, []*schema.Message, error) {
 				return m2, nil, nil
 			},
 		}
@@ -468,12 +468,12 @@ func TestRetryThenFailover(t *testing.T) {
 			BackoffFunc: func(_ context.Context, _ int) time.Duration { return 0 },
 		}
 
-		failoverCfg := &ModelFailoverConfig{
+		failoverCfg := &ModelFailoverConfig[*schema.Message]{
 			MaxRetries: 1,
 			ShouldFailover: func(_ context.Context, _ *schema.Message, err error) bool {
 				return err != nil
 			},
-			GetFailoverModel: func(_ context.Context, _ *FailoverContext) (model.BaseChatModel, []*schema.Message, error) {
+			GetFailoverModel: func(_ context.Context, _ *FailoverContext[*schema.Message]) (model.BaseChatModel, []*schema.Message, error) {
 				return nil, nil, nil
 			},
 		}
@@ -510,13 +510,13 @@ func TestRetryThenFailover(t *testing.T) {
 			BackoffFunc: func(_ context.Context, _ int) time.Duration { return 0 },
 		}
 
-		failoverCfg := &ModelFailoverConfig{
+		failoverCfg := &ModelFailoverConfig[*schema.Message]{
 			MaxRetries: 3,
 			ShouldFailover: func(_ context.Context, _ *schema.Message, err error) bool {
 				cancel()
 				return err != nil
 			},
-			GetFailoverModel: func(_ context.Context, _ *FailoverContext) (model.BaseChatModel, []*schema.Message, error) {
+			GetFailoverModel: func(_ context.Context, _ *FailoverContext[*schema.Message]) (model.BaseChatModel, []*schema.Message, error) {
 				atomic.AddInt32(&failoverModelCalled, 1)
 				return nil, nil, nil
 			},
@@ -550,13 +550,13 @@ func TestErrStreamCanceled_Failover(t *testing.T) {
 			}, ErrStreamCanceled), nil
 		})
 
-		failoverCfg := &ModelFailoverConfig{
+		failoverCfg := &ModelFailoverConfig[*schema.Message]{
 			MaxRetries: 2,
 			ShouldFailover: func(_ context.Context, _ *schema.Message, err error) bool {
 				atomic.AddInt32(&failoverCalled, 1)
 				return true
 			},
-			GetFailoverModel: func(_ context.Context, _ *FailoverContext) (model.BaseChatModel, []*schema.Message, error) {
+			GetFailoverModel: func(_ context.Context, _ *FailoverContext[*schema.Message]) (model.BaseChatModel, []*schema.Message, error) {
 				t.Fatal("GetFailoverModel should not be called for ErrStreamCanceled")
 				return nil, nil, nil
 			},
@@ -585,13 +585,13 @@ func TestErrStreamCanceled_Failover(t *testing.T) {
 			return nil, ErrStreamCanceled
 		}, nil)
 
-		failoverCfg := &ModelFailoverConfig{
+		failoverCfg := &ModelFailoverConfig[*schema.Message]{
 			MaxRetries: 2,
 			ShouldFailover: func(_ context.Context, _ *schema.Message, err error) bool {
 				atomic.AddInt32(&failoverCalled, 1)
 				return true
 			},
-			GetFailoverModel: func(_ context.Context, _ *FailoverContext) (model.BaseChatModel, []*schema.Message, error) {
+			GetFailoverModel: func(_ context.Context, _ *FailoverContext[*schema.Message]) (model.BaseChatModel, []*schema.Message, error) {
 				t.Fatal("GetFailoverModel should not be called for ErrStreamCanceled")
 				return nil, nil, nil
 			},


### PR DESCRIPTION
# Generify Retry, Failover, ModelContext, DeepAgent, and Filesystem Middleware for AgenticMessage

## Problem

After the initial AgenticMessage integration (PR #920), several ADK subsystems remained hardcoded to `*schema.Message`:

- `ModelRetryConfig` / retry mechanism — `RetryContext.OutputMessage` was `*schema.Message`, `ShouldRetry` callbacks only worked with `*schema.Message`
- `ModelFailoverConfig` / failover mechanism — `ShouldFailover` and `GetFailoverModel` callbacks were `*schema.Message`-typed, with internal type-assertion bridges (`any(outputMessage).(*schema.Message)`)
- `ModelContext` — carried `*ModelRetryConfig` and `*ModelFailoverConfig` (non-generic)
- `prebuilt/deep` — entirely `*schema.Message`-specific: `Config.ChatModel model.BaseChatModel`, `SubAgents []Agent`, `Handlers []ChatModelAgentMiddleware`
- `middlewares/filesystem` — non-generic, could not be used directly by agentic agents

This meant `TypedChatModelAgent[*schema.AgenticMessage]` could not use retry, failover, filesystem middleware, or the DeepAgent prebuilt with properly typed callbacks and sub-agents.

## Solution

### Retry (commits 1–4)

Apply the `TypedXXX[M MessageType]` + backward-compat alias pattern (retry types are released APIs):

1. **Retry**: `RetryContext` → `TypedRetryContext[M]`, `RetryDecision` → `TypedRetryDecision[M]`, `ModelRetryConfig` → `TypedModelRetryConfig[M]`
2. **RejectReason**: Added `RejectReason` field to `TypedRetryDecision[M]` and `WillRetryError` for richer retry diagnostics

Each original type becomes a type alias: `type ModelRetryConfig = TypedModelRetryConfig[*schema.Message]`. All existing code compiles unchanged.

### Failover (commits 1, 7)

Since `ModelFailoverConfig` and `FailoverContext` are **unreleased** APIs, they use the **generic-by-default** pattern — no `Typed` prefix, no non-generic alias:

3. **Failover**: `ModelFailoverConfig[M MessageType]` and `FailoverContext[M MessageType]` are the only forms
4. Existing `*schema.Message` users write `ModelFailoverConfig[*schema.Message]` explicitly

### ModelContext (commit 1)

5. **ModelContext**: `ModelContext` → `TypedModelContext[M]` (carries typed retry/failover configs). Since `TypedChatModelAgentMiddleware[M]` is unreleased, `WrapModel`'s signature takes `*TypedModelContext[M]` directly.

### Cleanup (commits 1–4)

- Removed `WillRetryError.OutputMessage` — unreleased field
- Removed `retryVerdict.OutputMessage` — dead internal field
- Removed `consumeStreamForMessage` — replaced by `typedConsumeStream`
- Removed type-assertion bridges in failover
- Fixed `buildStreamConvertOptions`: hardcoded `[*schema.Message]` → `[M]`
- Hoisted repeated `var zero M` declaration in `generateWithShouldRetry`

### DeepAgent Prebuilt (commit 5)

6. **`deep.TypedConfig[M]`**: Generic config with `model.BaseModel[M]`, `[]TypedAgent[M]`, `[]TypedChatModelAgentMiddleware[M]`, typed retry/failover configs
7. **`deep.NewTyped[M]`**: Generic constructor returning `TypedResumableAgent[M]`
8. **Task tool sub-agent**: Fully `TypedChatModelAgent[M]` — uses `typedGenModelInput[M]`, wrapped via `NewTypedAgentTool[M]`

### Exported MessageType & Filesystem Generification (commit 6)

9. **Exported `MessageType`** in `adk/interface.go` — eliminates duplicated local `messageType` constraints from `deep` and `filesystem` packages
10. **Generified filesystem middleware**: `filesystem.NewTyped[M]` + `typedFilesystemMiddleware[M]`; `filesystem.New` becomes a backward-compat wrapper
11. **Eliminated `middlewareAdapter[M]`** from deep package — replaced with direct `filesystem.NewTyped[M]` call (~40 lines of adapter code removed)
12. **Removed all unused backward-compat wrappers** from deep package (`Config`, `New`, etc.)
13. **Fixed `typedConsumeStream`** empty stream handling — preserved original `ConcatMessages` behavior (returns `&Message{}` not nil); removed incorrect `len(chunks) == 0` early returns that were added in commit 5

### Drop Typed Prefix for Unreleased APIs (commit 7)

14. **Renamed**: `TypedModelFailoverConfig[M]` → `ModelFailoverConfig[M]`, `TypedFailoverContext[M]` → `FailoverContext[M]`
15. **Removed non-generic aliases** — the generic form is now the only form

## Decisions

### Generic-by-default vs. `TypedXxx + alias` pattern

For **released** generic APIs (e.g., `ModelRetryConfig`, `ModelContext`), we use the `TypedXxx[M] + alias` pattern to preserve backward compatibility:
```go
type TypedModelRetryConfig[M MessageType] struct { ... }
type ModelRetryConfig = TypedModelRetryConfig[*schema.Message]
```

For **unreleased** generic APIs (e.g., `ModelFailoverConfig`, `FailoverContext`), we prefer **generic-by-default** — the generic type uses the clean name directly, with no `Typed` prefix and no non-generic alias. This avoids boilerplate and keeps the API surface clean. The small ergonomic cost (`ModelFailoverConfig[*schema.Message]` instead of `ModelFailoverConfig`) is worthwhile.

### Exported `MessageType` constraint

Initially, Go 1.18's limitation on exporting constraint interfaces required each package to define its own local `messageType` copy. This was resolved by exporting `MessageType` from `adk/interface.go` — all packages (`deep`, `filesystem`) now import `adk.MessageType` directly, eliminating the duplication.

### Sub-agent type enforcement by the type system

`SubAgents []adk.TypedAgent[M]` means an Agentic DeepAgent (`M = *schema.AgenticMessage`) can only accept Agentic sub-agents. A standard DeepAgent can only accept standard sub-agents. No runtime check needed — the compiler enforces this.

### `fullChatHistoryAsInput` stays `*schema.Message`-only

This feature converts full chat history into model input. `AgenticMessage` has a fundamentally different structure that doesn't map to this pattern. Kept as-is with a design comment.

### Cross-type agent tools stay blocked

An `AgenticMessage` agent cannot be wrapped as a tool in a `Message` agent (or vice versa). The event streams are incompatible.

### `planexecute` stays `*schema.Message`-only

It depends on workflow agents (`NewLoopAgent`/`NewSequentialAgent`) which are non-generic and complex to generify. Out of scope for this PR.

### Filesystem middleware generified directly

The filesystem middleware was generified with `NewTyped[M]` and `typedFilesystemMiddleware[M]`. This made the `middlewareAdapter[M]` bridge in `deep` unnecessary — replaced with a direct `filesystem.NewTyped[M]` call, removing ~40 lines of adapter code.

## Key Insight

When generifying an existing `*schema.Message`-specific API, type-assertion bridges (`any(x).(*schema.Message)`) are a code smell indicating the generic boundary was drawn at the wrong level. Moving the generic parameter into the config types (e.g., `ModelFailoverConfig[M]`) eliminates all bridges — the callback signatures enforce type safety at the API boundary.

For naming, there are two patterns:
- **Released APIs** → `TypedXxx[M] + alias` (backward-compat required)
- **Unreleased APIs** → Generic-by-default with the clean name (e.g., `ModelFailoverConfig[M]`, not `TypedModelFailoverConfig[M]`)

The `TypedXxx + alias` pattern is a backward-compatibility tax. For new or unreleased generic APIs, prefer the clean generic form to avoid accumulating unnecessary aliases.

## Summary

| Problem | Solution |
|---------|----------|
| Retry callbacks only accept `*schema.Message` | `TypedModelRetryConfig[M]` with typed `ShouldRetry` callback |
| No retry reject reason | Added `RejectReason` to `TypedRetryDecision[M]` and `WillRetryError` |
| Failover callbacks only accept `*schema.Message` | `ModelFailoverConfig[M]` (generic-by-default, no `Typed` prefix) |
| Internal type-assertion bridges in failover | Removed — generic types flow through directly |
| `WillRetryError.OutputMessage` needs dual fields | Removed the field (unreleased) |
| `buildStreamConvertOptions` hardcoded to `[*schema.Message]` | Fixed to use `[M]` |
| `typedConsumeStream` returned nil on empty stream | Fixed to preserve `ConcatMessages` behavior (return `&Message{}`) |
| DeepAgent hardcoded to `*schema.Message` | `TypedConfig[M]` + `NewTyped[M]` with backward-compat aliases |
| Sub-agents not type-safe across message types | `[]TypedAgent[M]` enforces same-type sub-agents |
| Duplicated `messageType` constraint in each package | Exported `MessageType` from `adk/interface.go` |
| Filesystem middleware non-generic | `filesystem.NewTyped[M]` + backward-compat `New` wrapper |
| `middlewareAdapter[M]` bridge in deep package | Eliminated — replaced by direct `filesystem.NewTyped[M]` call |
| Unreleased failover types carried unnecessary `Typed` prefix | Dropped prefix — `ModelFailoverConfig[M]` is the only form |

---

# 泛化 Retry、Failover、ModelContext、DeepAgent 和文件系统中间件以支持 AgenticMessage

## 问题

在初始 AgenticMessage 集成（PR #920）之后，几个 ADK 子系统仍然硬编码为 `*schema.Message`：

- `ModelRetryConfig` / 重试机制 — 回调只能处理 `*schema.Message`
- `ModelFailoverConfig` / 容灾机制 — 回调是 `*schema.Message` 类型，内部使用类型断言桥接
- `ModelContext` — 携带非泛型的重试/容灾配置
- `prebuilt/deep` — 完全 `*schema.Message` 特化
- `middlewares/filesystem` — 非泛型，无法直接被 Agentic 代理使用

## 解决方案

### 重试（提交 1–4）

对已发布的重试类型应用 `TypedXXX[M MessageType]` + 向后兼容别名模式：
1. `ModelRetryConfig` → `TypedModelRetryConfig[M]`，原类型变为别名
2. 新增 `RejectReason` 字段到 `TypedRetryDecision[M]` 和 `WillRetryError`

### 容灾（提交 1、7）

容灾类型为**未发布** API，使用**泛型默认**模式——无 `Typed` 前缀，无非泛型别名：
3. `ModelFailoverConfig[M MessageType]` 和 `FailoverContext[M MessageType]` 为唯一形式

### ModelContext（提交 1）

4. `ModelContext` → `TypedModelContext[M]`，携带类型化的重试/容灾配置

### DeepAgent 预构建（提交 5）

5. `deep.TypedConfig[M]`：泛型配置，包含类型化的模型、子代理、中间件
6. `deep.NewTyped[M]`：泛型构造函数
7. 任务工具子代理完全类型化为 `TypedChatModelAgent[M]`

### 导出 MessageType 与文件系统泛化（提交 6）

8. 在 `adk/interface.go` 中导出 `MessageType`，消除各包的重复约束定义
9. 泛化文件系统中间件：`filesystem.NewTyped[M]`，`New` 作为向后兼容包装
10. 从 deep 包中移除 `middlewareAdapter[M]`，替换为直接调用 `filesystem.NewTyped[M]`（约减少 40 行代码）
11. 修复 `typedConsumeStream` 空流处理——保留原始 `ConcatMessages` 行为（返回 `&Message{}` 而非 nil）

### 去除未发布 API 的 Typed 前缀（提交 7）

12. 重命名：`TypedModelFailoverConfig[M]` → `ModelFailoverConfig[M]`，`TypedFailoverContext[M]` → `FailoverContext[M]`
13. 移除非泛型别名——泛型形式为唯一形式

## 决策

### 泛型默认 vs. `TypedXxx + 别名` 模式

- **已发布 API**（如 `ModelRetryConfig`）→ `TypedXxx[M] + 别名`（需向后兼容）
- **未发布 API**（如 `ModelFailoverConfig`）→ 泛型默认，使用简洁名称，无前缀无别名

### 导出 `MessageType` 约束

最初由于 Go 1.18 的限制，每个包需定义本地 `messageType` 副本。通过从 `adk/interface.go` 导出 `MessageType` 解决，所有包直接导入 `adk.MessageType`。

### 子代理的类型安全由类型系统保证

`SubAgents []adk.TypedAgent[M]` 使编译器强制 Agentic DeepAgent 只接受 Agentic 子代理，标准 DeepAgent 只接受标准子代理。

### `fullChatHistoryAsInput` 保持 `*schema.Message` 专用

`AgenticMessage` 的结构不适用于此模式，保持不变。

### 跨类型代理工具仍不支持

`AgenticMessage` 代理不能作为 `Message` 代理的工具（反之亦然），事件流不兼容。

### `planexecute` 保持 `*schema.Message` 专用

依赖非泛型的工作流代理，泛化复杂，不在本 PR 范围内。

### 文件系统中间件直接泛化

通过 `filesystem.NewTyped[M]` 泛化文件系统中间件，使 deep 包中的 `middlewareAdapter[M]` 桥接不再需要，直接调用即可。

## 关键洞察

泛化现有 API 时，类型断言桥接（`any(x).(*schema.Message)`）是代码异味，表明泛型边界画在了错误的层级。将泛型参数移入配置类型可消除所有桥接。

命名方面有两种模式：
- **已发布 API** → `TypedXxx[M] + 别名`（需向后兼容）
- **未发布 API** → 泛型默认，使用简洁名称

`TypedXxx + 别名` 模式是向后兼容的代价。对于新的或未发布的泛型 API，优先使用简洁的泛型形式，避免积累不必要的别名。

## 摘要

| 问题 | 解决方案 |
|------|----------|
| 重试回调只接受 `*schema.Message` | `TypedModelRetryConfig[M]` 配合类型化回调 |
| 无重试拒绝原因 | 新增 `RejectReason` 到 `TypedRetryDecision[M]` 和 `WillRetryError` |
| 容灾回调只接受 `*schema.Message` | `ModelFailoverConfig[M]`（泛型默认，无 `Typed` 前缀） |
| 容灾内部的类型断言桥接 | 移除——泛型类型直接传递 |
| DeepAgent 硬编码为 `*schema.Message` | `TypedConfig[M]` + `NewTyped[M]` |
| 各包重复定义 `messageType` 约束 | 从 `adk/interface.go` 导出 `MessageType` |
| 文件系统中间件非泛型 | `filesystem.NewTyped[M]` + 向后兼容 `New` 包装 |
| deep 包中的 `middlewareAdapter[M]` 桥接 | 移除——替换为直接调用 `filesystem.NewTyped[M]` |
| 未发布容灾类型携带多余 `Typed` 前缀 | 去除前缀——`ModelFailoverConfig[M]` 为唯一形式 |
| `typedConsumeStream` 空流返回 nil | 修复为保留 `ConcatMessages` 行为 |
