### PR TITLE
fix(compose): skip typed-nil inputs when persisting checkpoints

### DIFF
--- a/compose/graph_run.go
+++ b/compose/graph_run.go
@@ -499,6 +499,28 @@ func getHitKey(tasks []*task, keys []string) []string {
 	return ret
 }
 
+// isNilCheckpointInput reports whether v should be omitted from cp.Inputs.
+// It catches both untyped nil and typed-nil values (e.g. (*T)(nil) boxed in
+// an interface{}). Typed-nil pointers compare unequal to nil at the interface
+// level but cannot be encoded by gob ("cannot encode nil pointer of type T
+// inside interface"), so they must be filtered out before persistence.
+//
+// Skipping a typed-nil entry is equivalent to omitting it: on resume,
+// restoreTasks reconstructs a zero-valued input via inputZeroValue() /
+// inputEmptyStream() for any rerun node that has no entry in cp.Inputs,
+// which yields the same nil-pointer value the producer originally captured.
+func isNilCheckpointInput(v any) bool {
+	if v == nil {
+		return true
+	}
+	rv := reflect.ValueOf(v)
+	switch rv.Kind() {
+	case reflect.Ptr, reflect.Interface, reflect.Map, reflect.Slice, reflect.Chan, reflect.Func:
+		return rv.IsNil()
+	}
+	return false
+}
+
 func (r *runner) handleInterrupt(
 	ctx context.Context,
 	tempInfo *interruptTempInfo,
@@ -545,7 +567,9 @@ func (r *runner) handleInterrupt(
 	cp.InterruptID2Addr, cp.InterruptID2State = core.SignalToPersistenceMaps(is)
 
 	for _, t := range nextTasks {
-		cp.Inputs[t.nodeKey] = t.input
+		if !isNilCheckpointInput(t.input) {
+			cp.Inputs[t.nodeKey] = t.input
+		}
 	}
 	err = r.checkPointer.convertCheckPoint(cp, isStream)
 	if err != nil {
@@ -683,7 +707,7 @@ func (r *runner) handleInterruptWithSubGraphAndRerunNodes(
 	}
 	for _, t := range rerunTasks {
 		cp.RerunNodes = append(cp.RerunNodes, t.nodeKey)
-		if t.originalInput != nil {
+		if !isNilCheckpointInput(t.originalInput) {
 			cp.Inputs[t.nodeKey] = t.originalInput
 		}
 	}


### PR DESCRIPTION
## Summary

| User-visible problem | Root cause | Fix |
|----------------------|-----------|-----|
| `failed to set checkpoint: gob marshal error: gob: cannot encode nil pointer of type *adk.agenticReactInput inside interface` when `CancelImmediate` fires during a `ChatModelAgent` run with `WithCheckPointStore + GobSerializer` | `cp.Inputs[nodeKey]` may receive a typed-nil pointer (e.g. `(*T)(nil)`) and the existing `!= nil` interface comparison lets it through. `encoding/gob` cannot encode a typed-nil pointer behind an `any` slot. | Filter typed-nil values via `reflect` before assigning to `cp.Inputs` in both `handleInterrupt` and `handleInterruptWithSubGraphAndRerunNodes`. |

## Why this happens

`compose.WithGraphInterrupt(ctx)` is the only way for ADK to perform a managed cancel that produces a resumable checkpoint. Per its contract, it implicitly enables **`persistRerunInput = true`** for every task in every nested graph, so each task captures `originalInput = currentTask.input` before executing. When `CancelImmediate` fires:

1. The cancel closure (registered via `cancelContext.setGraphInterruptFunc`) writes to the buffered `chan *time.Duration` and closes it.
2. The currently-running task is canceled by `taskManager.receiveWithListening`; the rerun task's `originalInput` snapshot is what gets persisted.
3. Under streaming or producer-side races, that snapshot can be a typed-nil pointer (e.g. the inner subgraph's `Init` task was queued with the channel's zero-value, or a canceled stream wrapper concated to a single zero chunk).
4. The existing guard `if t.originalInput != nil` (interface comparison) returns true for typed-nil, so the value flows into `cp.Inputs`.
5. The outer chain wraps the subgraph checkpoint into `cp.SubGraphs["AgenticReAct"]` and calls `GobSerializer.Marshal(cp)`, which fails on the typed-nil entry.

The same path exists for the simple-interrupt branch (`handleInterrupt`) when a top-level node receives a typed-nil input.

## Key insight

A Go `interface{}` holding a typed-nil pointer is **not equal to `nil`** at the interface level (`v != nil` is true), but `encoding/gob` correctly rejects it. The framework's nil-check therefore had a structural blind spot whenever any node could legitimately or accidentally produce a nil-pointer value. This is a property of the persistence layer, not of any specific node, so the right fix is at the framework's checkpoint-input population sites, not at the producer.

## What changed

- New unexported helper `isNilCheckpointInput(v any) bool` in `compose/graph_run.go` that uses `reflect.Value.IsNil` for `Ptr/Interface/Map/Slice/Chan/Func` kinds.
- `handleInterrupt` simple-interrupt path: skip when input is typed-nil.
- `handleInterruptWithSubGraphAndRerunNodes` rerun-tasks path: replace the existing interface-level `!= nil` guard with `!isNilCheckpointInput`.

## Behavior preservation

Skipping a typed-nil entry is observationally identical to storing it. On resume, `restoreTasks` already reconstructs a zero-valued input via `inputZeroValue()` / `inputEmptyStream()` for every rerun node missing from `cp.Inputs`, which yields the same nil-pointer the producer originally captured. No data is lost; gob never sees an entry it cannot encode.

## Scope and risk

- Only the checkpoint persistence path is touched; hot execution path is unaffected.
- The reflect call runs only on interrupt, bounded by the number of rerun/next tasks.
- No public API change; helper is unexported.
- `go test -race ./compose/...` passes.

---

## 摘要

| 用户可见问题 | 根因 | 修复 |
|-----|-----|-----|
| 在 ChatModelAgent 运行期间触发 CancelImmediate 时（启用 WithCheckPointStore + GobSerializer），出现 `failed to set checkpoint: gob marshal error: gob: cannot encode nil pointer of type *adk.agenticReactInput inside interface` | `cp.Inputs[nodeKey]` 可能写入 typed-nil 指针（如 `(*T)(nil)`），原有的 `!= nil` 接口判断对其无效。`encoding/gob` 无法编码隐藏在 `any` 槽位内的 typed-nil 指针。 | 在 `handleInterrupt` 与 `handleInterruptWithSubGraphAndRerunNodes` 写入 `cp.Inputs` 之前，使用 `reflect` 过滤掉 typed-nil 值。 |

## 关键洞察

Go 中接口槽位包裹的 typed-nil 指针在接口层面与 `nil` 不相等（`v != nil` 为真），但 `encoding/gob` 会正确拒绝它。框架原有的 nil 判断在「任意节点可能产生 nil 指针值」的场景下存在结构性盲点。修复点应在框架的 checkpoint 输入写入处，而非各个生产端。

## 行为保留

跳过 typed-nil 项与持久化它在观察上完全等价：恢复阶段 `restoreTasks` 会为 `cp.Inputs` 中缺失的 rerun 节点通过 `inputZeroValue()` / `inputEmptyStream()` 重建零值输入，得到的正是生产端原本捕获的 nil 指针。无数据丢失；gob 不再遇到无法编码的项。
