### PR TITLE
feat(adk): build ToolsNodeConfig via shallow copy + field override

### DIFF
--- a/adk/chatmodel.go
+++ b/adk/chatmodel.go
@@ -807,16 +807,13 @@ func (a *TypedChatModelAgent[M]) applyBeforeAgent(ctx context.Context, ec *execC
 		}
 	}
 
+	toolsNodeConf := ec.toolsNodeConf
+	toolsNodeConf.Tools = runCtx.Tools
+	toolsNodeConf.ToolCallMiddlewares = cloneSlice(ec.toolsNodeConf.ToolCallMiddlewares)
+
 	runtimeEC := &execContext{
-		instruction: runCtx.Instruction,
-		toolsNodeConf: compose.ToolsNodeConfig{
-			Tools:                runCtx.Tools,
-			ToolCallMiddlewares:  cloneSlice(ec.toolsNodeConf.ToolCallMiddlewares),
-			UnknownToolsHandler:  ec.toolsNodeConf.UnknownToolsHandler,
-			ExecuteSequentially:  ec.toolsNodeConf.ExecuteSequentially,
-			ToolArgumentsHandler: ec.toolsNodeConf.ToolArgumentsHandler,
-			ToolAliases:          ec.toolsNodeConf.ToolAliases,
-		},
+		instruction:    runCtx.Instruction,
+		toolsNodeConf:  toolsNodeConf,
 		returnDirectly: runCtx.ReturnDirectly,
 		toolSearchTool: runCtx.ToolSearchTool,
 		toolUpdated:    true,
@@ -836,14 +833,9 @@ func (a *TypedChatModelAgent[M]) applyBeforeAgent(ctx context.Context, ec *execC
 
 func (a *TypedChatModelAgent[M]) prepareExecContext(ctx context.Context) (*execContext, error) {
 	instruction := a.instruction
-	toolsNodeConf := compose.ToolsNodeConfig{
-		Tools:                cloneSlice(a.toolsConfig.Tools),
-		ToolCallMiddlewares:  cloneSlice(a.toolsConfig.ToolCallMiddlewares),
-		UnknownToolsHandler:  a.toolsConfig.UnknownToolsHandler,
-		ExecuteSequentially:  a.toolsConfig.ExecuteSequentially,
-		ToolArgumentsHandler: a.toolsConfig.ToolArgumentsHandler,
-		ToolAliases:          a.toolsConfig.ToolAliases,
-	}
+	toolsNodeConf := a.toolsConfig.ToolsNodeConfig
+	toolsNodeConf.Tools = cloneSlice(a.toolsConfig.Tools)
+	toolsNodeConf.ToolCallMiddlewares = cloneSlice(a.toolsConfig.ToolCallMiddlewares)
 	returnDirectly := copyMap(a.toolsConfig.ReturnDirectly)
 
 	transferToAgents := a.subAgents


### PR DESCRIPTION
Replace explicit field-by-field struct literals with a shallow copy of the source ToolsNodeConfig followed by overriding only the fields that need per-run isolation (Tools and ToolCallMiddlewares). New fields added to compose.ToolsNodeConfig in the future will be forwarded automatically instead of being silently dropped.

- applyBeforeAgent: reuse the already-cloned toolsNodeConf local instead of rebuilding the struct
- prepareExecContext: shallow-copy a.toolsConfig.ToolsNodeConfig then cloneSlice the Tools/ToolCallMiddlewares that will be appended to
