### PR TITLE
fix(serialization): fix ToolInfo.ParamsOneOf loss during checkpoint deep-copy

### DIFF
--- a/internal/serialization/serialization.go
+++ b/internal/serialization/serialization.go
@@ -305,7 +305,18 @@ func internalMarshal(v any, fieldType reflect.Type) (*internalStruct, error) {
 		}
 
 		if checkMarshaler(rt) {
-			jsonBytes, err := json.Marshal(rv.Interface())
+			// Use rv.Addr() when possible so that pointer-receiver MarshalJSON methods
+			// are callable. rv is addressable when obtained from pointer dereference.
+			// When not addressable, copy into an addressable temporary.
+			var marshalTarget any
+			if rv.CanAddr() {
+				marshalTarget = rv.Addr().Interface()
+			} else {
+				tmp := reflect.New(rt)
+				tmp.Elem().Set(rv)
+				marshalTarget = tmp.Interface()
+			}
+			jsonBytes, err := json.Marshal(marshalTarget)
 			if err != nil {
 				return nil, err
 			}


### PR DESCRIPTION
## Summary

| Problem | Solution |
|---------|----------|
| `ToolInfo.ParamsOneOf` lost after checkpoint deep-copy during interrupt/resume | Fix `InternalSerializer` to pass pointer to `json.Marshal`, enabling pointer-receiver `MarshalJSON` |

## Key Insight

`InternalSerializer.internalMarshal` uses reflection to detect types implementing `json.Marshaler` and delegates to `json.Marshal`. However, it passes the result of `rv.Interface()` — a non-addressable struct value. Go's method dispatch requires an addressable value to call pointer-receiver methods. Since `ToolInfo.MarshalJSON` is defined on `*ToolInfo`, the non-addressable `ToolInfo` value does NOT satisfy `json.Marshaler`. `json.Marshal` falls back to default struct encoding, which cannot access the unexported `ParamsOneOf` fields — causing silent data loss.

The fix ensures we always pass a pointer to `json.Marshal`:
- If `rv.CanAddr()`: use `rv.Addr().Interface()` directly
- Otherwise: allocate a temporary `reflect.New(rt)`, copy the value, and pass the pointer

## Changes

**`internal/serialization/serialization.go`** — In the `checkMarshaler` branch of `internalMarshal`, ensure `json.Marshal` always receives a pointer so that pointer-receiver `MarshalJSON` methods are invoked.

## Testing

- Existing `adk` interrupt/cancel tests pass with `-race` (200+ iterations)
- Existing `compose` tests pass with `-race`
- The fix is exercised whenever any type with pointer-receiver `MarshalJSON` is stored in graph state and checkpointed

---

## 摘要

| 问题 | 方案 |
|------|------|
| `ToolInfo.ParamsOneOf` 在 interrupt/resume checkpoint 深拷贝后丢失 | 修复 `InternalSerializer`，确保传递指针给 `json.Marshal`，使指针接收者 `MarshalJSON` 能被调用 |

## 核心洞察

`InternalSerializer.internalMarshal` 通过反射检测实现了 `json.Marshaler` 的类型，然后委托给 `json.Marshal`。但它传递的是 `rv.Interface()` 的结果——一个不可寻址的结构体值。Go 的方法分派要求可寻址的值才能调用指针接收者方法。由于 `ToolInfo.MarshalJSON` 定义在 `*ToolInfo` 上，不可寻址的 `ToolInfo` 值不满足 `json.Marshaler` 接口。`json.Marshal` 回退到默认结构体编码，无法访问未导出的 `ParamsOneOf` 字段——导致静默数据丢失。

修复确保始终传递指针给 `json.Marshal`：
- 若 `rv.CanAddr()`：直接使用 `rv.Addr().Interface()`
- 否则：分配临时 `reflect.New(rt)`，复制值，传递指针

## 变更

**`internal/serialization/serialization.go`** — 在 `internalMarshal` 的 `checkMarshaler` 分支中，确保 `json.Marshal` 始终接收指针，以调用指针接收者 `MarshalJSON` 方法。
