### PR TITLE
feat(adk): add WithPreserveReasoning option to preserve reasoning con…

### DIFF
--- a/adk/agent_tool.go
+++ b/adk/agent_tool.go
@@ -315,7 +315,10 @@ func getReactChatHistory(ctx context.Context, destAgentName string) ([]Message, 
 		}
 
 		if msg.Role == schema.Assistant || msg.Role == schema.Tool {
-			msg = rewriteMessage(msg, agentName)
+			// For agent tool context, we default to not preserving reasoning
+			// to maintain backward compatibility. Users should use WithPreserveReasoning()
+			// option when setting up flow agents if reasoning preservation is needed.
+			msg = rewriteMessage(msg, agentName, false)
 		}
 
 		history = append(history, msg)

--- a/adk/flow.go
+++ b/adk/flow.go
@@ -47,6 +47,7 @@ type flowAgent struct {
 
 	disallowTransferToParent bool
 	historyRewriter          HistoryRewriter
+	preserveReasoning        bool
 
 	checkPointStore compose.CheckPointStore
 }
@@ -58,6 +59,7 @@ func (a *flowAgent) deepCopy() *flowAgent {
 		parentAgent:              a.parentAgent,
 		disallowTransferToParent: a.disallowTransferToParent,
 		historyRewriter:          a.historyRewriter,
+		preserveReasoning:        a.preserveReasoning,
 		checkPointStore:          a.checkPointStore,
 	}
 
@@ -88,6 +90,17 @@ func WithHistoryRewriter(h HistoryRewriter) AgentOption {
 	}
 }
 
+// WithPreserveReasoning enables preservation of reasoning content during message rewriting.
+// When enabled, reasoning content from AssistantGenMultiContent will be preserved in the
+// message's ReasoningContent field when messages are converted between agents.
+// This is required for models operating in "thinking mode" that need reasoning context
+// to be passed back in subsequent API calls.
+func WithPreserveReasoning() AgentOption {
+	return func(fa *flowAgent) {
+		fa.preserveReasoning = true
+	}
+}
+
 func toFlowAgent(ctx context.Context, agent Agent, opts ...AgentOption) *flowAgent {
 	var fa *flowAgent
 	var ok bool
@@ -101,7 +114,7 @@ func toFlowAgent(ctx context.Context, agent Agent, opts ...AgentOption) *flowAge
 	}
 
 	if fa.historyRewriter == nil {
-		fa.historyRewriter = buildDefaultHistoryRewriter(agent.Name(ctx))
+		fa.historyRewriter = buildDefaultHistoryRewriter(agent.Name(ctx), fa.preserveReasoning)
 	}
 
 	return fa
@@ -168,7 +181,7 @@ func (a *flowAgent) getAgent(ctx context.Context, name string) *flowAgent {
 	return nil
 }
 
-func rewriteMessage(msg Message, agentName string) Message {
+func rewriteMessage(msg Message, agentName string, preserveReasoning bool) Message {
 	var sb strings.Builder
 	sb.WriteString("For context:")
 	if msg.Role == schema.Assistant {
@@ -195,8 +208,32 @@ func rewriteMessage(msg Message, agentName string) Message {
 		rewritten.UserInputMultiContent = append([]schema.MessageInputPart{}, msg.UserInputMultiContent...)
 	}
 
+	// Preserve reasoning content if enabled
+	if preserveReasoning {
+		// Start with existing ReasoningContent
+		var reasoningBuilder strings.Builder
+		if msg.ReasoningContent != "" {
+			reasoningBuilder.WriteString(msg.ReasoningContent)
+		}
+
+		// Extract reasoning from AssistantGenMultiContent
+		for _, part := range msg.AssistantGenMultiContent {
+			if part.Type == schema.ChatMessagePartTypeReasoning && part.Reasoning != nil {
+				if reasoningBuilder.Len() > 0 {
+					reasoningBuilder.WriteString("\n")
+				}
+				reasoningBuilder.WriteString(part.Reasoning.Text)
+			}
+		}
+
+		if reasoningBuilder.Len() > 0 {
+			rewritten.ReasoningContent = reasoningBuilder.String()
+		}
+	}
+
 	// Convert AssistantGenMultiContent to UserInputMultiContent, since the role changes to User.
-	// Reasoning parts have no user input equivalent and are dropped.
+	// Reasoning parts have no user input equivalent and are dropped from multi-content,
+	// but are preserved in ReasoningContent field if preserveReasoning is enabled.
 	for _, part := range msg.AssistantGenMultiContent {
 		switch part.Type {
 		case schema.ChatMessagePartTypeText:
@@ -235,10 +272,10 @@ func rewriteMessage(msg Message, agentName string) Message {
 	return rewritten
 }
 
-func genMsg(entry *HistoryEntry, agentName string) (Message, error) {
+func genMsg(entry *HistoryEntry, agentName string, preserveReasoning bool) (Message, error) {
 	msg := entry.Message
 	if entry.AgentName != agentName {
-		msg = rewriteMessage(msg, entry.AgentName)
+		msg = rewriteMessage(msg, entry.AgentName, preserveReasoning)
 	}
 
 	return msg, nil
@@ -310,14 +347,14 @@ func (a *flowAgent) genAgentInput(ctx context.Context, runCtx *runContext, skipT
 	return input, nil
 }
 
-func buildDefaultHistoryRewriter(agentName string) HistoryRewriter {
+func buildDefaultHistoryRewriter(agentName string, preserveReasoning bool) HistoryRewriter {
 	return func(ctx context.Context, entries []*HistoryEntry) ([]Message, error) {
 		messages := make([]Message, 0, len(entries))
 		var err error
 		for _, entry := range entries {
 			msg := entry.Message
 			if !entry.IsUserInput {
-				msg, err = genMsg(entry, agentName)
+				msg, err = genMsg(entry, agentName, preserveReasoning)
 				if err != nil {
 					return nil, fmt.Errorf("gen agent input failed: %w", err)
 				}

--- a/adk/flow_test.go
+++ b/adk/flow_test.go
@@ -54,7 +54,7 @@ func TestRewriteMessage(t *testing.T) {
 		},
 	}
 
-	rewritten := rewriteMessage(msg, "OtherAgent")
+	rewritten := rewriteMessage(msg, "OtherAgent", false)
 
 	assert.Equal(t, schema.User, rewritten.Role)
 
@@ -89,6 +89,75 @@ func TestRewriteMessage(t *testing.T) {
 
 	// reasoning is dropped; AssistantGenMultiContent is not set on rewritten message
 	assert.Empty(t, rewritten.AssistantGenMultiContent)
+}
+
+func TestRewriteMessageWithReasoningPreservation(t *testing.T) {
+	imageCommon := schema.MessagePartCommon{URL: strPtr("http://img.example.com")}
+
+	msg := &schema.Message{
+		Role:             schema.Assistant,
+		Content:          "hello",
+		ReasoningContent: "initial reasoning",
+		AssistantGenMultiContent: []schema.MessageOutputPart{
+			{Type: schema.ChatMessagePartTypeText, Text: "gen-text"},
+			{Type: schema.ChatMessagePartTypeImageURL, Image: &schema.MessageOutputImage{MessagePartCommon: imageCommon}},
+			{Type: schema.ChatMessagePartTypeReasoning, Reasoning: &schema.MessageOutputReasoning{
+				Text:      "deep thoughts about the problem",
+				Signature: "sig_abc123",
+			}},
+			{Type: schema.ChatMessagePartTypeReasoning, Reasoning: &schema.MessageOutputReasoning{
+				Text: "more analysis",
+			}},
+		},
+	}
+
+	// Test with preserveReasoning = true
+	rewritten := rewriteMessage(msg, "OtherAgent", true)
+
+	assert.Equal(t, schema.User, rewritten.Role)
+
+	// Reasoning content should be preserved and merged
+	expectedReasoning := "initial reasoning\ndeep thoughts about the problem\nmore analysis"
+	assert.Equal(t, expectedReasoning, rewritten.ReasoningContent)
+
+	// UserInputMultiContent should have text and image (not reasoning parts)
+	assert.Len(t, rewritten.UserInputMultiContent, 2) // text + image only
+
+	// Verify text conversion
+	assert.Equal(t, schema.ChatMessagePartTypeText, rewritten.UserInputMultiContent[0].Type)
+	assert.Equal(t, "gen-text", rewritten.UserInputMultiContent[0].Text)
+
+	// Verify image conversion
+	assert.Equal(t, schema.ChatMessagePartTypeImageURL, rewritten.UserInputMultiContent[1].Type)
+	assert.Equal(t, imageCommon, rewritten.UserInputMultiContent[1].Image.MessagePartCommon)
+
+	// AssistantGenMultiContent should not be set on rewritten message
+	assert.Empty(t, rewritten.AssistantGenMultiContent)
+}
+
+func TestRewriteMessageWithoutInitialReasoning(t *testing.T) {
+	msg := &schema.Message{
+		Role:    schema.Assistant,
+		Content: "hello",
+		AssistantGenMultiContent: []schema.MessageOutputPart{
+			{Type: schema.ChatMessagePartTypeText, Text: "gen-text"},
+			{Type: schema.ChatMessagePartTypeReasoning, Reasoning: &schema.MessageOutputReasoning{
+				Text: "only reasoning from parts",
+			}},
+		},
+	}
+
+	// Test with preserveReasoning = true
+	rewritten := rewriteMessage(msg, "OtherAgent", true)
+
+	assert.Equal(t, schema.User, rewritten.Role)
+
+	// Reasoning content should only contain the part from AssistantGenMultiContent
+	assert.Equal(t, "only reasoning from parts", rewritten.ReasoningContent)
+
+	// UserInputMultiContent should have only text
+	assert.Len(t, rewritten.UserInputMultiContent, 1)
+	assert.Equal(t, "gen-text", rewritten.UserInputMultiContent[0].Text)
 }
 
 // TestTransferToAgent tests the TransferToAgent functionality


### PR DESCRIPTION
This pull request enhances the agent-to-agent message rewriting logic by introducing an option to preserve reasoning content when converting messages between agents. This is particularly useful for models that require reasoning context to be maintained across interactions. The changes also add comprehensive tests to ensure correct behavior when reasoning preservation is enabled.

**Reasoning preservation for agent message rewriting:**

* Added a new `preserveReasoning` flag to the `flowAgent` struct and a corresponding `WithPreserveReasoning()` option, allowing users to enable preservation of reasoning content during agent message rewriting. [[1]](diffhunk://#diff-70e341bfd07932d33188842812c11b186331ae9494cfc6d06da1e41d0aa697a4R50) [[2]](diffhunk://#diff-70e341bfd07932d33188842812c11b186331ae9494cfc6d06da1e41d0aa697a4R93-R103)
* Modified the `rewriteMessage` function and related call sites to accept a `preserveReasoning` parameter, which, when enabled, merges reasoning content from both the `ReasoningContent` field and any reasoning parts found in `AssistantGenMultiContent`. [[1]](diffhunk://#diff-70e341bfd07932d33188842812c11b186331ae9494cfc6d06da1e41d0aa697a4L171-R184) [[2]](diffhunk://#diff-70e341bfd07932d33188842812c11b186331ae9494cfc6d06da1e41d0aa697a4R211-R236) [[3]](diffhunk://#diff-d2885eba3cc7df6822832d697ba97235f8ee5f427eb1a57f57148b113b9c7143L318-R321) [[4]](diffhunk://#diff-70e341bfd07932d33188842812c11b186331ae9494cfc6d06da1e41d0aa697a4L238-R278)
* Updated the `buildDefaultHistoryRewriter` and `genMsg` functions to propagate the `preserveReasoning` flag, ensuring consistent behavior throughout history rewriting. [[1]](diffhunk://#diff-70e341bfd07932d33188842812c11b186331ae9494cfc6d06da1e41d0aa697a4L104-R117) [[2]](diffhunk://#diff-70e341bfd07932d33188842812c11b186331ae9494cfc6d06da1e41d0aa697a4L238-R278) [[3]](diffhunk://#diff-70e341bfd07932d33188842812c11b186331ae9494cfc6d06da1e41d0aa697a4L313-R357)
* Enhanced the test suite with new tests that verify reasoning content is correctly preserved and merged when the option is enabled, and that the rewriting logic behaves as expected in different scenarios.
* Ensured backward compatibility by defaulting to not preserve reasoning unless explicitly enabled, and updated all relevant function signatures and usage sites. [[1]](diffhunk://#diff-d2885eba3cc7df6822832d697ba97235f8ee5f427eb1a57f57148b113b9c7143L318-R321) [[2]](diffhunk://#diff-05159aebd729d8da49bae52d7be438de056826abeb08224e1a71befc47ad3205L57-R57)

These changes make the message rewriting process more flexible and suitable for advanced agent flows that rely on maintaining reasoning context.…tent in multi-agent flows

Agent-Logs-Url: https://github.com/Jlan45/eino/sessions/de45cecc-9bbb-4548-9124-4e1ed3927aaa

#### What type of PR is this?
<!--
Add one of the following kinds:

build: Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)
ci: Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
docs: Documentation only changes
feat: A new feature
optimize: A new optimization
fix: A bug fix
perf: A code change that improves performance
refactor: A code change that neither fixes a bug nor adds a feature
style: Changes that do not affect the meaning of the code (white space, formatting, missing semi-colons, etc)
test: Adding missing tests or correcting existing tests
chore: Changes to the build process or auxiliary tools and libraries such as documentation generation
-->

#### Check the PR title.
<!--
The description of the title will be attached in Release Notes, 
so please describe it from user-oriented, what this PR does / why we need it.
Please check your PR title with the below requirements:
-->
- [ ] This PR title match the format: \<type\>(optional scope): \<description\>
- [ ] The description of this PR title is user-oriented and clear enough for others to understand.
- [ ] Attach the PR updating the user documentation if the current PR requires user awareness at the usage level. [User docs repo](https://github.com/cloudwego/cloudwego.github.io)


#### (Optional) Translate the PR title into Chinese.


#### (Optional) More detailed description for this PR(en: English/zh: Chinese).
<!--
Provide more detailed info for review(e.g., it's recommended to provide perf data if this is a perf type PR).
-->
en:
zh(optional): 


#### (Optional) Which issue(s) this PR fixes:
<!--
Automatically closes linked issue when PR is merged.
Eg: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

#### (optional) The PR that updates user documentation:
<!--
If the current PR requires user awareness at the usage level, please submit a PR to update user docs. [User docs repo](https://github.com/cloudwego/cloudwego.github.io)
-->
