### PR TITLE
fix(adk): preserve recursive agent tool resume checkpoint

### DIFF
--- a/adk/agent_tool.go
+++ b/adk/agent_tool.go
@@ -195,7 +195,7 @@ func (at *typedAgentTool[M]) InvokableRun(ctx context.Context, argumentsInJSON s
 
 		runner := newTypedInvokableAgentToolRunner[M](at.agent, ms, enableStreaming)
 		iter = runner.Run(ctx, input,
-			append(extractAndDeriveCancelCtx(ctx, at.agent.Name(ctx), opts), WithCheckPointID(bridgeCheckpointID), withSharedParentSession())...)
+			append(extractAndDeriveAgentToolCancelCtx(ctx, at.agent.Name(ctx), opts), WithCheckPointID(bridgeCheckpointID), withSharedParentSession())...)
 	} else {
 		if !hasState {
 			return "", fmt.Errorf("agent tool '%s' interrupt has happened, but cannot find interrupt state", at.agent.Name(ctx))
@@ -203,7 +203,7 @@ func (at *typedAgentTool[M]) InvokableRun(ctx context.Context, argumentsInJSON s
 
 		ms = newResumeBridgeStore(bridgeCheckpointID, state)
 
-		agentOpts := extractAndDeriveCancelCtx(ctx, at.agent.Name(ctx), opts)
+		agentOpts := extractAndDeriveAgentToolCancelCtx(ctx, at.agent.Name(ctx), opts)
 		agentOpts = append(agentOpts, withSharedParentSession())
 
 		runner := newTypedInvokableAgentToolRunner[M](at.agent, ms, enableStreaming)
@@ -320,11 +320,16 @@ func getOptionsByAgentName(agentName string, opts []tool.Option) []AgentRunOptio
 	return ret
 }
 
-func extractAndDeriveCancelCtx(ctx context.Context, agentName string, opts []tool.Option) []AgentRunOption {
+func extractAndDeriveAgentToolCancelCtx(ctx context.Context, agentName string, opts []tool.Option) []AgentRunOption {
 	agentOpts := getOptionsByAgentName(agentName, opts)
 	baseOpts := getCommonOptions(nil, agentOpts...)
-	if baseOpts.cancelCtx != nil {
-		childCtx := baseOpts.cancelCtx.deriveChild(ctx)
+	parentCtx := baseOpts.cancelCtx
+	if parentCtx == nil {
+		parentCtx = getCancelContext(ctx)
+	}
+	if parentCtx != nil {
+		parentCtx.markAgentToolDescendant()
+		childCtx := parentCtx.deriveAgentToolCancelContext(ctx)
 		agentOpts = append(agentOpts, WrapImplSpecificOptFn(func(o *options) {
 			o.cancelCtx = childCtx
 		}))

--- a/adk/agent_tool.go
+++ b/adk/agent_tool.go
@@ -152,6 +152,10 @@ func (at *typedAgentTool[M]) Info(ctx context.Context) (*schema.ToolInfo, error)
 }
 
 func (at *typedAgentTool[M]) InvokableRun(ctx context.Context, argumentsInJSON string, opts ...tool.Option) (string, error) {
+	if cancelCtx := getCancelContext(ctx); cancelCtx != nil {
+		cancelCtx.markAgentToolDescendant()
+	}
+
 	gen, enableStreaming := getEmitGeneratorAndEnableStreaming(opts)
 	var ms *bridgeStore
 	var iter *AsyncIterator[*TypedAgentEvent[M]]

--- a/adk/cancel.go
+++ b/adk/cancel.go
@@ -273,11 +273,11 @@ const (
 )
 
 // defaultCancelImmediateGracePeriod is the time a parent's graph interrupt
-// waits when the cancelContext has active children (via deriveChild). This
-// gives child agents time to propagate their interrupt signal back through
-// the agentTool as a CompositeInterrupt. If this proves insufficient for
-// deeply nested structures or too slow for latency-sensitive use cases,
-// consider making it configurable via an AgentCancelOption.
+// waits during recursive immediate cancel when an AgentTool descendant is in
+// the run. This gives descendant agents time to propagate their interrupt
+// signal back through the agentTool as a CompositeInterrupt. If this proves
+// insufficient for deeply nested structures or too slow for latency-sensitive
+// use cases, consider making it configurable via an AgentCancelOption.
 const defaultCancelImmediateGracePeriod = 1 * time.Second
 
 type cancelContextKey struct{}
@@ -317,10 +317,9 @@ type cancelContext struct {
 	recursiveChan chan struct{} // closed when recursive transitions from 0 to 1
 
 	root   bool           // true for the original cancelContext created by WithCancel(); false for derived children
-	parent *cancelContext // non-nil for derived children; used to decrement parent's activeChildren on markDone
+	parent *cancelContext // non-nil for derived children; used to propagate AgentTool boundary markers upward
 
-	activeChildren    int32 // atomic; number of derived children that haven't called markDone() yet
-	decrementedParent int32 // atomic CAS guard; ensures parent.activeChildren is decremented at most once
+	agentToolDescendant int32 // atomic; 1 once an AgentTool runs under this cancel context
 
 	cancelMu      sync.Mutex
 	timeoutOnce   sync.Once
@@ -368,7 +367,6 @@ func (cc *cancelContext) deriveChild(ctx context.Context) *cancelContext {
 	child := newCancelContext()
 	child.root = false
 	child.parent = cc
-	atomic.AddInt32(&cc.activeChildren, 1)
 
 	// Each goroutine below propagates one signal class (cancel / immediate) to
 	// the child. The pattern is a two-phase select:
@@ -551,26 +549,25 @@ func (cc *cancelContext) markDone() {
 	if atomic.CompareAndSwapInt32(&cc.state, stateRunning, stateDone) ||
 		atomic.CompareAndSwapInt32(&cc.state, stateCancelling, stateDone) {
 		cc.doneOnce.Do(func() { close(cc.doneChan) })
-		cc.detachFromParent()
 	}
 }
 
-func (cc *cancelContext) detachFromParent() {
-	if cc.parent != nil && atomic.CompareAndSwapInt32(&cc.decrementedParent, 0, 1) {
-		atomic.AddInt32(&cc.parent.activeChildren, -1)
-	}
+func (cc *cancelContext) hasAgentToolDescendant() bool {
+	return cc != nil && atomic.LoadInt32(&cc.agentToolDescendant) == 1
 }
 
-func (cc *cancelContext) hasActiveChildren() bool {
-	return cc != nil && atomic.LoadInt32(&cc.activeChildren) > 0
+func (cc *cancelContext) markAgentToolDescendant() {
+	for cur := cc; cur != nil; cur = cur.parent {
+		atomic.StoreInt32(&cur.agentToolDescendant, 1)
+	}
 }
 
 func (cc *cancelContext) wrapGraphInterruptWithGracePeriod(interrupt func(...compose.GraphInterruptOption)) func(...compose.GraphInterruptOption) {
 	return func(opts ...compose.GraphInterruptOption) {
-		// Grace period only applies in recursive mode: in shallow mode,
-		// children are unaware of the cancel and don't need time to propagate
-		// their interrupt signals back.
-		if cc.isRecursive() && cc.hasActiveChildren() {
+		// Grace period is for recursive AgentTool cancellation. AgentTool is the
+		// stable semantic boundary: its inner agent may share this cancel context,
+		// and its interrupt needs time to bubble back as a CompositeInterrupt.
+		if cc.isRecursive() && cc.hasAgentToolDescendant() {
 			newOpts := make([]compose.GraphInterruptOption, len(opts)+1)
 			copy(newOpts, opts)
 			newOpts[len(opts)] = compose.WithGraphInterruptTimeout(defaultCancelImmediateGracePeriod)
@@ -592,7 +589,6 @@ func (cc *cancelContext) markCancelHandled() bool {
 	}
 	if atomic.CompareAndSwapInt32(&cc.state, stateCancelling, stateCancelHandled) {
 		cc.doneOnce.Do(func() { close(cc.doneChan) })
-		cc.detachFromParent()
 		return true
 	}
 	return false

--- a/adk/cancel.go
+++ b/adk/cancel.go
@@ -272,12 +272,12 @@ const (
 	interruptImmediate int32 = 1
 )
 
-// defaultCancelImmediateGracePeriod is the time a parent's graph interrupt
-// waits during recursive immediate cancel when an AgentTool descendant is in
-// the run. This gives descendant agents time to propagate their interrupt
-// signal back through the agentTool as a CompositeInterrupt. If this proves
-// insufficient for deeply nested structures or too slow for latency-sensitive
-// use cases, consider making it configurable via an AgentCancelOption.
+// defaultCancelImmediateGracePeriod is the bounded time a recursive
+// AgentTool cancel waits before forcing the current level's graph interrupt.
+// This gives deeper AgentTool/internal-agent interrupts a chance to bubble up
+// as CompositeInterrupts. If this proves insufficient for deeply nested
+// structures or too slow for latency-sensitive use cases, consider making it
+// configurable via an AgentCancelOption.
 const defaultCancelImmediateGracePeriod = 1 * time.Second
 
 type cancelContextKey struct{}
@@ -313,11 +313,11 @@ type cancelContext struct {
 	startedMode      int32 // atomic, mode when state transitioned to cancelling
 	deadlineUnixNano int64 // atomic, 0 means no deadline
 
-	recursive     int32         // atomic; 1 if cancel should propagate to descendant agents via deriveChild
+	recursive     int32         // atomic; 1 if cancel should propagate into AgentTool internal agents
 	recursiveChan chan struct{} // closed when recursive transitions from 0 to 1
 
-	root   bool           // true for the original cancelContext created by WithCancel(); false for derived children
-	parent *cancelContext // non-nil for derived children; used to propagate AgentTool boundary markers upward
+	root   bool           // true for the original cancelContext created by WithCancel(); false for AgentTool internal agents
+	parent *cancelContext // non-nil for AgentTool internal agents; used to propagate AgentTool boundary markers upward
 
 	agentToolDescendant int32 // atomic; 1 once an AgentTool runs under this cancel context
 
@@ -356,11 +356,12 @@ func (cc *cancelContext) setRecursive(v bool) {
 	}
 }
 
-// deriveChild creates a child cancelContext that receives cancel propagation
-// from the parent. The caller MUST ensure the child's markDone() is eventually
+// deriveAgentToolCancelContext creates the cancelContext used by an AgentTool's
+// internal agent. It receives recursive cancel propagation from the parent
+// AgentTool call. The caller MUST ensure the child's markDone() is eventually
 // called (e.g., via wrapIterWithCancelCtx's defer) or that ctx is canceled;
 // otherwise the two propagation goroutines will leak.
-func (cc *cancelContext) deriveChild(ctx context.Context) *cancelContext {
+func (cc *cancelContext) deriveAgentToolCancelContext(ctx context.Context) *cancelContext {
 	if cc == nil {
 		return nil
 	}
@@ -507,6 +508,15 @@ func (cc *cancelContext) sendImmediateInterrupt() bool {
 	fns := make([]func(...compose.GraphInterruptOption), len(cc.graphInterruptFuncs))
 	copy(fns, cc.graphInterruptFuncs)
 
+	if cc.isRecursive() && cc.hasAgentToolDescendant() {
+		select {
+		case <-cc.doneChan:
+			cc.mu.Unlock()
+			return true
+		case <-time.After(defaultCancelImmediateGracePeriod):
+		}
+	}
+
 	if len(fns) == 0 {
 		cc.mu.Unlock()
 		return false
@@ -559,21 +569,6 @@ func (cc *cancelContext) hasAgentToolDescendant() bool {
 func (cc *cancelContext) markAgentToolDescendant() {
 	for cur := cc; cur != nil; cur = cur.parent {
 		atomic.StoreInt32(&cur.agentToolDescendant, 1)
-	}
-}
-
-func (cc *cancelContext) wrapGraphInterruptWithGracePeriod(interrupt func(...compose.GraphInterruptOption)) func(...compose.GraphInterruptOption) {
-	return func(opts ...compose.GraphInterruptOption) {
-		// Grace period is for recursive AgentTool cancellation. AgentTool is the
-		// stable semantic boundary: its inner agent may share this cancel context,
-		// and its interrupt needs time to bubble back as a CompositeInterrupt.
-		if cc.isRecursive() && cc.hasAgentToolDescendant() {
-			newOpts := make([]compose.GraphInterruptOption, len(opts)+1)
-			copy(newOpts, opts)
-			newOpts[len(opts)] = compose.WithGraphInterruptTimeout(defaultCancelImmediateGracePeriod)
-			opts = newOpts
-		}
-		interrupt(opts...)
 	}
 }
 
@@ -790,7 +785,7 @@ func (cc *cancelContext) buildCancelFunc() AgentCancelFunc {
 // It calls markDone when the inner iterator is fully drained, ensuring the
 // cancelContext's doneChan is closed and propagation goroutines can exit.
 //
-// For root cancelContexts (created by WithCancel, not deriveChild), it also
+// For root cancelContexts (created by WithCancel, not deriveAgentToolCancelContext), it also
 // converts interrupt ACTION events to CancelError when cancel is active.
 // This is the single point of interrupt-to-CancelError conversion in the
 // system — Runner.handleIter only enriches the resulting CancelError with

--- a/adk/cancel_edge_test.go
+++ b/adk/cancel_edge_test.go
@@ -1569,8 +1569,9 @@ func TestWithCancel_CancelImmediate_NestedAgentTool_ResumeFromToolsNode(t *testi
 			assert.True(t, hasCancelError, "expected CancelError from canceled nested agent tool")
 
 			// --- phase 2: resume with Runner.Resume (no ResumeWithParams, no interrupt ID) ---
-			// Build fresh agents for resume. The first model call after Resume should be
-			// the inner ChatModelAgent inside AgentTool, not the top-level ChatModelAgent.
+			// Build fresh agents for resume. Recursive cancel should resume the
+			// inner ChatModelAgent inside AgentTool before the top-level
+			// ChatModelAgent produces the final answer.
 			resumeFirstModelCall := make(chan string, 5)
 			resumeOuterModelCallCount := int32(0)
 			resumeOuterModel := &countingChatModel{
@@ -1636,13 +1637,13 @@ func TestWithCancel_CancelImmediate_NestedAgentTool_ResumeFromToolsNode(t *testi
 
 			select {
 			case firstModel := <-resumeFirstModelCall:
-				expectedFirstModel := "outer"
 				if tc.recursive {
-					expectedFirstModel = "inner"
+					assert.Equal(t, "inner", firstModel,
+						"recursive cancel should resume the AgentTool/internal ChatModelAgent first")
+				} else {
+					assert.Contains(t, []string{"outer", "inner"}, firstModel,
+						"non-recursive cancel does not define whether a root or already-persisted inner checkpoint resumes first")
 				}
-				assert.Equal(t, expectedFirstModel, firstModel,
-					"recursive cancel should resume the AgentTool/internal ChatModelAgent first; "+
-						"non-recursive cancel only guarantees root-agent cancellation")
 			case <-time.After(5 * time.Second):
 				t.Fatal("no model call observed during resume")
 			}

--- a/adk/cancel_edge_test.go
+++ b/adk/cancel_edge_test.go
@@ -1682,6 +1682,302 @@ func TestWithCancel_CancelImmediate_NestedAgentTool_ResumeFromToolsNode(t *testi
 	}
 }
 
+func TestWithCancel_CancelImmediate_RecursiveAgentTool_ResumeDeepestAgentTool(t *testing.T) {
+	ctx := context.Background()
+
+	leafModel := newBlockingChatModel(schema.AssistantMessage("leaf done", nil))
+	t.Cleanup(func() {
+		close(leafModel.unblockCh)
+	})
+	leafAgent, err := NewChatModelAgent(ctx, &ChatModelAgentConfig{
+		Name:        "LeafAgent",
+		Description: "leaf agent that blocks",
+		Instruction: "you are a leaf agent",
+		Model:       leafModel,
+	})
+	require.NoError(t, err)
+
+	middleModelCallCount := int32(0)
+	middleModel := &countingChatModel{
+		callCount: &middleModelCallCount,
+		responses: []*schema.Message{
+			toolCallMsg(toolCall("middle-leaf", "LeafAgent", `{"request":"leaf work"}`)),
+			schema.AssistantMessage("middle done", nil),
+		},
+	}
+	middleAgent, err := NewChatModelAgent(ctx, &ChatModelAgentConfig{
+		Name:        "MiddleAgent",
+		Description: "middle agent with an agent tool",
+		Instruction: "you are a middle agent",
+		Model:       middleModel,
+		ToolsConfig: ToolsConfig{
+			ToolsNodeConfig: compose.ToolsNodeConfig{
+				Tools: []tool.BaseTool{NewAgentTool(ctx, leafAgent)},
+			},
+		},
+	})
+	require.NoError(t, err)
+
+	outerModelCallCount := int32(0)
+	outerModel := &countingChatModel{
+		callCount: &outerModelCallCount,
+		responses: []*schema.Message{
+			toolCallMsg(toolCall("outer-middle", "MiddleAgent", `{"request":"middle work"}`)),
+			schema.AssistantMessage("outer done", nil),
+		},
+	}
+	outerAgent, err := NewChatModelAgent(ctx, &ChatModelAgentConfig{
+		Name:        "OuterAgent",
+		Description: "outer agent with recursive agent tool nesting",
+		Instruction: "you are an outer agent",
+		Model:       outerModel,
+		ToolsConfig: ToolsConfig{
+			ToolsNodeConfig: compose.ToolsNodeConfig{
+				Tools: []tool.BaseTool{NewAgentTool(ctx, middleAgent)},
+			},
+		},
+	})
+	require.NoError(t, err)
+
+	store := newCancelTestStore()
+	checkpointID := "cancel-recursive-agent-tool-resume"
+	runner1 := NewRunner(ctx, RunnerConfig{Agent: outerAgent, CheckPointStore: store})
+
+	cancelOpt, cancelFn := WithCancel()
+	iter := runner1.Run(ctx, []Message{schema.UserMessage("go")}, cancelOpt, WithCheckPointID(checkpointID))
+
+	select {
+	case <-leafModel.started:
+	case <-time.After(5 * time.Second):
+		t.Fatal("leaf model did not start")
+	}
+
+	handle, _ := cancelFn(WithRecursive())
+	require.NoError(t, handle.Wait())
+	_, hasCancelError := drainEvents(iter)
+	assert.True(t, hasCancelError, "expected CancelError from recursive nested agent tool")
+
+	firstModelCall := make(chan string, 8)
+	resumeLeafModelCallCount := int32(0)
+	resumeLeafModel := &countingChatModel{
+		callCount: &resumeLeafModelCallCount,
+		callCh:    firstModelCall,
+		callLabel: "leaf",
+		responses: []*schema.Message{schema.AssistantMessage("leaf done after resume", nil)},
+	}
+	resumeLeafAgent, err := NewChatModelAgent(ctx, &ChatModelAgentConfig{
+		Name:        "LeafAgent",
+		Description: "leaf agent that returns on resume",
+		Instruction: "you are a leaf agent",
+		Model:       resumeLeafModel,
+	})
+	require.NoError(t, err)
+
+	resumeMiddleModelCallCount := int32(0)
+	resumeMiddleModel := &countingChatModel{
+		callCount: &resumeMiddleModelCallCount,
+		callCh:    firstModelCall,
+		callLabel: "middle",
+		responses: []*schema.Message{schema.AssistantMessage("middle done after resume", nil)},
+	}
+	resumeMiddleAgent, err := NewChatModelAgent(ctx, &ChatModelAgentConfig{
+		Name:        "MiddleAgent",
+		Description: "middle agent with an agent tool",
+		Instruction: "you are a middle agent",
+		Model:       resumeMiddleModel,
+		ToolsConfig: ToolsConfig{
+			ToolsNodeConfig: compose.ToolsNodeConfig{
+				Tools: []tool.BaseTool{NewAgentTool(ctx, resumeLeafAgent)},
+			},
+		},
+	})
+	require.NoError(t, err)
+
+	resumeOuterModelCallCount := int32(0)
+	resumeOuterModel := &countingChatModel{
+		callCount: &resumeOuterModelCallCount,
+		callCh:    firstModelCall,
+		callLabel: "outer",
+		responses: []*schema.Message{schema.AssistantMessage("outer done after resume", nil)},
+	}
+	resumeOuterAgent, err := NewChatModelAgent(ctx, &ChatModelAgentConfig{
+		Name:        "OuterAgent",
+		Description: "outer agent with recursive agent tool nesting",
+		Instruction: "you are an outer agent",
+		Model:       resumeOuterModel,
+		ToolsConfig: ToolsConfig{
+			ToolsNodeConfig: compose.ToolsNodeConfig{
+				Tools: []tool.BaseTool{NewAgentTool(ctx, resumeMiddleAgent)},
+			},
+		},
+	})
+	require.NoError(t, err)
+
+	runner2 := NewRunner(ctx, RunnerConfig{Agent: resumeOuterAgent, CheckPointStore: store})
+	resumeIter, err := runner2.Resume(ctx, checkpointID)
+	require.NoError(t, err)
+
+	select {
+	case first := <-firstModelCall:
+		assert.Equal(t, "leaf", first, "recursive AgentTool nesting should resume the deepest internal agent first")
+	case <-time.After(5 * time.Second):
+		t.Fatal("no model call observed during resume")
+	}
+
+	resumeEvents, hasResumeCancelError := drainEvents(resumeIter)
+	require.False(t, hasResumeCancelError, "resume should complete without another CancelError")
+	assert.NotEmpty(t, resumeEvents)
+	assert.Equal(t, int32(1), atomic.LoadInt32(&resumeLeafModelCallCount))
+	assert.Equal(t, int32(1), atomic.LoadInt32(&resumeMiddleModelCallCount))
+	assert.Equal(t, int32(1), atomic.LoadInt32(&resumeOuterModelCallCount))
+}
+
+func TestWithCancel_CancelImmediate_ConcurrentAgentTools_ResumeWithoutRestart(t *testing.T) {
+	ctx := context.Background()
+
+	innerAModel := newBlockingChatModel(schema.AssistantMessage("inner A done", nil))
+	innerBModel := newBlockingChatModel(schema.AssistantMessage("inner B done", nil))
+	t.Cleanup(func() {
+		close(innerAModel.unblockCh)
+		close(innerBModel.unblockCh)
+	})
+
+	innerAAgent, err := NewChatModelAgent(ctx, &ChatModelAgentConfig{
+		Name:        "InnerAgentA",
+		Description: "inner agent A",
+		Instruction: "you are inner agent A",
+		Model:       innerAModel,
+	})
+	require.NoError(t, err)
+	innerBAgent, err := NewChatModelAgent(ctx, &ChatModelAgentConfig{
+		Name:        "InnerAgentB",
+		Description: "inner agent B",
+		Instruction: "you are inner agent B",
+		Model:       innerBModel,
+	})
+	require.NoError(t, err)
+
+	outerModelCallCount := int32(0)
+	outerModel := &countingChatModel{
+		callCount: &outerModelCallCount,
+		responses: []*schema.Message{
+			toolCallMsg(
+				toolCall("outer-a", "InnerAgentA", `{"request":"work A"}`),
+				toolCall("outer-b", "InnerAgentB", `{"request":"work B"}`),
+			),
+			schema.AssistantMessage("outer done", nil),
+		},
+	}
+	outerAgent, err := NewChatModelAgent(ctx, &ChatModelAgentConfig{
+		Name:        "OuterAgent",
+		Description: "outer agent with concurrent agent tools",
+		Instruction: "you are an outer agent",
+		Model:       outerModel,
+		ToolsConfig: ToolsConfig{
+			ToolsNodeConfig: compose.ToolsNodeConfig{
+				Tools: []tool.BaseTool{
+					NewAgentTool(ctx, innerAAgent),
+					NewAgentTool(ctx, innerBAgent),
+				},
+			},
+		},
+	})
+	require.NoError(t, err)
+
+	store := newCancelTestStore()
+	checkpointID := "cancel-concurrent-agent-tools-resume"
+	runner1 := NewRunner(ctx, RunnerConfig{Agent: outerAgent, CheckPointStore: store})
+
+	cancelOpt, cancelFn := WithCancel()
+	iter := runner1.Run(ctx, []Message{schema.UserMessage("go")}, cancelOpt, WithCheckPointID(checkpointID))
+
+	for _, started := range []chan struct{}{innerAModel.started, innerBModel.started} {
+		select {
+		case <-started:
+		case <-time.After(5 * time.Second):
+			t.Fatal("both concurrent inner models should start before cancel")
+		}
+	}
+
+	handle, _ := cancelFn(WithRecursive())
+	require.NoError(t, handle.Wait())
+	_, hasCancelError := drainEvents(iter)
+	assert.True(t, hasCancelError, "expected CancelError from concurrent agent tools")
+
+	firstModelCall := make(chan string, 8)
+	resumeInnerAModelCallCount := int32(0)
+	resumeInnerAModel := &countingChatModel{
+		callCount: &resumeInnerAModelCallCount,
+		callCh:    firstModelCall,
+		callLabel: "innerA",
+		responses: []*schema.Message{schema.AssistantMessage("inner A done after resume", nil)},
+	}
+	resumeInnerBModelCallCount := int32(0)
+	resumeInnerBModel := &countingChatModel{
+		callCount: &resumeInnerBModelCallCount,
+		callCh:    firstModelCall,
+		callLabel: "innerB",
+		responses: []*schema.Message{schema.AssistantMessage("inner B done after resume", nil)},
+	}
+
+	resumeInnerAAgent, err := NewChatModelAgent(ctx, &ChatModelAgentConfig{
+		Name:        "InnerAgentA",
+		Description: "inner agent A",
+		Instruction: "you are inner agent A",
+		Model:       resumeInnerAModel,
+	})
+	require.NoError(t, err)
+	resumeInnerBAgent, err := NewChatModelAgent(ctx, &ChatModelAgentConfig{
+		Name:        "InnerAgentB",
+		Description: "inner agent B",
+		Instruction: "you are inner agent B",
+		Model:       resumeInnerBModel,
+	})
+	require.NoError(t, err)
+
+	resumeOuterModelCallCount := int32(0)
+	resumeOuterModel := &countingChatModel{
+		callCount: &resumeOuterModelCallCount,
+		callCh:    firstModelCall,
+		callLabel: "outer",
+		responses: []*schema.Message{schema.AssistantMessage("outer done after resume", nil)},
+	}
+	resumeOuterAgent, err := NewChatModelAgent(ctx, &ChatModelAgentConfig{
+		Name:        "OuterAgent",
+		Description: "outer agent with concurrent agent tools",
+		Instruction: "you are an outer agent",
+		Model:       resumeOuterModel,
+		ToolsConfig: ToolsConfig{
+			ToolsNodeConfig: compose.ToolsNodeConfig{
+				Tools: []tool.BaseTool{
+					NewAgentTool(ctx, resumeInnerAAgent),
+					NewAgentTool(ctx, resumeInnerBAgent),
+				},
+			},
+		},
+	})
+	require.NoError(t, err)
+
+	runner2 := NewRunner(ctx, RunnerConfig{Agent: resumeOuterAgent, CheckPointStore: store})
+	resumeIter, err := runner2.Resume(ctx, checkpointID)
+	require.NoError(t, err)
+
+	select {
+	case first := <-firstModelCall:
+		assert.Contains(t, []string{"innerA", "innerB"}, first,
+			"concurrent AgentTools should resume an internal agent before the outer model")
+	case <-time.After(5 * time.Second):
+		t.Fatal("no model call observed during resume")
+	}
+
+	resumeEvents, hasResumeCancelError := drainEvents(resumeIter)
+	require.False(t, hasResumeCancelError, "resume should complete without another CancelError")
+	assert.NotEmpty(t, resumeEvents)
+	assert.Equal(t, int32(1), atomic.LoadInt32(&resumeInnerAModelCallCount))
+	assert.Equal(t, int32(1), atomic.LoadInt32(&resumeInnerBModelCallCount))
+	assert.Equal(t, int32(1), atomic.LoadInt32(&resumeOuterModelCallCount))
+}
+
 // countingChatModel is a chat model that counts calls and records inputs.
 // It returns responses from a fixed slice, indexed by call count.
 type countingChatModel struct {

--- a/adk/cancel_edge_test.go
+++ b/adk/cancel_edge_test.go
@@ -19,6 +19,7 @@ package adk
 import (
 	"context"
 	"errors"
+	"fmt"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -1447,4 +1448,299 @@ func TestWithCancel_CancelImmediate_StreamableToolAborted(t *testing.T) {
 	r := <-resultCh
 	assert.True(t, r.foundStreamCanceled, "expected ErrStreamCanceled on tool's MessageStream.Recv()")
 	assert.True(t, r.foundCancelError, "expected CancelError in event stream")
+}
+
+// TestWithCancel_CancelImmediate_NestedAgentTool_ResumeFromToolsNode verifies that
+// when a nested ChatModelAgent (wrapped as an AgentTool inside an outer ChatModelAgent)
+// is canceled via CancelImmediate and then resumed with Runner.Resume (no params),
+// the outer agent resumes from the ToolsNode rather than restarting from the beginning.
+//
+// Regression test: previously, the outer ChatModelAgent would restart from its Init/ChatModel
+// node instead of resuming from the ToolsNode, causing the outer model to be called again
+// with the original user message before the AgentTool and inner ChatModelAgent were resumed.
+func TestWithCancel_CancelImmediate_NestedAgentTool_ResumeFromToolsNode(t *testing.T) {
+	for _, tc := range []struct {
+		name            string
+		enableStreaming bool
+		innerHasTools   bool
+		recursive       bool
+	}{
+		{"Invoke_InnerNoTools_NonRecursive", false, false, false},
+		{"Stream_InnerNoTools_NonRecursive", true, false, false},
+		{"Invoke_InnerWithTools_NonRecursive", false, true, false},
+		{"Stream_InnerWithTools_NonRecursive", true, true, false},
+		{"Invoke_InnerNoTools_Recursive", false, false, true},
+		{"Stream_InnerNoTools_Recursive", true, false, true},
+		{"Invoke_InnerWithTools_Recursive", false, true, true},
+		{"Stream_InnerWithTools_Recursive", true, true, true},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			ctx := context.Background()
+
+			// --- inner agent: its model blocks so we can cancel mid-execution ---
+			var innerTools []tool.BaseTool
+			var innerModelResp *schema.Message
+			if tc.innerHasTools {
+				innerModelResp = toolCallMsg(toolCall("ic1", "inner_tool", `{"input":"x"}`))
+				innerTools = []tool.BaseTool{newBlockingTool("inner_tool")}
+			} else {
+				innerModelResp = &schema.Message{Role: schema.Assistant, Content: "inner agent done"}
+			}
+			innerModel := newBlockingChatModel(innerModelResp)
+			t.Cleanup(func() {
+				close(innerModel.unblockCh)
+			})
+
+			innerCfg := &ChatModelAgentConfig{
+				Name:        "InnerAgent",
+				Description: "inner agent that blocks",
+				Instruction: "you are an inner agent",
+				Model:       innerModel,
+			}
+			if len(innerTools) > 0 {
+				innerCfg.ToolsConfig = ToolsConfig{
+					ToolsNodeConfig: compose.ToolsNodeConfig{Tools: innerTools},
+				}
+			}
+			innerAgent, err := NewChatModelAgent(ctx, innerCfg)
+			require.NoError(t, err)
+
+			// --- outer agent: counting model ---
+			// Call 1: returns a tool call that invokes InnerAgent.
+			// Call 2 (only needed on resume): returns a plain final answer.
+			outerModelCallCount := int32(0)
+			outerModel := &countingChatModel{
+				callCount: &outerModelCallCount,
+				responses: []*schema.Message{
+					toolCallMsg(toolCall("c1", "InnerAgent", `{"request":"do something"}`)),
+					schema.AssistantMessage("outer completed", nil),
+				},
+			}
+
+			outerAgent, err := NewChatModelAgent(ctx, &ChatModelAgentConfig{
+				Name:        "OuterAgent",
+				Description: "outer agent with nested agent tool",
+				Instruction: "you are an outer agent",
+				Model:       outerModel,
+				ToolsConfig: ToolsConfig{
+					ToolsNodeConfig: compose.ToolsNodeConfig{
+						Tools: []tool.BaseTool{NewAgentTool(ctx, innerAgent)},
+					},
+				},
+			})
+			require.NoError(t, err)
+
+			store := newCancelTestStore()
+			checkpointID := "cancel-nested-resume-" + tc.name
+
+			runner1 := NewRunner(ctx, RunnerConfig{
+				Agent:           outerAgent,
+				EnableStreaming: tc.enableStreaming,
+				CheckPointStore: store,
+			})
+
+			// --- phase 1: run and cancel while inner agent model is blocked ---
+			cancelOpt, cancelFn := WithCancel()
+			iter := runner1.Run(ctx, []Message{schema.UserMessage("go")}, cancelOpt, WithCheckPointID(checkpointID))
+
+			// Wait for inner model to start (meaning outer model already returned tool call).
+			select {
+			case <-innerModel.started:
+			case <-time.After(5 * time.Second):
+				t.Fatal("inner model did not start")
+			}
+
+			// At this point outerModel should have been called exactly once.
+			assert.Equal(t, int32(1), atomic.LoadInt32(&outerModelCallCount),
+				"outer model should have been called once before cancel")
+
+			// Cancel immediately. Recursive cases additionally propagate the cancel
+			// request into the AgentTool's internal ChatModelAgent.
+			var handle *CancelHandle
+			if tc.recursive {
+				handle, _ = cancelFn(WithRecursive())
+			} else {
+				handle, _ = cancelFn()
+			}
+			cancelErr := handle.Wait()
+			assert.NoError(t, cancelErr)
+
+			_, hasCancelError := drainEvents(iter)
+			assert.True(t, hasCancelError, "expected CancelError from canceled nested agent tool")
+
+			// --- phase 2: resume with Runner.Resume (no ResumeWithParams, no interrupt ID) ---
+			// Build fresh agents for resume. The first model call after Resume should be
+			// the inner ChatModelAgent inside AgentTool, not the top-level ChatModelAgent.
+			resumeFirstModelCall := make(chan string, 5)
+			resumeOuterModelCallCount := int32(0)
+			resumeOuterModel := &countingChatModel{
+				callCount: &resumeOuterModelCallCount,
+				callCh:    resumeFirstModelCall,
+				callLabel: "outer",
+				responses: []*schema.Message{
+					schema.AssistantMessage("outer completed after resume", nil),
+				},
+			}
+
+			resumeInnerModelCallCount := int32(0)
+			resumeInnerResponses := []*schema.Message{schema.AssistantMessage("inner agent done after resume", nil)}
+			if len(innerTools) > 0 {
+				resumeInnerResponses = []*schema.Message{
+					toolCallMsg(toolCall("ic1", "inner_tool", `{"input":"x"}`)),
+					schema.AssistantMessage("inner agent done after resume", nil),
+				}
+			}
+			resumeInnerModel := &countingChatModel{
+				callCount: &resumeInnerModelCallCount,
+				callCh:    resumeFirstModelCall,
+				callLabel: "inner",
+				responses: resumeInnerResponses,
+			}
+			resumeInnerCfg := &ChatModelAgentConfig{
+				Name:        "InnerAgent",
+				Description: "inner agent that returns immediately on resume",
+				Instruction: "you are an inner agent",
+				Model:       resumeInnerModel,
+			}
+			if len(innerTools) > 0 {
+				resumeInnerCfg.ToolsConfig = ToolsConfig{
+					ToolsNodeConfig: compose.ToolsNodeConfig{
+						Tools: []tool.BaseTool{newSlowTool("inner_tool", 0, "inner tool result")},
+					},
+				}
+			}
+			resumeInnerAgent, err := NewChatModelAgent(ctx, resumeInnerCfg)
+			require.NoError(t, err)
+
+			resumeOuterAgent, err := NewChatModelAgent(ctx, &ChatModelAgentConfig{
+				Name:        "OuterAgent",
+				Description: "outer agent with nested agent tool",
+				Instruction: "you are an outer agent",
+				Model:       resumeOuterModel,
+				ToolsConfig: ToolsConfig{
+					ToolsNodeConfig: compose.ToolsNodeConfig{
+						Tools: []tool.BaseTool{NewAgentTool(ctx, resumeInnerAgent)},
+					},
+				},
+			})
+			require.NoError(t, err)
+
+			runner2 := NewRunner(ctx, RunnerConfig{
+				Agent:           resumeOuterAgent,
+				EnableStreaming: tc.enableStreaming,
+				CheckPointStore: store,
+			})
+
+			resumeIter, err := runner2.Resume(ctx, checkpointID)
+			require.NoError(t, err)
+
+			select {
+			case firstModel := <-resumeFirstModelCall:
+				expectedFirstModel := "outer"
+				if tc.recursive {
+					expectedFirstModel = "inner"
+				}
+				assert.Equal(t, expectedFirstModel, firstModel,
+					"recursive cancel should resume the AgentTool/internal ChatModelAgent first; "+
+						"non-recursive cancel only guarantees root-agent cancellation")
+			case <-time.After(5 * time.Second):
+				t.Fatal("no model call observed during resume")
+			}
+
+			var resumeEvents []*AgentEvent
+			for {
+				event, ok := resumeIter.Next()
+				if !ok {
+					break
+				}
+				if event.Err != nil {
+					t.Fatalf("unexpected error during resume: %v", event.Err)
+				}
+				resumeEvents = append(resumeEvents, event)
+			}
+
+			// The outer model should have been called exactly once during resume
+			// (to produce the final answer after receiving tool results).
+			// If it was called with the original user message (restarting from scratch),
+			// the counting model would either exceed its response list or the call count
+			// would be wrong.
+			assert.Equal(t, int32(1), atomic.LoadInt32(&resumeOuterModelCallCount),
+				"outer model should be called exactly once during resume (for final answer after tool results), "+
+					"not restarted from the beginning")
+
+			// Verify we got the completion output.
+			var gotOutput bool
+			for _, event := range resumeEvents {
+				content, err := messageOutputContent(event)
+				require.NoError(t, err)
+				if content == "outer completed after resume" {
+					gotOutput = true
+				}
+			}
+			assert.True(t, gotOutput, "should get final output from resumed outer agent")
+		})
+	}
+}
+
+// countingChatModel is a chat model that counts calls and records inputs.
+// It returns responses from a fixed slice, indexed by call count.
+type countingChatModel struct {
+	callCount *int32
+	inputsCh  chan []*schema.Message // optional: receives a copy of each input
+	callCh    chan string            // optional: receives callLabel when Generate is called
+	callLabel string
+	responses []*schema.Message
+}
+
+func (m *countingChatModel) Generate(_ context.Context, input []*schema.Message, _ ...model.Option) (*schema.Message, error) {
+	idx := int(atomic.AddInt32(m.callCount, 1)) - 1
+	if m.callCh != nil {
+		select {
+		case m.callCh <- m.callLabel:
+		default:
+		}
+	}
+	if m.inputsCh != nil {
+		cp := make([]*schema.Message, len(input))
+		copy(cp, input)
+		select {
+		case m.inputsCh <- cp:
+		default:
+		}
+	}
+	if idx >= len(m.responses) {
+		return nil, fmt.Errorf("countingChatModel: call %d exceeds %d responses (outer model was called too many times - possible restart from beginning)", idx+1, len(m.responses))
+	}
+	return m.responses[idx], nil
+}
+
+func (m *countingChatModel) Stream(_ context.Context, input []*schema.Message, opts ...model.Option) (*schema.StreamReader[*schema.Message], error) {
+	msg, err := m.Generate(context.Background(), input, opts...)
+	if err != nil {
+		return nil, err
+	}
+	return schema.StreamReaderFromArray([]*schema.Message{msg}), nil
+}
+
+func (m *countingChatModel) BindTools(_ []*schema.ToolInfo) error { return nil }
+
+func messageOutputContent(event *AgentEvent) (string, error) {
+	if event.Output == nil || event.Output.MessageOutput == nil {
+		return "", nil
+	}
+	mo := event.Output.MessageOutput
+	if mo.IsStreaming {
+		msg, err := schema.ConcatMessageStream(mo.MessageStream)
+		if err != nil {
+			return "", err
+		}
+		if msg == nil {
+			return "", nil
+		}
+		return msg.Content, nil
+	}
+	if mo.Message == nil {
+		return "", nil
+	}
+	return mo.Message.Content, nil
 }

--- a/adk/cancel_edge_test.go
+++ b/adk/cancel_edge_test.go
@@ -258,6 +258,41 @@ func TestWithCancel_AfterCompletion(t *testing.T) {
 	assert.ErrorIs(t, cancelErr, ErrExecutionEnded)
 }
 
+// TestWithCancel_DerivedAgentToolCancelContextMarkedDoneAfterRun verifies that
+// an explicitly derived AgentTool child cancel context is owned by the child run,
+// even when the Go context also carries the parent cancel context.
+func TestWithCancel_DerivedAgentToolCancelContextMarkedDoneAfterRun(t *testing.T) {
+	ctx := context.Background()
+
+	agent, err := NewChatModelAgent(ctx, &ChatModelAgentConfig{
+		Name:        "ChildAgent",
+		Description: "test child agent",
+		Model:       &plainResponseModel{text: "done"},
+	})
+	require.NoError(t, err)
+
+	parent := newCancelContext()
+	parentCtx := withCancelContext(ctx, parent)
+	child := parent.deriveAgentToolCancelContext(parentCtx)
+
+	childOpt := WrapImplSpecificOptFn(func(o *options) {
+		o.cancelCtx = child
+	})
+	iter := agent.Run(parentCtx, &AgentInput{Messages: []Message{schema.UserMessage("hi")}}, childOpt)
+	for {
+		_, ok := iter.Next()
+		if !ok {
+			break
+		}
+	}
+
+	select {
+	case <-child.doneChan:
+	case <-time.After(time.Second):
+		t.Fatal("derived AgentTool cancel context was not marked done after child run completion")
+	}
+}
+
 // TestWithCancel_AfterBusinessInterrupt verifies cancelFn returns ErrExecutionEnded
 // when called after the agent has been interrupted by business logic.
 func TestWithCancel_AfterBusinessInterrupt(t *testing.T) {

--- a/adk/cancel_recursive_test.go
+++ b/adk/cancel_recursive_test.go
@@ -388,7 +388,7 @@ func TestDeriveChild_Race(t *testing.T) {
 	})
 }
 
-func TestGracePeriod_OnlyWhenRecursive(t *testing.T) {
+func TestGracePeriod_OnlyWhenRecursiveWithAgentToolDescendant(t *testing.T) {
 	parent, _, _ := setupParentChild(t)
 
 	var nonRecursiveOptCount int
@@ -404,6 +404,10 @@ func TestGracePeriod_OnlyWhenRecursive(t *testing.T) {
 	wrappedRecursive := parent.wrapGraphInterruptWithGracePeriod(func(opts ...compose.GraphInterruptOption) {
 		recursiveOptCount = len(opts)
 	})
+	wrappedRecursive()
+	assert.Equal(t, 0, recursiveOptCount)
+
+	parent.markAgentToolDescendant()
 	wrappedRecursive()
 	assert.Equal(t, 1, recursiveOptCount)
 }

--- a/adk/cancel_recursive_test.go
+++ b/adk/cancel_recursive_test.go
@@ -24,8 +24,6 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/assert"
-
-	"github.com/cloudwego/eino/compose"
 )
 
 func assertNotClosedWithin(t *testing.T, ch <-chan struct{}, d time.Duration) {
@@ -40,7 +38,7 @@ func assertNotClosedWithin(t *testing.T, ch <-chan struct{}, d time.Duration) {
 func setupParentChild(t *testing.T) (parent, child *cancelContext, cleanup func()) {
 	parent = newCancelContext()
 	ctx, cancel := context.WithCancel(context.Background())
-	child = parent.deriveChild(ctx)
+	child = parent.deriveAgentToolCancelContext(ctx)
 	cleanup = func() {
 		child.markDone()
 		cancel()
@@ -49,7 +47,7 @@ func setupParentChild(t *testing.T) (parent, child *cancelContext, cleanup func(
 	return parent, child, cleanup
 }
 
-func TestDeriveChild(t *testing.T) {
+func TestDeriveAgentToolCancelContext(t *testing.T) {
 	t.Run("Shallow", func(t *testing.T) {
 		t.Run("DoesNotPropagateSafePoint", func(t *testing.T) {
 			parent, child, _ := setupParentChild(t)
@@ -71,8 +69,8 @@ func TestDeriveChild(t *testing.T) {
 			a := newCancelContext()
 			ctx, cancel := context.WithCancel(context.Background())
 
-			b := a.deriveChild(ctx)
-			c := b.deriveChild(ctx)
+			b := a.deriveAgentToolCancelContext(ctx)
+			c := b.deriveAgentToolCancelContext(ctx)
 			t.Cleanup(func() {
 				c.markDone()
 				b.markDone()
@@ -93,7 +91,7 @@ func TestDeriveChild(t *testing.T) {
 			parent := newCancelContext()
 			ctx, cancel := context.WithCancel(context.Background())
 
-			child := parent.deriveChild(ctx)
+			child := parent.deriveAgentToolCancelContext(ctx)
 
 			parent.triggerCancel(CancelAfterChatModel)
 			time.Sleep(100 * time.Millisecond)
@@ -143,8 +141,8 @@ func TestDeriveChild(t *testing.T) {
 			a := newCancelContext()
 			ctx, cancel := context.WithCancel(context.Background())
 
-			b := a.deriveChild(ctx)
-			c := b.deriveChild(ctx)
+			b := a.deriveAgentToolCancelContext(ctx)
+			c := b.deriveAgentToolCancelContext(ctx)
 			t.Cleanup(func() {
 				c.markDone()
 				b.markDone()
@@ -192,7 +190,7 @@ func TestDeriveChild(t *testing.T) {
 			parent.setRecursive(true)
 			parent.triggerCancel(CancelAfterChatModel)
 
-			child := parent.deriveChild(ctx)
+			child := parent.deriveAgentToolCancelContext(ctx)
 			t.Cleanup(func() {
 				child.markDone()
 				cancel()
@@ -244,13 +242,13 @@ func TestDeriveChild(t *testing.T) {
 	})
 }
 
-func TestDeriveChild_Race(t *testing.T) {
+func TestDeriveAgentToolCancelContext_Race(t *testing.T) {
 	t.Run("SetRecursiveConcurrentWithCancelChan", func(t *testing.T) {
 		for i := 0; i < 100; i++ {
 			parent := newCancelContext()
 			ctx, cancel := context.WithCancel(context.Background())
 
-			child := parent.deriveChild(ctx)
+			child := parent.deriveAgentToolCancelContext(ctx)
 
 			var wg sync.WaitGroup
 			wg.Add(2)
@@ -284,7 +282,7 @@ func TestDeriveChild_Race(t *testing.T) {
 		ctx, cancel := context.WithCancel(context.Background())
 		defer cancel()
 
-		child := parent.deriveChild(ctx)
+		child := parent.deriveAgentToolCancelContext(ctx)
 
 		parent.triggerCancel(CancelAfterChatModel)
 		time.Sleep(50 * time.Millisecond)
@@ -302,8 +300,8 @@ func TestDeriveChild_Race(t *testing.T) {
 		ctx, cancel := context.WithCancel(context.Background())
 		defer cancel()
 
-		child1 := parent.deriveChild(ctx)
-		child2 := parent.deriveChild(ctx)
+		child1 := parent.deriveAgentToolCancelContext(ctx)
+		child2 := parent.deriveAgentToolCancelContext(ctx)
 
 		parent.triggerCancel(CancelAfterChatModel)
 		time.Sleep(50 * time.Millisecond)
@@ -332,7 +330,7 @@ func TestDeriveChild_Race(t *testing.T) {
 			parent := newCancelContext()
 			ctx, cancel := context.WithCancel(context.Background())
 
-			child := parent.deriveChild(ctx)
+			child := parent.deriveAgentToolCancelContext(ctx)
 
 			parent.triggerCancel(CancelAfterChatModel)
 
@@ -386,28 +384,4 @@ func TestDeriveChild_Race(t *testing.T) {
 
 		assert.True(t, parent.isRecursive())
 	})
-}
-
-func TestGracePeriod_OnlyWhenRecursiveWithAgentToolDescendant(t *testing.T) {
-	parent, _, _ := setupParentChild(t)
-
-	var nonRecursiveOptCount int
-	wrappedNonRecursive := parent.wrapGraphInterruptWithGracePeriod(func(opts ...compose.GraphInterruptOption) {
-		nonRecursiveOptCount = len(opts)
-	})
-	wrappedNonRecursive()
-	assert.Equal(t, 0, nonRecursiveOptCount)
-
-	parent.setRecursive(true)
-
-	var recursiveOptCount int
-	wrappedRecursive := parent.wrapGraphInterruptWithGracePeriod(func(opts ...compose.GraphInterruptOption) {
-		recursiveOptCount = len(opts)
-	})
-	wrappedRecursive()
-	assert.Equal(t, 0, recursiveOptCount)
-
-	parent.markAgentToolDescendant()
-	wrappedRecursive()
-	assert.Equal(t, 1, recursiveOptCount)
 }

--- a/adk/cancel_test.go
+++ b/adk/cancel_test.go
@@ -3170,54 +3170,8 @@ func TestCancelAfterToolCalls_LoopTransitionBoundary(t *testing.T) {
 	assert.Equal(t, CancelAfterToolCalls, cancelErr.Info.Mode)
 }
 
-func TestCancelContext_ActiveChildren_Tracking(t *testing.T) {
-	t.Run("DeriveChild_IncrementsActiveChildren", func(t *testing.T) {
-		parent := newCancelContext()
-		assert.False(t, parent.hasActiveChildren())
-
-		ctx := context.Background()
-		child := parent.deriveChild(ctx)
-		assert.True(t, parent.hasActiveChildren())
-		assert.Equal(t, int32(1), atomic.LoadInt32(&parent.activeChildren))
-
-		child.markDone()
-		time.Sleep(10 * time.Millisecond)
-		assert.False(t, parent.hasActiveChildren())
-		assert.Equal(t, int32(0), atomic.LoadInt32(&parent.activeChildren))
-	})
-
-	t.Run("MultipleChildren_AllTracked", func(t *testing.T) {
-		parent := newCancelContext()
-		ctx := context.Background()
-
-		child1 := parent.deriveChild(ctx)
-		child2 := parent.deriveChild(ctx)
-		assert.Equal(t, int32(2), atomic.LoadInt32(&parent.activeChildren))
-
-		child1.markDone()
-		time.Sleep(10 * time.Millisecond)
-		assert.Equal(t, int32(1), atomic.LoadInt32(&parent.activeChildren))
-		assert.True(t, parent.hasActiveChildren())
-
-		child2.markDone()
-		time.Sleep(10 * time.Millisecond)
-		assert.False(t, parent.hasActiveChildren())
-	})
-
-	t.Run("MarkCancelHandled_AlsoDecrementsParent", func(t *testing.T) {
-		parent := newCancelContext()
-		ctx := context.Background()
-
-		child := parent.deriveChild(ctx)
-		assert.True(t, parent.hasActiveChildren())
-
-		child.triggerCancel(CancelImmediate)
-		child.markCancelHandled()
-		time.Sleep(10 * time.Millisecond)
-		assert.False(t, parent.hasActiveChildren())
-	})
-
-	t.Run("GracePeriodWrapper_AppliesWhenChildrenActive", func(t *testing.T) {
+func TestCancelContext_RecursiveGraceBoundary(t *testing.T) {
+	t.Run("GracePeriodWrapper_AppliesForRecursiveAgentToolDescendant", func(t *testing.T) {
 		parent := newCancelContext()
 		ctx := context.Background()
 
@@ -3232,23 +3186,36 @@ func TestCancelContext_ActiveChildren_Tracking(t *testing.T) {
 		wrapped()
 		assert.Empty(t, receivedOpts, "Should pass no extra options when no children")
 
-		_ = parent.deriveChild(ctx)
-
-		receivedOpts = nil
-		wrapped()
-		assert.Empty(t, receivedOpts, "Should pass no extra options when children are active but not recursive")
-
 		parent.setRecursive(true)
 
 		receivedOpts = nil
 		wrapped()
-		assert.Len(t, receivedOpts, 1, "Should add exactly one timeout option when children are active and recursive")
+		assert.Empty(t, receivedOpts, "Should pass no extra options when recursive but no AgentTool descendant exists")
+
+		child := parent.deriveChild(ctx)
+
+		receivedOpts = nil
+		wrapped()
+		assert.Empty(t, receivedOpts, "Should not add timeout for derived children alone")
+
+		child.markAgentToolDescendant()
+
+		receivedOpts = nil
+		wrapped()
+		assert.Len(t, receivedOpts, 1, "Should add exactly one timeout option when an AgentTool descendant exists")
+
+		child.markDone()
+		time.Sleep(10 * time.Millisecond)
+
+		receivedOpts = nil
+		wrapped()
+		assert.Len(t, receivedOpts, 1, "Should keep grace after the AgentTool descendant has detached")
 
 		receivedOpts = nil
 		callerOpt := compose.WithGraphInterruptTimeout(0)
 		wrapped(callerOpt)
 		assert.Len(t, receivedOpts, 2,
-			"Should append timeout option after caller-provided options when children are active and recursive")
+			"Should append timeout option after caller-provided options when AgentTool descendant exists")
 		// Note: verifying the exact timeout value (defaultCancelImmediateGracePeriod)
 		// requires access to unexported compose.graphInterruptOptions. The integration
 		// tests (TestCancelImmediate_AgentTool_PreservesChildCheckpoint) verify the

--- a/adk/cancel_test.go
+++ b/adk/cancel_test.go
@@ -435,7 +435,7 @@ func TestWithCancel_WithTools(t *testing.T) {
 		ctx, cancel := context.WithCancel(context.Background())
 		defer cancel()
 
-		child := cc.deriveChild(ctx)
+		child := cc.deriveAgentToolCancelContext(ctx)
 		assert.NotNil(t, child)
 
 		cc.setRecursive(true)
@@ -3171,55 +3171,24 @@ func TestCancelAfterToolCalls_LoopTransitionBoundary(t *testing.T) {
 }
 
 func TestCancelContext_RecursiveGraceBoundary(t *testing.T) {
-	t.Run("GracePeriodWrapper_AppliesForRecursiveAgentToolDescendant", func(t *testing.T) {
+	t.Run("AgentToolDescendantMarker_PropagatesToParents", func(t *testing.T) {
 		parent := newCancelContext()
 		ctx := context.Background()
+		child := parent.deriveAgentToolCancelContext(ctx)
+		grandchild := child.deriveAgentToolCancelContext(ctx)
+		t.Cleanup(func() {
+			grandchild.markDone()
+			child.markDone()
+		})
 
-		var receivedOpts []compose.GraphInterruptOption
-		mockInterrupt := func(opts ...compose.GraphInterruptOption) {
-			receivedOpts = opts
-		}
+		assert.False(t, parent.hasAgentToolDescendant())
+		assert.False(t, child.hasAgentToolDescendant())
 
-		wrapped := parent.wrapGraphInterruptWithGracePeriod(mockInterrupt)
+		grandchild.markAgentToolDescendant()
 
-		receivedOpts = nil
-		wrapped()
-		assert.Empty(t, receivedOpts, "Should pass no extra options when no children")
-
-		parent.setRecursive(true)
-
-		receivedOpts = nil
-		wrapped()
-		assert.Empty(t, receivedOpts, "Should pass no extra options when recursive but no AgentTool descendant exists")
-
-		child := parent.deriveChild(ctx)
-
-		receivedOpts = nil
-		wrapped()
-		assert.Empty(t, receivedOpts, "Should not add timeout for derived children alone")
-
-		child.markAgentToolDescendant()
-
-		receivedOpts = nil
-		wrapped()
-		assert.Len(t, receivedOpts, 1, "Should add exactly one timeout option when an AgentTool descendant exists")
-
-		child.markDone()
-		time.Sleep(10 * time.Millisecond)
-
-		receivedOpts = nil
-		wrapped()
-		assert.Len(t, receivedOpts, 1, "Should keep grace after the AgentTool descendant has detached")
-
-		receivedOpts = nil
-		callerOpt := compose.WithGraphInterruptTimeout(0)
-		wrapped(callerOpt)
-		assert.Len(t, receivedOpts, 2,
-			"Should append timeout option after caller-provided options when AgentTool descendant exists")
-		// Note: verifying the exact timeout value (defaultCancelImmediateGracePeriod)
-		// requires access to unexported compose.graphInterruptOptions. The integration
-		// tests (TestCancelImmediate_AgentTool_PreservesChildCheckpoint) verify the
-		// actual behavioral effect — child interrupts propagate within the grace period.
+		assert.True(t, grandchild.hasAgentToolDescendant())
+		assert.True(t, child.hasAgentToolDescendant())
+		assert.True(t, parent.hasAgentToolDescendant())
 	})
 }
 

--- a/adk/chatmodel.go
+++ b/adk/chatmodel.go
@@ -1024,7 +1024,7 @@ func (a *TypedChatModelAgent[M]) buildNoToolsRunFunc(_ context.Context) (typedRu
 		if cancelCtx != nil {
 			var interrupt func(...compose.GraphInterruptOption)
 			ctx, interrupt = compose.WithGraphInterrupt(ctx)
-			cancelCtx.setGraphInterruptFunc(cancelCtx.wrapGraphInterruptWithGracePeriod(interrupt))
+			cancelCtx.setGraphInterruptFunc(interrupt)
 		}
 
 		r, err := chain.Compile(ctx, compileOptions...)
@@ -1161,7 +1161,7 @@ func (a *TypedChatModelAgent[M]) buildMessageReActRunFunc(ctx context.Context, b
 		if cancelCtx != nil {
 			var interrupt func(...compose.GraphInterruptOption)
 			ctx, interrupt = compose.WithGraphInterrupt(ctx)
-			cancelCtx.setGraphInterruptFunc(cancelCtx.wrapGraphInterruptWithGracePeriod(interrupt))
+			cancelCtx.setGraphInterruptFunc(interrupt)
 		}
 
 		runnable, err_ := chain.Compile(ctx, compileOptions...)
@@ -1298,7 +1298,7 @@ func (a *TypedChatModelAgent[M]) buildAgenticReActRunFunc(ctx context.Context, b
 		if cancelCtx != nil {
 			var interrupt func(...compose.GraphInterruptOption)
 			ctx, interrupt = compose.WithGraphInterrupt(ctx)
-			cancelCtx.setGraphInterruptFunc(cancelCtx.wrapGraphInterruptWithGracePeriod(interrupt))
+			cancelCtx.setGraphInterruptFunc(interrupt)
 		}
 
 		runnable, err_ := chain.Compile(ctx, compileOptions...)

--- a/adk/chatmodel.go
+++ b/adk/chatmodel.go
@@ -481,6 +481,14 @@ type typedRunParams[M MessageType] struct {
 
 type typedRunFunc[M MessageType] func(ctx context.Context, p *typedRunParams[M])
 
+func resolveRunCancelContext(ctx context.Context, o *options) (*cancelContext, bool) {
+	inherited := getCancelContext(ctx)
+	if o.cancelCtx != nil {
+		return o.cancelCtx, o.cancelCtx != inherited
+	}
+	return inherited, false
+}
+
 // NewChatModelAgent creates a new ChatModelAgent with the given config.
 func NewChatModelAgent(ctx context.Context, config *ChatModelAgentConfig) (*ChatModelAgent, error) {
 	return NewTypedChatModelAgent[*schema.Message](ctx, config)
@@ -1441,11 +1449,7 @@ func (a *TypedChatModelAgent[M]) Run(ctx context.Context, input *TypedAgentInput
 	iterator, generator := NewAsyncIteratorPair[*TypedAgentEvent[M]]()
 
 	o := getCommonOptions(nil, opts...)
-	cancelCtx := o.cancelCtx
-	cancelCtxOwned := cancelCtx != nil && getCancelContext(ctx) == nil
-	if cancelCtx == nil {
-		cancelCtx = getCancelContext(ctx)
-	}
+	cancelCtx, cancelCtxOwned := resolveRunCancelContext(ctx, o)
 
 	ctx, run, bc, err := a.getRunFunc(ctx)
 	if err != nil {
@@ -1517,11 +1521,7 @@ func (a *TypedChatModelAgent[M]) Resume(ctx context.Context, info *ResumeInfo, o
 	iterator, generator := NewAsyncIteratorPair[*TypedAgentEvent[M]]()
 
 	o := getCommonOptions(nil, opts...)
-	cancelCtx := o.cancelCtx
-	cancelCtxOwned := cancelCtx != nil && getCancelContext(ctx) == nil
-	if cancelCtx == nil {
-		cancelCtx = getCancelContext(ctx)
-	}
+	cancelCtx, cancelCtxOwned := resolveRunCancelContext(ctx, o)
 
 	ctx, run, bc, err := a.getRunFunc(ctx)
 	if err != nil {

--- a/adk/turn_loop_test.go
+++ b/adk/turn_loop_test.go
@@ -4555,9 +4555,9 @@ func TestNewTurnLoop_NilPrepareAgent_Panics(t *testing.T) {
 	})
 }
 
-func TestDeriveChild_NilParent_ReturnsNil(t *testing.T) {
+func TestDeriveAgentToolCancelContext_NilParent_ReturnsNil(t *testing.T) {
 	var cc *cancelContext
-	assert.Nil(t, cc.deriveChild(context.Background()))
+	assert.Nil(t, cc.deriveAgentToolCancelContext(context.Background()))
 }
 
 func TestUntilIdleFor(t *testing.T) {
@@ -5394,7 +5394,7 @@ func TestAttack_SkipCheckpoint_Sticky(t *testing.T) {
 //
 // IMPORTANT: child.markDone() is NOT called by the probe. The test MUST
 // call it (e.g. via t.Cleanup) after verifying propagation to avoid a
-// race between markDone closing child.doneChan and the deriveChild
+// race between markDone closing child.doneChan and the deriveAgentToolCancelContext
 // goroutines propagating the cancel signal.
 type turnLoopNestedProbeAgent struct {
 	parentCCCh chan *cancelContext
@@ -5408,7 +5408,7 @@ func (a *turnLoopNestedProbeAgent) Run(ctx context.Context, _ *AgentInput, opts 
 	o := getCommonOptions(nil, opts...)
 	cc := o.cancelCtx
 
-	child := cc.deriveChild(ctx)
+	child := cc.deriveAgentToolCancelContext(ctx)
 	a.parentCCCh <- cc
 	a.childCCCh <- child
 


### PR DESCRIPTION
## Problem

Recursive `CancelImmediate` inside `AgentTool` could lose the nested interrupt boundary. `Runner.Resume` could restart the outer `ChatModelAgent` model instead of resuming `ToolsNode -> AgentTool -> internal ChatModelAgent`.

## Solution

Mark the `AgentTool` boundary when it runs under a cancel context. Recursive immediate cancellation applies the graph-interrupt grace window only when that boundary exists, so nested interrupts can bubble up without making root-only `WithImmediate()` wait.

## Key Insight

`activeChildren` is not the right signal because `AgentTool` can share the parent cancel context. The stable semantic boundary is `AgentTool` itself.

---

## 问题

`AgentTool` 内部发生递归 `CancelImmediate` 时，嵌套 interrupt 边界可能丢失。`Runner.Resume` 可能重新调用外层 `ChatModelAgent` model，而不是恢复 `ToolsNode -> AgentTool -> internal ChatModelAgent`。

## 解决方案

在 `AgentTool` 运行于 cancel context 下时标记该边界。递归 immediate cancel 只有在这个边界存在时才应用 graph-interrupt grace window，让嵌套 interrupt 能向上冒泡，同时保持 root-only `WithImmediate()` 的 immediate 语义。

## 关键洞察

`activeChildren` 不是正确信号，因为 `AgentTool` 可能共享 parent cancel context。稳定的语义边界是 `AgentTool` 本身。