### PR TITLE
feat(components): support call-time index option

### DIFF
--- a/components/indexer/interface.go
+++ b/components/indexer/interface.go
@@ -30,8 +30,9 @@ import (
 // the implementation generates vectors before storing — the same embedder
 // must be used by the paired [retriever.Retriever].
 //
-// Use [Options.SubIndexes] to write documents into logical sub-partitions
-// within the same store.
+// Use [Options.Index] to choose a backend index at call time, and
+// [Options.SubIndexes] to write documents into logical sub-partitions within
+// the same store.
 //
 //go:generate  mockgen -destination ../../internal/mock/components/indexer/indexer_mock.go --package indexer -source interface.go
 type Indexer interface {

--- a/components/indexer/option.go
+++ b/components/indexer/option.go
@@ -20,10 +20,21 @@ import "github.com/cloudwego/eino/components/embedding"
 
 // Options is the options for the indexer.
 type Options struct {
+	// Index is the index for the indexer, index in different indexers may be different.
+	Index *string
 	// SubIndexes is the sub indexes to be indexed.
 	SubIndexes []string
 	// Embedding is the embedding component.
 	Embedding embedding.Embedder
+}
+
+// WithIndex wraps the index option.
+func WithIndex(index string) Option {
+	return Option{
+		apply: func(opts *Options) {
+			opts.Index = &index
+		},
+	}
 }
 
 // WithSubIndexes is the option to set the sub indexes for the indexer.

--- a/components/indexer/option_test.go
+++ b/components/indexer/option_test.go
@@ -27,17 +27,20 @@ import (
 func TestOptions(t *testing.T) {
 	convey.Convey("test options", t, func() {
 		var (
+			index      = "index"
 			subIndexes = []string{"index_1", "index_2"}
 			e          = &embedding.MockEmbedder{}
 		)
 
 		opts := GetCommonOptions(
 			&Options{},
+			WithIndex(index),
 			WithSubIndexes(subIndexes),
 			WithEmbedding(e),
 		)
 
 		convey.So(opts, convey.ShouldResemble, &Options{
+			Index:      &index,
 			SubIndexes: subIndexes,
 			Embedding:  e,
 		})


### PR DESCRIPTION
## Summary

- Add `indexer.WithIndex` and `Options.Index` for call-time index selection.
- Document that indexers can use `Options.Index` for backend index selection alongside `SubIndexes`.
- Cover the new option in indexer option tests.

## Motivation

Retrievers already expose `retriever.WithIndex` for call-time index overrides. Adding the same standard option for indexers lets storage implementations support dynamic target indexes without implementation-specific option APIs.

## Tests

- `go test ./components/indexer`
