### PR TITLE
fix(adk): fix preempt contaminating InterruptedItems on subsequent Stop

### DIFF
--- a/adk/turn_loop.go
+++ b/adk/turn_loop.go
@@ -388,14 +388,14 @@ type TurnLoopConfig[T any, M MessageType] struct {
 	//     never called and the loop proceeds via GenInput.
 	//
 	// It receives:
-	//   - inFlightItems: the items being processed when the prior run was interrupted / canceled
+	//   - interruptedItems: the items being processed when the prior run was interrupted / canceled
 	//   - unhandledItems: items buffered but not processed when the prior run exited
 	//   - newItems: items that were Push()-ed before Run() was called
 	//
 	// It returns a GenResumeResult describing how to resume the interrupted agent
 	// turn (optional ResumeParams) and how to manipulate the buffer
 	// (Consumed/Remaining) before continuing.
-	GenResume func(ctx context.Context, loop *TurnLoop[T, M], inFlightItems, unhandledItems, newItems []T) (*GenResumeResult[T, M], error)
+	GenResume func(ctx context.Context, loop *TurnLoop[T, M], interruptedItems, unhandledItems, newItems []T) (*GenResumeResult[T, M], error)
 
 	// PrepareAgent returns an Agent configured to handle the consumed items.
 	// This callback should set up the agent with appropriate system prompt,
@@ -427,7 +427,7 @@ type TurnLoopConfig[T any, M MessageType] struct {
 	// Store is the checkpoint store for persistence and resume. Optional.
 	// When set together with CheckpointID, enables automatic checkpoint-based resume.
 	// The TurnLoop always persists both runner checkpoint bytes and item bookkeeping
-	// (InFlightItems, UnhandledItems) via gob encoding, so T must be gob-encodable
+	// (InterruptedItems, UnhandledItems) via gob encoding, so T must be gob-encodable
 	// when Store is used.
 	Store CheckPointStore
 
@@ -501,7 +501,7 @@ type GenResumeResult[T any, M MessageType] struct {
 	// Remaining are the items to keep in the buffer for a future turn.
 	// TurnLoop pushes Remaining back into the buffer before resuming the agent.
 	//
-	// Items from (inFlightItems, unhandledItems, newItems) that are in neither Consumed
+	// Items from (interruptedItems, unhandledItems, newItems) that are in neither Consumed
 	// nor Remaining are dropped by the loop.
 	Remaining []T
 }
@@ -560,7 +560,7 @@ func (l *TurnLoop[T, M]) planTurn(
 	if l.config.GenResume == nil {
 		return nil, errors.New("GenResume is required for resume")
 	}
-	resumeResult, err := l.config.GenResume(ctx, l, pr.inFlight, pr.unhandled, pr.newItems)
+	resumeResult, err := l.config.GenResume(ctx, l, pr.interrupted, pr.unhandled, pr.newItems)
 	if err != nil {
 		return nil, err
 	}
@@ -620,11 +620,11 @@ type TurnLoopExitState[T any, M MessageType] struct {
 	// This is always valid regardless of ExitReason.
 	UnhandledItems []T
 
-	// InFlightItems contains the items whose turn was interrupted — either by
+	// InterruptedItems contains the items whose turn was interrupted — either by
 	// a cancel (Stop with cancel options → *CancelError) or by a business
 	// interrupt (AgentAction.Interrupted → *InterruptError).
-	// On resume, these are passed to GenResume's inFlightItems parameter.
-	InFlightItems []T
+	// On resume, these are passed to GenResume's interruptedItems parameter.
+	InterruptedItems []T
 
 	// StopCause is the business-supplied reason passed via WithStopCause.
 	// Empty if Stop was not called or no cause was provided.
@@ -729,7 +729,7 @@ type TurnLoop[T any, M MessageType] struct {
 
 	runErr error
 
-	inFlightItems []T
+	interruptedItems []T
 
 	checkPointRunnerBytes []byte
 	interruptContexts     []*InterruptCtx
@@ -835,7 +835,7 @@ func (l *TurnLoop[T, M]) tryLoadCheckpoint(ctx context.Context) error {
 			return fmt.Errorf("checkpoint[%s] has runner state but bytes are empty", checkPointID)
 		}
 		l.pendingResume = &turnLoopPendingResume[T]{
-			inFlight:    append([]T{}, cp.CanceledItems...),
+			interrupted: append([]T{}, cp.CanceledItems...),
 			unhandled:   append([]T{}, cp.UnhandledItems...),
 			newItems:    append([]T{}, newItems...),
 			resumeBytes: append([]byte{}, cp.RunnerCheckpoint...),
@@ -851,7 +851,7 @@ func (l *TurnLoop[T, M]) tryLoadCheckpoint(ctx context.Context) error {
 }
 
 type turnLoopPendingResume[T any] struct {
-	inFlight    []T
+	interrupted []T
 	unhandled   []T
 	newItems    []T
 	resumeBytes []byte
@@ -1416,8 +1416,8 @@ func (l *TurnLoop[T, M]) run(ctx context.Context) {
 			pr = l.pendingResume
 			l.pendingResume = nil
 
-			pushBack = make([]T, 0, len(pr.inFlight)+len(pr.unhandled)+len(pr.newItems))
-			pushBack = append(pushBack, pr.inFlight...)
+			pushBack = make([]T, 0, len(pr.interrupted)+len(pr.unhandled)+len(pr.newItems))
+			pushBack = append(pushBack, pr.interrupted...)
 			pushBack = append(pushBack, pr.unhandled...)
 			pushBack = append(pushBack, pr.newItems...)
 		} else {
@@ -1539,11 +1539,11 @@ func (l *TurnLoop[T, M]) run(ctx context.Context) {
 		l.preemptSig.endTurnAndUnhold()
 
 		if runErr != nil {
-			// Set inFlightItems when a cancel or interrupt was captured from the
+			// Set interruptedItems when a cancel or interrupt was captured from the
 			// event stream, regardless of what the user's callback returned. The items
 			// were factually mid-execution when the signal arrived.
 			if l.capturedCancelErr != nil || l.interruptContexts != nil {
-				l.inFlightItems = append([]T{}, plan.spec.consumed...)
+				l.interruptedItems = append([]T{}, plan.spec.consumed...)
 			}
 			l.runErr = runErr
 			return
@@ -1551,7 +1551,7 @@ func (l *TurnLoop[T, M]) run(ctx context.Context) {
 
 		// Business interrupt: agent produced an Interrupted action, exit to persist checkpoint.
 		if l.interruptContexts != nil {
-			l.inFlightItems = append([]T{}, plan.spec.consumed...)
+			l.interruptedItems = append([]T{}, plan.spec.consumed...)
 			l.runErr = &InterruptError{InterruptContexts: l.interruptContexts}
 			return
 		}
@@ -1837,7 +1837,7 @@ func (l *TurnLoop[T, M]) runAgentAndHandleEvents(
 //     caller (run loop) via l.interruptContexts, so return nil here.
 //
 // In all cases, the caller uses l.capturedCancelErr and l.interruptContexts to
-// determine inFlightItems independently of the returned error.
+// determine interruptedItems independently of the returned error.
 func (l *TurnLoop[T, M]) applyFrameworkCapturedError(handleErr error) error {
 	if handleErr != nil {
 		return handleErr
@@ -1853,7 +1853,7 @@ func (l *TurnLoop[T, M]) cleanup(ctx context.Context) {
 
 	unhandled := l.buffer.TakeAll()
 	checkpointID := l.config.CheckpointID
-	isIdle := len(l.checkPointRunnerBytes) == 0 && len(unhandled) == 0 && len(l.inFlightItems) == 0
+	isIdle := len(l.checkPointRunnerBytes) == 0 && len(unhandled) == 0 && len(l.interruptedItems) == 0
 
 	// Only save checkpoint when the loop exited due to an explicit Stop(),
 	// a CancelError, or a business interrupt (InterruptError).
@@ -1873,7 +1873,7 @@ func (l *TurnLoop[T, M]) cleanup(ctx context.Context) {
 			RunnerCheckpoint: l.checkPointRunnerBytes,
 			HasRunnerState:   len(l.checkPointRunnerBytes) > 0,
 			UnhandledItems:   unhandled,
-			CanceledItems:    l.inFlightItems,
+			CanceledItems:    l.interruptedItems,
 		}
 		checkpointed = true
 		checkpointErr = l.saveTurnLoopCheckpoint(ctx, checkpointID, cp)
@@ -1887,7 +1887,7 @@ func (l *TurnLoop[T, M]) cleanup(ctx context.Context) {
 	l.result = &TurnLoopExitState[T, M]{
 		ExitReason:          l.runErr,
 		UnhandledItems:      unhandled,
-		InFlightItems:       l.inFlightItems,
+		InterruptedItems:    l.interruptedItems,
 		StopCause:           l.stopSig.getStopCause(),
 		CheckpointAttempted: checkpointed,
 		CheckpointErr:       checkpointErr,

--- a/adk/turn_loop.go
+++ b/adk/turn_loop.go
@@ -1538,20 +1538,20 @@ func (l *TurnLoop[T, M]) run(ctx context.Context) {
 
 		l.preemptSig.endTurnAndUnhold()
 
-		// Set inFlightItems whenever a cancel or interrupt was captured from the
-		// event stream, regardless of what the user's callback returned. The items
-		// were factually mid-execution when the signal arrived.
-		if (l.capturedCancelErr != nil || l.interruptContexts != nil) && len(l.inFlightItems) == 0 {
-			l.inFlightItems = append([]T{}, plan.spec.consumed...)
-		}
-
 		if runErr != nil {
+			// Set inFlightItems when a cancel or interrupt was captured from the
+			// event stream, regardless of what the user's callback returned. The items
+			// were factually mid-execution when the signal arrived.
+			if l.capturedCancelErr != nil || l.interruptContexts != nil {
+				l.inFlightItems = append([]T{}, plan.spec.consumed...)
+			}
 			l.runErr = runErr
 			return
 		}
 
 		// Business interrupt: agent produced an Interrupted action, exit to persist checkpoint.
 		if l.interruptContexts != nil {
+			l.inFlightItems = append([]T{}, plan.spec.consumed...)
 			l.runErr = &InterruptError{InterruptContexts: l.interruptContexts}
 			return
 		}

--- a/adk/turn_loop_test.go
+++ b/adk/turn_loop_test.go
@@ -1324,7 +1324,7 @@ func TestTurnLoop_StopDuringAgentExecution(t *testing.T) {
 
 	result := loop.Wait()
 	assert.NoError(t, result.ExitReason)
-	assert.Empty(t, result.InFlightItems)
+	assert.Empty(t, result.InterruptedItems)
 }
 
 // TestTurnLoop_BareStop_AgentRunsToCompletion verifies the core contract of
@@ -1403,8 +1403,8 @@ func TestTurnLoop_BareStop_AgentRunsToCompletion(t *testing.T) {
 	// 3. ExitReason is nil (clean exit, not a CancelError).
 	assert.NoError(t, result.ExitReason)
 
-	// 4. InFlightItems is empty (agent was not interrupted).
-	assert.Empty(t, result.InFlightItems)
+	// 4. InterruptedItems is empty (agent was not interrupted).
+	assert.Empty(t, result.InterruptedItems)
 
 	// 5. Only one turn executed; the second item is unhandled.
 	assert.Equal(t, int32(1), atomic.LoadInt32(&turnsExecuted),
@@ -1468,7 +1468,7 @@ func TestTurnLoop_StopCheckPointIDInCancelError(t *testing.T) {
 }
 
 // TestTurnLoop_CancelError_CapturedIndependentlyOfCallback verifies that the TurnLoop
-// correctly reports *CancelError as ExitReason and populates InFlightItems even when
+// correctly reports *CancelError as ExitReason and populates InterruptedItems even when
 // the user's custom OnAgentEvents callback swallows the CancelError (returns nil).
 // This tests the documented guarantee: "the callback should NEVER propagate CancelError
 // — the framework handles it automatically."
@@ -1533,9 +1533,9 @@ func TestTurnLoop_CancelError_CapturedIndependentlyOfCallback(t *testing.T) {
 	assert.True(t, errors.As(result.ExitReason, &cancelErr),
 		"ExitReason should be *CancelError even when OnAgentEvents swallows it, got: %v", result.ExitReason)
 
-	// InFlightItems should be populated.
-	assert.Equal(t, []string{"msg1"}, result.InFlightItems,
-		"InFlightItems should contain the items that were being processed")
+	// InterruptedItems should be populated.
+	assert.Equal(t, []string{"msg1"}, result.InterruptedItems,
+		"InterruptedItems should contain the items that were being processed")
 
 	// Checkpoint should be saved.
 	store.mu.Lock()
@@ -1544,11 +1544,11 @@ func TestTurnLoop_CancelError_CapturedIndependentlyOfCallback(t *testing.T) {
 	assert.True(t, ok, "checkpoint should be saved under the configured CheckpointID")
 }
 
-// TestTurnLoop_CancelError_CustomErrorWins_InFlightItemsStillSet verifies that when
+// TestTurnLoop_CancelError_CustomErrorWins_InterruptedItemsStillSet verifies that when
 // the user's OnAgentEvents callback returns a custom error during a cancel, the custom
-// error becomes ExitReason (not overwritten by CancelError), but InFlightItems is still
+// error becomes ExitReason (not overwritten by CancelError), but InterruptedItems is still
 // populated because the items were factually mid-execution when the cancel signal arrived.
-func TestTurnLoop_CancelError_CustomErrorWins_InFlightItemsStillSet(t *testing.T) {
+func TestTurnLoop_CancelError_CustomErrorWins_InterruptedItemsStillSet(t *testing.T) {
 	ctx := context.Background()
 	modelStarted := make(chan struct{}, 1)
 	checkpointID := "cancel-custom-error-wins-1"
@@ -1608,9 +1608,9 @@ func TestTurnLoop_CancelError_CustomErrorWins_InFlightItemsStillSet(t *testing.T
 	assert.ErrorIs(t, result.ExitReason, customErr,
 		"ExitReason should be the user's custom error, not CancelError")
 
-	// But InFlightItems should still be populated (items were factually in-flight).
-	assert.Equal(t, []string{"msg1"}, result.InFlightItems,
-		"InFlightItems should contain the items that were being processed")
+	// But InterruptedItems should still be populated (items were factually in-flight).
+	assert.Equal(t, []string{"msg1"}, result.InterruptedItems,
+		"InterruptedItems should contain the items that were being processed")
 
 	// Checkpoint should be saved (cancel was captured, items were in-flight).
 	store.mu.Lock()
@@ -1818,10 +1818,10 @@ func TestTurnLoop_StopDuringAgentExecution_PersistAndResume(t *testing.T) {
 	loop2 := NewTurnLoop(TurnLoopConfig[string, *schema.Message]{
 		Store:        store,
 		CheckpointID: cpID,
-		GenResume: func(ctx context.Context, _ *TurnLoop[string, *schema.Message], inFlightItems []string, unhandledItems []string, newItems []string) (*GenResumeResult[string, *schema.Message], error) {
+		GenResume: func(ctx context.Context, _ *TurnLoop[string, *schema.Message], interruptedItems []string, unhandledItems []string, newItems []string) (*GenResumeResult[string, *schema.Message], error) {
 			genResumeCalled = true
 			return &GenResumeResult[string, *schema.Message]{
-				Consumed:  inFlightItems,
+				Consumed:  interruptedItems,
 				Remaining: append(append([]string{}, unhandledItems...), newItems...),
 			}, nil
 		},
@@ -1853,12 +1853,12 @@ func TestTurnLoop_StopDuringAgentExecution_PersistAndResume(t *testing.T) {
 	assert.False(t, genInputCalled)
 }
 
-// TestTurnLoop_StopCancel_InFlightItems_PersistAndRestore verifies the full
+// TestTurnLoop_StopCancel_InterruptedItems_PersistAndRestore verifies the full
 // lifecycle: Stop(WithImmediate()) cancels a running agent, the exit state
-// reports the correct InFlightItems, the checkpoint persists them, and a new
+// reports the correct InterruptedItems, the checkpoint persists them, and a new
 // TurnLoop restoring from that checkpoint passes the exact same items to
-// GenResume's inFlightItems parameter.
-func TestTurnLoop_StopCancel_InFlightItems_PersistAndRestore(t *testing.T) {
+// GenResume's interruptedItems parameter.
+func TestTurnLoop_StopCancel_InterruptedItems_PersistAndRestore(t *testing.T) {
 	ctx := context.Background()
 	modelStarted := make(chan struct{}, 1)
 	store := &turnLoopCheckpointStore{m: make(map[string][]byte)}
@@ -1906,9 +1906,9 @@ func TestTurnLoop_StopCancel_InFlightItems_PersistAndRestore(t *testing.T) {
 	var cancelErr *CancelError
 	require.True(t, errors.As(exit.ExitReason, &cancelErr), "expected *CancelError, got: %v", exit.ExitReason)
 
-	// InFlightItems must contain the consumed items.
-	assert.Equal(t, []string{"msg1"}, exit.InFlightItems,
-		"InFlightItems in exit state should contain the items that were mid-execution")
+	// InterruptedItems must contain the consumed items.
+	assert.Equal(t, []string{"msg1"}, exit.InterruptedItems,
+		"InterruptedItems in exit state should contain the items that were mid-execution")
 
 	// Checkpoint must be saved.
 	assert.True(t, exit.CheckpointAttempted, "checkpoint should be attempted")
@@ -1919,22 +1919,22 @@ func TestTurnLoop_StopCancel_InFlightItems_PersistAndRestore(t *testing.T) {
 	store.mu.Unlock()
 	require.True(t, cpExists, "checkpoint should exist in store")
 
-	// Phase 2: Restore from checkpoint, verify GenResume receives the exact InFlightItems.
+	// Phase 2: Restore from checkpoint, verify GenResume receives the exact InterruptedItems.
 	slowModel.setDelay(10 * time.Millisecond)
 
 	var genResumeCalled bool
-	var resumeInFlightItems []string
+	var resumeInterruptedItems []string
 	var resumeUnhandledItems []string
 
 	loop2 := NewTurnLoop(TurnLoopConfig[string, *schema.Message]{
 		Store:        store,
 		CheckpointID: cpID,
-		GenResume: func(ctx context.Context, _ *TurnLoop[string, *schema.Message], inFlightItems, unhandledItems, newItems []string) (*GenResumeResult[string, *schema.Message], error) {
+		GenResume: func(ctx context.Context, _ *TurnLoop[string, *schema.Message], interruptedItems, unhandledItems, newItems []string) (*GenResumeResult[string, *schema.Message], error) {
 			genResumeCalled = true
-			resumeInFlightItems = append([]string{}, inFlightItems...)
+			resumeInterruptedItems = append([]string{}, interruptedItems...)
 			resumeUnhandledItems = append([]string{}, unhandledItems...)
 			return &GenResumeResult[string, *schema.Message]{
-				Consumed:  inFlightItems,
+				Consumed:  interruptedItems,
 				Remaining: append(append([]string{}, unhandledItems...), newItems...),
 			}, nil
 		},
@@ -1962,16 +1962,16 @@ func TestTurnLoop_StopCancel_InFlightItems_PersistAndRestore(t *testing.T) {
 
 	assert.NoError(t, exit2.ExitReason)
 	assert.True(t, genResumeCalled, "GenResume should be called when restoring from a cancel checkpoint")
-	assert.Equal(t, []string{"msg1"}, resumeInFlightItems,
-		"GenResume's inFlightItems should match the original exit state's InFlightItems")
+	assert.Equal(t, []string{"msg1"}, resumeInterruptedItems,
+		"GenResume's interruptedItems should match the original exit state's InterruptedItems")
 	assert.Empty(t, resumeUnhandledItems,
 		"unhandledItems should be empty (all items were consumed before cancel)")
 }
 
-// TestTurnLoop_PreemptThenStop_InFlightItems_ReflectsStoppedTurn verifies that
+// TestTurnLoop_PreemptThenStop_InterruptedItems_ReflectsStoppedTurn verifies that
 // when a preempt interrupts turn 1 and then Stop(WithImmediate()) cancels turn 2,
-// the reported InFlightItems correspond to turn 2's consumed items (not turn 1's).
-func TestTurnLoop_PreemptThenStop_InFlightItems_ReflectsStoppedTurn(t *testing.T) {
+// the reported InterruptedItems correspond to turn 2's consumed items (not turn 1's).
+func TestTurnLoop_PreemptThenStop_InterruptedItems_ReflectsStoppedTurn(t *testing.T) {
 	ctx := context.Background()
 	store := &turnLoopCheckpointStore{m: make(map[string][]byte)}
 	cpID := "preempt-then-stop-session"
@@ -2036,12 +2036,12 @@ func TestTurnLoop_PreemptThenStop_InFlightItems_ReflectsStoppedTurn(t *testing.T
 	var cancelErr *CancelError
 	require.True(t, errors.As(exit.ExitReason, &cancelErr), "expected *CancelError, got: %v", exit.ExitReason)
 
-	// KEY ASSERTION: InFlightItems must reflect turn 2's consumed items (which
+	// KEY ASSERTION: InterruptedItems must reflect turn 2's consumed items (which
 	// includes both "a" and "b" since GenInput consumes all items), NOT turn 1's ["a"].
 	// Turn 2 consumed whatever GenInput received (the re-buffered items from preempt + "b").
-	assert.NotEmpty(t, exit.InFlightItems, "InFlightItems should not be empty after Stop cancel")
-	assert.Contains(t, exit.InFlightItems, "b",
-		"InFlightItems should contain 'b' which was part of turn 2's consumed items")
+	assert.NotEmpty(t, exit.InterruptedItems, "InterruptedItems should not be empty after Stop cancel")
+	assert.Contains(t, exit.InterruptedItems, "b",
+		"InterruptedItems should contain 'b' which was part of turn 2's consumed items")
 }
 
 func TestTurnLoop_BusinessInterrupt_PersistAndResume(t *testing.T) {
@@ -2076,8 +2076,8 @@ func TestTurnLoop_BusinessInterrupt_PersistAndResume(t *testing.T) {
 	// 2. InterruptContexts is populated.
 	require.NotEmpty(t, intErr.InterruptContexts)
 
-	// 3. InFlightItems contains the items being processed.
-	assert.Equal(t, []string{"msg1"}, exit.InFlightItems)
+	// 3. InterruptedItems contains the items being processed.
+	assert.Equal(t, []string{"msg1"}, exit.InterruptedItems)
 
 	// 4. Checkpoint was persisted.
 	assert.True(t, exit.CheckpointAttempted)
@@ -2090,15 +2090,15 @@ func TestTurnLoop_BusinessInterrupt_PersistAndResume(t *testing.T) {
 
 	// 5. Resume: new TurnLoop with same CheckpointID gets GenResume called.
 	var genResumeCalled bool
-	var resumeInFlightItems []string
+	var resumeInterruptedItems []string
 	loop2 := NewTurnLoop(TurnLoopConfig[string, *schema.Message]{
 		Store:        store,
 		CheckpointID: cpID,
-		GenResume: func(ctx context.Context, _ *TurnLoop[string, *schema.Message], inFlightItems []string, unhandledItems []string, newItems []string) (*GenResumeResult[string, *schema.Message], error) {
+		GenResume: func(ctx context.Context, _ *TurnLoop[string, *schema.Message], interruptedItems []string, unhandledItems []string, newItems []string) (*GenResumeResult[string, *schema.Message], error) {
 			genResumeCalled = true
-			resumeInFlightItems = append([]string{}, inFlightItems...)
+			resumeInterruptedItems = append([]string{}, interruptedItems...)
 			return &GenResumeResult[string, *schema.Message]{
-				Consumed:  inFlightItems,
+				Consumed:  interruptedItems,
 				Remaining: append(append([]string{}, unhandledItems...), newItems...),
 			}, nil
 		},
@@ -2128,7 +2128,7 @@ func TestTurnLoop_BusinessInterrupt_PersistAndResume(t *testing.T) {
 	exit2 := loop2.Wait()
 	assert.NoError(t, exit2.ExitReason)
 	assert.True(t, genResumeCalled, "GenResume should be called on checkpoint resume")
-	assert.Equal(t, []string{"msg1"}, resumeInFlightItems, "inFlightItems should contain the original items")
+	assert.Equal(t, []string{"msg1"}, resumeInterruptedItems, "interruptedItems should contain the original items")
 }
 
 // turnLoopInterruptAgent is a test agent that produces a business interrupt event.
@@ -4884,7 +4884,7 @@ func TestTurnLoop_StopBeforeRun_PushThenStop(t *testing.T) {
 
 	assert.NoError(t, result.ExitReason)
 	assert.Equal(t, []string{"item1", "item2"}, result.UnhandledItems)
-	assert.Empty(t, result.InFlightItems)
+	assert.Empty(t, result.InterruptedItems)
 	assert.Empty(t, result.TakeLateItems())
 }
 
@@ -4912,7 +4912,7 @@ func TestTurnLoop_StopBeforeRun_StopThenPush(t *testing.T) {
 
 	assert.NoError(t, result.ExitReason)
 	assert.Empty(t, result.UnhandledItems)
-	assert.Empty(t, result.InFlightItems)
+	assert.Empty(t, result.InterruptedItems)
 	assert.Equal(t, []string{"item1", "item2"}, result.TakeLateItems())
 }
 
@@ -5589,7 +5589,7 @@ func TestAttack_StopSignal_NilCancelOptsDoNotDeescalate(t *testing.T) {
 	assert.Equal(t, CancelImmediate, ce.Info.Mode)
 }
 
-func TestAttack_InFlightItems_EmptyWhenAgentFinishesNormally(t *testing.T) {
+func TestAttack_InterruptedItems_EmptyWhenAgentFinishesNormally(t *testing.T) {
 	agentStarted := make(chan struct{})
 	loop := newAndRunTurnLoop(context.Background(), TurnLoopConfig[string, *schema.Message]{
 		GenInput: func(ctx context.Context, _ *TurnLoop[string, *schema.Message], items []string) (*GenInputResult[string, *schema.Message], error) {
@@ -5616,7 +5616,7 @@ func TestAttack_InFlightItems_EmptyWhenAgentFinishesNormally(t *testing.T) {
 
 	exit := loop.Wait()
 	assert.NoError(t, exit.ExitReason)
-	assert.Empty(t, exit.InFlightItems, "InFlightItems must be empty when agent finished normally")
+	assert.Empty(t, exit.InterruptedItems, "InterruptedItems must be empty when agent finished normally")
 }
 
 func TestAttack_TurnBuffer_WakeupDoesNotLoseItems(t *testing.T) {
@@ -6107,7 +6107,7 @@ func TestAttack_BusinessInterrupt_NoStore_ExitsWithoutPanic(t *testing.T) {
 
 	var intErr *InterruptError
 	require.True(t, errors.As(exit.ExitReason, &intErr), "expected *InterruptError, got: %v", exit.ExitReason)
-	assert.Equal(t, []string{"msg1"}, exit.InFlightItems)
+	assert.Equal(t, []string{"msg1"}, exit.InterruptedItems)
 	assert.False(t, exit.CheckpointAttempted, "no store → no checkpoint attempt")
 }
 
@@ -6135,5 +6135,5 @@ func TestAttack_BusinessInterrupt_EmptyConsumed_NoCheckpoint(t *testing.T) {
 
 	var intErr *InterruptError
 	require.True(t, errors.As(exit.ExitReason, &intErr), "expected *InterruptError, got: %v", exit.ExitReason)
-	assert.Empty(t, exit.InFlightItems, "consumed was empty → InFlightItems should be empty")
+	assert.Empty(t, exit.InterruptedItems, "consumed was empty → InterruptedItems should be empty")
 }

--- a/adk/turn_loop_test.go
+++ b/adk/turn_loop_test.go
@@ -1853,6 +1853,197 @@ func TestTurnLoop_StopDuringAgentExecution_PersistAndResume(t *testing.T) {
 	assert.False(t, genInputCalled)
 }
 
+// TestTurnLoop_StopCancel_InFlightItems_PersistAndRestore verifies the full
+// lifecycle: Stop(WithImmediate()) cancels a running agent, the exit state
+// reports the correct InFlightItems, the checkpoint persists them, and a new
+// TurnLoop restoring from that checkpoint passes the exact same items to
+// GenResume's inFlightItems parameter.
+func TestTurnLoop_StopCancel_InFlightItems_PersistAndRestore(t *testing.T) {
+	ctx := context.Background()
+	modelStarted := make(chan struct{}, 1)
+	store := &turnLoopCheckpointStore{m: make(map[string][]byte)}
+	cpID := "inflight-persist-session"
+
+	slowModel := &cancelTestChatModel{
+		delayNs: int64(500 * time.Millisecond),
+		response: &schema.Message{
+			Role:    schema.Assistant,
+			Content: "Hello",
+		},
+		startedChan: modelStarted,
+		doneChan:    make(chan struct{}, 1),
+	}
+
+	agent, err := NewChatModelAgent(ctx, &ChatModelAgentConfig{
+		Name:        "TestAgent",
+		Description: "Test agent",
+		Instruction: "You are a test assistant",
+		Model:       slowModel,
+	})
+	require.NoError(t, err)
+
+	// Phase 1: Run, cancel mid-turn, verify exit state.
+	loop := newAndRunTurnLoop(ctx, TurnLoopConfig[string, *schema.Message]{
+		Store:        store,
+		CheckpointID: cpID,
+		GenInput: func(ctx context.Context, _ *TurnLoop[string, *schema.Message], items []string) (*GenInputResult[string, *schema.Message], error) {
+			return &GenInputResult[string, *schema.Message]{
+				Input:    &AgentInput{Messages: []Message{schema.UserMessage(items[0])}},
+				Consumed: items,
+			}, nil
+		},
+		PrepareAgent: func(ctx context.Context, _ *TurnLoop[string, *schema.Message], consumed []string) (Agent, error) {
+			return agent, nil
+		},
+	})
+
+	loop.Push("msg1")
+	<-modelStarted
+	loop.Stop(WithImmediate())
+	exit := loop.Wait()
+
+	// ExitReason must be CancelError.
+	var cancelErr *CancelError
+	require.True(t, errors.As(exit.ExitReason, &cancelErr), "expected *CancelError, got: %v", exit.ExitReason)
+
+	// InFlightItems must contain the consumed items.
+	assert.Equal(t, []string{"msg1"}, exit.InFlightItems,
+		"InFlightItems in exit state should contain the items that were mid-execution")
+
+	// Checkpoint must be saved.
+	assert.True(t, exit.CheckpointAttempted, "checkpoint should be attempted")
+	assert.NoError(t, exit.CheckpointErr, "checkpoint save should succeed")
+
+	store.mu.Lock()
+	_, cpExists := store.m[cpID]
+	store.mu.Unlock()
+	require.True(t, cpExists, "checkpoint should exist in store")
+
+	// Phase 2: Restore from checkpoint, verify GenResume receives the exact InFlightItems.
+	slowModel.setDelay(10 * time.Millisecond)
+
+	var genResumeCalled bool
+	var resumeInFlightItems []string
+	var resumeUnhandledItems []string
+
+	loop2 := NewTurnLoop(TurnLoopConfig[string, *schema.Message]{
+		Store:        store,
+		CheckpointID: cpID,
+		GenResume: func(ctx context.Context, _ *TurnLoop[string, *schema.Message], inFlightItems, unhandledItems, newItems []string) (*GenResumeResult[string, *schema.Message], error) {
+			genResumeCalled = true
+			resumeInFlightItems = append([]string{}, inFlightItems...)
+			resumeUnhandledItems = append([]string{}, unhandledItems...)
+			return &GenResumeResult[string, *schema.Message]{
+				Consumed:  inFlightItems,
+				Remaining: append(append([]string{}, unhandledItems...), newItems...),
+			}, nil
+		},
+		GenInput: func(ctx context.Context, _ *TurnLoop[string, *schema.Message], items []string) (*GenInputResult[string, *schema.Message], error) {
+			t.Fatal("GenInput should not be called when resuming from a cancel checkpoint")
+			return nil, nil
+		},
+		PrepareAgent: func(ctx context.Context, _ *TurnLoop[string, *schema.Message], consumed []string) (Agent, error) {
+			return agent, nil
+		},
+		OnAgentEvents: func(ctx context.Context, tc *TurnContext[string, *schema.Message], events *AsyncIterator[*AgentEvent]) error {
+			for {
+				_, ok := events.Next()
+				if !ok {
+					break
+				}
+			}
+			tc.Loop.Stop()
+			return nil
+		},
+	})
+
+	loop2.Run(ctx)
+	exit2 := loop2.Wait()
+
+	assert.NoError(t, exit2.ExitReason)
+	assert.True(t, genResumeCalled, "GenResume should be called when restoring from a cancel checkpoint")
+	assert.Equal(t, []string{"msg1"}, resumeInFlightItems,
+		"GenResume's inFlightItems should match the original exit state's InFlightItems")
+	assert.Empty(t, resumeUnhandledItems,
+		"unhandledItems should be empty (all items were consumed before cancel)")
+}
+
+// TestTurnLoop_PreemptThenStop_InFlightItems_ReflectsStoppedTurn verifies that
+// when a preempt interrupts turn 1 and then Stop(WithImmediate()) cancels turn 2,
+// the reported InFlightItems correspond to turn 2's consumed items (not turn 1's).
+func TestTurnLoop_PreemptThenStop_InFlightItems_ReflectsStoppedTurn(t *testing.T) {
+	ctx := context.Background()
+	store := &turnLoopCheckpointStore{m: make(map[string][]byte)}
+	cpID := "preempt-then-stop-session"
+
+	turnCount := int32(0)
+	modelStarted := make(chan struct{}, 10)
+
+	slowModel := &cancelTestChatModel{
+		delayNs: int64(5 * time.Second),
+		response: &schema.Message{
+			Role:    schema.Assistant,
+			Content: "Hello",
+		},
+		startedChan: modelStarted,
+		doneChan:    make(chan struct{}, 10),
+	}
+
+	agent, err := NewChatModelAgent(ctx, &ChatModelAgentConfig{
+		Name:        "TestAgent",
+		Description: "Test agent",
+		Instruction: "You are a test assistant",
+		Model:       slowModel,
+	})
+	require.NoError(t, err)
+
+	loop := newAndRunTurnLoop(ctx, TurnLoopConfig[string, *schema.Message]{
+		Store:        store,
+		CheckpointID: cpID,
+		GenInput: func(ctx context.Context, _ *TurnLoop[string, *schema.Message], items []string) (*GenInputResult[string, *schema.Message], error) {
+			n := atomic.AddInt32(&turnCount, 1)
+			_ = n
+			return &GenInputResult[string, *schema.Message]{
+				Input:    &AgentInput{Messages: []Message{schema.UserMessage(items[0])}},
+				Consumed: items,
+			}, nil
+		},
+		PrepareAgent: func(ctx context.Context, _ *TurnLoop[string, *schema.Message], consumed []string) (Agent, error) {
+			return agent, nil
+		},
+	})
+
+	// Turn 1: push "a", wait for agent to start, then preempt with "b".
+	loop.Push("a")
+	<-modelStarted
+
+	_, ack := loop.Push("b", WithPreemptTimeout[string, *schema.Message](AnySafePoint, 10*time.Millisecond))
+	// Wait for the preempt to be acknowledged.
+	select {
+	case <-ack:
+	case <-time.After(5 * time.Second):
+		t.Fatal("preempt ack timed out")
+	}
+
+	// Turn 2: the loop restarts with all buffered items. Wait for agent to start.
+	<-modelStarted
+
+	// Now stop with immediate cancel on turn 2.
+	loop.Stop(WithImmediate())
+	exit := loop.Wait()
+
+	// ExitReason must be CancelError.
+	var cancelErr *CancelError
+	require.True(t, errors.As(exit.ExitReason, &cancelErr), "expected *CancelError, got: %v", exit.ExitReason)
+
+	// KEY ASSERTION: InFlightItems must reflect turn 2's consumed items (which
+	// includes both "a" and "b" since GenInput consumes all items), NOT turn 1's ["a"].
+	// Turn 2 consumed whatever GenInput received (the re-buffered items from preempt + "b").
+	assert.NotEmpty(t, exit.InFlightItems, "InFlightItems should not be empty after Stop cancel")
+	assert.Contains(t, exit.InFlightItems, "b",
+		"InFlightItems should contain 'b' which was part of turn 2's consumed items")
+}
+
 func TestTurnLoop_BusinessInterrupt_PersistAndResume(t *testing.T) {
 	ctx := context.Background()
 	store := &turnLoopCheckpointStore{m: make(map[string][]byte)}


### PR DESCRIPTION
## Summary

| Problem | Solution |
|---------|----------|
| Preempt contaminates `InterruptedItems` — after a preempt cancels turn N, the consumed items from that turn are incorrectly stored. If Stop subsequently cancels turn N+1, stale items from turn N persist to the checkpoint. | Move `interruptedItems` assignment inside terminal-exit paths only (`runErr != nil` and `interruptContexts != nil`), so preempts (which return nil and continue the loop) never set the field. |
| `InFlightItems` naming is ambiguous — could mean items dispatched but not yet acknowledged (queue semantics). | Rename to `InterruptedItems` which precisely describes the semantics: items whose turn was actively executing when interrupted. |

## Key Insight

The `interruptedItems` assignment was placed **before** the `if runErr != nil` check. After a preempt, `runAgentAndHandleEvents` returns `nil` (the loop continues), but `capturedCancelErr` was already set by the event proxy. This caused the guard `l.capturedCancelErr != nil` to fire for the non-terminal preempt path, and the `len(l.interruptedItems) == 0` guard subsequently prevented the correct items from being recorded on the actual terminal Stop.

The fix is minimal: only record `interruptedItems` on paths that actually terminate the loop (cancel error or business interrupt), never on paths that continue to the next turn.

## Changes

- `adk/turn_loop.go`:
  - Move `interruptedItems` assignment inside `if runErr != nil` block; add explicit assignment in the `interruptContexts != nil` (business interrupt) path.
  - Remove the unnecessary `len(l.interruptedItems) == 0` guard (dead code — the field is zero-initialized and the assignment is in a terminal path that executes at most once).
  - Rename `InFlightItems` to `InterruptedItems` in `TurnLoopExitState` and all related internal fields/comments.
  - Rename internal `turnLoopPendingResume.inFlight` to `.interrupted` for consistency.
- `adk/turn_loop_test.go`: Add two tests:
  - `TestTurnLoop_StopCancel_InterruptedItems_PersistAndRestore` — end-to-end: Stop cancels agent, InterruptedItems persisted, restored via GenResume.
  - `TestTurnLoop_PreemptThenStop_InterruptedItems_ReflectsStoppedTurn` — reproduces the bug: preempt turn N, then Stop turn N+1, asserts InterruptedItems reflects turn N+1's items, not turn N's.

---

## 概要

| 问题 | 方案 |
|------|------|
| Preempt 污染 `InterruptedItems`：当 preempt 取消 turn N 后，turn N 的 consumed items 被错误存入。若随后 Stop 取消 turn N+1，checkpoint 中持久化的是 turn N 的过期数据。 | 将 `interruptedItems` 赋值移入终止路径（`runErr != nil` 和 `interruptContexts != nil`），使非终止的 preempt 路径不会触发赋值。 |
| `InFlightItems` 命名歧义 — 可被理解为"已发出但尚未确认"的队列语义。 | 重命名为 `InterruptedItems`，精确表达语义：turn 正在执行时被中断的 items。 |

## 核心洞察

`interruptedItems` 赋值原本位于 `if runErr != nil` 检查**之前**。Preempt 后 `runAgentAndHandleEvents` 返回 nil（循环继续），但 event proxy 已设置 `capturedCancelErr`。这导致 `l.capturedCancelErr != nil` 在非终止的 preempt 路径上为真，且 `len(l.interruptedItems) == 0` 守卫在真正的 Stop 终止时阻止了正确 items 的记录。

修复策略：仅在实际终止循环的路径（cancel error 或 business interrupt）记录 `interruptedItems`，在继续下一 turn 的路径上不触碰该字段。同时移除了不可达的 `len == 0` 守卫（dead code）。
