### PR TITLE
feat(adk): validate pages parameter in MultiModalReadFileTool

### DIFF
--- a/adk/middlewares/filesystem/filesystem.go
+++ b/adk/middlewares/filesystem/filesystem.go
@@ -634,13 +634,39 @@ func formatLineNumbers(content string, startLine int) string {
 	return b.String()
 }
 
+const maxPagesPerRequest = 20
+
+func validatePages(pages string) error {
+	parts := strings.SplitN(pages, "-", 2)
+	start, err := strconv.Atoi(parts[0])
+	if err != nil || start < 1 {
+		return fmt.Errorf("invalid pages parameter %q: expected format like \"3\" or \"1-10\"", pages)
+	}
+	if len(parts) == 1 {
+		return nil
+	}
+	if parts[1] == "" {
+		return fmt.Errorf("invalid pages parameter %q: expected format like \"3\" or \"1-10\"", pages)
+	}
+	end, err := strconv.Atoi(parts[1])
+	if err != nil || end < 1 {
+		return fmt.Errorf("invalid pages parameter %q: expected format like \"3\" or \"1-10\"", pages)
+	}
+	if end < start {
+		return fmt.Errorf("invalid pages parameter %q: end page must be >= start page", pages)
+	}
+	if end-start+1 > maxPagesPerRequest {
+		return fmt.Errorf("invalid pages parameter %q: range exceeds maximum of %d pages per request", pages, maxPagesPerRequest)
+	}
+	return nil
+}
+
 func newMultiModalReadFileTool(fs filesystem.Backend, name string, desc string) (tool.BaseTool, error) {
 	er, ok := fs.(filesystem.MultiModalReader)
 	if !ok {
 		return nil, fmt.Errorf("UseMultiModalRead is enabled, but backend (type %T) does not implement filesystem.MultiModalReader interface. "+
 			"Either implement the MultiModalReader interface on your backend, or set UseMultiModalRead to false", fs)
 	}
-
 	toolName := selectToolName(name, ToolNameReadFile)
 	d, err := selectToolDesc(desc, ReadFileToolDesc, ReadFileToolDescChinese)
 	if err != nil {
@@ -662,6 +688,14 @@ func newMultiModalReadFileTool(fs filesystem.Backend, name string, desc string) 
 		}
 		if input.Limit <= 0 {
 			input.Limit = 2000
+		}
+
+		if input.Pages != "" {
+			if err := validatePages(input.Pages); err != nil {
+				return &schema.ToolResult{
+					Parts: []schema.ToolOutputPart{{Type: schema.ToolPartTypeText, Text: err.Error()}},
+				}, nil
+			}
 		}
 
 		fileCt, err := er.MultiModalRead(ctx, &filesystem.MultiModalReadRequest{

--- a/adk/middlewares/filesystem/filesystem_test.go
+++ b/adk/middlewares/filesystem/filesystem_test.go
@@ -2612,3 +2612,36 @@ func TestMultiModalReadFileTool_NilResult(t *testing.T) {
 	assert.Contains(t, result.Parts[0].Text, "No content found at path")
 	assert.Contains(t, result.Parts[0].Text, "/missing.txt")
 }
+
+func TestValidatePages(t *testing.T) {
+	tests := []struct {
+		name    string
+		pages   string
+		wantErr string
+	}{
+		{name: "single page", pages: "3"},
+		{name: "valid range", pages: "1-10"},
+		{name: "same start end", pages: "1-1"},
+		{name: "max 20 pages", pages: "1-20"},
+		{name: "trailing dash", pages: "1-", wantErr: "expected format"},
+		{name: "leading dash", pages: "-5", wantErr: "expected format"},
+		{name: "non-numeric", pages: "abc", wantErr: "expected format"},
+		{name: "non-numeric end", pages: "1-abc", wantErr: "expected format"},
+		{name: "zero start", pages: "0-5", wantErr: "expected format"},
+		{name: "zero end", pages: "1-0", wantErr: "expected format"},
+		{name: "end less than start", pages: "10-5", wantErr: "end page must be >= start page"},
+		{name: "exceeds max pages", pages: "1-21", wantErr: "range exceeds maximum of 20"},
+		{name: "large range", pages: "1-30", wantErr: "range exceeds maximum of 20"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := validatePages(tt.pages)
+			if tt.wantErr == "" {
+				assert.NoError(t, err)
+			} else {
+				assert.ErrorContains(t, err, tt.wantErr)
+			}
+		})
+	}
+}


### PR DESCRIPTION
- Add validatePages function to check format (must be "N" or "N-M")
- Reject invalid formats such as "1-", "-5", non-numeric values
- Enforce end >= start and max 20 pages per request
- Return validation error as ToolResult so the model can self-correct
