### PR TITLE
fix(adk): separate FailoverChatModel trace span from inner model span

### DIFF
--- a/adk/failover_chatmodel.go
+++ b/adk/failover_chatmodel.go
@@ -59,30 +59,39 @@ func getFailoverHasMoreAttempts(ctx context.Context) bool {
 type typedFailoverProxyModel[M MessageType] struct {
 }
 
-func (m *typedFailoverProxyModel[M]) prepareCallbacks(ctx context.Context) (context.Context, model.BaseModel[M], error) {
+func (m *typedFailoverProxyModel[M]) prepareTarget(ctx context.Context) (model.BaseModel[M], error) {
 	target, ok := typedGetFailoverCurrentModel[M](ctx)
 	if !ok {
-		return nil, nil, errors.New("failover current model not found in context")
+		return nil, errors.New("failover current model not found in context")
 	}
-
-	typ, _ := components.GetType(target)
-	ctx = callbacks.EnsureRunInfo(ctx, typ, components.ComponentOfChatModel)
 
 	if !components.IsCallbacksEnabled(target) {
 		target = typedCallbackInjectionModelWrapper[M]{}.wrapModel(target)
 	}
 
-	return ctx, target, nil
+	return target, nil
 }
 
 func (m *typedFailoverProxyModel[M]) Generate(ctx context.Context, input []M, opts ...model.Option) (M, error) {
-	nCtx, target, err := m.prepareCallbacks(ctx)
+	target, err := m.prepareTarget(ctx)
 	if err != nil {
 		var zero M
 		return zero, err
 	}
 
+	// Override compose-level RunInfo with FailoverChatModel identity for the outer span.
+	ctx = callbacks.ReuseHandlers(ctx, &callbacks.RunInfo{
+		Type:      "FailoverChatModel",
+		Component: components.ComponentOfChatModel,
+	})
 	ctx = callbacks.OnStart(ctx, input)
+
+	// Create child RunInfo for the target model.
+	targetType, _ := components.GetType(target)
+	nCtx := callbacks.ReuseHandlers(ctx, &callbacks.RunInfo{
+		Type:      targetType,
+		Component: components.ComponentOfChatModel,
+	})
 
 	result, err := target.Generate(nCtx, input, opts...)
 	if err != nil {
@@ -96,12 +105,24 @@ func (m *typedFailoverProxyModel[M]) Generate(ctx context.Context, input []M, op
 }
 
 func (m *typedFailoverProxyModel[M]) Stream(ctx context.Context, input []M, opts ...model.Option) (*schema.StreamReader[M], error) {
-	nCtx, target, err := m.prepareCallbacks(ctx)
+	target, err := m.prepareTarget(ctx)
 	if err != nil {
 		return nil, err
 	}
 
+	// Override compose-level RunInfo with FailoverChatModel identity for the outer span.
+	ctx = callbacks.ReuseHandlers(ctx, &callbacks.RunInfo{
+		Type:      "FailoverChatModel",
+		Component: components.ComponentOfChatModel,
+	})
 	ctx = callbacks.OnStart(ctx, input)
+
+	// Create child RunInfo for the target model.
+	targetType, _ := components.GetType(target)
+	nCtx := callbacks.ReuseHandlers(ctx, &callbacks.RunInfo{
+		Type:      targetType,
+		Component: components.ComponentOfChatModel,
+	})
 
 	result, err := target.Stream(nCtx, input, opts...)
 	if err != nil {

--- a/adk/failover_chatmodel.go
+++ b/adk/failover_chatmodel.go
@@ -59,21 +59,23 @@ func getFailoverHasMoreAttempts(ctx context.Context) bool {
 type typedFailoverProxyModel[M MessageType] struct {
 }
 
-func (m *typedFailoverProxyModel[M]) prepareTarget(ctx context.Context) (model.BaseModel[M], error) {
+func (m *typedFailoverProxyModel[M]) prepareTarget(ctx context.Context) (model.BaseModel[M], string, error) {
 	target, ok := typedGetFailoverCurrentModel[M](ctx)
 	if !ok {
-		return nil, errors.New("failover current model not found in context")
+		return nil, "", errors.New("failover current model not found in context")
 	}
+
+	targetType, _ := components.GetType(target)
 
 	if !components.IsCallbacksEnabled(target) {
 		target = typedCallbackInjectionModelWrapper[M]{}.wrapModel(target)
 	}
 
-	return target, nil
+	return target, targetType, nil
 }
 
 func (m *typedFailoverProxyModel[M]) Generate(ctx context.Context, input []M, opts ...model.Option) (M, error) {
-	target, err := m.prepareTarget(ctx)
+	target, targetType, err := m.prepareTarget(ctx)
 	if err != nil {
 		var zero M
 		return zero, err
@@ -87,7 +89,6 @@ func (m *typedFailoverProxyModel[M]) Generate(ctx context.Context, input []M, op
 	ctx = callbacks.OnStart(ctx, input)
 
 	// Create child RunInfo for the target model.
-	targetType, _ := components.GetType(target)
 	nCtx := callbacks.ReuseHandlers(ctx, &callbacks.RunInfo{
 		Type:      targetType,
 		Component: components.ComponentOfChatModel,
@@ -105,7 +106,7 @@ func (m *typedFailoverProxyModel[M]) Generate(ctx context.Context, input []M, op
 }
 
 func (m *typedFailoverProxyModel[M]) Stream(ctx context.Context, input []M, opts ...model.Option) (*schema.StreamReader[M], error) {
-	target, err := m.prepareTarget(ctx)
+	target, targetType, err := m.prepareTarget(ctx)
 	if err != nil {
 		return nil, err
 	}
@@ -118,7 +119,6 @@ func (m *typedFailoverProxyModel[M]) Stream(ctx context.Context, input []M, opts
 	ctx = callbacks.OnStart(ctx, input)
 
 	// Create child RunInfo for the target model.
-	targetType, _ := components.GetType(target)
 	nCtx := callbacks.ReuseHandlers(ctx, &callbacks.RunInfo{
 		Type:      targetType,
 		Component: components.ComponentOfChatModel,


### PR DESCRIPTION
## Summary

When `ModelFailoverConfig` is enabled, the `typedFailoverProxyModel` creates an extra trace span with the same identity (`Component=ChatModel`) alongside the inner target model's span. This results in two "ChatModel" spans appearing at the same level in the trace view, even when no actual failover retry occurs.

This PR gives the failover proxy its own distinct trace identity (`Type="FailoverChatModel"`) using `callbacks.ReuseHandlers`, and nests the target model call as a child span underneath it.

## Changes

- Refactor `prepareCallbacks` → `prepareTarget` (no longer responsible for RunInfo setup)
- In `Generate`/`Stream`, use `callbacks.ReuseHandlers` to set the proxy's own RunInfo as `Type="FailoverChatModel"`
- Create a separate child `RunInfo` for the target model with the target's actual type

## Before

```
ChatModel [type="model"]    ← extra span from proxy (redundant, confusing)
ChatModel [type="ep-xxx"]   ← actual model span
```

Two "ChatModel" spans at the same level — the proxy creates a redundant span that is hard to distinguish from the real model call.

## After

```
FailoverChatModel               ← clearly identified wrapper span
  └── ChatModel [type="ep-xxx"] ← actual model span (nested as child)
```

The failover wrapper now has its own distinct identity, and the actual model call is nested as a child span.

## Test plan

- [x] All existing failover tests pass (`TestFailoverModelWrapper_Generate`, `TestFailoverModelWrapper_Stream`, `TestRetryThenFailover`, `TestErrStreamCanceled_Failover`, `TestBuildModelWrappers_FailoverProxyInner`, etc.)
- [ ] Verify trace display in observability UI shows the correct hierarchy