### PR TITLE
fix(adk): preserve agentic tool search results

### DIFF
--- a/adk/middlewares/patchtoolcalls/patchtoolcalls.go
+++ b/adk/middlewares/patchtoolcalls/patchtoolcalls.go
@@ -179,8 +179,15 @@ func hasCorrespondingToolMessage(messages []*schema.Message, toolCallID string) 
 func hasCorrespondingAgenticToolResult(messages []*schema.AgenticMessage, toolCallID string) bool {
 	for _, msg := range messages {
 		for _, block := range msg.ContentBlocks {
-			if block != nil && block.Type == schema.ContentBlockTypeFunctionToolResult &&
+			if block == nil {
+				continue
+			}
+			if block.Type == schema.ContentBlockTypeFunctionToolResult &&
 				block.FunctionToolResult != nil && block.FunctionToolResult.CallID == toolCallID {
+				return true
+			}
+			if block.Type == schema.ContentBlockTypeToolSearchResult &&
+				block.ToolSearchFunctionToolResult != nil && block.ToolSearchFunctionToolResult.CallID == toolCallID {
 				return true
 			}
 		}

--- a/adk/middlewares/patchtoolcalls/patchtoolcalls_test.go
+++ b/adk/middlewares/patchtoolcalls/patchtoolcalls_test.go
@@ -238,8 +238,8 @@ func testPatchToolCallsGeneric[M adk.MessageType](t *testing.T) {
 			if tt.checkPatchedAt >= 0 && tt.checkPatchedAt < len(newState.Messages) {
 				patched := newState.Messages[tt.checkPatchedAt]
 				assertToolResultID(t, patched, tt.wantCallID)
-			assertToolResultName(t, patched, tt.wantToolName)
-			assertMsgContent(t, patched, tt.wantContent)
+				assertToolResultName(t, patched, tt.wantToolName)
+				assertMsgContent(t, patched, tt.wantContent)
 			}
 		})
 	}
@@ -248,6 +248,36 @@ func testPatchToolCallsGeneric[M adk.MessageType](t *testing.T) {
 func TestPatchToolCallsGeneric(t *testing.T) {
 	t.Run("Message", testPatchToolCallsGeneric[*schema.Message])
 	t.Run("AgenticMessage", testPatchToolCallsGeneric[*schema.AgenticMessage])
+}
+
+func TestPatchToolCallsAgenticToolSearchResult(t *testing.T) {
+	ctx := context.Background()
+	mw, err := NewTyped[*schema.AgenticMessage](ctx, nil)
+	require.NoError(t, err)
+
+	messages := []*schema.AgenticMessage{
+		makeAssistantMsgWithToolCalls[*schema.AgenticMessage]("", []testToolCall{
+			{ID: "call_1", Name: "tool_search", Arguments: `{"query":"dynamic"}`},
+		}),
+		{
+			Role: schema.AgenticRoleTypeUser,
+			ContentBlocks: []*schema.ContentBlock{
+				schema.NewContentBlock(&schema.ToolSearchFunctionToolResult{
+					CallID: "call_1",
+					Name:   "tool_search",
+					Result: &schema.ToolSearchResult{Tools: []*schema.ToolInfo{
+						{Name: "dynamic_tool", Desc: "dynamic tool"},
+					}},
+				}),
+			},
+		},
+	}
+
+	state := &adk.TypedChatModelAgentState[*schema.AgenticMessage]{Messages: messages}
+	_, newState, err := mw.BeforeModelRewriteState(ctx, state, nil)
+	require.NoError(t, err)
+	assert.Len(t, newState.Messages, 2)
+	assert.Equal(t, schema.ContentBlockTypeToolSearchResult, newState.Messages[1].ContentBlocks[0].Type)
 }
 
 // TestPatchToolCalls_NilFunctionToolCallInBlock verifies the middleware handles

--- a/adk/react.go
+++ b/adk/react.go
@@ -801,7 +801,7 @@ func newAgenticReact(ctx context.Context, config *agenticReactConfig) (agenticRe
 }
 
 // extractToolIdentifiers extracts the tool name and call ID from an AgenticMessage
-// that contains a FunctionToolResult content block.
+// that contains a tool result content block.
 // Assumes one tool result per message, which is guaranteed by AgenticToolsNode
 // (see compose.toolMessageToAgenticMessage).
 func extractToolIdentifiers(msg *schema.AgenticMessage) (toolName, callID string) {
@@ -809,8 +809,14 @@ func extractToolIdentifiers(msg *schema.AgenticMessage) (toolName, callID string
 		return "", ""
 	}
 	for _, block := range msg.ContentBlocks {
-		if block != nil && block.Type == schema.ContentBlockTypeFunctionToolResult && block.FunctionToolResult != nil {
+		if block == nil {
+			continue
+		}
+		if block.Type == schema.ContentBlockTypeFunctionToolResult && block.FunctionToolResult != nil {
 			return block.FunctionToolResult.Name, block.FunctionToolResult.CallID
+		}
+		if block.Type == schema.ContentBlockTypeToolSearchResult && block.ToolSearchFunctionToolResult != nil {
+			return block.ToolSearchFunctionToolResult.Name, block.ToolSearchFunctionToolResult.CallID
 		}
 	}
 	return "", ""

--- a/adk/wrappers.go
+++ b/adk/wrappers.go
@@ -596,6 +596,35 @@ func functionToolResultAgenticMessage(callID, name string, content []*schema.Fun
 	}
 }
 
+func toolSearchResultAgenticMessage(callID, name string, tr *schema.ToolResult) (*schema.AgenticMessage, bool) {
+	if tr == nil || len(tr.Parts) != 1 {
+		return nil, false
+	}
+
+	part := tr.Parts[0]
+	if part.Type != schema.ToolPartTypeToolSearchResult || part.ToolSearchResult == nil {
+		return nil, false
+	}
+
+	return &schema.AgenticMessage{
+		Role: schema.AgenticRoleTypeUser,
+		ContentBlocks: []*schema.ContentBlock{
+			schema.NewContentBlock(&schema.ToolSearchFunctionToolResult{
+				CallID: callID,
+				Name:   name,
+				Result: part.ToolSearchResult,
+			}),
+		},
+	}, true
+}
+
+func toolResultAgenticMessage(callID, name string, tr *schema.ToolResult) *schema.AgenticMessage {
+	if msg, ok := toolSearchResultAgenticMessage(callID, name, tr); ok {
+		return msg
+	}
+	return functionToolResultAgenticMessage(callID, name, toolResultToBlocks(tr))
+}
+
 // toolResultToBlocks converts a ToolResult's multimodal parts into FunctionToolResultBlocks.
 // This preserves all media types (text, image, audio, video, file), unlike toolResultText
 // which only extracts text.
@@ -749,7 +778,7 @@ func typedToolEnhancedInvokeEvent[M MessageType](callID, toolName, toolMsgID str
 		event := EventFromMessage(msg, nil, schema.Tool, toolName)
 		return any(event).(*TypedAgentEvent[M]), nil
 	case *schema.AgenticMessage:
-		msg := functionToolResultAgenticMessage(callID, toolName, toolResultToBlocks(result))
+		msg := toolResultAgenticMessage(callID, toolName, result)
 		msg.Extra = internal.SetMessageID(msg.Extra, toolMsgID)
 		event := EventFromAgenticMessage(msg, nil, schema.AgenticRoleTypeUser)
 		return any(event).(*TypedAgentEvent[M]), nil
@@ -785,7 +814,7 @@ func typedToolEnhancedStreamEvent[M MessageType](callID, toolName, toolMsgID str
 	case *schema.AgenticMessage:
 		first := true
 		cvt := func(in *schema.ToolResult) (*schema.AgenticMessage, error) {
-			msg := functionToolResultAgenticMessage(callID, toolName, toolResultToBlocks(in))
+			msg := toolResultAgenticMessage(callID, toolName, in)
 			if first {
 				first = false
 				msg.Extra = internal.SetMessageID(msg.Extra, toolMsgID)

--- a/adk/wrappers_test.go
+++ b/adk/wrappers_test.go
@@ -2043,3 +2043,76 @@ func Test_functionToolResultAgenticMessage(t *testing.T) {
 		assert.Equal(t, "https://example.com/img.png", ftr.Content[1].Image.URL)
 	})
 }
+
+func TestTypedToolEnhancedEventAgenticToolSearchResult(t *testing.T) {
+	result := &schema.ToolResult{Parts: []schema.ToolOutputPart{
+		{
+			Type: schema.ToolPartTypeToolSearchResult,
+			ToolSearchResult: &schema.ToolSearchResult{Tools: []*schema.ToolInfo{
+				{Name: "dynamic_tool", Desc: "dynamic tool"},
+			}},
+		},
+	}}
+
+	t.Run("invoke", func(t *testing.T) {
+		event, err := typedToolEnhancedInvokeEvent[*schema.AgenticMessage]("call_1", "tool_search", "msg_1", result)
+		require.NoError(t, err)
+		require.NotNil(t, event)
+		require.NotNil(t, event.Output)
+		require.NotNil(t, event.Output.MessageOutput)
+
+		msg := event.Output.MessageOutput.Message
+		require.NotNil(t, msg)
+		require.Len(t, msg.ContentBlocks, 1)
+		block := msg.ContentBlocks[0]
+		assert.Equal(t, schema.ContentBlockTypeToolSearchResult, block.Type)
+		require.NotNil(t, block.ToolSearchFunctionToolResult)
+		assert.Equal(t, "call_1", block.ToolSearchFunctionToolResult.CallID)
+		assert.Equal(t, "tool_search", block.ToolSearchFunctionToolResult.Name)
+		require.NotNil(t, block.ToolSearchFunctionToolResult.Result)
+		require.Len(t, block.ToolSearchFunctionToolResult.Result.Tools, 1)
+		assert.Equal(t, "dynamic_tool", block.ToolSearchFunctionToolResult.Result.Tools[0].Name)
+	})
+
+	t.Run("stream", func(t *testing.T) {
+		event := typedToolEnhancedStreamEvent[*schema.AgenticMessage](
+			"call_2",
+			"tool_search",
+			"msg_2",
+			schema.StreamReaderFromArray([]*schema.ToolResult{result}),
+		)
+		require.NotNil(t, event)
+		require.NotNil(t, event.Output)
+		require.NotNil(t, event.Output.MessageOutput)
+
+		msg, err := event.Output.MessageOutput.MessageStream.Recv()
+		require.NoError(t, err)
+		require.NotNil(t, msg)
+		require.Len(t, msg.ContentBlocks, 1)
+		block := msg.ContentBlocks[0]
+		assert.Equal(t, schema.ContentBlockTypeToolSearchResult, block.Type)
+		require.NotNil(t, block.ToolSearchFunctionToolResult)
+		assert.Equal(t, "call_2", block.ToolSearchFunctionToolResult.CallID)
+		assert.Equal(t, "tool_search", block.ToolSearchFunctionToolResult.Name)
+		require.NotNil(t, block.ToolSearchFunctionToolResult.Result)
+		require.Len(t, block.ToolSearchFunctionToolResult.Result.Tools, 1)
+		assert.Equal(t, "dynamic_tool", block.ToolSearchFunctionToolResult.Result.Tools[0].Name)
+	})
+}
+
+func TestExtractToolIdentifiersToolSearchResult(t *testing.T) {
+	msg := &schema.AgenticMessage{
+		Role: schema.AgenticRoleTypeUser,
+		ContentBlocks: []*schema.ContentBlock{
+			schema.NewContentBlock(&schema.ToolSearchFunctionToolResult{
+				CallID: "call_1",
+				Name:   "tool_search",
+				Result: &schema.ToolSearchResult{},
+			}),
+		},
+	}
+
+	toolName, callID := extractToolIdentifiers(msg)
+	assert.Equal(t, "tool_search", toolName)
+	assert.Equal(t, "call_1", callID)
+}

--- a/compose/agentic_tools_node.go
+++ b/compose/agentic_tools_node.go
@@ -82,6 +82,11 @@ func agenticMessageToToolCallMessage(input *schema.AgenticMessage) *schema.Messa
 func toolMessageToAgenticMessage(input []*schema.Message) []*schema.AgenticMessage {
 	results := make([]*schema.AgenticMessage, len(input))
 	for i, m := range input {
+		if msg, ok := toolSearchResultMessageToAgenticMessage(m, nil); ok {
+			results[i] = msg
+			continue
+		}
+
 		ftr := &schema.FunctionToolResult{
 			CallID: m.ToolCallID,
 			Name:   m.ToolName,
@@ -113,6 +118,11 @@ func streamToolMessageToAgenticMessage(input *schema.StreamReader[[]*schema.Mess
 			if m == nil {
 				continue
 			}
+			if msg, ok := toolSearchResultMessageToAgenticMessage(m, &schema.StreamingMeta{Index: i}); ok {
+				results[i] = msg
+				continue
+			}
+
 			ftr := &schema.FunctionToolResult{
 				CallID: m.ToolCallID,
 				Name:   m.ToolName,
@@ -137,6 +147,31 @@ func streamToolMessageToAgenticMessage(input *schema.StreamReader[[]*schema.Mess
 		}
 		return results, nil
 	})
+}
+
+func toolSearchResultMessageToAgenticMessage(m *schema.Message, meta *schema.StreamingMeta) (*schema.AgenticMessage, bool) {
+	if m == nil || len(m.UserInputMultiContent) != 1 {
+		return nil, false
+	}
+
+	part := m.UserInputMultiContent[0]
+	if part.Type != schema.ChatMessagePartTypeToolSearchResult || part.ToolSearchResult == nil {
+		return nil, false
+	}
+
+	block := schema.NewContentBlock(&schema.ToolSearchFunctionToolResult{
+		CallID: m.ToolCallID,
+		Name:   m.ToolName,
+		Result: part.ToolSearchResult,
+	})
+	block.StreamingMeta = meta
+	block.Extra = m.Extra
+
+	return &schema.AgenticMessage{
+		Role:          schema.AgenticRoleTypeUser,
+		ContentBlocks: []*schema.ContentBlock{block},
+		Extra:         m.Extra,
+	}, true
 }
 
 func messageInputPartsToFunctionToolBlocks(parts []schema.MessageInputPart) []*schema.FunctionToolResultContentBlock {

--- a/compose/agentic_tools_node_test.go
+++ b/compose/agentic_tools_node_test.go
@@ -22,6 +22,7 @@ import (
 
 	"github.com/bytedance/sonic"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"github.com/cloudwego/eino/schema"
 )
@@ -207,6 +208,36 @@ func TestToolMessageToAgenticMessage(t *testing.T) {
 		assert.Equal(t, 1, len(ftr.Content))
 		assert.Equal(t, "only text", ftr.Content[0].Text.Text)
 	})
+
+	t.Run("tool search result", func(t *testing.T) {
+		input := []*schema.Message{
+			{
+				Role:       schema.Tool,
+				ToolCallID: "call_1",
+				ToolName:   "tool_search",
+				UserInputMultiContent: []schema.MessageInputPart{
+					{
+						Type: schema.ChatMessagePartTypeToolSearchResult,
+						ToolSearchResult: &schema.ToolSearchResult{Tools: []*schema.ToolInfo{
+							{Name: "dynamic_tool", Desc: "dynamic tool"},
+						}},
+					},
+				},
+			},
+		}
+
+		ret := toolMessageToAgenticMessage(input)
+		require.Len(t, ret, 1)
+		require.Len(t, ret[0].ContentBlocks, 1)
+		block := ret[0].ContentBlocks[0]
+		assert.Equal(t, schema.ContentBlockTypeToolSearchResult, block.Type)
+		require.NotNil(t, block.ToolSearchFunctionToolResult)
+		assert.Equal(t, "call_1", block.ToolSearchFunctionToolResult.CallID)
+		assert.Equal(t, "tool_search", block.ToolSearchFunctionToolResult.Name)
+		require.NotNil(t, block.ToolSearchFunctionToolResult.Result)
+		require.Len(t, block.ToolSearchFunctionToolResult.Result.Tools, 1)
+		assert.Equal(t, "dynamic_tool", block.ToolSearchFunctionToolResult.Result.Tools[0].Name)
+	})
 }
 
 func TestStreamToolMessageToAgenticMessage(t *testing.T) {
@@ -274,6 +305,41 @@ func TestStreamToolMessageToAgenticMessage(t *testing.T) {
 		assert.Equal(t, "2", ftr2.CallID)
 		assert.Equal(t, 1, len(ftr2.Content))
 		assert.Equal(t, "result2", ftr2.Content[0].Text.Text)
+	})
+
+	t.Run("tool search result", func(t *testing.T) {
+		input := schema.StreamReaderFromArray([][]*schema.Message{
+			{
+				{
+					Role:       schema.Tool,
+					ToolName:   "tool_search",
+					ToolCallID: "call_1",
+					UserInputMultiContent: []schema.MessageInputPart{
+						{
+							Type: schema.ChatMessagePartTypeToolSearchResult,
+							ToolSearchResult: &schema.ToolSearchResult{Tools: []*schema.ToolInfo{
+								{Name: "dynamic_tool", Desc: "dynamic tool"},
+							}},
+						},
+					},
+				},
+			},
+		})
+
+		ret := streamToolMessageToAgenticMessage(input)
+		chunk, err := ret.Recv()
+		require.NoError(t, err)
+		require.Len(t, chunk, 1)
+		require.Len(t, chunk[0].ContentBlocks, 1)
+		block := chunk[0].ContentBlocks[0]
+		assert.Equal(t, schema.ContentBlockTypeToolSearchResult, block.Type)
+		assert.Equal(t, &schema.StreamingMeta{Index: 0}, block.StreamingMeta)
+		require.NotNil(t, block.ToolSearchFunctionToolResult)
+		assert.Equal(t, "call_1", block.ToolSearchFunctionToolResult.CallID)
+		assert.Equal(t, "tool_search", block.ToolSearchFunctionToolResult.Name)
+		require.NotNil(t, block.ToolSearchFunctionToolResult.Result)
+		require.Len(t, block.ToolSearchFunctionToolResult.Result.Tools, 1)
+		assert.Equal(t, "dynamic_tool", block.ToolSearchFunctionToolResult.Result.Tools[0].Name)
 	})
 }
 


### PR DESCRIPTION
## Summary
- Preserve enhanced `ToolSearchResult` as `ToolSearchFunctionToolResult` in AgenticMessage tool-result paths.
- Teach the AgenticToolsNode bridge, ReAct tool-result extraction, and PatchToolCalls middleware to recognize tool-search result blocks.
- Add coverage for invoke/stream conversion, bridge conversion, and patch handling.

## Motivation
Client-executed model tool search returns a structured `ToolResult` containing full deferred tool definitions. That result must remain a tool-search result so model adapters can replay it as provider-native `tool_search_output`; downgrading it to a regular function result loses the semantics.

## Tests
- `go test ./adk ./compose ./adk/middlewares/patchtoolcalls`