### PR TITLE
fix(flow/retriever/parent): validate ParentIDKey is non-empty in NewRetriever

### DIFF
--- a/flow/retriever/parent/parent.go
+++ b/flow/retriever/parent/parent.go
@@ -74,6 +74,9 @@ func NewRetriever(ctx context.Context, config *Config) (retriever.Retriever, err
 	if config.OrigDocGetter == nil {
 		return nil, fmt.Errorf("orig doc getter is required")
 	}
+	if config.ParentIDKey == "" {
+		return nil, fmt.Errorf("parent id key is required")
+	}
 	return &parentRetriever{
 		retriever:     config.Retriever,
 		parentIDKey:   config.ParentIDKey,

--- a/flow/retriever/parent/parent_test.go
+++ b/flow/retriever/parent/parent_test.go
@@ -41,6 +41,27 @@ func (t *testRetriever) Retrieve(ctx context.Context, query string, opts ...retr
 	return ret, nil
 }
 
+func TestNewRetrieverValidation(t *testing.T) {
+	ctx := context.Background()
+	tr := &testRetriever{}
+	getter := func(ctx context.Context, ids []string) ([]*schema.Document, error) { return nil, nil }
+
+	_, err := NewRetriever(ctx, &Config{Retriever: nil, ParentIDKey: "k", OrigDocGetter: getter})
+	if err == nil {
+		t.Error("expected error when Retriever is nil")
+	}
+
+	_, err = NewRetriever(ctx, &Config{Retriever: tr, ParentIDKey: "k", OrigDocGetter: nil})
+	if err == nil {
+		t.Error("expected error when OrigDocGetter is nil")
+	}
+
+	_, err = NewRetriever(ctx, &Config{Retriever: tr, ParentIDKey: "", OrigDocGetter: getter})
+	if err == nil {
+		t.Error("expected error when ParentIDKey is empty")
+	}
+}
+
 func TestParentRetriever(t *testing.T) {
 	tests := []struct {
 		name   string


### PR DESCRIPTION
Fixes #952

## Problem

`NewRetriever` in `flow/retriever/parent` validates `Retriever` and `OrigDocGetter` but silently accepts an empty `ParentIDKey`. When `ParentIDKey` is empty, `Retrieve` looks up `subDoc.MetaData[""]` for every sub-document — a key that is never populated — so the function silently returns empty results regardless of the actual retrieval output.

This is the retriever-side companion to the indexer fix in #953.

## Solution

Added a `config.ParentIDKey == ""` validation check in `NewRetriever`, consistent with the existing field validation pattern.

## Testing

Added `TestNewRetrieverValidation` covering all three required-field error cases (nil Retriever, nil OrigDocGetter, empty ParentIDKey). Existing `TestParentRetriever` passes unchanged.