### PR TITLE
chore(adk/prebuilt/deep): move TODO type declaration before init() and document gob names

### DIFF
--- a/.auto-pr/SPEC.md
+++ b/.auto-pr/SPEC.md
@@ -1,0 +1,35 @@
+# SPEC: Fix TODO struct registration ordering in adk/prebuilt/deep/deep.go
+
+## Problem
+In `adk/prebuilt/deep/deep.go`, the `init()` function calls `schema.RegisterName[TODO](...)` and
+`schema.RegisterName[[]TODO](...)` using the identifier `TODO` — but the `TODO` struct is defined
+later in the same file. While Go allows forward references within a package, having `schema.RegisterName[TODO]`
+at the top of the file before `type TODO struct` is defined is confusing for readers who don't know whether
+`TODO` is the Go built-in placeholder keyword or an actual type.
+
+Additionally, there is no comment explaining *why* these gob names are registered — this is important
+for checkpoint compatibility (changing the name would break existing saved checkpoints).
+
+## Acceptance criteria
+- [ ] The `TODO` struct definition appears before the `init()` function that references it, or
+      alternatively the `init()` is moved to the same location where `TODO` is defined.
+- [ ] A short doc comment explains that the registered names are checkpoint-compatibility identifiers
+      that must not be changed.
+- [ ] All existing tests continue to pass (`go test ./adk/prebuilt/deep/...`).
+- [ ] No lint errors introduced.
+
+## Approach
+1. Move `type TODO struct` and `type writeTodosArguments struct` to the top of the file (after imports),
+   before the `init()` function, so the code reads in declaration order.
+2. Add a comment above `init()` explaining the checkpoint gob names.
+
+## Files likely touched
+- `adk/prebuilt/deep/deep.go`
+
+## Risk / blast radius
+- Low. Pure code reordering + comment addition. No logic changes. Checkpoint names unchanged.
+
+## Test plan
+- `go vet ./adk/prebuilt/deep/...`
+- `go build ./adk/prebuilt/deep/...`
+- `go test ./adk/prebuilt/deep/...` (if tests exist)

--- a/.auto-pr/target-repo.txt
+++ b/.auto-pr/target-repo.txt
@@ -1,0 +1,1 @@
+cloudwego/eino

--- a/adk/prebuilt/deep/deep.go
+++ b/adk/prebuilt/deep/deep.go
@@ -32,6 +32,20 @@ import (
 	"github.com/cloudwego/eino/schema"
 )
 
+// TODO represents a single task item tracked by the write_todos tool.
+type TODO struct {
+	Content    string `json:"content"`
+	ActiveForm string `json:"activeForm"`
+	Status     string `json:"status" jsonschema:"enum=pending,enum=in_progress,enum=completed"`
+}
+
+type writeTodosArguments struct {
+	Todos []TODO `json:"todos"`
+}
+
+// init registers gob type names used for checkpoint serialization.
+// These names are part of the checkpoint format and must not be changed,
+// as doing so would break deserialization of existing saved checkpoints.
 func init() {
 	schema.RegisterName[TODO]("_eino_adk_prebuilt_deep_todo")
 	schema.RegisterName[[]TODO]("_eino_adk_prebuilt_deep_todo_slice")
@@ -187,16 +201,6 @@ func buildBuiltinAgentMiddlewares(ctx context.Context, cfg *Config) ([]adk.ChatM
 	}
 
 	return ms, nil
-}
-
-type TODO struct {
-	Content    string `json:"content"`
-	ActiveForm string `json:"activeForm"`
-	Status     string `json:"status" jsonschema:"enum=pending,enum=in_progress,enum=completed"`
-}
-
-type writeTodosArguments struct {
-	Todos []TODO `json:"todos"`
 }
 
 func newWriteTodos() (adk.ChatModelAgentMiddleware, error) {


### PR DESCRIPTION
## Summary

- Moves `type TODO struct` and `type writeTodosArguments struct` to appear **before** the `init()` function that references them, so declarations appear in natural top-to-bottom order.
- Adds a `// TODO represents...` doc comment on the struct (previously it had none).
- Adds a comment on `init()` explaining that the registered gob names (`_eino_adk_prebuilt_deep_todo`, `_eino_adk_prebuilt_deep_todo_slice`) are checkpoint-compatibility identifiers that must not be changed.

Previously, readers encountering `schema.RegisterName[TODO](...)` at the top of the file had no way to know whether `TODO` was the Go placeholder keyword or an actual type — the struct was defined much later in the same file. This reordering removes that ambiguity.

## Test plan

- [x] `go vet ./adk/prebuilt/deep/...` — clean
- [x] `go build ./adk/prebuilt/deep/...` — clean
- [x] `go test ./adk/prebuilt/deep/...` — all pass
- [x] `go build ./...` (full module) — clean
- No logic changes; checkpoint gob names unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)