### PR TITLE
fix(adk): preserve full ToolsNodeConfig fields on runtime tool updates

### DIFF
--- a/adk/chatmodel.go
+++ b/adk/chatmodel.go
@@ -610,12 +610,13 @@ func (a *ChatModelAgent) applyBeforeAgent(ctx context.Context, ec *execContext) 
 		}
 	}
 
+	toolsNodeConf := ec.toolsNodeConf
+	toolsNodeConf.Tools = runCtx.Tools
+	toolsNodeConf.ToolCallMiddlewares = cloneSlice(ec.toolsNodeConf.ToolCallMiddlewares)
+
 	runtimeEC := &execContext{
-		instruction: runCtx.Instruction,
-		toolsNodeConf: compose.ToolsNodeConfig{
-			Tools:               runCtx.Tools,
-			ToolCallMiddlewares: cloneSlice(ec.toolsNodeConf.ToolCallMiddlewares),
-		},
+		instruction:    runCtx.Instruction,
+		toolsNodeConf:  toolsNodeConf,
 		returnDirectly: runCtx.ReturnDirectly,
 		toolUpdated:    true,
 		rebuildGraph: (len(ec.toolsNodeConf.Tools) == 0 && len(runCtx.Tools) > 0) ||
@@ -634,13 +635,10 @@ func (a *ChatModelAgent) applyBeforeAgent(ctx context.Context, ec *execContext) 
 
 func (a *ChatModelAgent) prepareExecContext(ctx context.Context) (*execContext, error) {
 	instruction := a.instruction
-	toolsNodeConf := compose.ToolsNodeConfig{
-		Tools:                cloneSlice(a.toolsConfig.Tools),
-		ToolCallMiddlewares:  cloneSlice(a.toolsConfig.ToolCallMiddlewares),
-		UnknownToolsHandler:  a.toolsConfig.UnknownToolsHandler,
-		ExecuteSequentially:  a.toolsConfig.ExecuteSequentially,
-		ToolArgumentsHandler: a.toolsConfig.ToolArgumentsHandler,
-	}
+	toolsNodeConf := a.toolsConfig.ToolsNodeConfig
+	toolsNodeConf.Tools = cloneSlice(a.toolsConfig.Tools)
+	toolsNodeConf.ToolCallMiddlewares = cloneSlice(a.toolsConfig.ToolCallMiddlewares)
+
 	returnDirectly := copyMap(a.toolsConfig.ReturnDirectly)
 
 	transferToAgents := a.subAgents


### PR DESCRIPTION
Switch from explicit field-by-field construction to shallow-copy + override for compose.ToolsNodeConfig in ChatModelAgent, so that UnknownToolsHandler, ExecuteSequentially, and ToolArgumentsHandler are no longer dropped when BeforeAgent callbacks update runtime tools.

- applyBeforeAgent: shallow-copy ec.toolsNodeConf and override Tools / ToolCallMiddlewares, instead of building a fresh config that lost unknown-tool / sequential / arguments handler settings.
- prepareExecContext: align with the same shallow-copy + override style for consistency; behavior is equivalent to the previous explicit form.
