### PR TITLE
refactor: reimplement tool patching via reverse traversal

### DIFF
--- a/adk/middlewares/patchtoolcalls/patchtoolcalls.go
+++ b/adk/middlewares/patchtoolcalls/patchtoolcalls.go
@@ -20,7 +20,6 @@ package patchtoolcalls
 import (
 	"context"
 	"fmt"
-	"maps"
 
 	"github.com/cloudwego/eino/adk"
 	"github.com/cloudwego/eino/adk/internal"
@@ -160,7 +159,9 @@ func patchToolCallsForAgenticMessage[M adk.MessageType](ctx context.Context,
 		}
 
 		patched = append(patched, msg)
-		maps.Copy(seenIDs, currentToolIDs)
+		for k, v := range currentToolIDs {
+			seenIDs[k] = v
+		}
 	}
 
 	nState := *state

--- a/adk/middlewares/patchtoolcalls/patchtoolcalls.go
+++ b/adk/middlewares/patchtoolcalls/patchtoolcalls.go
@@ -94,13 +94,11 @@ func patchToolCallsForMessage[M adk.MessageType](ctx context.Context,
 ) (context.Context, *adk.TypedChatModelAgentState[M], error) {
 	// seenIDs stores unique tool call IDs collected by reverse traversal
 	seenIDs := make(map[string]struct{})
-	groupedMessages := make([][]*schema.Message, 0, len(state.Messages))
-	totalMsgCount := 0
+	patched := make([]*schema.Message, 0, len(state.Messages))
 
 	// Iterate messages in reverse order to track existing tool call IDs
 	for i := len(state.Messages) - 1; i >= 0; i-- {
 		msg := state.Messages[i]
-		currentMessages := []*schema.Message{msg}
 
 		if msg.Role == schema.Tool {
 			seenIDs[msg.ToolCallID] = struct{}{}
@@ -113,22 +111,16 @@ func patchToolCallsForMessage[M adk.MessageType](ctx context.Context,
 					if err != nil {
 						return ctx, nil, err
 					}
-					currentMessages = append(currentMessages, toolMsg)
+					patched = append(patched, toolMsg)
 				}
 			}
 		}
 
-		groupedMessages = append(groupedMessages, currentMessages)
-		totalMsgCount += len(currentMessages)
-	}
-
-	patched := make([]*schema.Message, 0, totalMsgCount)
-	for i := len(groupedMessages) - 1; i >= 0; i-- {
-		patched = append(patched, groupedMessages[i]...)
+		patched = append(patched, msg)
 	}
 
 	nState := *state
-	nState.Messages = patched
+	nState.Messages = reverse(patched)
 	return ctx, any(&nState).(*adk.TypedChatModelAgentState[M]), nil
 }
 
@@ -139,13 +131,11 @@ func patchToolCallsForAgenticMessage[M adk.MessageType](ctx context.Context,
 ) (context.Context, *adk.TypedChatModelAgentState[M], error) {
 	// seenIDs stores unique tool call IDs collected by reverse traversal
 	seenIDs := make(map[string]struct{})
-	groupedMessages := make([][]*schema.AgenticMessage, 0, len(state.Messages))
-	totalMsgCount := 0
+	patched := make([]*schema.AgenticMessage, 0, len(state.Messages))
 
 	// Iterate messages in reverse order to track existing tool call IDs
 	for i := len(state.Messages) - 1; i >= 0; i-- {
 		msg := state.Messages[i]
-		currentMessages := []*schema.AgenticMessage{msg}
 		currentToolIDs := make(map[string]struct{})
 
 		for _, block := range msg.ContentBlocks {
@@ -164,22 +154,17 @@ func patchToolCallsForAgenticMessage[M adk.MessageType](ctx context.Context,
 					if err != nil {
 						return ctx, nil, err
 					}
-					currentMessages = append(currentMessages, toolMsg)
+					patched = append(patched, toolMsg)
 				}
 			}
 		}
-		maps.Copy(seenIDs, currentToolIDs)
-		groupedMessages = append(groupedMessages, currentMessages)
-		totalMsgCount += len(currentMessages)
-	}
 
-	patched := make([]*schema.AgenticMessage, 0, totalMsgCount)
-	for i := len(groupedMessages) - 1; i >= 0; i-- {
-		patched = append(patched, groupedMessages[i]...)
+		patched = append(patched, msg)
+		maps.Copy(seenIDs, currentToolIDs)
 	}
 
 	nState := *state
-	nState.Messages = patched
+	nState.Messages = reverse(patched)
 	return ctx, any(&nState).(*adk.TypedChatModelAgentState[M]), nil
 }
 
@@ -227,6 +212,13 @@ func createPatchedAgenticToolMessage(ctx context.Context, gen func(ctx context.C
 			}),
 		},
 	}, nil
+}
+
+func reverse[M adk.MessageType](s []M) []M {
+	for i, j := 0, len(s)-1; i < j; i, j = i+1, j-1 {
+		s[i], s[j] = s[j], s[i]
+	}
+	return s
 }
 
 const (

--- a/adk/middlewares/patchtoolcalls/patchtoolcalls.go
+++ b/adk/middlewares/patchtoolcalls/patchtoolcalls.go
@@ -20,6 +20,7 @@ package patchtoolcalls
 import (
 	"context"
 	"fmt"
+	"maps"
 
 	"github.com/cloudwego/eino/adk"
 	"github.com/cloudwego/eino/adk/internal"
@@ -69,8 +70,8 @@ type typedMiddleware[M adk.MessageType] struct {
 }
 
 func (m *typedMiddleware[M]) BeforeModelRewriteState(ctx context.Context, state *adk.TypedChatModelAgentState[M],
-	mc *adk.TypedModelContext[M]) (context.Context, *adk.TypedChatModelAgentState[M], error) {
-
+	mc *adk.TypedModelContext[M],
+) (context.Context, *adk.TypedChatModelAgentState[M], error) {
 	if len(state.Messages) == 0 {
 		return ctx, state, nil
 	}
@@ -89,28 +90,41 @@ func (m *typedMiddleware[M]) BeforeModelRewriteState(ctx context.Context, state 
 func patchToolCallsForMessage[M adk.MessageType](ctx context.Context,
 	gen func(ctx context.Context, toolName, toolCallID string) (string, error),
 	state *adk.TypedChatModelAgentState[*schema.Message],
-	_ *adk.TypedModelContext[M]) (context.Context, *adk.TypedChatModelAgentState[M], error) {
+	_ *adk.TypedModelContext[M],
+) (context.Context, *adk.TypedChatModelAgentState[M], error) {
+	// seenIDs stores unique tool call IDs collected by reverse traversal
+	seenIDs := make(map[string]struct{})
+	groupedMessages := make([][]*schema.Message, 0, len(state.Messages))
+	totalMsgCount := 0
 
-	patched := make([]*schema.Message, 0, len(state.Messages))
+	// Iterate messages in reverse order to track existing tool call IDs
+	for i := len(state.Messages) - 1; i >= 0; i-- {
+		msg := state.Messages[i]
+		currentMessages := []*schema.Message{msg}
 
-	for i, msg := range state.Messages {
-		patched = append(patched, msg)
-
-		if msg.Role != schema.Assistant || len(msg.ToolCalls) == 0 {
-			continue
+		if msg.Role == schema.Tool {
+			seenIDs[msg.ToolCallID] = struct{}{}
 		}
 
-		for _, tc := range msg.ToolCalls {
-			if hasCorrespondingToolMessage(state.Messages[i+1:], tc.ID) {
-				continue
+		if msg.Role == schema.Assistant && len(msg.ToolCalls) > 0 {
+			for _, tc := range msg.ToolCalls {
+				if _, exists := seenIDs[tc.ID]; !exists {
+					toolMsg, err := createPatchedToolMessage(ctx, gen, tc)
+					if err != nil {
+						return ctx, nil, err
+					}
+					currentMessages = append(currentMessages, toolMsg)
+				}
 			}
-
-			toolMsg, err := createPatchedToolMessage(ctx, gen, tc)
-			if err != nil {
-				return ctx, nil, err
-			}
-			patched = append(patched, toolMsg)
 		}
+
+		groupedMessages = append(groupedMessages, currentMessages)
+		totalMsgCount += len(currentMessages)
+	}
+
+	patched := make([]*schema.Message, 0, totalMsgCount)
+	for i := len(groupedMessages) - 1; i >= 0; i-- {
+		patched = append(patched, groupedMessages[i]...)
 	}
 
 	nState := *state
@@ -121,78 +135,52 @@ func patchToolCallsForMessage[M adk.MessageType](ctx context.Context,
 func patchToolCallsForAgenticMessage[M adk.MessageType](ctx context.Context,
 	gen func(ctx context.Context, toolName, toolCallID string) (string, error),
 	state *adk.TypedChatModelAgentState[*schema.AgenticMessage],
-	_ *adk.TypedModelContext[M]) (context.Context, *adk.TypedChatModelAgentState[M], error) {
+	_ *adk.TypedModelContext[M],
+) (context.Context, *adk.TypedChatModelAgentState[M], error) {
+	// seenIDs stores unique tool call IDs collected by reverse traversal
+	seenIDs := make(map[string]struct{})
+	groupedMessages := make([][]*schema.AgenticMessage, 0, len(state.Messages))
+	totalMsgCount := 0
 
-	patched := make([]*schema.AgenticMessage, 0, len(state.Messages))
+	// Iterate messages in reverse order to track existing tool call IDs
+	for i := len(state.Messages) - 1; i >= 0; i-- {
+		msg := state.Messages[i]
+		currentMessages := []*schema.AgenticMessage{msg}
+		currentToolIDs := make(map[string]struct{})
 
-	for i, msg := range state.Messages {
-		patched = append(patched, msg)
-
-		if msg.Role != schema.AgenticRoleTypeAssistant {
-			continue
-		}
-
-		// Collect tool call IDs from this assistant message.
-		var toolCalls []struct {
-			callID string
-			name   string
-		}
 		for _, block := range msg.ContentBlocks {
-			if block != nil && block.Type == schema.ContentBlockTypeFunctionToolCall && block.FunctionToolCall != nil {
-				toolCalls = append(toolCalls, struct {
-					callID string
-					name   string
-				}{callID: block.FunctionToolCall.CallID, name: block.FunctionToolCall.Name})
-			}
-		}
-		if len(toolCalls) == 0 {
-			continue
-		}
-
-		for _, tc := range toolCalls {
-			if hasCorrespondingAgenticToolResult(state.Messages[i+1:], tc.callID) {
+			if block == nil {
 				continue
 			}
-
-			toolMsg, err := createPatchedAgenticToolMessage(ctx, gen, tc.name, tc.callID)
-			if err != nil {
-				return ctx, nil, err
+			if block.Type == schema.ContentBlockTypeFunctionToolResult && block.FunctionToolResult != nil {
+				currentToolIDs[block.FunctionToolResult.CallID] = struct{}{}
 			}
-			patched = append(patched, toolMsg)
+			if block.Type == schema.ContentBlockTypeToolSearchResult && block.ToolSearchFunctionToolResult != nil {
+				currentToolIDs[block.ToolSearchFunctionToolResult.CallID] = struct{}{}
+			}
+			if block.Type == schema.ContentBlockTypeFunctionToolCall && block.FunctionToolCall != nil {
+				if _, exists := seenIDs[block.FunctionToolCall.CallID]; !exists {
+					toolMsg, err := createPatchedAgenticToolMessage(ctx, gen, block.FunctionToolCall.Name, block.FunctionToolCall.CallID)
+					if err != nil {
+						return ctx, nil, err
+					}
+					currentMessages = append(currentMessages, toolMsg)
+				}
+			}
 		}
+		maps.Copy(seenIDs, currentToolIDs)
+		groupedMessages = append(groupedMessages, currentMessages)
+		totalMsgCount += len(currentMessages)
+	}
+
+	patched := make([]*schema.AgenticMessage, 0, totalMsgCount)
+	for i := len(groupedMessages) - 1; i >= 0; i-- {
+		patched = append(patched, groupedMessages[i]...)
 	}
 
 	nState := *state
 	nState.Messages = patched
 	return ctx, any(&nState).(*adk.TypedChatModelAgentState[M]), nil
-}
-
-func hasCorrespondingToolMessage(messages []*schema.Message, toolCallID string) bool {
-	for _, msg := range messages {
-		if msg.Role == schema.Tool && msg.ToolCallID == toolCallID {
-			return true
-		}
-	}
-	return false
-}
-
-func hasCorrespondingAgenticToolResult(messages []*schema.AgenticMessage, toolCallID string) bool {
-	for _, msg := range messages {
-		for _, block := range msg.ContentBlocks {
-			if block == nil {
-				continue
-			}
-			if block.Type == schema.ContentBlockTypeFunctionToolResult &&
-				block.FunctionToolResult != nil && block.FunctionToolResult.CallID == toolCallID {
-				return true
-			}
-			if block.Type == schema.ContentBlockTypeToolSearchResult &&
-				block.ToolSearchFunctionToolResult != nil && block.ToolSearchFunctionToolResult.CallID == toolCallID {
-				return true
-			}
-		}
-	}
-	return false
 }
 
 func createPatchedToolMessage(ctx context.Context, gen func(ctx context.Context, toolName, toolCallID string) (string, error), tc schema.ToolCall) (*schema.Message, error) {

--- a/adk/middlewares/patchtoolcalls/patchtoolcalls.go
+++ b/adk/middlewares/patchtoolcalls/patchtoolcalls.go
@@ -135,17 +135,16 @@ func patchToolCallsForAgenticMessage[M adk.MessageType](ctx context.Context,
 	// Iterate messages in reverse order to track existing tool call IDs
 	for i := len(state.Messages) - 1; i >= 0; i-- {
 		msg := state.Messages[i]
-		currentToolIDs := make(map[string]struct{})
 
 		for _, block := range msg.ContentBlocks {
 			if block == nil {
 				continue
 			}
 			if block.Type == schema.ContentBlockTypeFunctionToolResult && block.FunctionToolResult != nil {
-				currentToolIDs[block.FunctionToolResult.CallID] = struct{}{}
+				seenIDs[block.FunctionToolResult.CallID] = struct{}{}
 			}
 			if block.Type == schema.ContentBlockTypeToolSearchResult && block.ToolSearchFunctionToolResult != nil {
-				currentToolIDs[block.ToolSearchFunctionToolResult.CallID] = struct{}{}
+				seenIDs[block.ToolSearchFunctionToolResult.CallID] = struct{}{}
 			}
 			if block.Type == schema.ContentBlockTypeFunctionToolCall && block.FunctionToolCall != nil {
 				if _, exists := seenIDs[block.FunctionToolCall.CallID]; !exists {
@@ -159,9 +158,6 @@ func patchToolCallsForAgenticMessage[M adk.MessageType](ctx context.Context,
 		}
 
 		patched = append(patched, msg)
-		for k, v := range currentToolIDs {
-			seenIDs[k] = v
-		}
 	}
 
 	nState := *state


### PR DESCRIPTION
## PR Description

### 中文
重构工具调用补全逻辑，通过维护工具调用 ID 集合 + 反向遍历的方式，将时间复杂度从 **O(n²)** 优化到 **O(n)**。
移除了原有的冗余线性查找，提升长消息列表下的性能，同时保持原有功能完全不变。

### English
Refactor the tool call patching logic.
Optimize time complexity from **O(n²)** to **O(n)** by tracking tool call IDs with a set and using reverse traversal.
Remove redundant linear lookups to improve performance with long message lists, while keeping all functionality unchanged.