### PR TITLE
fix(adk): set streaming meta for agentic tool chunks

### DIFF
--- a/adk/wrappers.go
+++ b/adk/wrappers.go
@@ -594,6 +594,18 @@ func functionToolResultAgenticMessage(callID, name string, content []*schema.Fun
 	}
 }
 
+func markAgenticMessageStreamingMeta(msg *schema.AgenticMessage, index int) {
+	if msg == nil {
+		return
+	}
+	for _, block := range msg.ContentBlocks {
+		if block == nil {
+			continue
+		}
+		block.StreamingMeta = &schema.StreamingMeta{Index: index}
+	}
+}
+
 func toolSearchResultAgenticMessage(callID, name string, tr *schema.ToolResult) (*schema.AgenticMessage, bool) {
 	if tr == nil || len(tr.Parts) != 1 {
 		return nil, false
@@ -745,6 +757,7 @@ func typedToolStreamEvent[M MessageType](callID, toolName, toolMsgID string, str
 		first := true
 		cvt := func(in string) (*schema.AgenticMessage, error) {
 			msg := functionToolResultAgenticMessage(callID, toolName, textToFunctionToolResultBlocks(in))
+			markAgenticMessageStreamingMeta(msg, 0)
 			if first {
 				first = false
 				msg.Extra = internal.SetMessageID(msg.Extra, toolMsgID)
@@ -813,6 +826,7 @@ func typedToolEnhancedStreamEvent[M MessageType](callID, toolName, toolMsgID str
 		first := true
 		cvt := func(in *schema.ToolResult) (*schema.AgenticMessage, error) {
 			msg := toolResultAgenticMessage(callID, toolName, in)
+			markAgenticMessageStreamingMeta(msg, 0)
 			if first {
 				first = false
 				msg.Extra = internal.SetMessageID(msg.Extra, toolMsgID)

--- a/adk/wrappers_test.go
+++ b/adk/wrappers_test.go
@@ -1974,6 +1974,75 @@ func TestAgenticEventSenderToolHandler(t *testing.T) {
 	})
 }
 
+func TestTypedToolStreamEventAgenticMessageSetsStreamingMeta(t *testing.T) {
+	event := typedToolStreamEvent[*schema.AgenticMessage](
+		"call_1",
+		"execute",
+		"msg_1",
+		schema.StreamReaderFromArray([]string{"first\n", "second\n"}),
+	)
+	require.NotNil(t, event)
+	require.NotNil(t, event.Output)
+	require.NotNil(t, event.Output.MessageOutput)
+	require.True(t, event.Output.MessageOutput.IsStreaming)
+	require.NotNil(t, event.Output.MessageOutput.MessageStream)
+
+	first, err := event.Output.MessageOutput.MessageStream.Recv()
+	require.NoError(t, err)
+	require.Len(t, first.ContentBlocks, 1)
+	assert.Equal(t, &schema.StreamingMeta{Index: 0}, first.ContentBlocks[0].StreamingMeta)
+
+	second, err := event.Output.MessageOutput.MessageStream.Recv()
+	require.NoError(t, err)
+	require.Len(t, second.ContentBlocks, 1)
+	assert.Equal(t, &schema.StreamingMeta{Index: 0}, second.ContentBlocks[0].StreamingMeta)
+
+	result, err := schema.ConcatAgenticMessages([]*schema.AgenticMessage{first, second})
+	require.NoError(t, err)
+	require.Len(t, result.ContentBlocks, 1)
+	assert.Nil(t, result.ContentBlocks[0].StreamingMeta)
+	require.NotNil(t, result.ContentBlocks[0].FunctionToolResult)
+	require.Len(t, result.ContentBlocks[0].FunctionToolResult.Content, 2)
+	assert.Equal(t, "first\n", result.ContentBlocks[0].FunctionToolResult.Content[0].Text.Text)
+	assert.Equal(t, "second\n", result.ContentBlocks[0].FunctionToolResult.Content[1].Text.Text)
+}
+
+func TestTypedToolEnhancedStreamEventAgenticMessageSetsStreamingMeta(t *testing.T) {
+	event := typedToolEnhancedStreamEvent[*schema.AgenticMessage](
+		"call_1",
+		"execute",
+		"msg_1",
+		schema.StreamReaderFromArray([]*schema.ToolResult{
+			{Parts: []schema.ToolOutputPart{{Type: schema.ToolPartTypeText, Text: "first\n"}}},
+			{Parts: []schema.ToolOutputPart{{Type: schema.ToolPartTypeText, Text: "second\n"}}},
+		}),
+	)
+	require.NotNil(t, event)
+	require.NotNil(t, event.Output)
+	require.NotNil(t, event.Output.MessageOutput)
+	require.True(t, event.Output.MessageOutput.IsStreaming)
+	require.NotNil(t, event.Output.MessageOutput.MessageStream)
+
+	first, err := event.Output.MessageOutput.MessageStream.Recv()
+	require.NoError(t, err)
+	require.Len(t, first.ContentBlocks, 1)
+	assert.Equal(t, &schema.StreamingMeta{Index: 0}, first.ContentBlocks[0].StreamingMeta)
+
+	second, err := event.Output.MessageOutput.MessageStream.Recv()
+	require.NoError(t, err)
+	require.Len(t, second.ContentBlocks, 1)
+	assert.Equal(t, &schema.StreamingMeta{Index: 0}, second.ContentBlocks[0].StreamingMeta)
+
+	result, err := schema.ConcatAgenticMessages([]*schema.AgenticMessage{first, second})
+	require.NoError(t, err)
+	require.Len(t, result.ContentBlocks, 1)
+	assert.Nil(t, result.ContentBlocks[0].StreamingMeta)
+	require.NotNil(t, result.ContentBlocks[0].FunctionToolResult)
+	require.Len(t, result.ContentBlocks[0].FunctionToolResult.Content, 2)
+	assert.Equal(t, "first\n", result.ContentBlocks[0].FunctionToolResult.Content[0].Text.Text)
+	assert.Equal(t, "second\n", result.ContentBlocks[0].FunctionToolResult.Content[1].Text.Text)
+}
+
 // multimodalEnhancedInvokableTestTool returns a pre-built multimodal ToolResult.
 type multimodalEnhancedInvokableTestTool struct {
 	name   string
@@ -2091,6 +2160,7 @@ func TestTypedToolEnhancedEventAgenticToolSearchResult(t *testing.T) {
 		require.Len(t, msg.ContentBlocks, 1)
 		block := msg.ContentBlocks[0]
 		assert.Equal(t, schema.ContentBlockTypeToolSearchResult, block.Type)
+		assert.Equal(t, &schema.StreamingMeta{Index: 0}, block.StreamingMeta)
 		require.NotNil(t, block.ToolSearchFunctionToolResult)
 		assert.Equal(t, "call_2", block.ToolSearchFunctionToolResult.CallID)
 		assert.Equal(t, "tool_search", block.ToolSearchFunctionToolResult.Name)


### PR DESCRIPTION
# Agentic Tool Stream Metadata

## Problem
Streamable tool results emitted through the ADK event sender were converted into `AgenticMessage` chunks without `StreamingMeta`.

Expected behavior:
- streamed chunks from the same tool result are grouped by stream index
- `schema.ConcatAgenticMessages` materializes them into one final `function_tool_result` block

Actual behavior:
- every chunk looked like an independent non-streaming `function_tool_result`
- materialization could not group chunks because the stream grouping signal was missing

## Solution
Mark `AgenticMessage` chunks produced by `typedToolStreamEvent` and `typedToolEnhancedStreamEvent` with `StreamingMeta{Index: 0}`.

This matches the existing `AgenticToolsNode.Stream` behavior and gives `schema.ConcatAgenticMessages` the grouping signal it needs. The final materialized message still drops transient `StreamingMeta`; it only uses the metadata while concatenating stream chunks.


## Key Insight
There are two Agentic tool streaming producers:
- `AgenticToolsNode.Stream`, which already attaches `StreamingMeta`
- ADK event-sender wrappers, which re-wrap tool stream chunks for user-visible events and also need to attach `StreamingMeta`

`StreamingMeta` is not persisted as final message state. It is a transient stream-concat hint used before materialization.

## Summary
| Problem | Solution |
|---------|----------|
| ADK streamable tool chunks lacked `StreamingMeta` | Set `StreamingMeta{Index: 0}` in `typedToolStreamEvent` |
| Enhanced streamable tool chunks had the same risk | Set `StreamingMeta{Index: 0}` in `typedToolEnhancedStreamEvent` |

---

# Agentic 工具流式元数据

## 问题
ADK event sender 发出的 Streamable tool result 会被转换成 `AgenticMessage` chunk，但这些 chunk 没有 `StreamingMeta`。

预期行为：
- 同一个 tool result 的流式 chunk 按 stream index 分组
- `schema.ConcatAgenticMessages` 将它们物化成一个最终的 `function_tool_result` block

实际行为：
- 每个 chunk 都像独立的非流式 `function_tool_result`
- 因缺少 stream 分组信号，物化过程无法将这些 chunk 归并到同一个 tool result

## 解决方案
在 `typedToolStreamEvent` 和 `typedToolEnhancedStreamEvent` 生成的 `AgenticMessage` chunk 上设置 `StreamingMeta{Index: 0}`。

这与现有 `AgenticToolsNode.Stream` 行为保持一致，并为 `schema.ConcatAgenticMessages` 提供正确的分组信号。最终物化后的 message 仍然不会保留临时的 `StreamingMeta`；它只在流式 chunk 拼接阶段使用。


## 关键洞察
Agentic tool streaming 有两个生产者：
- `AgenticToolsNode.Stream`，它已经会设置 `StreamingMeta`
- ADK event-sender wrappers，它会重新包装 tool stream chunk 作为用户可见事件，也需要设置 `StreamingMeta`

`StreamingMeta` 不是最终消息状态的一部分。它是物化前用于 stream concat 的临时分组信号。

## 总结
| 问题 | 解决方案 |
|------|----------|
| ADK streamable tool chunk 缺少 `StreamingMeta` | 在 `typedToolStreamEvent` 中设置 `StreamingMeta{Index: 0}` |
| enhanced streamable tool chunk 有同样风险 | 在 `typedToolEnhancedStreamEvent` 中设置 `StreamingMeta{Index: 0}` |
