### PR TITLE
refactor: Only consider subsequent tool result messages after the too…

### DIFF
--- a/adk/middlewares/patchtoolcalls/patchtoolcalls.go
+++ b/adk/middlewares/patchtoolcalls/patchtoolcalls.go
@@ -169,7 +169,7 @@ func patchToolCallsForAgenticMessage[M adk.MessageType](ctx context.Context,
 
 func hasCorrespondingToolMessage(messages []*schema.Message, toolCallID string) bool {
 	for _, msg := range messages {
-		// Only consider subsequent tool messages after the tool call message
+		// Only consider successive tool messages after the tool call message
 		if msg.Role != schema.Tool {
 			return false
 		}
@@ -182,7 +182,7 @@ func hasCorrespondingToolMessage(messages []*schema.Message, toolCallID string) 
 
 func hasCorrespondingAgenticToolResult(messages []*schema.AgenticMessage, toolCallID string) bool {
 	for _, msg := range messages {
-		// Only consider subsequent tool messages after the tool call message
+		// Only consider successive tool messages after the tool call message
 		if msg.Role != schema.AgenticRoleTypeUser {
 			return false
 		}

--- a/adk/middlewares/patchtoolcalls/patchtoolcalls.go
+++ b/adk/middlewares/patchtoolcalls/patchtoolcalls.go
@@ -69,8 +69,8 @@ type typedMiddleware[M adk.MessageType] struct {
 }
 
 func (m *typedMiddleware[M]) BeforeModelRewriteState(ctx context.Context, state *adk.TypedChatModelAgentState[M],
-	mc *adk.TypedModelContext[M]) (context.Context, *adk.TypedChatModelAgentState[M], error) {
-
+	mc *adk.TypedModelContext[M],
+) (context.Context, *adk.TypedChatModelAgentState[M], error) {
 	if len(state.Messages) == 0 {
 		return ctx, state, nil
 	}
@@ -89,8 +89,8 @@ func (m *typedMiddleware[M]) BeforeModelRewriteState(ctx context.Context, state 
 func patchToolCallsForMessage[M adk.MessageType](ctx context.Context,
 	gen func(ctx context.Context, toolName, toolCallID string) (string, error),
 	state *adk.TypedChatModelAgentState[*schema.Message],
-	_ *adk.TypedModelContext[M]) (context.Context, *adk.TypedChatModelAgentState[M], error) {
-
+	_ *adk.TypedModelContext[M],
+) (context.Context, *adk.TypedChatModelAgentState[M], error) {
 	patched := make([]*schema.Message, 0, len(state.Messages))
 
 	for i, msg := range state.Messages {
@@ -121,8 +121,8 @@ func patchToolCallsForMessage[M adk.MessageType](ctx context.Context,
 func patchToolCallsForAgenticMessage[M adk.MessageType](ctx context.Context,
 	gen func(ctx context.Context, toolName, toolCallID string) (string, error),
 	state *adk.TypedChatModelAgentState[*schema.AgenticMessage],
-	_ *adk.TypedModelContext[M]) (context.Context, *adk.TypedChatModelAgentState[M], error) {
-
+	_ *adk.TypedModelContext[M],
+) (context.Context, *adk.TypedChatModelAgentState[M], error) {
 	patched := make([]*schema.AgenticMessage, 0, len(state.Messages))
 
 	for i, msg := range state.Messages {
@@ -169,7 +169,11 @@ func patchToolCallsForAgenticMessage[M adk.MessageType](ctx context.Context,
 
 func hasCorrespondingToolMessage(messages []*schema.Message, toolCallID string) bool {
 	for _, msg := range messages {
-		if msg.Role == schema.Tool && msg.ToolCallID == toolCallID {
+		// Only consider subsequent tool messages after the tool call message
+		if msg.Role != schema.Tool {
+			return false
+		}
+		if msg.ToolCallID == toolCallID {
 			return true
 		}
 	}
@@ -178,18 +182,30 @@ func hasCorrespondingToolMessage(messages []*schema.Message, toolCallID string) 
 
 func hasCorrespondingAgenticToolResult(messages []*schema.AgenticMessage, toolCallID string) bool {
 	for _, msg := range messages {
+		// Only consider subsequent tool messages after the tool call message
+		if msg.Role != schema.AgenticRoleTypeUser {
+			return false
+		}
+		hasToolResult := false
 		for _, block := range msg.ContentBlocks {
 			if block == nil {
 				continue
 			}
-			if block.Type == schema.ContentBlockTypeFunctionToolResult &&
-				block.FunctionToolResult != nil && block.FunctionToolResult.CallID == toolCallID {
-				return true
+			if block.Type == schema.ContentBlockTypeFunctionToolResult {
+				hasToolResult = true
+				if block.FunctionToolResult != nil && block.FunctionToolResult.CallID == toolCallID {
+					return true
+				}
 			}
-			if block.Type == schema.ContentBlockTypeToolSearchResult &&
-				block.ToolSearchFunctionToolResult != nil && block.ToolSearchFunctionToolResult.CallID == toolCallID {
-				return true
+			if block.Type == schema.ContentBlockTypeToolSearchResult {
+				hasToolResult = true
+				if block.ToolSearchFunctionToolResult != nil && block.ToolSearchFunctionToolResult.CallID == toolCallID {
+					return true
+				}
 			}
+		}
+		if !hasToolResult {
+			return false
 		}
 	}
 	return false

--- a/adk/middlewares/patchtoolcalls/patchtoolcalls_test.go
+++ b/adk/middlewares/patchtoolcalls/patchtoolcalls_test.go
@@ -221,6 +221,38 @@ func testPatchToolCallsGeneric[M adk.MessageType](t *testing.T) {
 			wantToolName:   "tool_b",
 			wantContent:    "123 tool_b call_2",
 		},
+		{
+			name:   "two consecutive assistant messages with tool calls",
+			config: nil,
+			messages: []M{
+				makeUserMsg[M]("hello"),
+				makeAssistantMsgWithToolCalls[M]("", []testToolCall{
+					{ID: "call_1", Name: "tool_a", Arguments: "{}"},
+				}),
+				makeAssistantMsgWithToolCalls[M]("continued...", nil),
+			},
+			wantLen:        4,
+			checkPatchedAt: 2,
+			wantCallID:     "call_1",
+			wantToolName:   "tool_a",
+			wantContent:    fmt.Sprintf(defaultPatchedToolMessageTemplate, "tool_a", "call_1"),
+		},
+		{
+			name:   "assistant message followed by user message without tool result",
+			config: nil,
+			messages: []M{
+				makeUserMsg[M]("hello"),
+				makeAssistantMsgWithToolCalls[M]("", []testToolCall{
+					{ID: "call_1", Name: "tool_a", Arguments: "{}"},
+				}),
+				makeUserMsg[M]("continued..."),
+			},
+			wantLen:        4,
+			checkPatchedAt: 2,
+			wantCallID:     "call_1",
+			wantToolName:   "tool_a",
+			wantContent:    fmt.Sprintf(defaultPatchedToolMessageTemplate, "tool_a", "call_1"),
+		},
 	}
 
 	for _, tt := range tests {
@@ -316,6 +348,46 @@ func TestPatchToolCalls_NilFunctionToolCallInBlock(t *testing.T) {
 		if block != nil && block.Type == schema.ContentBlockTypeFunctionToolResult &&
 			block.FunctionToolResult != nil && block.FunctionToolResult.CallID == "call_1" {
 			foundResult = true
+		}
+	}
+	assert.True(t, foundResult, "patched message should contain tool result for call_1")
+}
+
+// TestPatchToolCalls_AgenticMessage_NilBlockInUserMessage verifies the middleware handles
+// a User Agentic Message with nil ContentBlock without panicking.
+func TestPatchToolCalls_AgenticMessage_NilBlockInUserMessage(t *testing.T) {
+	ctx := context.Background()
+	mw, err := NewTyped[*schema.AgenticMessage](ctx, nil)
+	require.NoError(t, err)
+
+	msgs := []*schema.AgenticMessage{
+		schema.UserAgenticMessage("hello"),
+		makeAssistantMsgWithToolCalls[*schema.AgenticMessage]("", []testToolCall{
+			{ID: "call_1", Name: "tool_a", Arguments: "{}"},
+		}),
+		{
+			Role: schema.AgenticRoleTypeUser,
+			ContentBlocks: []*schema.ContentBlock{
+				nil, // nil block to test robustness
+			},
+		},
+	}
+
+	state := &adk.TypedChatModelAgentState[*schema.AgenticMessage]{Messages: msgs}
+	_, newState, err := mw.BeforeModelRewriteState(ctx, state, nil)
+	assert.NoError(t, err, "should not panic when encountering nil block in user message")
+	assert.Len(t, newState.Messages, 4, "should patch call_1 and insert tool response")
+
+	// Verify the patched message is inserted at index 2
+	patchMsg := newState.Messages[2]
+	assert.Equal(t, schema.AgenticRoleTypeUser, patchMsg.Role)
+
+	foundResult := false
+	for _, block := range patchMsg.ContentBlocks {
+		if block != nil && block.Type == schema.ContentBlockTypeFunctionToolResult &&
+			block.FunctionToolResult != nil && block.FunctionToolResult.CallID == "call_1" {
+			foundResult = true
+			break
 		}
 	}
 	assert.True(t, foundResult, "patched message should contain tool result for call_1")


### PR DESCRIPTION
## 优化工具调用响应校验逻辑
仅校验工具调用后连续的工具响应结果，遇到非工具消息立即终止遍历；
原逻辑无此判断，会遍历所有后续消息。

## optimize tool call response validation logic
Only check consecutive tool responses after the tool call and stop traversing when a non-tool message is encountered;
The original logic traversed all subsequent messages without this judgment,.