### PR TITLE
feat(adk): persist TurnLoop checkpoint on business interrupt

### DIFF
--- a/adk/turn_loop.go
+++ b/adk/turn_loop.go
@@ -733,6 +733,7 @@ type TurnLoop[T any, M MessageType] struct {
 
 	checkPointRunnerBytes []byte
 	interruptContexts     []*InterruptCtx
+	capturedCancelErr     *CancelError
 
 	pendingResume *turnLoopPendingResume[T]
 
@@ -1537,17 +1538,20 @@ func (l *TurnLoop[T, M]) run(ctx context.Context) {
 
 		l.preemptSig.endTurnAndUnhold()
 
+		// Set inFlightItems whenever a cancel or interrupt was captured from the
+		// event stream, regardless of what the user's callback returned. The items
+		// were factually mid-execution when the signal arrived.
+		if (l.capturedCancelErr != nil || l.interruptContexts != nil) && len(l.inFlightItems) == 0 {
+			l.inFlightItems = append([]T{}, plan.spec.consumed...)
+		}
+
 		if runErr != nil {
-			if errors.As(runErr, new(*CancelError)) && len(l.inFlightItems) == 0 {
-				l.inFlightItems = append([]T{}, plan.spec.consumed...)
-			}
 			l.runErr = runErr
 			return
 		}
 
 		// Business interrupt: agent produced an Interrupted action, exit to persist checkpoint.
 		if l.interruptContexts != nil {
-			l.inFlightItems = append([]T{}, plan.spec.consumed...)
 			l.runErr = &InterruptError{InterruptContexts: l.interruptContexts}
 			return
 		}
@@ -1670,6 +1674,7 @@ func (l *TurnLoop[T, M]) runAgentAndHandleEvents(
 	spec *turnRunSpec[T, M],
 ) error {
 	l.interruptContexts = nil
+	l.capturedCancelErr = nil
 	l.checkPointRunnerBytes = nil
 
 	var iter *AsyncIterator[*TypedAgentEvent[M]]
@@ -1718,8 +1723,9 @@ func (l *TurnLoop[T, M]) runAgentAndHandleEvents(
 		iter = runner.Run(ctx, spec.input.Messages, runOpts...)
 	}
 
-	// Wrap iterator to capture InterruptContexts from business interrupt events
-	// before they flow to OnAgentEvents.
+	// Wrap iterator to capture framework-level signals (CancelError, InterruptContexts)
+	// from events before they flow to OnAgentEvents. This ensures the framework can
+	// track these signals independently of what the user's callback returns.
 	srcIter := iter
 	proxyIter, proxyGen := NewAsyncIteratorPair[*TypedAgentEvent[M]]()
 	go func() {
@@ -1729,8 +1735,16 @@ func (l *TurnLoop[T, M]) runAgentAndHandleEvents(
 			if !ok {
 				break
 			}
-			if event != nil && event.Action != nil && event.Action.Interrupted != nil {
-				l.interruptContexts = event.Action.Interrupted.InterruptContexts
+			if event != nil {
+				if event.Err != nil {
+					var cancelErr *CancelError
+					if errors.As(event.Err, &cancelErr) {
+						l.capturedCancelErr = cancelErr
+					}
+				}
+				if event.Action != nil && event.Action.Interrupted != nil {
+					l.interruptContexts = event.Action.Interrupted.InterruptContexts
+				}
 			}
 			proxyGen.Send(event)
 		}
@@ -1798,7 +1812,7 @@ func (l *TurnLoop[T, M]) runAgentAndHandleEvents(
 				handleErr = err
 			}
 		}
-		return handleErr
+		return l.applyFrameworkCapturedError(handleErr)
 	case <-preemptDone:
 		<-done
 		return nil
@@ -1811,8 +1825,27 @@ func (l *TurnLoop[T, M]) runAgentAndHandleEvents(
 				handleErr = err
 			}
 		}
+		return l.applyFrameworkCapturedError(handleErr)
+	}
+}
+
+// applyFrameworkCapturedError resolves the final error for runAgentAndHandleEvents.
+// Priority scheme:
+//   - If handleErr != nil: the user's callback error wins (framework does not overwrite).
+//   - If handleErr == nil and a CancelError was captured: use the captured CancelError.
+//   - If handleErr == nil and interrupt contexts were captured: this is handled by the
+//     caller (run loop) via l.interruptContexts, so return nil here.
+//
+// In all cases, the caller uses l.capturedCancelErr and l.interruptContexts to
+// determine inFlightItems independently of the returned error.
+func (l *TurnLoop[T, M]) applyFrameworkCapturedError(handleErr error) error {
+	if handleErr != nil {
 		return handleErr
 	}
+	if l.capturedCancelErr != nil {
+		return l.capturedCancelErr
+	}
+	return nil
 }
 
 func (l *TurnLoop[T, M]) cleanup(ctx context.Context) {
@@ -1824,10 +1857,10 @@ func (l *TurnLoop[T, M]) cleanup(ctx context.Context) {
 
 	// Only save checkpoint when the loop exited due to an explicit Stop(),
 	// a CancelError, or a business interrupt (InterruptError).
-	// If Stop() was called but a callback error happened concurrently,
-	// the state may be inconsistent — don't checkpoint in that case.
-	exitCausedByStop := l.runErr == nil || errors.As(l.runErr, new(*CancelError))
-	businessInterrupt := errors.As(l.runErr, new(*InterruptError))
+	// Also checkpoint when a cancel/interrupt was captured from the event stream
+	// but the user's callback returned a custom error (the items were still in-flight).
+	exitCausedByStop := l.runErr == nil || errors.As(l.runErr, new(*CancelError)) || l.capturedCancelErr != nil
+	businessInterrupt := errors.As(l.runErr, new(*InterruptError)) || l.interruptContexts != nil
 	shouldSaveCheckpoint := l.config.Store != nil && checkpointID != "" &&
 		((l.stopSig.isStopped() && exitCausedByStop) || businessInterrupt) &&
 		!isIdle && !l.stopSig.isSkipCheckpoint()

--- a/adk/turn_loop.go
+++ b/adk/turn_loop.go
@@ -383,19 +383,19 @@ type TurnLoopConfig[T any, M MessageType] struct {
 	// GenResume is called at most once during Run(). When CheckpointID is
 	// configured, Run() queries Store for the checkpoint:
 	//   - If the checkpoint contains runner state (i.e. an agent was interrupted
-	//     mid-turn), Run() calls GenResume to plan a resume turn.
+	//     or canceled mid-turn), Run() calls GenResume to plan a resume turn.
 	//   - Otherwise (no checkpoint, or between-turns checkpoint), GenResume is
 	//     never called and the loop proceeds via GenInput.
 	//
 	// It receives:
-	//   - canceledItems: the items being processed when the prior run was canceled
+	//   - inFlightItems: the items being processed when the prior run was interrupted / canceled
 	//   - unhandledItems: items buffered but not processed when the prior run exited
 	//   - newItems: items that were Push()-ed before Run() was called
 	//
 	// It returns a GenResumeResult describing how to resume the interrupted agent
 	// turn (optional ResumeParams) and how to manipulate the buffer
 	// (Consumed/Remaining) before continuing.
-	GenResume func(ctx context.Context, loop *TurnLoop[T, M], canceledItems, unhandledItems, newItems []T) (*GenResumeResult[T, M], error)
+	GenResume func(ctx context.Context, loop *TurnLoop[T, M], inFlightItems, unhandledItems, newItems []T) (*GenResumeResult[T, M], error)
 
 	// PrepareAgent returns an Agent configured to handle the consumed items.
 	// This callback should set up the agent with appropriate system prompt,
@@ -427,13 +427,13 @@ type TurnLoopConfig[T any, M MessageType] struct {
 	// Store is the checkpoint store for persistence and resume. Optional.
 	// When set together with CheckpointID, enables automatic checkpoint-based resume.
 	// The TurnLoop always persists both runner checkpoint bytes and item bookkeeping
-	// (CanceledItems, UnhandledItems) via gob encoding, so T must be gob-encodable
+	// (InFlightItems, UnhandledItems) via gob encoding, so T must be gob-encodable
 	// when Store is used.
 	Store CheckPointStore
 
 	// CheckpointID, when set together with Store, enables automatic
 	// checkpoint-based resume. On Run(), the TurnLoop queries Store for this ID:
-	//   - If a checkpoint exists with runner state (mid-turn interrupt),
+	//   - If a checkpoint exists with runner state (mid-turn interrupt / cancel),
 	//     GenResume is called to plan the resume turn.
 	//   - If a checkpoint exists without runner state (between-turns),
 	//     the stored unhandled items are buffered and the loop proceeds
@@ -501,7 +501,7 @@ type GenResumeResult[T any, M MessageType] struct {
 	// Remaining are the items to keep in the buffer for a future turn.
 	// TurnLoop pushes Remaining back into the buffer before resuming the agent.
 	//
-	// Items from (canceledItems, unhandledItems, newItems) that are in neither Consumed
+	// Items from (inFlightItems, unhandledItems, newItems) that are in neither Consumed
 	// nor Remaining are dropped by the loop.
 	Remaining []T
 }
@@ -560,7 +560,7 @@ func (l *TurnLoop[T, M]) planTurn(
 	if l.config.GenResume == nil {
 		return nil, errors.New("GenResume is required for resume")
 	}
-	resumeResult, err := l.config.GenResume(ctx, l, pr.canceled, pr.unhandled, pr.newItems)
+	resumeResult, err := l.config.GenResume(ctx, l, pr.inFlight, pr.unhandled, pr.newItems)
 	if err != nil {
 		return nil, err
 	}
@@ -585,6 +585,24 @@ func (l *TurnLoop[T, M]) planTurn(
 	}, nil
 }
 
+// InterruptError is the ExitReason when the TurnLoop exits due to a business
+// interrupt (AgentAction.Interrupted). It carries InterruptContexts needed for
+// targeted resumption via ResumeParams, parallel to CancelError.
+//
+// Unlike CancelError (which indicates forceful cancellation), InterruptError
+// indicates the agent voluntarily paused execution at a business-defined point.
+type InterruptError struct {
+	// InterruptContexts provides the interrupt contexts needed for targeted
+	// resumption via ResumeParams. Each context represents a step in the agent
+	// hierarchy that was interrupted. Use each InterruptCtx.ID as a key in
+	// ResumeParams.Targets.
+	InterruptContexts []*InterruptCtx
+}
+
+func (e *InterruptError) Error() string {
+	return fmt.Sprintf("agent interrupted: %d context(s)", len(e.InterruptContexts))
+}
+
 // TurnLoopExitState is returned when TurnLoop exits, containing the exit reason
 // and any items that were not processed.
 type TurnLoopExitState[T any, M MessageType] struct {
@@ -602,20 +620,20 @@ type TurnLoopExitState[T any, M MessageType] struct {
 	// This is always valid regardless of ExitReason.
 	UnhandledItems []T
 
-	// CanceledItems contains the items whose turn was actually interrupted
-	// by a cancel (Stop with WithImmediate, WithGraceful, or WithGracefulTimeout).
-	// Only populated when ExitReason is a *CancelError — if the agent finishes
-	// normally before the cancel takes effect, CanceledItems is empty.
-	// On resume, these are passed to GenResume's CanceledItems parameter.
-	CanceledItems []T
+	// InFlightItems contains the items whose turn was interrupted — either by
+	// a cancel (Stop with cancel options → *CancelError) or by a business
+	// interrupt (AgentAction.Interrupted → *InterruptError).
+	// On resume, these are passed to GenResume's inFlightItems parameter.
+	InFlightItems []T
 
 	// StopCause is the business-supplied reason passed via WithStopCause.
 	// Empty if Stop was not called or no cause was provided.
 	StopCause string
 
 	// CheckpointAttempted indicates whether a checkpoint save was attempted when the loop exited.
-	// True only when Store is configured, CheckpointID is set, Stop() was called,
-	// the loop was not idle at exit time, and WithSkipCheckpoint was not used.
+	// True when Store is configured, CheckpointID is set, the loop was not idle
+	// at exit time, WithSkipCheckpoint was not used, and the exit was caused by
+	// Stop() (clean or cancel) or a business interrupt (*InterruptError).
 	CheckpointAttempted bool
 
 	// CheckpointErr is the error from checkpoint save, if any.
@@ -711,9 +729,10 @@ type TurnLoop[T any, M MessageType] struct {
 
 	runErr error
 
-	canceledItems []T
+	inFlightItems []T
 
 	checkPointRunnerBytes []byte
+	interruptContexts     []*InterruptCtx
 
 	pendingResume *turnLoopPendingResume[T]
 
@@ -742,7 +761,7 @@ type turnLoopCheckpoint[T any] struct {
 	// interrupted (e.g. Stop() before the first turn or between turns).
 	HasRunnerState bool
 	UnhandledItems []T
-	CanceledItems  []T
+	CanceledItems  []T // gob-compat: kept as CanceledItems for deserialization of existing checkpoints
 }
 
 func marshalTurnLoopCheckpoint[T any](c *turnLoopCheckpoint[T]) ([]byte, error) {
@@ -815,7 +834,7 @@ func (l *TurnLoop[T, M]) tryLoadCheckpoint(ctx context.Context) error {
 			return fmt.Errorf("checkpoint[%s] has runner state but bytes are empty", checkPointID)
 		}
 		l.pendingResume = &turnLoopPendingResume[T]{
-			canceled:    append([]T{}, cp.CanceledItems...),
+			inFlight:    append([]T{}, cp.CanceledItems...),
 			unhandled:   append([]T{}, cp.UnhandledItems...),
 			newItems:    append([]T{}, newItems...),
 			resumeBytes: append([]byte{}, cp.RunnerCheckpoint...),
@@ -831,7 +850,7 @@ func (l *TurnLoop[T, M]) tryLoadCheckpoint(ctx context.Context) error {
 }
 
 type turnLoopPendingResume[T any] struct {
-	canceled    []T
+	inFlight    []T
 	unhandled   []T
 	newItems    []T
 	resumeBytes []byte
@@ -1396,8 +1415,8 @@ func (l *TurnLoop[T, M]) run(ctx context.Context) {
 			pr = l.pendingResume
 			l.pendingResume = nil
 
-			pushBack = make([]T, 0, len(pr.canceled)+len(pr.unhandled)+len(pr.newItems))
-			pushBack = append(pushBack, pr.canceled...)
+			pushBack = make([]T, 0, len(pr.inFlight)+len(pr.unhandled)+len(pr.newItems))
+			pushBack = append(pushBack, pr.inFlight...)
 			pushBack = append(pushBack, pr.unhandled...)
 			pushBack = append(pushBack, pr.newItems...)
 		} else {
@@ -1519,10 +1538,17 @@ func (l *TurnLoop[T, M]) run(ctx context.Context) {
 		l.preemptSig.endTurnAndUnhold()
 
 		if runErr != nil {
-			if errors.As(runErr, new(*CancelError)) && len(l.canceledItems) == 0 {
-				l.canceledItems = append([]T{}, plan.spec.consumed...)
+			if errors.As(runErr, new(*CancelError)) && len(l.inFlightItems) == 0 {
+				l.inFlightItems = append([]T{}, plan.spec.consumed...)
 			}
 			l.runErr = runErr
+			return
+		}
+
+		// Business interrupt: agent produced an Interrupted action, exit to persist checkpoint.
+		if l.interruptContexts != nil {
+			l.inFlightItems = append([]T{}, plan.spec.consumed...)
+			l.runErr = &InterruptError{InterruptContexts: l.interruptContexts}
 			return
 		}
 	}
@@ -1643,6 +1669,9 @@ func (l *TurnLoop[T, M]) runAgentAndHandleEvents(
 	agent TypedAgent[M],
 	spec *turnRunSpec[T, M],
 ) error {
+	l.interruptContexts = nil
+	l.checkPointRunnerBytes = nil
+
 	var iter *AsyncIterator[*TypedAgentEvent[M]]
 
 	runOpts, ms, err := l.setupBridgeStore(spec, spec.runOpts)
@@ -1688,6 +1717,25 @@ func (l *TurnLoop[T, M]) runAgentAndHandleEvents(
 	} else {
 		iter = runner.Run(ctx, spec.input.Messages, runOpts...)
 	}
+
+	// Wrap iterator to capture InterruptContexts from business interrupt events
+	// before they flow to OnAgentEvents.
+	srcIter := iter
+	proxyIter, proxyGen := NewAsyncIteratorPair[*TypedAgentEvent[M]]()
+	go func() {
+		defer proxyGen.Close()
+		for {
+			event, ok := srcIter.Next()
+			if !ok {
+				break
+			}
+			if event != nil && event.Action != nil && event.Action.Interrupted != nil {
+				l.interruptContexts = event.Action.Interrupted.InterruptContexts
+			}
+			proxyGen.Send(event)
+		}
+	}()
+	iter = proxyIter
 
 	handleEvents := func() error {
 		return l.onAgentEvents(ctx, tc, iter)
@@ -1743,13 +1791,11 @@ func (l *TurnLoop[T, M]) runAgentAndHandleEvents(
 			return nil
 		default:
 		}
-		if l.stopSig.isStopped() {
-			if err := finalizeCheckpoint(); err != nil {
-				if handleErr != nil {
-					handleErr = fmt.Errorf("%w; checkpoint error: %v", handleErr, err)
-				} else {
-					handleErr = err
-				}
+		if err := finalizeCheckpoint(); err != nil {
+			if handleErr != nil {
+				handleErr = fmt.Errorf("%w; checkpoint error: %v", handleErr, err)
+			} else {
+				handleErr = err
 			}
 		}
 		return handleErr
@@ -1774,15 +1820,17 @@ func (l *TurnLoop[T, M]) cleanup(ctx context.Context) {
 
 	unhandled := l.buffer.TakeAll()
 	checkpointID := l.config.CheckpointID
-	isIdle := len(l.checkPointRunnerBytes) == 0 && len(unhandled) == 0 && len(l.canceledItems) == 0
+	isIdle := len(l.checkPointRunnerBytes) == 0 && len(unhandled) == 0 && len(l.inFlightItems) == 0
 
-	// Only save checkpoint when the loop exited due to an explicit Stop().
+	// Only save checkpoint when the loop exited due to an explicit Stop(),
+	// a CancelError, or a business interrupt (InterruptError).
 	// If Stop() was called but a callback error happened concurrently,
 	// the state may be inconsistent — don't checkpoint in that case.
-	// We consider the exit Stop-caused if runErr is nil (clean stop between
-	// turns) or a *CancelError (Stop canceled a running agent).
 	exitCausedByStop := l.runErr == nil || errors.As(l.runErr, new(*CancelError))
-	shouldSaveCheckpoint := l.config.Store != nil && checkpointID != "" && l.stopSig.isStopped() && exitCausedByStop && !isIdle && !l.stopSig.isSkipCheckpoint()
+	businessInterrupt := errors.As(l.runErr, new(*InterruptError))
+	shouldSaveCheckpoint := l.config.Store != nil && checkpointID != "" &&
+		((l.stopSig.isStopped() && exitCausedByStop) || businessInterrupt) &&
+		!isIdle && !l.stopSig.isSkipCheckpoint()
 
 	var checkpointed bool
 	var checkpointErr error
@@ -1792,7 +1840,7 @@ func (l *TurnLoop[T, M]) cleanup(ctx context.Context) {
 			RunnerCheckpoint: l.checkPointRunnerBytes,
 			HasRunnerState:   len(l.checkPointRunnerBytes) > 0,
 			UnhandledItems:   unhandled,
-			CanceledItems:    l.canceledItems,
+			CanceledItems:    l.inFlightItems,
 		}
 		checkpointed = true
 		checkpointErr = l.saveTurnLoopCheckpoint(ctx, checkpointID, cp)
@@ -1806,7 +1854,7 @@ func (l *TurnLoop[T, M]) cleanup(ctx context.Context) {
 	l.result = &TurnLoopExitState[T, M]{
 		ExitReason:          l.runErr,
 		UnhandledItems:      unhandled,
-		CanceledItems:       l.canceledItems,
+		InFlightItems:       l.inFlightItems,
 		StopCause:           l.stopSig.getStopCause(),
 		CheckpointAttempted: checkpointed,
 		CheckpointErr:       checkpointErr,

--- a/adk/turn_loop_test.go
+++ b/adk/turn_loop_test.go
@@ -1324,7 +1324,7 @@ func TestTurnLoop_StopDuringAgentExecution(t *testing.T) {
 
 	result := loop.Wait()
 	assert.NoError(t, result.ExitReason)
-	assert.Empty(t, result.CanceledItems)
+	assert.Empty(t, result.InFlightItems)
 }
 
 // TestTurnLoop_BareStop_AgentRunsToCompletion verifies the core contract of
@@ -1403,8 +1403,8 @@ func TestTurnLoop_BareStop_AgentRunsToCompletion(t *testing.T) {
 	// 3. ExitReason is nil (clean exit, not a CancelError).
 	assert.NoError(t, result.ExitReason)
 
-	// 4. CanceledItems is empty (agent was not canceled).
-	assert.Empty(t, result.CanceledItems)
+	// 4. InFlightItems is empty (agent was not interrupted).
+	assert.Empty(t, result.InFlightItems)
 
 	// 5. Only one turn executed; the second item is unhandled.
 	assert.Equal(t, int32(1), atomic.LoadInt32(&turnsExecuted),
@@ -1666,10 +1666,10 @@ func TestTurnLoop_StopDuringAgentExecution_PersistAndResume(t *testing.T) {
 	loop2 := NewTurnLoop(TurnLoopConfig[string, *schema.Message]{
 		Store:        store,
 		CheckpointID: cpID,
-		GenResume: func(ctx context.Context, _ *TurnLoop[string, *schema.Message], canceledItems []string, unhandledItems []string, newItems []string) (*GenResumeResult[string, *schema.Message], error) {
+		GenResume: func(ctx context.Context, _ *TurnLoop[string, *schema.Message], inFlightItems []string, unhandledItems []string, newItems []string) (*GenResumeResult[string, *schema.Message], error) {
 			genResumeCalled = true
 			return &GenResumeResult[string, *schema.Message]{
-				Consumed:  canceledItems,
+				Consumed:  inFlightItems,
 				Remaining: append(append([]string{}, unhandledItems...), newItems...),
 			}, nil
 		},
@@ -1699,6 +1699,112 @@ func TestTurnLoop_StopDuringAgentExecution_PersistAndResume(t *testing.T) {
 	assert.Equal(t, []string{"msg1"}, consumed2)
 	assert.True(t, genResumeCalled)
 	assert.False(t, genInputCalled)
+}
+
+func TestTurnLoop_BusinessInterrupt_PersistAndResume(t *testing.T) {
+	ctx := context.Background()
+	store := &turnLoopCheckpointStore{m: make(map[string][]byte)}
+	cpID := "interrupt-session"
+
+	// Agent that produces a business interrupt via Interrupt() call.
+	interruptAgent := &turnLoopInterruptAgent{interruptInfo: "approval_needed"}
+
+	loop := newAndRunTurnLoop(ctx, TurnLoopConfig[string, *schema.Message]{
+		Store:        store,
+		CheckpointID: cpID,
+		GenInput: func(ctx context.Context, _ *TurnLoop[string, *schema.Message], items []string) (*GenInputResult[string, *schema.Message], error) {
+			return &GenInputResult[string, *schema.Message]{
+				Input:    &AgentInput{Messages: []Message{schema.UserMessage(items[0])}},
+				Consumed: items,
+			}, nil
+		},
+		PrepareAgent: func(ctx context.Context, _ *TurnLoop[string, *schema.Message], consumed []string) (Agent, error) {
+			return interruptAgent, nil
+		},
+	})
+
+	loop.Push("msg1")
+	exit := loop.Wait()
+
+	// 1. ExitReason is an *InterruptError (not nil, not *CancelError).
+	var intErr *InterruptError
+	require.True(t, errors.As(exit.ExitReason, &intErr), "expected *InterruptError, got: %v", exit.ExitReason)
+
+	// 2. InterruptContexts is populated.
+	require.NotEmpty(t, intErr.InterruptContexts)
+
+	// 3. InFlightItems contains the items being processed.
+	assert.Equal(t, []string{"msg1"}, exit.InFlightItems)
+
+	// 4. Checkpoint was persisted.
+	assert.True(t, exit.CheckpointAttempted)
+	assert.NoError(t, exit.CheckpointErr)
+
+	store.mu.Lock()
+	_, cpExists := store.m[cpID]
+	store.mu.Unlock()
+	assert.True(t, cpExists, "checkpoint should exist in store")
+
+	// 5. Resume: new TurnLoop with same CheckpointID gets GenResume called.
+	var genResumeCalled bool
+	var resumeInFlightItems []string
+	loop2 := NewTurnLoop(TurnLoopConfig[string, *schema.Message]{
+		Store:        store,
+		CheckpointID: cpID,
+		GenResume: func(ctx context.Context, _ *TurnLoop[string, *schema.Message], inFlightItems []string, unhandledItems []string, newItems []string) (*GenResumeResult[string, *schema.Message], error) {
+			genResumeCalled = true
+			resumeInFlightItems = append([]string{}, inFlightItems...)
+			return &GenResumeResult[string, *schema.Message]{
+				Consumed:  inFlightItems,
+				Remaining: append(append([]string{}, unhandledItems...), newItems...),
+			}, nil
+		},
+		GenInput: func(ctx context.Context, _ *TurnLoop[string, *schema.Message], items []string) (*GenInputResult[string, *schema.Message], error) {
+			return &GenInputResult[string, *schema.Message]{Input: &AgentInput{}, Consumed: items}, nil
+		},
+		PrepareAgent: func(ctx context.Context, _ *TurnLoop[string, *schema.Message], consumed []string) (Agent, error) {
+			// On resume, agent completes normally.
+			return &turnLoopMockAgent{
+				name:   "ResumeAgent",
+				events: []*AgentEvent{{Output: &AgentOutput{}}},
+			}, nil
+		},
+		OnAgentEvents: func(ctx context.Context, tc *TurnContext[string, *schema.Message], events *AsyncIterator[*AgentEvent]) error {
+			for {
+				_, ok := events.Next()
+				if !ok {
+					break
+				}
+			}
+			tc.Loop.Stop()
+			return nil
+		},
+	})
+
+	loop2.Run(ctx)
+	exit2 := loop2.Wait()
+	assert.NoError(t, exit2.ExitReason)
+	assert.True(t, genResumeCalled, "GenResume should be called on checkpoint resume")
+	assert.Equal(t, []string{"msg1"}, resumeInFlightItems, "inFlightItems should contain the original items")
+}
+
+// turnLoopInterruptAgent is a test agent that produces a business interrupt event.
+type turnLoopInterruptAgent struct {
+	interruptInfo any
+}
+
+func (a *turnLoopInterruptAgent) Name(_ context.Context) string { return "InterruptAgent" }
+func (a *turnLoopInterruptAgent) Description(_ context.Context) string {
+	return "agent that interrupts"
+}
+func (a *turnLoopInterruptAgent) Run(ctx context.Context, _ *AgentInput, _ ...AgentRunOption) *AsyncIterator[*AgentEvent] {
+	iter, gen := NewAsyncIteratorPair[*AgentEvent]()
+	go func() {
+		defer gen.Close()
+		event := Interrupt(ctx, a.interruptInfo)
+		gen.Send(event)
+	}()
+	return iter
 }
 
 func TestTurnLoop_CheckpointIDWithoutStore_FreshStart(t *testing.T) {
@@ -4435,7 +4541,7 @@ func TestTurnLoop_StopBeforeRun_PushThenStop(t *testing.T) {
 
 	assert.NoError(t, result.ExitReason)
 	assert.Equal(t, []string{"item1", "item2"}, result.UnhandledItems)
-	assert.Empty(t, result.CanceledItems)
+	assert.Empty(t, result.InFlightItems)
 	assert.Empty(t, result.TakeLateItems())
 }
 
@@ -4463,7 +4569,7 @@ func TestTurnLoop_StopBeforeRun_StopThenPush(t *testing.T) {
 
 	assert.NoError(t, result.ExitReason)
 	assert.Empty(t, result.UnhandledItems)
-	assert.Empty(t, result.CanceledItems)
+	assert.Empty(t, result.InFlightItems)
 	assert.Equal(t, []string{"item1", "item2"}, result.TakeLateItems())
 }
 
@@ -5140,7 +5246,7 @@ func TestAttack_StopSignal_NilCancelOptsDoNotDeescalate(t *testing.T) {
 	assert.Equal(t, CancelImmediate, ce.Info.Mode)
 }
 
-func TestAttack_CanceledItems_EmptyWhenAgentFinishesNormally(t *testing.T) {
+func TestAttack_InFlightItems_EmptyWhenAgentFinishesNormally(t *testing.T) {
 	agentStarted := make(chan struct{})
 	loop := newAndRunTurnLoop(context.Background(), TurnLoopConfig[string, *schema.Message]{
 		GenInput: func(ctx context.Context, _ *TurnLoop[string, *schema.Message], items []string) (*GenInputResult[string, *schema.Message], error) {
@@ -5167,7 +5273,7 @@ func TestAttack_CanceledItems_EmptyWhenAgentFinishesNormally(t *testing.T) {
 
 	exit := loop.Wait()
 	assert.NoError(t, exit.ExitReason)
-	assert.Empty(t, exit.CanceledItems, "CanceledItems must be empty when agent finished normally")
+	assert.Empty(t, exit.InFlightItems, "InFlightItems must be empty when agent finished normally")
 }
 
 func TestAttack_TurnBuffer_WakeupDoesNotLoseItems(t *testing.T) {

--- a/adk/turn_loop_test.go
+++ b/adk/turn_loop_test.go
@@ -1467,6 +1467,158 @@ func TestTurnLoop_StopCheckPointIDInCancelError(t *testing.T) {
 	assert.True(t, ok, "checkpoint should be saved under the configured CheckpointID")
 }
 
+// TestTurnLoop_CancelError_CapturedIndependentlyOfCallback verifies that the TurnLoop
+// correctly reports *CancelError as ExitReason and populates InFlightItems even when
+// the user's custom OnAgentEvents callback swallows the CancelError (returns nil).
+// This tests the documented guarantee: "the callback should NEVER propagate CancelError
+// — the framework handles it automatically."
+func TestTurnLoop_CancelError_CapturedIndependentlyOfCallback(t *testing.T) {
+	ctx := context.Background()
+	modelStarted := make(chan struct{}, 1)
+	checkpointID := "cancel-capture-independent-1"
+	store := &turnLoopCheckpointStore{m: make(map[string][]byte)}
+
+	slowModel := &cancelTestChatModel{
+		delayNs: int64(500 * time.Millisecond),
+		response: &schema.Message{
+			Role:    schema.Assistant,
+			Content: "Hello",
+		},
+		startedChan: modelStarted,
+		doneChan:    make(chan struct{}, 1),
+	}
+
+	agent, err := NewChatModelAgent(ctx, &ChatModelAgentConfig{
+		Name:        "TestAgent",
+		Description: "Test agent",
+		Instruction: "You are a test assistant",
+		Model:       slowModel,
+	})
+	assert.NoError(t, err)
+
+	loop := newAndRunTurnLoop(ctx, TurnLoopConfig[string, *schema.Message]{
+		Store:        store,
+		CheckpointID: checkpointID,
+		GenInput: func(ctx context.Context, _ *TurnLoop[string, *schema.Message], items []string) (*GenInputResult[string, *schema.Message], error) {
+			return &GenInputResult[string, *schema.Message]{
+				Input:    &AgentInput{Messages: []Message{schema.UserMessage(items[0])}},
+				Consumed: items,
+			}, nil
+		},
+		PrepareAgent: func(ctx context.Context, _ *TurnLoop[string, *schema.Message], consumed []string) (Agent, error) {
+			return agent, nil
+		},
+		// Custom OnAgentEvents that deliberately swallows all errors including CancelError.
+		OnAgentEvents: func(ctx context.Context, tc *TurnContext[string, *schema.Message], events *AsyncIterator[*TypedAgentEvent[*schema.Message]]) error {
+			for {
+				_, ok := events.Next()
+				if !ok {
+					break
+				}
+				// Deliberately ignore event.Err — do NOT propagate CancelError.
+			}
+			return nil // swallow everything
+		},
+	})
+
+	loop.Push("msg1")
+
+	<-modelStarted
+	loop.Stop(WithImmediate())
+
+	result := loop.Wait()
+
+	// The framework should capture CancelError independently of the callback's return value.
+	var cancelErr *CancelError
+	assert.True(t, errors.As(result.ExitReason, &cancelErr),
+		"ExitReason should be *CancelError even when OnAgentEvents swallows it, got: %v", result.ExitReason)
+
+	// InFlightItems should be populated.
+	assert.Equal(t, []string{"msg1"}, result.InFlightItems,
+		"InFlightItems should contain the items that were being processed")
+
+	// Checkpoint should be saved.
+	store.mu.Lock()
+	defer store.mu.Unlock()
+	_, ok := store.m[checkpointID]
+	assert.True(t, ok, "checkpoint should be saved under the configured CheckpointID")
+}
+
+// TestTurnLoop_CancelError_CustomErrorWins_InFlightItemsStillSet verifies that when
+// the user's OnAgentEvents callback returns a custom error during a cancel, the custom
+// error becomes ExitReason (not overwritten by CancelError), but InFlightItems is still
+// populated because the items were factually mid-execution when the cancel signal arrived.
+func TestTurnLoop_CancelError_CustomErrorWins_InFlightItemsStillSet(t *testing.T) {
+	ctx := context.Background()
+	modelStarted := make(chan struct{}, 1)
+	checkpointID := "cancel-custom-error-wins-1"
+	store := &turnLoopCheckpointStore{m: make(map[string][]byte)}
+	customErr := fmt.Errorf("user callback encountered a problem")
+
+	slowModel := &cancelTestChatModel{
+		delayNs: int64(500 * time.Millisecond),
+		response: &schema.Message{
+			Role:    schema.Assistant,
+			Content: "Hello",
+		},
+		startedChan: modelStarted,
+		doneChan:    make(chan struct{}, 1),
+	}
+
+	agent, err := NewChatModelAgent(ctx, &ChatModelAgentConfig{
+		Name:        "TestAgent",
+		Description: "Test agent",
+		Instruction: "You are a test assistant",
+		Model:       slowModel,
+	})
+	assert.NoError(t, err)
+
+	loop := newAndRunTurnLoop(ctx, TurnLoopConfig[string, *schema.Message]{
+		Store:        store,
+		CheckpointID: checkpointID,
+		GenInput: func(ctx context.Context, _ *TurnLoop[string, *schema.Message], items []string) (*GenInputResult[string, *schema.Message], error) {
+			return &GenInputResult[string, *schema.Message]{
+				Input:    &AgentInput{Messages: []Message{schema.UserMessage(items[0])}},
+				Consumed: items,
+			}, nil
+		},
+		PrepareAgent: func(ctx context.Context, _ *TurnLoop[string, *schema.Message], consumed []string) (Agent, error) {
+			return agent, nil
+		},
+		// Custom OnAgentEvents that returns a custom error instead of the CancelError.
+		OnAgentEvents: func(ctx context.Context, tc *TurnContext[string, *schema.Message], events *AsyncIterator[*TypedAgentEvent[*schema.Message]]) error {
+			for {
+				_, ok := events.Next()
+				if !ok {
+					break
+				}
+			}
+			return customErr
+		},
+	})
+
+	loop.Push("msg1")
+
+	<-modelStarted
+	loop.Stop(WithImmediate())
+
+	result := loop.Wait()
+
+	// User's custom error should win as ExitReason.
+	assert.ErrorIs(t, result.ExitReason, customErr,
+		"ExitReason should be the user's custom error, not CancelError")
+
+	// But InFlightItems should still be populated (items were factually in-flight).
+	assert.Equal(t, []string{"msg1"}, result.InFlightItems,
+		"InFlightItems should contain the items that were being processed")
+
+	// Checkpoint should be saved (cancel was captured, items were in-flight).
+	store.mu.Lock()
+	defer store.mu.Unlock()
+	_, ok := store.m[checkpointID]
+	assert.True(t, ok, "checkpoint should be saved even when user returns custom error")
+}
+
 func TestTurnLoop_StopWithoutCheckpointIDDoesNotPersist(t *testing.T) {
 	ctx := context.Background()
 	modelStarted := make(chan struct{}, 1)
@@ -5741,4 +5893,56 @@ func TestTurnLoop_Preempt_LoopStalledAfterSecondPreemptPush(t *testing.T) {
 	result := loop.Wait()
 	assert.NoError(t, result.ExitReason)
 	assert.Equal(t, int32(3), atomic.LoadInt32(&turnCount), "expected 3 turns to be processed")
+}
+
+func TestAttack_BusinessInterrupt_NoStore_ExitsWithoutPanic(t *testing.T) {
+	ctx := context.Background()
+	interruptAgent := &turnLoopInterruptAgent{interruptInfo: "no_store_test"}
+
+	loop := newAndRunTurnLoop(ctx, TurnLoopConfig[string, *schema.Message]{
+		GenInput: func(ctx context.Context, _ *TurnLoop[string, *schema.Message], items []string) (*GenInputResult[string, *schema.Message], error) {
+			return &GenInputResult[string, *schema.Message]{
+				Input:    &AgentInput{Messages: []Message{schema.UserMessage(items[0])}},
+				Consumed: items,
+			}, nil
+		},
+		PrepareAgent: func(ctx context.Context, _ *TurnLoop[string, *schema.Message], consumed []string) (Agent, error) {
+			return interruptAgent, nil
+		},
+	})
+
+	loop.Push("msg1")
+	exit := loop.Wait()
+
+	var intErr *InterruptError
+	require.True(t, errors.As(exit.ExitReason, &intErr), "expected *InterruptError, got: %v", exit.ExitReason)
+	assert.Equal(t, []string{"msg1"}, exit.InFlightItems)
+	assert.False(t, exit.CheckpointAttempted, "no store → no checkpoint attempt")
+}
+
+func TestAttack_BusinessInterrupt_EmptyConsumed_NoCheckpoint(t *testing.T) {
+	ctx := context.Background()
+	store := &turnLoopCheckpointStore{m: make(map[string][]byte)}
+	interruptAgent := &turnLoopInterruptAgent{interruptInfo: "idle_test"}
+
+	loop := newAndRunTurnLoop(ctx, TurnLoopConfig[string, *schema.Message]{
+		Store:        store,
+		CheckpointID: "idle-cp",
+		GenInput: func(ctx context.Context, _ *TurnLoop[string, *schema.Message], items []string) (*GenInputResult[string, *schema.Message], error) {
+			return &GenInputResult[string, *schema.Message]{
+				Input:    &AgentInput{Messages: []Message{schema.UserMessage("x")}},
+				Consumed: []string{},
+			}, nil
+		},
+		PrepareAgent: func(ctx context.Context, _ *TurnLoop[string, *schema.Message], consumed []string) (Agent, error) {
+			return interruptAgent, nil
+		},
+	})
+
+	loop.Push("msg1")
+	exit := loop.Wait()
+
+	var intErr *InterruptError
+	require.True(t, errors.As(exit.ExitReason, &intErr), "expected *InterruptError, got: %v", exit.ExitReason)
+	assert.Empty(t, exit.InFlightItems, "consumed was empty → InFlightItems should be empty")
 }


### PR DESCRIPTION
## Summary

| Dimension | Before | After |
|-----------|--------|-------|
| Business interrupt checkpoint | Not persisted — Resume impossible | Persisted with same semantics as CancelError |
| ExitReason for interrupt | None (silent exit) | `*InterruptError` with `InterruptContexts` |
| Public field naming | `CanceledItems` (misleading for interrupt) | `InFlightItems` (neutral, covers both paths) |

## Key Insight

The TurnLoop previously only persisted checkpoints when a `CancelError` was encountered (forceful stop). Business interrupts (`AgentAction.Interrupted`) — which represent voluntary pause points defined by the agent — exited silently without saving state. This meant `Resume` was impossible for the interrupt path, creating a serious gap between cancel and interrupt semantics.

The## Summary

| Dimension | Before | After |
|-----------|--------|-------|
| Business interrupt checkpoint | Not persisted — Resume impossible | Persisted with same semantics as CancelError |
| ExitReason for interrte
|uptContext|-----------|--------|-------## Design Decisions

1. **`Interr| ExitReason for interrupt | None (silent exit) | `*InterruptError` with `InterruptContexts` |
| Public field naming so| Public field naming | `CanceledItems` (misleading for interrupt) | `InFlightItems` (neutralet
## Key Insight

The TurnLoop previously only persisted checkpoints when a `CancelError` was encountered (forcefulcap
The TurnLooprup
The## Summary

| Dimension | Before | After |
|-----------|--------|-------|
| Business interrupt checkpoint | Not persisted — Resume impossible | Persisted with same semantics as CancelError |
| ExitReason for interrte
|uptContext|-----------|--------|-------## Design Decisions

1. **`Interr| ExitReason for interrupt | None (silent exit) | `*InterruptError` with `Interruptbil
| Dimensionlwa|-----------|--------|-------`*| Business interrupt checkpoiSt| ExitReason for interrte
|uptContext|-----------|--------|-------## Design Decisions

1. **`Interr| ExitReason for iy.|uptContext|-----------|ce
1. **`Interr| ExitReason for interrupt | None (silent exirat| Public field naming so| Public field naming | `CanceledItems` (misleading for interrupt) | `InFlightIte),## Key Insight

The TurnLoop previously only persisted checkpoints when a `CancelError` was encountered (fosistAndResume
The TurnLoop??he TurnLooprup
The## Summary

| Dimension | Before | After |
|-----------|--------|-------|
| BusigeThe## Summary
ru
| Dimension???-----------|--------|-------? Business interrupt checkpoiPR| ExitReason for interrte
|uptContext|-----------|--------|-------## Design Decisions

1. **`Interr| ExitReason for iIn|uptContext|-----------|nc
1. **`Interr| ExitReason for interrupt | None (silent exiter| Dimensionlwa|-----------|--------|-------`*| Business interrupt checkpoiSt| ExitReason for inteli|uptContext|-----------|--------|-------## Design Decisions

1. **`Interr| Exit）。