### PR TITLE
refactor: streamline summarization finalizers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -55,6 +55,7 @@ reports/
 CLAUDE.md
 *.jsonl
 *.txt
+.agents/
 
 # Specs directories
 */specs

--- a/adk/middlewares/summarization/consts.go
+++ b/adk/middlewares/summarization/consts.go
@@ -33,6 +33,7 @@ type summarizationContentType string
 
 const (
 	contentTypeSummary summarizationContentType = "summary"
+	contentTypeSkills  summarizationContentType = "skills"
 )
 
 type ctxKeyModelInput struct{}

--- a/adk/middlewares/summarization/finalizer_builder.go
+++ b/adk/middlewares/summarization/finalizer_builder.go
@@ -45,59 +45,61 @@ func DefaultFinalize[M adk.MessageType](ctx context.Context, originalMessages []
 		return nil, err
 	}
 
-	return append(systemMsgs, processed), nil
+	result := make([]M, 0, len(systemMsgs)+1)
+	result = append(result, systemMsgs...)
+	result = append(result, processed)
+	return result, nil
 }
 
-// TypedFinalizerBuilder builds a TypedFinalizeFunc by chaining handlers
-// and an optional custom finalizer, generic over message type M.
+// TypedFinalizerBuilder builds a TypedFinalizeFunc by chaining handlers,
+// generic over message type M.
+type TypedFinalizerBuilder[M adk.MessageType] struct {
+	handlers []TypedFinalizeFunc[M]
+	errs     []error
+}
+
+// FinalizerBuilder is a backward-compatible alias for TypedFinalizerBuilder
+// specialized with *schema.Message.
 //
-// Handlers (e.g. PreserveSkills) transform the summary message sequentially,
-// and the custom finalizer (set via Custom) determines the final output messages.
+// Deprecated: use TypedFinalizerBuilder[*schema.Message] instead.
+type FinalizerBuilder = TypedFinalizerBuilder[*schema.Message]
+
+// NewTypedFinalizer creates a new TypedFinalizerBuilder.
+//
+// Handlers run in registration order, and the summary message is post-processed
+// as DefaultFinalize does after all handlers have run. For example, with
+// PreserveSkills and a system message in originalMessages, the final output is:
+//
+//	[system message, preserved skill message, processed summary]
 //
 // Example:
 //
-//	finalizer, err := NewFinalizer().
+//	finalizer, err := NewTypedFinalizer[*schema.Message]().
 //	    PreserveSkills(&PreserveSkillsConfig{}).
-//	    Custom(func(ctx context.Context, originalMessages []adk.Message, summary adk.Message) ([]adk.Message, error) {
-//	        return []adk.Message{schema.SystemMessage("system prompt"), summary}, nil
-//	    }).
 //	    Build()
 //
 //	cfg := &Config{
 //	    Finalize: finalizer,
 //	    // ...
 //	}
-type TypedFinalizerBuilder[M adk.MessageType] struct {
-	handlers []TypedFinalizeFunc[M]
-	custom   TypedFinalizeFunc[M]
-	errs     []error
-}
-
-// FinalizerBuilder is a backward-compatible alias for TypedFinalizerBuilder
-// specialized with *schema.Message.
-type FinalizerBuilder = TypedFinalizerBuilder[*schema.Message]
-
-// NewTypedFinalizer creates a new TypedFinalizerBuilder that builds a TypedFinalizeFunc
-// by chaining handlers and an optional custom finalizer.
 func NewTypedFinalizer[M adk.MessageType]() *TypedFinalizerBuilder[M] {
 	return &TypedFinalizerBuilder[M]{}
 }
 
 // NewFinalizer creates a new FinalizerBuilder that builds a FinalizeFunc
-// by chaining handlers and an optional custom finalizer.
+// by chaining handlers.
+//
+// Deprecated: use NewTypedFinalizer[*schema.Message] instead.
 func NewFinalizer() *FinalizerBuilder {
 	return &FinalizerBuilder{}
 }
 
-// Custom sets a custom finalizer that determines the final output messages.
-// If called multiple times, the last custom finalizer takes effect.
-func (b *TypedFinalizerBuilder[M]) Custom(fn TypedFinalizeFunc[M]) *TypedFinalizerBuilder[M] {
-	b.custom = fn
-	return b
-}
-
 // Build constructs the final TypedFinalizeFunc by chaining all registered handlers
-// and the optional custom finalizer.
+// and post-processing the summary message as DefaultFinalize does.
+// For example, with PreserveSkills and a system message in
+// originalMessages, the final output is:
+//
+//	[system message, preserved skill message, processed summary]
 func (b *TypedFinalizerBuilder[M]) Build() (TypedFinalizeFunc[M], error) {
 	if len(b.errs) > 0 {
 		msgs := make([]string, len(b.errs))
@@ -107,28 +109,42 @@ func (b *TypedFinalizerBuilder[M]) Build() (TypedFinalizeFunc[M], error) {
 		return nil, fmt.Errorf("failed to build finalizer:\n%s", strings.Join(msgs, "\n"))
 	}
 
-	if len(b.handlers) == 0 && b.custom == nil {
-		return nil, fmt.Errorf("at least one handler or custom finalizer is required")
+	if len(b.handlers) == 0 {
+		return nil, fmt.Errorf("at least one handler is required")
 	}
 
 	handlers := make([]TypedFinalizeFunc[M], len(b.handlers))
 	copy(handlers, b.handlers)
-	custom := b.custom
 
 	return func(ctx context.Context, originalMessages []M, summary M) ([]M, error) {
+		var extraMessages []M
 		for _, fn := range handlers {
 			result, err := fn(ctx, originalMessages, summary)
 			if err != nil {
 				return nil, err
 			}
-			summary = result[0]
+			if len(result) == 0 {
+				return nil, fmt.Errorf("finalizer handler returned no messages")
+			}
+			extraMessages = append(extraMessages, result[:len(result)-1]...)
+			summary = result[len(result)-1]
 		}
 
-		if custom != nil {
-			return custom(ctx, originalMessages, summary)
+		systemMsgs, contextMsgs := splitSystemAndContextMsgs(originalMessages)
+
+		processed, err := postProcessSummary(ctx, &postProcessSummaryParams[M]{
+			contextMsgs:    contextMsgs,
+			summaryContent: getAssistantTextContent(summary),
+		})
+		if err != nil {
+			return nil, err
 		}
 
-		return []M{summary}, nil
+		result := make([]M, 0, len(systemMsgs)+len(extraMessages)+1)
+		result = append(result, systemMsgs...)
+		result = append(result, extraMessages...)
+		result = append(result, processed)
+		return result, nil
 	}, nil
 }
 
@@ -159,9 +175,18 @@ type PreserveSkillsConfig struct {
 	SkillsTokenBudget *int
 }
 
-// PreserveSkills extracts skill contents loaded by the ADK skill middleware
-// from the conversation history and prepends them to the summary message,
-// ensuring the agent retains skill knowledge after the context window is compacted.
+// PreserveSkills preserves skill contents loaded by the ADK skill middleware.
+// It scans the conversation for matching skill tool calls and returns the preserved
+// skill content as a user message before the summary.
+//
+// Example:
+//
+//	messages: [assistant(tool_call: skill "foo"), tool(content: "bar")]
+//	summary:  S
+//
+// When skill content is found, PreserveSkills returns:
+//
+//	[]M{user("<preserved foo: bar>"), S}
 func (b *TypedFinalizerBuilder[M]) PreserveSkills(config *PreserveSkillsConfig) *TypedFinalizerBuilder[M] {
 	if err := config.check(); err != nil {
 		b.errs = append(b.errs, fmt.Errorf("PreserveSkills: %w", err))
@@ -184,33 +209,15 @@ func (b *TypedFinalizerBuilder[M]) PreserveSkills(config *PreserveSkillsConfig) 
 			return nil, err
 		}
 
-		if skillText != "" {
-			summary = prependMsgTextContent(summary, skillText)
+		if skillText == "" {
+			return []M{summary}, nil
 		}
 
-		return []M{summary}, nil
+		preserved := makeUserMsg[M](skillText)
+		setMsgExtra(preserved, extraKeyContentType, string(contentTypeSkills))
+		return []M{preserved, summary}, nil
 	})
 	return b
-}
-
-func prependMsgTextContent[M adk.MessageType](msg M, text string) M {
-	switch m := any(msg).(type) {
-	case *schema.Message:
-		m.UserInputMultiContent = append([]schema.MessageInputPart{
-			{
-				Type: schema.ChatMessagePartTypeText,
-				Text: text,
-			},
-		}, m.UserInputMultiContent...)
-		return any(m).(M)
-	case *schema.AgenticMessage:
-		m.ContentBlocks = append([]*schema.ContentBlock{
-			schema.NewContentBlock(&schema.UserInputText{Text: text}),
-		}, m.ContentBlocks...)
-		return any(m).(M)
-	default:
-		panic("unreachable")
-	}
 }
 
 func (c *PreserveSkillsConfig) check() error {

--- a/adk/middlewares/summarization/finalizer_builder_test.go
+++ b/adk/middlewares/summarization/finalizer_builder_test.go
@@ -33,14 +33,17 @@ func TestNewFinalizer(t *testing.T) {
 	b := NewFinalizer()
 	assert.NotNil(t, b)
 	assert.Empty(t, b.handlers)
-	assert.Nil(t, b.custom)
+
+	tb := NewTypedFinalizer[*schema.Message]()
+	assert.NotNil(t, tb)
+	assert.Empty(t, tb.handlers)
 }
 
 func TestBuildEmpty(t *testing.T) {
 	finalizer, err := NewFinalizer().Build()
 	assert.Error(t, err)
 	assert.Nil(t, finalizer)
-	assert.Contains(t, err.Error(), "at least one handler or custom finalizer is required")
+	assert.Contains(t, err.Error(), "at least one handler is required")
 }
 
 func TestBuildConfigError(t *testing.T) {
@@ -67,46 +70,20 @@ func TestBuildConfigError(t *testing.T) {
 	})
 }
 
-func TestBuildWithCustomOnly(t *testing.T) {
+func TestDefaultFinalizeBasic(t *testing.T) {
 	ctx := context.Background()
 
-	finalizer, err := NewFinalizer().
-		Custom(func(ctx context.Context, originalMessages []adk.Message, summary adk.Message) ([]adk.Message, error) {
-			return []adk.Message{
-				schema.SystemMessage("system prompt"),
-				summary,
-			}, nil
-		}).
-		Build()
-	assert.NoError(t, err)
-
-	summary := schema.UserMessage("test summary")
-	result, err := finalizer(ctx, []adk.Message{}, summary)
+	result, err := DefaultFinalize(ctx, []adk.Message{
+		schema.SystemMessage("system prompt"),
+		schema.UserMessage("original user"),
+	}, schema.AssistantMessage("raw summary", nil))
 	assert.NoError(t, err)
 	assert.Len(t, result, 2)
+
 	assert.Equal(t, schema.System, result[0].Role)
-	assert.Equal(t, "system prompt", result[0].Content)
-	assert.Equal(t, "test summary", result[1].Content)
-}
-
-func TestBuildCustomOverrides(t *testing.T) {
-	ctx := context.Background()
-
-	finalizer, err := NewFinalizer().
-		Custom(func(ctx context.Context, originalMessages []adk.Message, summary adk.Message) ([]adk.Message, error) {
-			return []adk.Message{schema.UserMessage("first")}, nil
-		}).
-		Custom(func(ctx context.Context, originalMessages []adk.Message, summary adk.Message) ([]adk.Message, error) {
-			return []adk.Message{schema.UserMessage("second")}, nil
-		}).
-		Build()
-	assert.NoError(t, err)
-
-	summary := schema.UserMessage("test")
-	result, err := finalizer(ctx, []adk.Message{}, summary)
-	assert.NoError(t, err)
-	assert.Len(t, result, 1)
-	assert.Equal(t, "second", result[0].Content)
+	assert.Equal(t, schema.User, result[1].Role)
+	assert.Equal(t, contentTypeSummary, typedGetContentType(result[1]))
+	assert.Contains(t, result[1].Content, "raw summary")
 }
 
 func TestBuildStepChaining(t *testing.T) {
@@ -125,37 +102,12 @@ func TestBuildStepChaining(t *testing.T) {
 	finalizer, err := b.Build()
 	assert.NoError(t, err)
 
-	summary := schema.UserMessage("start")
+	summary := schema.AssistantMessage("start", nil)
 	result, err := finalizer(ctx, []adk.Message{}, summary)
 	assert.NoError(t, err)
 	assert.Len(t, result, 1)
-	assert.Equal(t, "start | step1 | step2", result[0].Content)
-}
-
-func TestBuildStepChainingWithCustom(t *testing.T) {
-	ctx := context.Background()
-
-	b := NewFinalizer()
-	b.handlers = append(b.handlers, func(ctx context.Context, originalMessages []adk.Message, summary adk.Message) ([]adk.Message, error) {
-		summary.Content = summary.Content + " | step1"
-		return []adk.Message{summary}, nil
-	})
-	b.Custom(func(ctx context.Context, originalMessages []adk.Message, summary adk.Message) ([]adk.Message, error) {
-		return []adk.Message{
-			schema.SystemMessage("sys"),
-			summary,
-		}, nil
-	})
-
-	finalizer, err := b.Build()
-	assert.NoError(t, err)
-
-	summary := schema.UserMessage("start")
-	result, err := finalizer(ctx, []adk.Message{}, summary)
-	assert.NoError(t, err)
-	assert.Len(t, result, 2)
-	assert.Equal(t, schema.System, result[0].Role)
-	assert.Equal(t, "start | step1", result[1].Content)
+	assert.Equal(t, schema.User, result[0].Role)
+	assert.Contains(t, result[0].Content, "start | step1 | step2")
 }
 
 func TestBuildStepError(t *testing.T) {
@@ -173,6 +125,48 @@ func TestBuildStepError(t *testing.T) {
 	_, err = finalizer(ctx, []adk.Message{}, summary)
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "step failed")
+}
+
+func TestBuildHandlerReturnsEmpty(t *testing.T) {
+	ctx := context.Background()
+
+	b := NewFinalizer()
+	b.handlers = append(b.handlers, func(ctx context.Context, originalMessages []adk.Message, summary adk.Message) ([]adk.Message, error) {
+		return []adk.Message{}, nil
+	})
+
+	finalizer, err := b.Build()
+	assert.NoError(t, err)
+
+	_, err = finalizer(ctx, []adk.Message{}, schema.AssistantMessage("test", nil))
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "finalizer handler returned no messages")
+}
+
+func TestBuildPostProcessError(t *testing.T) {
+	ctx := context.Background()
+
+	b := NewFinalizer()
+	b.handlers = append(b.handlers, func(ctx context.Context, originalMessages []adk.Message, summary adk.Message) ([]adk.Message, error) {
+		return []adk.Message{schema.UserMessage("not assistant")}, nil
+	})
+
+	finalizer, err := b.Build()
+	assert.NoError(t, err)
+
+	_, err = finalizer(ctx, []adk.Message{}, schema.AssistantMessage("test", nil))
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "summary content is empty")
+}
+
+func TestDefaultFinalizeError(t *testing.T) {
+	ctx := context.Background()
+
+	_, err := DefaultFinalize(ctx, []adk.Message{
+		schema.UserMessage("original"),
+	}, schema.UserMessage("not an assistant message"))
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "summary content is empty")
 }
 
 func TestPreserveSkillsConfigCheck(t *testing.T) {
@@ -246,7 +240,11 @@ func TestPreserveSkillsViaBuilder(t *testing.T) {
 		Build()
 	assert.NoError(t, err)
 
-	messages := []adk.Message{
+	originalMessages := []adk.Message{
+		schema.SystemMessage("system prompt"),
+		schema.UserMessage("original"),
+	}
+	modelInput := []adk.Message{
 		{
 			Role: schema.Assistant,
 			ToolCalls: []schema.ToolCall{
@@ -265,76 +263,25 @@ func TestPreserveSkillsViaBuilder(t *testing.T) {
 			Content:    "skill content 1",
 		},
 	}
+	ctx = context.WithValue(ctx, ctxKeyModelInput{}, modelInput)
 
-	ctx = context.WithValue(ctx, ctxKeyModelInput{}, messages)
-
-	summary := &schema.Message{
-		Role: schema.Assistant,
-		UserInputMultiContent: []schema.MessageInputPart{
-			{Type: schema.ChatMessagePartTypeText, Text: "test summary"},
-		},
-	}
-
-	result, err := finalizer(ctx, []adk.Message{schema.UserMessage("original")}, summary)
-	assert.NoError(t, err)
-	assert.Len(t, result, 1)
-
-	assert.Empty(t, result[0].Content)
-	assert.Len(t, result[0].UserInputMultiContent, 2)
-	assert.Contains(t, result[0].UserInputMultiContent[0].Text, "test-skill")
-	assert.Contains(t, result[0].UserInputMultiContent[0].Text, "skill content 1")
-	assert.Equal(t, "test summary", result[0].UserInputMultiContent[1].Text)
-}
-
-func TestPreserveSkillsWithCustom(t *testing.T) {
-	ptr := func(i int) *int { return &i }
-	ctx := context.Background()
-
-	finalizer, err := NewFinalizer().
-		PreserveSkills(&PreserveSkillsConfig{
-			MaxSkills:     ptr(2),
-			SkillToolName: "load_skill",
-		}).
-		Custom(func(ctx context.Context, originalMessages []adk.Message, summary adk.Message) ([]adk.Message, error) {
-			return []adk.Message{
-				schema.SystemMessage("system prompt"),
-				summary,
-			}, nil
-		}).
-		Build()
-	assert.NoError(t, err)
-
-	messages := []adk.Message{
-		{
-			Role: schema.Assistant,
-			ToolCalls: []schema.ToolCall{
-				{
-					ID: "call_1",
-					Function: schema.FunctionCall{
-						Name:      "load_skill",
-						Arguments: `{"skill": "test-skill"}`,
-					},
-				},
-			},
-		},
-		{
-			Role:       schema.Tool,
-			ToolCallID: "call_1",
-			Content:    "skill content 1",
-		},
-	}
-
-	ctx = context.WithValue(ctx, ctxKeyModelInput{}, messages)
 	summary := schema.AssistantMessage("test summary", nil)
 
-	result, err := finalizer(ctx, []adk.Message{schema.UserMessage("original")}, summary)
+	result, err := finalizer(ctx, originalMessages, summary)
 	assert.NoError(t, err)
-	assert.Len(t, result, 2)
+	assert.Len(t, result, 3)
 
 	assert.Equal(t, schema.System, result[0].Role)
 	assert.Equal(t, "system prompt", result[0].Content)
 
-	assert.Contains(t, result[1].UserInputMultiContent[0].Text, "test-skill")
+	assert.Equal(t, schema.User, result[1].Role)
+	assert.Equal(t, contentTypeSkills, typedGetContentType(result[1]))
+	assert.Contains(t, result[1].Content, "test-skill")
+	assert.Contains(t, result[1].Content, "skill content 1")
+
+	assert.Equal(t, schema.User, result[2].Role)
+	assert.Equal(t, contentTypeSummary, typedGetContentType(result[2]))
+	assert.Contains(t, result[2].Content, "test summary")
 }
 
 func TestBuildPreservedSkillsText(t *testing.T) {

--- a/adk/middlewares/summarization/summarization.go
+++ b/adk/middlewares/summarization/summarization.go
@@ -651,6 +651,9 @@ func buildInternalFinalizer[M adk.MessageType](cfg *TypedConfig[M]) TypedFinaliz
 func getAssistantTextContent[M adk.MessageType](msg M) string {
 	switch r := any(msg).(type) {
 	case *schema.Message:
+		if r.Role != schema.Assistant {
+			return ""
+		}
 		var parts []string
 		for _, part := range r.AssistantGenMultiContent {
 			if part.Type == schema.ChatMessagePartTypeText && part.Text != "" {
@@ -662,6 +665,9 @@ func getAssistantTextContent[M adk.MessageType](msg M) string {
 		}
 		return r.Content
 	case *schema.AgenticMessage:
+		if r.Role != schema.AgenticRoleTypeAssistant {
+			return ""
+		}
 		var parts []string
 		for _, block := range r.ContentBlocks {
 			if block != nil && block.AssistantGenText != nil {
@@ -680,8 +686,11 @@ type postProcessSummaryParams[M adk.MessageType] struct {
 	transcriptPath string
 }
 
-func postProcessSummary[M adk.MessageType](ctx context.Context, p *postProcessSummaryParams[M]) (M, error) {
+func postProcessSummary[M adk.MessageType](ctx context.Context, p *postProcessSummaryParams[M]) (processed M, err error) {
 	content := p.summaryContent
+	if content == "" {
+		return processed, fmt.Errorf("summary content is empty")
+	}
 
 	if len(p.contextMsgs) > 0 {
 		newContent, err := replaceUserMessagesInSummary(ctx, &replaceUserMessagesInSummaryParams[M]{
@@ -689,8 +698,7 @@ func postProcessSummary[M adk.MessageType](ctx context.Context, p *postProcessSu
 			summaryText: content,
 		})
 		if err != nil {
-			var zero M
-			return zero, fmt.Errorf("failed to populate user messages in summary: %w", err)
+			return processed, fmt.Errorf("failed to populate user messages in summary: %w", err)
 		}
 		content = newContent
 	}
@@ -702,9 +710,9 @@ func postProcessSummary[M adk.MessageType](ctx context.Context, p *postProcessSu
 	content = appendSection(getSummaryPreamble(), content)
 	content = appendSection(content, getContinueInstruction())
 
-	newSummary := newTypedSummaryMessage[M](content)
+	processed = newTypedSummaryMessage[M](content)
 
-	return newSummary, nil
+	return processed, nil
 }
 
 type replaceUserMessagesInSummaryParams[M adk.MessageType] struct {
@@ -716,7 +724,7 @@ func replaceUserMessagesInSummary[M adk.MessageType](ctx context.Context, p *rep
 	var userMsgs []M
 	var hasUserMsgs bool
 	for _, msg := range p.contextMsgs {
-		if typedGetContentType(msg) == contentTypeSummary {
+		if isInternalUserMessage(msg) {
 			continue
 		}
 		if isUserRole(msg) {
@@ -1205,6 +1213,14 @@ func typedGetContentType[M adk.MessageType](msg M) summarizationContentType {
 		return ""
 	}
 	return summarizationContentType(ct)
+}
+
+func isInternalUserMessage[M adk.MessageType](msg M) bool {
+	return typedGetContentType(msg) == contentTypeSummary || isPreservedMessage(msg)
+}
+
+func isPreservedMessage[M adk.MessageType](msg M) bool {
+	return typedGetContentType(msg) == contentTypeSkills
 }
 
 func typedShouldFailover[M adk.MessageType](ctx context.Context, cfg *TypedFailoverConfig[M], resp M, err error) bool {

--- a/adk/middlewares/summarization/summarization_test.go
+++ b/adk/middlewares/summarization/summarization_test.go
@@ -2035,6 +2035,21 @@ func testSummarizationHelpers[M adk.MessageType](t *testing.T) {
 			assert.Equal(t, "summary content", m.ContentBlocks[0].UserInputText.Text)
 		}
 	})
+
+	t.Run("isInnerMessage", func(t *testing.T) {
+		summaryMsg := newTypedSummaryMessage[M]("summary content")
+		assert.True(t, isInternalUserMessage(summaryMsg))
+		assert.False(t, isPreservedMessage(summaryMsg))
+
+		skillsMsg := makeUserMsg[M]("skills content")
+		setMsgExtra(skillsMsg, extraKeyContentType, string(contentTypeSkills))
+		assert.True(t, isInternalUserMessage(skillsMsg))
+		assert.True(t, isPreservedMessage(skillsMsg))
+
+		normalMsg := makeUserMsg[M]("normal content")
+		assert.False(t, isInternalUserMessage(normalMsg))
+		assert.False(t, isPreservedMessage(normalMsg))
+	})
 }
 
 func testSummarizationFlow[M adk.MessageType](t *testing.T) {


### PR DESCRIPTION
## Summary

This refactors the ADK summarization finalizer pipeline to use handler-based construction only and preserve skill context through explicit internal message markers. It keeps preserved skill messages separate from generated summaries, so they can survive default finalization without being treated as normal user history.

## Breaking Changes

1. `TypedFinalizerBuilder.Custom` has been removed. Callers should compose finalizer behavior through registered handlers instead.

## API Changes

1. **Deprecated**: `FinalizerBuilder`; use `TypedFinalizerBuilder[*schema.Message]` instead.
2. **Deprecated**: `NewFinalizer`; use `NewTypedFinalizer[*schema.Message]` instead.

## Key Changes

1. Finalizer handlers now return prefix messages followed by the active summary, allowing handlers such as `PreserveSkills` to emit retained context independently.
2. Preserved skill messages are tagged with a dedicated `skills` content type and retained by `DefaultFinalize`.
3. Internal summary and preserved skill messages are excluded from generic user-message replacement.
