### PR TITLE
fix(adk): prevent TurnLoop stall after between-turns preempt drain

### DIFF
--- a/adk/turn_loop.go
+++ b/adk/turn_loop.go
@@ -342,6 +342,19 @@ func (s *preemptSignal) endTurnAndUnhold() {
 	s.cond.Broadcast()
 }
 
+// resetBetweenTurns clears all preemptSignal state between turns without
+// setting the drained flag. This allows the signal to continue functioning
+// for future Push(WithPreempt) calls in subsequent iterations.
+func (s *preemptSignal) resetBetweenTurns() {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.holdCount = 0
+	s.currentTC = nil
+	s.currentRunCtx = nil
+	s.resetLocked()
+	s.cond.Broadcast()
+}
+
 // drainAll forcefully resets all preemptSignal state and closes any pending
 // ack channels. Called during TurnLoop cleanup to prevent ack channels from
 // leaking when the run loop exits (e.g. due to Stop) while a Push caller
@@ -1453,13 +1466,13 @@ func (l *TurnLoop[T, M]) run(ctx context.Context) {
 		// Drain any pending preempt that arrived between turns. A Push caller
 		// may have called holdRunLoop + requestPreempt while the loop was
 		// between iterations; acknowledge and release before planning the
-		// next turn. Use drainAll to release all pusher holds at once —
-		// multiple concurrent Push(WithPreempt) callers each hold a ref.
+		// next turn. Use resetBetweenTurns (not drainAll) so the signal
+		// remains usable for future Push(WithPreempt) calls.
 		if preempted, _, ackList := l.preemptSig.waitForPreemptOrUnhold(); preempted {
 			for _, ack := range ackList {
 				close(ack)
 			}
-			l.preemptSig.drainAll()
+			l.preemptSig.resetBetweenTurns()
 		}
 
 		plan, err := l.planTurn(ctx, isResume, items, pr)

--- a/adk/turn_loop_test.go
+++ b/adk/turn_loop_test.go
@@ -5535,3 +5535,104 @@ func TestSetupBridgeStore_NilStore_Resume(t *testing.T) {
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "checkpoint store is nil")
 }
+
+// TestTurnLoop_Preempt_LoopStalledAfterSecondPreemptPush reproduces a bug where
+// the loop gets stuck between turns when:
+//  1. Item A is processed, preempted by item B pushed with WithPreempt(AnySafePoint).
+//  2. Item B's turn runs and OnAgentEvents completes successfully.
+//  3. Item C is pushed with WithPreempt(AnySafePoint).
+//  4. The loop never processes item C — it hangs at waitForPreemptOrUnhold.
+//
+// Root cause: drainAll() called between turns (after the first preempt) sets
+// drained=true permanently. Subsequent Push(WithPreempt) calls holdRunLoop()
+// (incrementing holdCount) but requestPreempt() is a no-op (drained=true), so
+// waitForPreemptOrUnhold blocks forever with holdCount>0 and preemptRequested=false.
+func TestTurnLoop_Preempt_LoopStalledAfterSecondPreemptPush(t *testing.T) {
+	// turnCount tracks how many turns have been fully processed.
+	var turnCount int32
+
+	// Channels to synchronize the test with each turn's lifecycle.
+	firstAgentStarted := make(chan struct{})
+	secondTurnDone := make(chan struct{})
+	thirdTurnDone := make(chan struct{})
+
+	var firstAgentStartedOnce, secondTurnDoneOnce, thirdTurnDoneOnce sync.Once
+
+	agent := &turnLoopCancellableMockAgent{
+		name: "test",
+		runFunc: func(ctx context.Context, input *AgentInput) (*AgentOutput, error) {
+			turn := atomic.AddInt32(&turnCount, 1)
+			switch turn {
+			case 1:
+				// First turn: signal started, then block until preempted.
+				firstAgentStartedOnce.Do(func() { close(firstAgentStarted) })
+				<-ctx.Done()
+			case 2, 3:
+				// Subsequent turns: complete immediately.
+			}
+			return &AgentOutput{}, nil
+		},
+	}
+
+	loop := newAndRunTurnLoop(context.Background(), TurnLoopConfig[string, *schema.Message]{
+		PrepareAgent: func(ctx context.Context, _ *TurnLoop[string, *schema.Message], consumed []string) (Agent, error) {
+			return agent, nil
+		},
+		GenInput: func(ctx context.Context, _ *TurnLoop[string, *schema.Message], items []string) (*GenInputResult[string, *schema.Message], error) {
+			return &GenInputResult[string, *schema.Message]{
+				Input:     &AgentInput{Messages: []Message{schema.UserMessage(items[0])}},
+				Consumed:  []string{items[0]},
+				Remaining: items[1:],
+			}, nil
+		},
+		OnAgentEvents: func(ctx context.Context, tc *TurnContext[string, *schema.Message], events *AsyncIterator[*AgentEvent]) error {
+			for {
+				if _, ok := events.Next(); !ok {
+					break
+				}
+			}
+			turn := atomic.LoadInt32(&turnCount)
+			switch turn {
+			case 2:
+				secondTurnDoneOnce.Do(func() { close(secondTurnDone) })
+			case 3:
+				thirdTurnDoneOnce.Do(func() { close(thirdTurnDone) })
+			}
+			return nil
+		},
+	})
+
+	// Step 1: Push item A (no preempt). Wait for agent to start.
+	loop.Push("A")
+	select {
+	case <-firstAgentStarted:
+	case <-time.After(2 * time.Second):
+		t.Fatal("agent did not start for item A")
+	}
+
+	// Step 2: Push item B with preempt. This cancels the first turn.
+	loop.Push("B", WithPreempt[string, *schema.Message](AnySafePoint))
+
+	// Wait for the second turn (item B) to complete successfully.
+	select {
+	case <-secondTurnDone:
+	case <-time.After(2 * time.Second):
+		t.Fatal("second turn (item B) did not complete")
+	}
+
+	// Step 3: Push item C with preempt. This is the scenario that triggers
+	// the bug — the loop should process item C but instead gets stuck.
+	loop.Push("C", WithPreempt[string, *schema.Message](AnySafePoint))
+
+	// The loop should process item C. If the bug is present, this will timeout.
+	select {
+	case <-thirdTurnDone:
+	case <-time.After(2 * time.Second):
+		t.Fatal("third turn (item C) was never processed — loop is stuck between turns")
+	}
+
+	loop.Stop()
+	result := loop.Wait()
+	assert.NoError(t, result.ExitReason)
+	assert.Equal(t, int32(3), atomic.LoadInt32(&turnCount), "expected 3 turns to be processed")
+}


### PR DESCRIPTION
# TurnLoop Stalls After Between-Turns Preempt Drain

## Problem

When a `Push(WithPreempt)` preempts a running turn, the loop processes the preempting item on the next turn correctly. But any *subsequent* `Push(WithPreempt)` call permanently stalls the loop — it never processes the new item.

Concrete scenario:
1. Item A is processing, item B arrives with `WithPreempt(AnySafePoint)` → agent is canceled, loop advances to process B. ✅
2. B finishes successfully via `OnAgentEvents`.
3. Item C arrives with `WithPreempt(AnySafePoint)` → loop hangs forever. ❌

## Solution

The between-turns preempt drain (after step 1) was calling `drainAll()`, which sets a permanent `drained = true` flag. This flag is designed for cleanup when the loop is exiting — it turns `requestPreempt()` into a no-op that just closes the ack channel.

But `holdRunLoop()` doesn't check `drained`, so after step 2, when item C is pushed:
- `holdRunLoop()` increments `holdCount` to 1
- `requestPreempt()` sees `drained=true`, closes ack immediately, never sets `preemptRequested`
- Loop calls `waitForPreemptOrUnhold()` → blocks forever (holdCount > 0, preemptRequested = false)

Fix: replace `drainAll()` with a new `resetBetweenTurns()` that clears all preempt state without setting the `drained` flag:

```go
func (s *preemptSignal) resetBetweenTurns() {
    s.mu.Lock()
    defer s.mu.Unlock()
    s.holdCount = 0
    s.currentTC = nil
    s.currentRunCtx = nil
    s.resetLocked()
    s.cond.Broadcast()
}
```

## Key Insight

`drainAll()` is a terminal operation — it poisons the signal permanently. It must only be called when the loop is exiting (in `cleanup()`). The between-turns drain needs the same state reset but must preserve the signal's ability to accept future preempt requests. These are distinct lifecycle phases that require distinct methods.

## Summary

| Problem | Solution |
|---------|----------|
| Loop stalls on 2nd+ `Push(WithPreempt)` after an earlier preempt | Replace `drainAll()` with `resetBetweenTurns()` in the between-turns drain path |

---

# TurnLoop 在 Between-Turns Preempt Drain 后卡死

## 问题

当 `Push(WithPreempt)` 抢占正在运行的 turn 后，loop 能正确处理抢占项。但任何**后续的** `Push(WithPreempt)` 调用会导致 loop 永久卡死——新 item 永远不会被处理。

具体场景：
1. Item A 正在处理，item B 带着 `WithPreempt(AnySafePoint)` 到达 → agent 被取消，loop 前进处理 B。✅
2. B 通过 `OnAgentEvents` 成功完成。
3. Item C 带着 `WithPreempt(AnySafePoint)` 到达 → loop 永久挂起。❌

## 解决方案

between-turns preempt drain（步骤 1 之后）调用了 `drainAll()`，该方法设置了永久的 `drained = true` 标志。这个标志是为 loop 退出时的 cleanup 设计的——它让 `requestPreempt()` 变成一个仅关闭 ack channel 的空操作。

但 `holdRunLoop()` 不检查 `drained`，所以在步骤 2 之后，当 item C 被 push 时：
- `holdRunLoop()` 将 `holdCount` 增加到 1
- `requestPreempt()` 看到 `drained=true`，立即关闭 ack，从不设置 `preemptRequested`
- Loop 调用 `waitForPreemptOrUnhold()` → 永久阻塞（holdCount > 0，preemptRequested = false）

修复：用新的 `resetBetweenTurns()` 替换 `drainAll()`，清除所有 preempt 状态但不设置 `drained` 标志。

## 关键洞察

`drainAll()` 是一个终态操作——它永久性地毒化了 signal。它只应在 loop 退出时（在 `cleanup()` 中）被调用。between-turns drain 需要相同的状态重置，但必须保留 signal 接受未来 preempt 请求的能力。这是两个不同的生命周期阶段，需要不同的方法。

## 总结

| 问题 | 解决方案 |
|------|----------|
| 在先前 preempt 之后第 2 次+ `Push(WithPreempt)` 导致 loop 卡死 | 在 between-turns drain 路径中用 `resetBetweenTurns()` 替换 `drainAll()` |
