### PR TITLE
fix(serialization): ensure pointer-receiver MarshalJSON is invoked in…

### DIFF
--- a/internal/serialization/serialization.go
+++ b/internal/serialization/serialization.go
@@ -305,7 +305,18 @@ func internalMarshal(v any, fieldType reflect.Type) (*internalStruct, error) {
 		}
 
 		if checkMarshaler(rt) {
-			jsonBytes, err := json.Marshal(rv.Interface())
+			// Use rv.Addr() when possible so that pointer-receiver MarshalJSON methods
+			// are callable. rv is addressable when obtained from pointer dereference.
+			// When not addressable, copy into an addressable temporary.
+			var marshalTarget any
+			if rv.CanAddr() {
+				marshalTarget = rv.Addr().Interface()
+			} else {
+				tmp := reflect.New(rt)
+				tmp.Elem().Set(rv)
+				marshalTarget = tmp.Interface()
+			}
+			jsonBytes, err := json.Marshal(marshalTarget)
 			if err != nil {
 				return nil, err
 			}


### PR DESCRIPTION
… InternalSerializer

When InternalSerializer marshals a struct value that implements json.Marshaler via pointer receiver (e.g. *ToolInfo), rv.Interface() produces a non-addressable copy. json.Marshal then cannot call the pointer method and falls back to default struct encoding, which skips unexported fields — causing ParamsOneOf data loss after deepCopyState during interrupt/resume.

Fix: pass a pointer to json.Marshal by using rv.Addr() when addressable, or copying into reflect.New() otherwise.

