### PR TITLE
fix(adk): correct tool handler wrapping order to match model path

### DIFF
--- a/adk/handler_test.go
+++ b/adk/handler_test.go
@@ -615,7 +615,7 @@ func TestToolCallWrapperHandlers(t *testing.T) {
 			}
 		}
 
-		assert.Equal(t, []string{"wrapper2-before", "wrapper1-before", "wrapper1-after", "wrapper2-after"}, callOrder)
+		assert.Equal(t, []string{"wrapper1-before", "wrapper2-before", "wrapper2-after", "wrapper1-after"}, callOrder)
 	})
 
 	t.Run("StreamingToolWrappersPipeline", func(t *testing.T) {
@@ -702,7 +702,7 @@ func TestToolCallWrapperHandlers(t *testing.T) {
 		}
 
 		assert.True(t, hasStreamingToolResult, "Should have streaming tool result")
-		assert.Equal(t, []string{"wrapper2-stream-before", "wrapper1-stream-before", "wrapper1-stream-after", "wrapper2-stream-after"}, callOrder,
+		assert.Equal(t, []string{"wrapper1-stream-before", "wrapper2-stream-before", "wrapper2-stream-after", "wrapper1-stream-after"}, callOrder,
 			"Streaming wrappers should be called in correct order")
 	})
 

--- a/adk/wrappers.go
+++ b/adk/wrappers.go
@@ -93,8 +93,10 @@ func (m *callbackInjectedModel) Stream(ctx context.Context, input []*schema.Mess
 
 func handlersToToolMiddlewares(handlers []ChatModelAgentMiddleware) []compose.ToolMiddleware {
 	var middlewares []compose.ToolMiddleware
-	for i := len(handlers) - 1; i >= 0; i-- {
-		handler := handlers[i]
+	// Forward iteration: compose.wrapToolCall applies middlewares in reverse order
+	// (len-1 down to 0), so keeping the original handler order here means
+	// handlers[0] ends up outermost — matching the model wrapping convention.
+	for _, handler := range handlers {
 
 		m := compose.ToolMiddleware{}
 

--- a/adk/wrappers_test.go
+++ b/adk/wrappers_test.go
@@ -207,22 +207,22 @@ func TestHandlersToToolMiddlewaresEnhanced(t *testing.T) {
 		invokableEndpoint := func(ctx context.Context, input *compose.ToolInput) (*compose.ToolOutput, error) {
 			return &compose.ToolOutput{Result: "test"}, nil
 		}
-		_, _ = middlewares[3].Invokable(invokableEndpoint)(context.Background(), &compose.ToolInput{Name: "test", CallID: "1", Arguments: "{}"})
+		_, _ = middlewares[0].Invokable(invokableEndpoint)(context.Background(), &compose.ToolInput{Name: "test", CallID: "1", Arguments: "{}"})
 
 		streamableEndpoint := func(ctx context.Context, input *compose.ToolInput) (*compose.StreamToolOutput, error) {
 			return &compose.StreamToolOutput{Result: schema.StreamReaderFromArray([]string{"test"})}, nil
 		}
-		_, _ = middlewares[2].Streamable(streamableEndpoint)(context.Background(), &compose.ToolInput{Name: "test", CallID: "1", Arguments: "{}"})
+		_, _ = middlewares[1].Streamable(streamableEndpoint)(context.Background(), &compose.ToolInput{Name: "test", CallID: "1", Arguments: "{}"})
 
 		enhancedInvokableEndpoint := func(ctx context.Context, input *compose.ToolInput) (*compose.EnhancedInvokableToolOutput, error) {
 			return &compose.EnhancedInvokableToolOutput{Result: &schema.ToolResult{}}, nil
 		}
-		_, _ = middlewares[1].EnhancedInvokable(enhancedInvokableEndpoint)(context.Background(), &compose.ToolInput{Name: "test", CallID: "1", Arguments: "{}"})
+		_, _ = middlewares[2].EnhancedInvokable(enhancedInvokableEndpoint)(context.Background(), &compose.ToolInput{Name: "test", CallID: "1", Arguments: "{}"})
 
 		enhancedStreamableEndpoint := func(ctx context.Context, input *compose.ToolInput) (*compose.EnhancedStreamableToolOutput, error) {
 			return &compose.EnhancedStreamableToolOutput{Result: schema.StreamReaderFromArray([]*schema.ToolResult{{}})}, nil
 		}
-		_, _ = middlewares[0].EnhancedStreamable(enhancedStreamableEndpoint)(context.Background(), &compose.ToolInput{Name: "test", CallID: "1", Arguments: "{}"})
+		_, _ = middlewares[3].EnhancedStreamable(enhancedStreamableEndpoint)(context.Background(), &compose.ToolInput{Name: "test", CallID: "1", Arguments: "{}"})
 
 		assert.True(t, invokableCalled)
 		assert.True(t, streamableCalled)
@@ -339,7 +339,7 @@ func TestHandlersToToolMiddlewaresEnhanced(t *testing.T) {
 		wrapped := middlewares[0].EnhancedInvokable(middlewares[1].EnhancedInvokable(mockEndpoint))
 		_, err := wrapped(context.Background(), &compose.ToolInput{Name: "test", CallID: "1", Arguments: "{}"})
 		assert.NoError(t, err)
-		assert.Equal(t, []string{"handler2-before", "handler1-before", "handler1-after", "handler2-after"}, executionOrder)
+		assert.Equal(t, []string{"handler1-before", "handler2-before", "handler2-after", "handler1-after"}, executionOrder)
 	})
 
 	t.Run("MultipleEnhancedStreamableWrappers", func(t *testing.T) {
@@ -389,7 +389,7 @@ func TestHandlersToToolMiddlewaresEnhanced(t *testing.T) {
 		wrapped := middlewares[0].EnhancedStreamable(middlewares[1].EnhancedStreamable(mockEndpoint))
 		_, err := wrapped(context.Background(), &compose.ToolInput{Name: "test", CallID: "1", Arguments: "{}"})
 		assert.NoError(t, err)
-		assert.Equal(t, []string{"handler2-before", "handler1-before", "handler1-after", "handler2-after"}, executionOrder)
+		assert.Equal(t, []string{"handler1-before", "handler2-before", "handler2-after", "handler1-after"}, executionOrder)
 	})
 }
 


### PR DESCRIPTION
## Problem

`handlersToToolMiddlewares` iterated handlers in reverse (`len-1` down to `0`), but `compose.wrapToolCall` also iterates in reverse when applying middlewares. This double-reverse caused **last-registered handlers to be outermost** for tool wrapping — contradicting the model path where **first-registered is outermost**.

For example, with `Handlers: [A, B, C]`:
- **Model path** (correct): `A(B(C(model)))` — A outermost
- **Tool path** (was broken): `C(B(A(tool)))` — C outermost

This violated the documented convention at `chatmodel.go:389`:
> Handler order: first registered is outermost. So [A, B, C] wraps as A(B(C(tool))).

## Fix

Changed `handlersToToolMiddlewares` from reverse iteration to forward `range` loop. Since compose's `wrapToolCall` already applies middlewares in reverse, keeping the original handler order in the slice means `handlers[0]` ends up outermost — matching the model wrapping convention.

The `eventSenderToolWrapper` is unaffected: it is prepended to `ToolCallMiddlewares[0]` independently of `handlersToToolMiddlewares`, and compose's reverse iteration makes `[0]` outermost regardless.

## Changes

- `adk/wrappers.go`: Forward iteration in `handlersToToolMiddlewares` with explanatory comment
- `adk/wrappers_test.go`: Updated order assertions and middleware index references
- `adk/handler_test.go`: Updated integration test order assertions
