### PR TITLE
fix(adk): avoid nested agentsmd system reminder

### DIFF
--- a/adk/middlewares/agentsmd/agentsmd.go
+++ b/adk/middlewares/agentsmd/agentsmd.go
@@ -111,7 +111,7 @@ func (m *typedMiddleware[M]) BeforeModelRewriteState(ctx context.Context, state 
 	}
 
 	nState := *state
-	nState.Messages = typedInsertBeforeFirstUser(state.Messages, fmt.Sprintf("<system-reminder>\n%s\n</system-reminder>", content))
+	nState.Messages = typedInsertBeforeFirstUser(state.Messages, content)
 	return ctx, &nState, nil
 }
 

--- a/adk/middlewares/agentsmd/agentsmd_generic_test.go
+++ b/adk/middlewares/agentsmd/agentsmd_generic_test.go
@@ -149,6 +149,12 @@ func testAgentsMDGeneric[M adk.MessageType](t *testing.T) {
 				if !strings.Contains(getMsgContent(state.Messages[0]), "<system-reminder>") {
 					t.Fatalf("expected system-reminder tag, got %q", getMsgContent(state.Messages[0]))
 				}
+				if count := strings.Count(getMsgContent(state.Messages[0]), "<system-reminder>"); count != 1 {
+					t.Fatalf("expected exactly one opening system-reminder tag, got %d in %q", count, getMsgContent(state.Messages[0]))
+				}
+				if count := strings.Count(getMsgContent(state.Messages[0]), "</system-reminder>"); count != 1 {
+					t.Fatalf("expected exactly one closing system-reminder tag, got %d in %q", count, getMsgContent(state.Messages[0]))
+				}
 				if getMsgContent(state.Messages[1]) != "hello" {
 					t.Fatalf("expected original message preserved, got %q", getMsgContent(state.Messages[1]))
 				}

--- a/adk/middlewares/agentsmd/agentsmd_test.go
+++ b/adk/middlewares/agentsmd/agentsmd_test.go
@@ -127,6 +127,12 @@ func TestMiddleware_BasicInjection(t *testing.T) {
 	if !strings.Contains(state.Messages[0].Content, "<system-reminder>") {
 		t.Fatalf("expected system-reminder tag, got %q", state.Messages[0].Content)
 	}
+	if count := strings.Count(state.Messages[0].Content, "<system-reminder>"); count != 1 {
+		t.Fatalf("expected exactly one opening system-reminder tag, got %d in %q", count, state.Messages[0].Content)
+	}
+	if count := strings.Count(state.Messages[0].Content, "</system-reminder>"); count != 1 {
+		t.Fatalf("expected exactly one closing system-reminder tag, got %d in %q", count, state.Messages[0].Content)
+	}
 	if state.Messages[1].Content != "hello" {
 		t.Fatalf("expected original message preserved, got %q", state.Messages[1].Content)
 	}


### PR DESCRIPTION
## Summary
- avoid wrapping agentsmd formatted content with an extra `<system-reminder>` tag
- add assertions that injected agentsmd messages contain exactly one opening and closing system-reminder tag

## Test
- go test ./adk/middlewares/agentsmd