### PR TITLE
fix(schema): handle multiple complete tool calls with the same index

### DIFF
--- a/schema/message.go
+++ b/schema/message.go
@@ -1309,9 +1309,25 @@ func concatToolCalls(chunks []ToolCall) ([]ToolCall, error) {
 				if toolID == "" {
 					toolID = chunk.ID
 				} else if toolID != chunk.ID {
-					return nil, fmt.Errorf("cannot concat ToolCalls with different tool id: '%s' '%s'", toolID, chunk.ID)
-				}
+					// A different name on the new chunk means this is an independent
+					// complete tool call reusing the same index (some models emit all
+					// tool calls with index=0). Finalize the current call and reset.
+					if chunk.Function.Name != "" && chunk.Function.Name != toolName {
+						toolCall.ID = toolID
+						toolCall.Type = toolType
+						toolCall.Function.Name = toolName
+						toolCall.Function.Arguments = args.String()
+						merged = append(merged, toolCall)
 
+						toolCall = chunk
+						toolID = chunk.ID
+						toolType = ""
+						toolName = ""
+						args.Reset()
+					} else {
+						return nil, fmt.Errorf("cannot concat ToolCalls with different tool id: '%s' '%s'", toolID, chunk.ID)
+					}
+				}
 			}
 
 			if chunk.Type != "" {

--- a/schema/message_test.go
+++ b/schema/message_test.go
@@ -1089,6 +1089,43 @@ func TestConcatToolCalls(t *testing.T) {
 		assert.ErrorContains(t, err, "cannot concat ToolCalls with different tool id")
 	})
 
+	t.Run("multiple_complete_calls_same_index", func(t *testing.T) {
+		// Some models (e.g. DeepSeek, certain Qwen variants) emit every tool call
+		// with index=0 as a standalone complete chunk rather than streaming the
+		// arguments across multiple chunks. concatToolCalls must treat a chunk with
+		// a different non-empty name as a new independent call, not an error.
+		givenToolCalls := []ToolCall{
+			{
+				Index: generic.PtrOf(0),
+				ID:    "call_111",
+				Type:  "function",
+				Function: FunctionCall{
+					Name:      "ls",
+					Arguments: `{"path":"./memory"}`,
+				},
+			},
+			{
+				Index: generic.PtrOf(0),
+				ID:    "call_222",
+				Type:  "function",
+				Function: FunctionCall{
+					Name:      "user_completed_work",
+					Arguments: `{"weeks_ago":0}`,
+				},
+			},
+		}
+
+		tc, err := concatToolCalls(givenToolCalls)
+		assert.NoError(t, err)
+		assert.Len(t, tc, 2)
+		assert.Equal(t, "call_111", tc[0].ID)
+		assert.Equal(t, "ls", tc[0].Function.Name)
+		assert.Equal(t, `{"path":"./memory"}`, tc[0].Function.Arguments)
+		assert.Equal(t, "call_222", tc[1].ID)
+		assert.Equal(t, "user_completed_work", tc[1].Function.Name)
+		assert.Equal(t, `{"weeks_ago":0}`, tc[1].Function.Arguments)
+	})
+
 	t.Run("different_tool_type", func(t *testing.T) {
 		givenToolCalls := []ToolCall{
 			{


### PR DESCRIPTION
## Summary

Fixes #927.

Some models (DeepSeek, certain Qwen variants) emit every tool call as a **standalone complete chunk**, all with `index=0`, rather than streaming a single call's arguments across multiple chunks. `concatToolCalls` groups chunks by index, so both calls land in the same bucket and the second chunk's different ID triggered:

```
cannot concat ToolCalls with different tool id: 'call_a22ee75...' 'call_067d72...'
```

**Root cause**: the function assumed that within one index-group all chunks belong to the same logical tool call. That holds for streaming-argument models but not for models that emit complete calls with a shared index.

**Fix**: when a chunk has a non-empty ID *and* a non-empty `Function.Name` that differs from the accumulated name, treat it as a new independent tool call — finalize the current accumulation into `merged` and start fresh. The existing same-name/different-id error path is preserved (that case is still ambiguous and wrong).

## Test plan

- [x] New sub-test `multiple_complete_calls_same_index` exercises the exact pattern from the issue (two complete calls, index=0, different ids/names → two entries in output)
- [x] Existing `different_tool_id` test (same name, different id → still errors) still passes
- [x] Full `go test ./schema/...` passes

Assisted-by: Claude Sonnet 4.6 <noreply@anthropic.com>