### PR TITLE
feat(components): add unexported messageType constraint to BaseModel

### DIFF
--- a/components/model/interface.go
+++ b/components/model/interface.go
@@ -22,12 +22,18 @@ import (
 	"github.com/cloudwego/eino/schema"
 )
 
+// messageType is the sealed type constraint for message types used in BaseModel.
+// Only *schema.Message and *schema.AgenticMessage satisfy this constraint.
+type messageType interface {
+	*schema.Message | *schema.AgenticMessage
+}
+
 // BaseModel is the generic base model interface parameterized by message type M.
 // It exposes two modes of interaction:
 //   - [BaseModel.Generate]: blocks until the model returns a complete response.
 //   - [BaseModel.Stream]: returns a [schema.StreamReader] that yields message
 //     chunks incrementally as the model generates them.
-type BaseModel[M any] interface {
+type BaseModel[M messageType] interface {
 	Generate(ctx context.Context, input []M, opts ...Option) (M, error)
 	Stream(ctx context.Context, input []M, opts ...Option) (*schema.StreamReader[M], error)
 }


### PR DESCRIPTION
## Summary

| Problem | Solution |
|---------|----------|
| `BaseModel[M any]` accepts arbitrary type arguments (e.g., `BaseModel[int]`) with no compile-time guard | Add unexported `messageType` constraint restricting M to `*schema.Message \| *schema.AgenticMessage` |

## Key Insight

Go's type constraint resolution is structural, not name-based. An **unexported** union constraint still permits external packages to instantiate the generic with the union's member types. This means we can tighten `BaseModel` without breaking any downstream code — all external consumers use the type aliases (`BaseChatModel`, `AgenticModel`) or instantiate with the concrete schema types directly, both of which satisfy the unexported constraint.

## What Changed

- Added `messageType` (unexported, sealed union) interface in `components/model/interface.go`
- Changed `BaseModel[M any]` → `BaseModel[M messageType]`
- No API breakage: `BaseChatModel`, `AgenticModel`, and all `model.BaseModel[*schema.Message]` / `model.BaseModel[*schema.AgenticMessage]` usages compile without modification

## Verification

- `go build ./...` passes
- `go test -race ./components/model/...` passes
- `go test -race ./adk/...` passes (heaviest consumer of `BaseModel[M]`)

---

## 摘要

| 问题 | 方案 |
|------|------|
| `BaseModel[M any]` 允许任意类型参数（如 `BaseModel[int]`），无编译期防护 | 添加未导出的 `messageType` 约束，将 M 限制为 `*schema.Message \| *schema.AgenticMessage` |

## 核心洞察

Go 的类型约束解析是结构化的，而非基于名称。未导出的 union constraint 仍然允许外部包用 union 中的成员类型来实例化泛型。这意味着我们可以收紧 `BaseModel` 的约束而不破坏任何下游代码——所有外部使用者要么使用类型别名（`BaseChatModel`、`AgenticModel`），要么直接用具体的 schema 类型实例化，两者都满足该未导出约束。

## 变更内容

- 在 `components/model/interface.go` 中添加 `messageType`（未导出、密封联合）接口
- 将 `BaseModel[M any]` 改为 `BaseModel[M messageType]`
- 无 API 破坏：`BaseChatModel`、`AgenticModel` 及所有 `model.BaseModel[*schema.Message]` / `model.BaseModel[*schema.AgenticMessage]` 用法无需任何修改即可编译
