### PR TITLE
feat(adk): deprecate SummarizeMessages

### DIFF
--- a/adk/middlewares/summarization/summarization.go
+++ b/adk/middlewares/summarization/summarization.go
@@ -267,6 +267,8 @@ type middleware struct {
 }
 
 // SummarizeOutput contains the output of a synchronous Summarize call.
+//
+// Deprecated: See SummarizeMessages.
 type SummarizeOutput struct {
 	// FinalizedMessages is the message list after summarization,
 	// ready to be used as the new conversation history.
@@ -278,6 +280,11 @@ type SummarizeOutput struct {
 
 // SummarizeMessages performs synchronous summarization of the given messages.
 // EmitInternalEvents and Trigger are not supported and will return an error if set.
+//
+// Deprecated: Use the summarization middleware (created via New) within a dedicated summarization
+// agent instead. In practice, summarization often requires preprocessing by other middlewares
+// (e.g., message reduction, tool call patching), which is naturally supported by composing
+// middlewares in an agent pipeline.
 func SummarizeMessages(ctx context.Context, cfg *Config, messages []adk.Message) (*SummarizeOutput, error) {
 	if cfg.EmitInternalEvents {
 		return nil, fmt.Errorf("emitInternalEvents is not supported in synchronous summarization")


### PR DESCRIPTION
#### What type of PR is this?
<!--
Add one of the following kinds:

build: Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)
ci: Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
docs: Documentation only changes
feat: A new feature
optimize: A new optimization
fix: A bug fix
perf: A code change that improves performance
refactor: A code change that neither fixes a bug nor adds a feature
style: Changes that do not affect the meaning of the code (white space, formatting, missing semi-colons, etc)
test: Adding missing tests or correcting existing tests
chore: Changes to the build process or auxiliary tools and libraries such as documentation generation
-->

#### Check the PR title.
<!--
The description of the title will be attached in Release Notes, 
so please describe it from user-oriented, what this PR does / why we need it.
Please check your PR title with the below requirements:
-->
- [ ] This PR title match the format: \<type\>(optional scope): \<description\>
- [ ] The description of this PR title is user-oriented and clear enough for others to understand.
- [ ] Attach the PR updating the user documentation if the current PR requires user awareness at the usage level. [User docs repo](https://github.com/cloudwego/cloudwego.github.io)


#### (Optional) Translate the PR title into Chinese.


#### (Optional) More detailed description for this PR(en: English/zh: Chinese).
<!--
Provide more detailed info for review(e.g., it's recommended to provide perf data if this is a perf type PR).
-->
en:
zh(optional): 


#### (Optional) Which issue(s) this PR fixes:
<!--
Automatically closes linked issue when PR is merged.
Eg: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

#### (optional) The PR that updates user documentation:
<!--
If the current PR requires user awareness at the usage level, please submit a PR to update user docs. [User docs repo](https://github.com/cloudwego/cloudwego.github.io)
-->
