### PR TITLE
fix(compose): correct off-by-one in mergeStream error message

### DIFF
--- a/compose/values_merge.go
+++ b/compose/values_merge.go
@@ -57,7 +57,7 @@ func mergeValues(vs []any, opts *mergeOptions) (any, error) {
 			sri, ok_ := vs[i+1].(streamReader)
 			if !ok_ {
 				return nil, fmt.Errorf("(mergeStream) unexpected type. "+
-					"expect: %v, got: %v", t0, reflect.TypeOf(vs[i]))
+					"expect: %v, got: %v", t0, reflect.TypeOf(vs[i+1]))
 			}
 
 			if st := sri.getChunkType(); st != t {


### PR DESCRIPTION
## Summary

Fixes #974.

In `compose/values_merge.go`, the loop asserts `vs[i+1]` as a `streamReader` but on failure logs `reflect.TypeOf(vs[i])` — the element *before* the one that failed:

```go
sri, ok_ := vs[i+1].(streamReader)
if !ok_ {
    return nil, fmt.Errorf("(mergeStream) unexpected type. "+
        "expect: %v, got: %v", t0, reflect.TypeOf(vs[i]))  // wrong index
}
```

Changed `vs[i]` → `vs[i+1]` so the error message reports the type of the element that actually failed the assertion.

## Test plan

- [x] `go test ./compose/...` passes

Assisted-by: Claude Sonnet 4.6 <noreply@anthropic.com>