### PR TITLE
feat: add BeforeModelRewriteState hook to plantask middleware to inje…

### DIFF
--- a/adk/middlewares/plantask/plantask.go
+++ b/adk/middlewares/plantask/plantask.go
@@ -110,12 +110,12 @@ func (m *typedMiddleware[M]) BeforeModelRewriteState(ctx context.Context, state 
 	}
 
 	// Task information is already present in the conversation history.
-	if hasTaskMessagesInHistory(state.Messages) {
+	if hasTaskInfoInContext(state) {
 		return ctx, state, nil
 	}
 
-	// A reminder message has already been injected — avoid duplicate warnings.
-	if hasReminderMessageInHistory(state.Messages) {
+	// Idempotent: if we already injected, return early.
+	if taskReminderAlreadyInjected(state) {
 		return ctx, state, nil
 	}
 
@@ -125,22 +125,20 @@ func (m *typedMiddleware[M]) BeforeModelRewriteState(ctx context.Context, state 
 	return ctx, &nState, nil
 }
 
-// hasTaskMessagesInHistory checks whether the conversation history already contains task-related messages.
-func hasTaskMessagesInHistory[M adk.MessageType](messages []M) bool {
-	for _, msg := range messages {
-		if hasTaskInMessage(msg) {
+// hasTaskInfoInContext checks whether the conversation history already contains task-related messages.
+func hasTaskInfoInContext[M adk.MessageType](state *adk.TypedChatModelAgentState[M]) bool {
+	for _, msg := range state.Messages {
+		if hasTaskInfo(msg) {
 			return true
 		}
 	}
 	return false
 }
 
-// hasTaskInMessage checks whether a single message contains task-related content.
-func hasTaskInMessage[M adk.MessageType](msg M) bool {
-	var zero M
-	switch any(zero).(type) {
+// hasTaskInfo checks whether a single message contains task-related content.
+func hasTaskInfo[M adk.MessageType](msg M) bool {
+	switch m := any(msg).(type) {
 	case *schema.Message:
-		m := any(msg).(*schema.Message)
 		if m.Role == schema.Tool && m.ToolName == TaskListToolName {
 			return true
 		}
@@ -152,7 +150,6 @@ func hasTaskInMessage[M adk.MessageType](msg M) bool {
 			}
 		}
 	case *schema.AgenticMessage:
-		m := any(msg).(*schema.AgenticMessage)
 		for _, block := range m.ContentBlocks {
 			if block == nil {
 				continue
@@ -172,28 +169,27 @@ func hasTaskInMessage[M adk.MessageType](msg M) bool {
 	return false
 }
 
-// hasReminderMessageInHistory checks whether any message in the history is a reminder injected by this middleware.
-func hasReminderMessageInHistory[M adk.MessageType](messages []M) bool {
-	for _, msg := range messages {
-		if hasReminderMessage(msg) {
+// taskReminderAlreadyInjected checks whether any message in the history is a reminder injected by this middleware.
+func taskReminderAlreadyInjected[M adk.MessageType](state *adk.TypedChatModelAgentState[M]) bool {
+	for _, msg := range state.Messages {
+		if hasTaskReminderExtra(msg) {
 			return true
 		}
 	}
 	return false
 }
 
-// hasReminderMessage checks whether a message is a reminder injected by this middleware.
-func hasReminderMessage[M adk.MessageType](msg M) bool {
-	var zero M
-	switch any(zero).(type) {
+// hasTaskReminderExtra checks whether a message is a reminder injected by this middleware.
+func hasTaskReminderExtra[M adk.MessageType](msg M) bool {
+	switch m := any(msg).(type) {
 	case *schema.Message:
-		if m := any(msg).(*schema.Message); m.Extra != nil {
+		if m.Extra != nil {
 			if _, ok := m.Extra[reminderMessageFlag]; ok {
 				return true
 			}
 		}
 	case *schema.AgenticMessage:
-		if m := any(msg).(*schema.AgenticMessage); m.Extra != nil {
+		if m.Extra != nil {
 			if _, ok := m.Extra[reminderMessageFlag]; ok {
 				return true
 			}

--- a/adk/middlewares/plantask/plantask.go
+++ b/adk/middlewares/plantask/plantask.go
@@ -22,10 +22,11 @@ import (
 	"sync"
 
 	"github.com/cloudwego/eino/adk"
+	"github.com/cloudwego/eino/adk/internal"
 	"github.com/cloudwego/eino/schema"
 )
 
-// Config is the configuration for the tool search middleware.
+// Config is the configuration for the plan task middleware.
 type Config struct {
 	Backend Backend
 	BaseDir string
@@ -79,3 +80,158 @@ func (m *typedMiddleware[M]) BeforeAgent(ctx context.Context, runCtx *adk.ChatMo
 
 	return ctx, &nRunCtx, nil
 }
+
+// BeforeModelRewriteState ensures that when tasks exist, their information is preserved in the conversation context.
+//
+// When tasks have been created, this middleware guarantees that either:
+//   - The task messages (via task_list or task_create tool calls) are already present in the context, or
+//   - A reminder message is injected to prompt the model to retrieve the task list.
+//
+// This prevents task information from vanishing after summarization or context truncation.
+func (m *typedMiddleware[M]) BeforeModelRewriteState(ctx context.Context, state *adk.TypedChatModelAgentState[M], mc *adk.TypedModelContext[M]) (context.Context, *adk.TypedChatModelAgentState[M], error) {
+	if state == nil {
+		return ctx, nil, nil
+	}
+	if len(state.Messages) == 0 {
+		return ctx, state, nil
+	}
+
+	// Query the backend to discover if any tasks have been created.
+	fileInfos, err := m.backend.LsInfo(ctx, &LsInfoRequest{
+		Path: m.baseDir,
+	})
+	if err != nil {
+		return ctx, nil, err
+	}
+
+	// No tasks exist yet — nothing to preserve.
+	if len(fileInfos) == 0 {
+		return ctx, state, nil
+	}
+
+	// Task information is already present in the conversation history.
+	if hasTaskMessagesInHistory(state.Messages) {
+		return ctx, state, nil
+	}
+
+	// A reminder message has already been injected — avoid duplicate warnings.
+	if hasReminderMessageInHistory(state.Messages) {
+		return ctx, state, nil
+	}
+
+	// Inject a reminder message so the model knows to retrieve the task list.
+	nState := *state
+	nState.Messages = append(append([]M(nil), state.Messages...), buildReminderMessage[M]())
+	return ctx, &nState, nil
+}
+
+// hasTaskMessagesInHistory checks whether the conversation history already contains task-related messages.
+func hasTaskMessagesInHistory[M adk.MessageType](messages []M) bool {
+	for _, msg := range messages {
+		if hasTaskInMessage(msg) {
+			return true
+		}
+	}
+	return false
+}
+
+// hasTaskInMessage checks whether a single message contains task-related content.
+func hasTaskInMessage[M adk.MessageType](msg M) bool {
+	var zero M
+	switch any(zero).(type) {
+	case *schema.Message:
+		m := any(msg).(*schema.Message)
+		if m.Role == schema.Tool && m.ToolName == TaskListToolName {
+			return true
+		}
+		if m.Role == schema.Assistant && len(m.ToolCalls) > 0 {
+			for _, tc := range m.ToolCalls {
+				if tc.Function.Name == TaskCreateToolName {
+					return true
+				}
+			}
+		}
+	case *schema.AgenticMessage:
+		m := any(msg).(*schema.AgenticMessage)
+		for _, block := range m.ContentBlocks {
+			if block == nil {
+				continue
+			}
+			if block.Type == schema.ContentBlockTypeFunctionToolCall &&
+				block.FunctionToolCall != nil && block.FunctionToolCall.Name == TaskCreateToolName {
+				return true
+			}
+			if block.Type == schema.ContentBlockTypeFunctionToolResult &&
+				block.FunctionToolResult != nil && block.FunctionToolResult.Name == TaskListToolName {
+				return true
+			}
+		}
+	default:
+		panic("unreachable: unknown MessageType")
+	}
+	return false
+}
+
+// hasReminderMessageInHistory checks whether any message in the history is a reminder injected by this middleware.
+func hasReminderMessageInHistory[M adk.MessageType](messages []M) bool {
+	for _, msg := range messages {
+		if hasReminderMessage(msg) {
+			return true
+		}
+	}
+	return false
+}
+
+// hasReminderMessage checks whether a message is a reminder injected by this middleware.
+func hasReminderMessage[M adk.MessageType](msg M) bool {
+	var zero M
+	switch any(zero).(type) {
+	case *schema.Message:
+		if m := any(msg).(*schema.Message); m.Extra != nil {
+			if _, ok := m.Extra[reminderMessageFlag]; ok {
+				return true
+			}
+		}
+	case *schema.AgenticMessage:
+		if m := any(msg).(*schema.AgenticMessage); m.Extra != nil {
+			if _, ok := m.Extra[reminderMessageFlag]; ok {
+				return true
+			}
+		}
+	default:
+		panic("unreachable: unknown MessageType")
+	}
+	return false
+}
+
+// buildReminderMessage constructs a reminder message prompting the model to retrieve the task list.
+func buildReminderMessage[M adk.MessageType]() M {
+	var zero M
+	desc := internal.SelectPrompt(internal.I18nPrompts{
+		English: defaultTaskNotInContextTemplate,
+		Chinese: defaultTaskNotInContextTemplateChinese,
+	})
+	switch any(zero).(type) {
+	case *schema.Message:
+		return any(&schema.Message{
+			Role:    schema.User,
+			Content: desc,
+			Extra:   map[string]any{reminderMessageFlag: struct{}{}},
+		}).(M)
+	case *schema.AgenticMessage:
+		return any(&schema.AgenticMessage{
+			Role: schema.AgenticRoleTypeUser,
+			ContentBlocks: []*schema.ContentBlock{
+				schema.NewContentBlock(&schema.UserInputText{Text: desc}),
+			},
+			Extra: map[string]any{reminderMessageFlag: struct{}{}},
+		}).(M)
+	default:
+		panic("unreachable: unknown MessageType")
+	}
+}
+
+const (
+	defaultTaskNotInContextTemplate        = "Reminder: Tasks exist but task information is not in the current context. Call " + TaskListToolName + " to retrieve the task list."
+	defaultTaskNotInContextTemplateChinese = "提醒：系统存在任务但任务信息不在当前上下文中，请调用 " + TaskListToolName + " 获取任务列表。"
+)

--- a/adk/middlewares/plantask/plantask_test.go
+++ b/adk/middlewares/plantask/plantask_test.go
@@ -135,3 +135,260 @@ func TestNewTypedAgenticMessage(t *testing.T) {
 
 	var _ adk.TypedChatModelAgentMiddleware[*schema.AgenticMessage] = mw
 }
+
+// TestBeforeModelRewriteState_Generic runs the same tests for both Message and AgenticMessage
+func TestBeforeModelRewriteState_Generic(t *testing.T) {
+	t.Run("Message", testBeforeModelRewriteStateGeneric[*schema.Message])
+	t.Run("AgenticMessage", testBeforeModelRewriteStateGeneric[*schema.AgenticMessage])
+}
+
+func testBeforeModelRewriteStateGeneric[M adk.MessageType](t *testing.T) {
+	ctx := context.Background()
+	defer func() {
+		adk.SetLanguage(adk.LanguageEnglish)
+	}()
+
+	t.Run("nil state returns nil", func(t *testing.T) {
+		backend := newInMemoryBackend()
+		mw := newTypedMiddlewareForTestGeneric[M](backend)
+		_, newState, err := mw.BeforeModelRewriteState(ctx, nil, nil)
+		assert.NoError(t, err)
+		assert.Nil(t, newState)
+	})
+
+	t.Run("empty messages returns state with empty messages", func(t *testing.T) {
+		backend := newInMemoryBackend()
+		mw := newTypedMiddlewareForTestGeneric[M](backend)
+		state := &adk.TypedChatModelAgentState[M]{
+			Messages: []M{},
+		}
+		_, newState, err := mw.BeforeModelRewriteState(ctx, state, nil)
+		assert.NoError(t, err)
+		assert.NotNil(t, newState)
+		assert.Len(t, newState.Messages, 0)
+	})
+
+	t.Run("no tasks in backend does not inject reminder", func(t *testing.T) {
+		backend := newInMemoryBackend()
+		mw := newTypedMiddlewareForTestGeneric[M](backend)
+		state := &adk.TypedChatModelAgentState[M]{
+			Messages: []M{makeUserMsg[M]("hello"), makeAssistantMsg[M]("hi")},
+		}
+		_, newState, err := mw.BeforeModelRewriteState(ctx, state, nil)
+		assert.NoError(t, err)
+		assert.Equal(t, state.Messages, newState.Messages)
+		assert.Len(t, newState.Messages, 2)
+	})
+
+	t.Run("task info in messages does not inject reminder", func(t *testing.T) {
+		tests := []struct {
+			name     string
+			messages []M
+		}{
+			{
+				name:     "TaskList result in messages",
+				messages: []M{makeUserMsg[M]("hello"), makeTaskListResultMsg[M]("call_1")},
+			},
+			{
+				name:     "TaskCreate call in messages",
+				messages: []M{makeUserMsg[M]("create task"), makeTaskCreateCallMsg[M]("call_2")},
+			},
+		}
+
+		for _, tt := range tests {
+			t.Run(tt.name, func(t *testing.T) {
+				backend := newInMemoryBackendWithTask(ctx)
+				mw := newTypedMiddlewareForTestGeneric[M](backend)
+				state := &adk.TypedChatModelAgentState[M]{
+					Messages: tt.messages,
+				}
+				_, newState, err := mw.BeforeModelRewriteState(ctx, state, nil)
+				assert.NoError(t, err)
+				assert.Equal(t, state.Messages, newState.Messages)
+				assert.Len(t, newState.Messages, len(tt.messages))
+			})
+		}
+	})
+
+	t.Run("tasks exist but reminder already injected does not duplicate", func(t *testing.T) {
+		backend := newInMemoryBackendWithTask(ctx)
+		mw := newTypedMiddlewareForTestGeneric[M](backend)
+		state := &adk.TypedChatModelAgentState[M]{
+			Messages: []M{makeUserMsg[M]("hello"), makeReminderMsg[M]("reminder")},
+		}
+		_, newState, err := mw.BeforeModelRewriteState(ctx, state, nil)
+		assert.NoError(t, err)
+		assert.Equal(t, state.Messages, newState.Messages)
+		assert.Len(t, newState.Messages, 2)
+	})
+
+	t.Run("tasks exist injects reminder", func(t *testing.T) {
+		tests := []struct {
+			name        string
+			language    adk.Language
+			expectedMsg string
+		}{
+			{
+				name:        "English",
+				language:    adk.LanguageEnglish,
+				expectedMsg: defaultTaskNotInContextTemplate,
+			},
+			{
+				name:        "Chinese",
+				language:    adk.LanguageChinese,
+				expectedMsg: defaultTaskNotInContextTemplateChinese,
+			},
+		}
+
+		for _, tt := range tests {
+			t.Run(tt.name, func(t *testing.T) {
+				adk.SetLanguage(tt.language)
+				backend := newInMemoryBackendWithTask(ctx)
+				mw := newTypedMiddlewareForTestGeneric[M](backend)
+				state := &adk.TypedChatModelAgentState[M]{
+					Messages: []M{makeUserMsg[M]("hello")},
+				}
+				_, newState, err := mw.BeforeModelRewriteState(ctx, state, nil)
+				assert.NoError(t, err)
+				assert.Len(t, newState.Messages, 2)
+
+				reminder := newState.Messages[1]
+				assertIsReminderMessage(t, reminder, tt.expectedMsg)
+			})
+		}
+	})
+}
+
+// Helper functions for BeforeModelRewriteState tests
+
+func makeUserMsg[M adk.MessageType](content string) M {
+	var zero M
+	switch any(zero).(type) {
+	case *schema.Message:
+		return any(schema.UserMessage(content)).(M)
+	case *schema.AgenticMessage:
+		return any(schema.UserAgenticMessage(content)).(M)
+	}
+	panic("unreachable")
+}
+
+func makeAssistantMsg[M adk.MessageType](content string) M {
+	var zero M
+	switch any(zero).(type) {
+	case *schema.Message:
+		return any(schema.AssistantMessage(content, nil)).(M)
+	case *schema.AgenticMessage:
+		return any(&schema.AgenticMessage{
+			Role: schema.AgenticRoleTypeAssistant,
+			ContentBlocks: []*schema.ContentBlock{
+				schema.NewContentBlock(&schema.UserInputText{Text: content}),
+			},
+		}).(M)
+	}
+	panic("unreachable")
+}
+
+func makeTaskListResultMsg[M adk.MessageType](callID string) M {
+	var zero M
+	switch any(zero).(type) {
+	case *schema.Message:
+		return any(schema.ToolMessage("task list result", callID, schema.WithToolName(TaskListToolName))).(M)
+	case *schema.AgenticMessage:
+		return any(&schema.AgenticMessage{
+			Role: schema.AgenticRoleTypeUser,
+			ContentBlocks: []*schema.ContentBlock{
+				schema.NewContentBlock(&schema.FunctionToolResult{
+					CallID: callID,
+					Name:   TaskListToolName,
+					Content: []*schema.FunctionToolResultContentBlock{
+						{Type: schema.FunctionToolResultContentBlockTypeText, Text: &schema.UserInputText{Text: "task list result"}},
+					},
+				}),
+			},
+		}).(M)
+	}
+	panic("unreachable")
+}
+
+func makeTaskCreateCallMsg[M adk.MessageType](callID string) M {
+	var zero M
+	switch any(zero).(type) {
+	case *schema.Message:
+		return any(schema.AssistantMessage("", []schema.ToolCall{
+			{ID: callID, Function: schema.FunctionCall{Name: TaskCreateToolName, Arguments: "{}"}},
+		})).(M)
+	case *schema.AgenticMessage:
+		return any(&schema.AgenticMessage{
+			Role: schema.AgenticRoleTypeAssistant,
+			ContentBlocks: []*schema.ContentBlock{
+				schema.NewContentBlock(&schema.FunctionToolCall{
+					CallID:    callID,
+					Name:      TaskCreateToolName,
+					Arguments: "{}",
+				}),
+			},
+		}).(M)
+	}
+	panic("unreachable")
+}
+
+func makeReminderMsg[M adk.MessageType](content string) M {
+	var zero M
+	switch any(zero).(type) {
+	case *schema.Message:
+		return any(&schema.Message{
+			Role:    schema.User,
+			Content: content,
+			Extra:   map[string]any{reminderMessageFlag: struct{}{}},
+		}).(M)
+	case *schema.AgenticMessage:
+		return any(&schema.AgenticMessage{
+			Role: schema.AgenticRoleTypeUser,
+			ContentBlocks: []*schema.ContentBlock{
+				schema.NewContentBlock(&schema.UserInputText{Text: content}),
+			},
+			Extra: map[string]any{reminderMessageFlag: struct{}{}},
+		}).(M)
+	}
+	panic("unreachable")
+}
+
+func assertIsReminderMessage[M adk.MessageType](t *testing.T, msg M, expectedContent string) {
+	t.Helper()
+	var zero M
+	switch any(zero).(type) {
+	case *schema.Message:
+		m := any(msg).(*schema.Message)
+		assert.Equal(t, schema.User, m.Role, "reminder message should have User role")
+		_, ok := m.Extra[reminderMessageFlag]
+		assert.True(t, ok, "message should have reminderMessageFlag")
+		assert.Equal(t, expectedContent, m.Content, "reminder message content should match")
+	case *schema.AgenticMessage:
+		m := any(msg).(*schema.AgenticMessage)
+		assert.Equal(t, schema.AgenticRoleTypeUser, m.Role, "reminder message should have User role")
+		_, ok := m.Extra[reminderMessageFlag]
+		assert.True(t, ok, "message should have reminderMessageFlag")
+		for _, block := range m.ContentBlocks {
+			if block != nil && block.Type == schema.ContentBlockTypeUserInputText && block.UserInputText != nil {
+				assert.Equal(t, expectedContent, block.UserInputText.Text, "reminder message content should match")
+				return
+			}
+		}
+		t.Fatal("reminder message should have UserInputText content block")
+	}
+}
+
+func newTypedMiddlewareForTestGeneric[M adk.MessageType](backend Backend) *typedMiddleware[M] {
+	return &typedMiddleware[M]{
+		backend: backend,
+		baseDir: "/tmp/tasks",
+	}
+}
+
+func newInMemoryBackendWithTask(ctx context.Context) Backend {
+	backend := newInMemoryBackend()
+	lock := &sync.Mutex{}
+	createTool := newTaskCreateTool(backend, "/tmp/tasks", lock)
+	_, _ = createTool.InvokableRun(ctx, `{"subject": "Test Task", "description": "Test desc"}`)
+	return backend
+}

--- a/adk/middlewares/plantask/task.go
+++ b/adk/middlewares/plantask/task.go
@@ -25,7 +25,10 @@ import (
 
 var validTaskIDRegex = regexp.MustCompile(`^\d+$`)
 
-const highWatermarkFileName = ".highwatermark"
+const (
+	highWatermarkFileName = ".highwatermark"
+	reminderMessageFlag   = "_plantask_mw_reminded"
+)
 
 type task struct {
 	ID          string         `json:"id"`
@@ -50,10 +53,12 @@ const (
 	taskStatusDeleted    = "deleted"
 )
 
-type FileInfo = filesystem.FileInfo
-type LsInfoRequest = filesystem.LsInfoRequest
-type ReadRequest = filesystem.ReadRequest
-type WriteRequest = filesystem.WriteRequest
+type (
+	FileInfo      = filesystem.FileInfo
+	LsInfoRequest = filesystem.LsInfoRequest
+	ReadRequest   = filesystem.ReadRequest
+	WriteRequest  = filesystem.WriteRequest
+)
 
 type DeleteRequest struct {
 	FilePath string


### PR DESCRIPTION
## Background

Task info may disappear from context after summarization, causing the model to lose awareness of existing tasks.

## Changes

Add `BeforeModelRewriteState` hook to plantask middleware:
- Query backend for existing tasks
- If task info missing from context but tasks exist, inject a reminder message prompting the model to call TaskList tool
- Avoid duplicate reminders via flag check

## 背景

任务信息在 summarization 后可能从上下文中消失，导致模型无法感知已有任务。

## 改动

为 plantask 中间件添加 `BeforeModelRewriteState` 钩子：
- 查询 backend 确认任务是否存在
- 若任务存在但上下文中无任务信息，则注入提醒消息，引导模型调用 TaskList 工具
- 通过 flag 避免重复注入提醒