### PR TITLE
fix: misc code quality improvements

### DIFF
--- a/adk/flow.go
+++ b/adk/flow.go
@@ -119,7 +119,7 @@ func setSubAgents(ctx context.Context, agent Agent, subAgents []Agent) (*flowAge
 		return nil, errors.New("agent's sub-agents has already been set")
 	}
 
-	if onAgent, ok_ := fa.Agent.(OnSubAgents); ok_ {
+	if onAgent, isSubAgent := fa.Agent.(OnSubAgents); isSubAgent {
 		err := onAgent.OnSetSubAgents(ctx, subAgents)
 		if err != nil {
 			return nil, err
@@ -134,7 +134,7 @@ func setSubAgents(ctx context.Context, agent Agent, subAgents []Agent) (*flowAge
 		}
 
 		fsa.parentAgent = fa
-		if onAgent, ok__ := fsa.Agent.(OnSubAgents); ok__ {
+		if onAgent, isSubAgent := fsa.Agent.(OnSubAgents); isSubAgent {
 			err := onAgent.OnSetAsSubAgent(ctx, agent)
 			if err != nil {
 				return nil, err
@@ -525,8 +525,8 @@ func (a *flowAgent) run(
 
 		subAIter := agentToRun.Run(ctxForSubAgents, nil /*subagents get input from runCtx*/, opts...)
 		for {
-			subEvent, ok_ := subAIter.Next()
-			if !ok_ {
+			subEvent, hasNext := subAIter.Next()
+			if !hasNext {
 				break
 			}
 

--- a/adk/react.go
+++ b/adk/react.go
@@ -31,6 +31,8 @@ import (
 // ErrExceedMaxIterations indicates the agent reached the maximum iterations limit.
 var ErrExceedMaxIterations = errors.New("exceeds max iterations")
 
+const defaultMaxIterations = 20
+
 // State holds agent runtime state including messages and user-extensible storage.
 //
 // Deprecated: This type will be unexported in v1.0.0. Use ChatModelAgentState
@@ -290,7 +292,7 @@ func genReactState(config *reactConfig) func(ctx context.Context) *State {
 		st := &State{
 			AgentName: config.agentName,
 		}
-		maxIter := 20
+		maxIter := defaultMaxIterations
 		if config.maxIterations > 0 {
 			maxIter = config.maxIterations
 		}

--- a/adk/utils.go
+++ b/adk/utils.go
@@ -73,6 +73,9 @@ func cloneSlice[T any](s []T) []T {
 }
 
 func concatInstructions(instructions ...string) string {
+	if len(instructions) == 0 {
+		return ""
+	}
 	var sb strings.Builder
 	sb.WriteString(instructions[0])
 	for i := 1; i < len(instructions); i++ {

--- a/compose/graph.go
+++ b/compose/graph.go
@@ -646,7 +646,7 @@ func (g *graph) compile(ctx context.Context, opt *graphCompileOptions) (*composa
 	cb := pregelChannelBuilder
 	if isChain(g.cmp) || isWorkflow(g.cmp) {
 		if opt != nil && opt.nodeTriggerMode != "" {
-			return nil, errors.New(fmt.Sprintf("%s doesn't support node trigger mode option", g.cmp))
+			return nil, fmt.Errorf("%s doesn't support node trigger mode option", g.cmp)
 		}
 	}
 	if (opt != nil && opt.nodeTriggerMode == AllPredecessor) || isWorkflow(g.cmp) {


### PR DESCRIPTION
## Summary

- **compose/graph.go**: Replace `errors.New(fmt.Sprintf(...))` with idiomatic `fmt.Errorf`
- **adk/utils.go**: Add empty input guard in `concatInstructions` to prevent potential index-out-of-bounds panic
- **adk/flow.go**: Rename `ok_`/`ok__` variables to descriptive names (`isSubAgent`, `hasNext`) for better readability
- **adk/react.go**: Extract hardcoded `maxIter` value `20` to a named constant `defaultMaxIterations`

## Test plan

- [x] `go build ./compose/... ./adk/...` passes
- [x] `go test ./compose/...` passes
- [x] `go test ./adk/` passes