### PR TITLE
fix(adk): preserve resume checkpoint state

### DIFF
--- a/adk/runner.go
+++ b/adk/runner.go
@@ -150,7 +150,7 @@ func (r *TypedRunner[M]) ResumeWithParams(ctx context.Context, checkPointID stri
 
 func (r *TypedRunner[M]) resumeInternal(ctx context.Context, checkPointID string, resumeData map[string]any,
 	opts ...AgentRunOption) (*AsyncIterator[*TypedAgentEvent[M]], error) {
-	return typedRunnerResumeInternalImpl(r.a, r.enableStreaming, r.store, ctx, checkPointID, resumeData, opts...)
+	return typedRunnerResumeInternalImpl(r.a, r.store, ctx, checkPointID, resumeData, opts...)
 }
 
 func typedRunnerRunImpl[M MessageType](a TypedAgent[M], enableStreaming bool, store CheckPointStore, ctx context.Context, messages []M, opts ...AgentRunOption) *AsyncIterator[*TypedAgentEvent[M]] {
@@ -202,7 +202,7 @@ func typedRunnerRunImpl[M MessageType](a TypedAgent[M], enableStreaming bool, st
 	return niter
 }
 
-func typedRunnerResumeInternalImpl[M MessageType](a TypedAgent[M], enableStreaming bool, store CheckPointStore, ctx context.Context, checkPointID string, resumeData map[string]any, //nolint:revive // argument-limit
+func typedRunnerResumeInternalImpl[M MessageType](a TypedAgent[M], store CheckPointStore, ctx context.Context, checkPointID string, resumeData map[string]any, //nolint:revive // argument-limit
 	opts ...AgentRunOption) (*AsyncIterator[*TypedAgentEvent[M]], error) {
 	if store == nil {
 		return nil, fmt.Errorf("failed to resume: store is nil")
@@ -212,6 +212,12 @@ func typedRunnerResumeInternalImpl[M MessageType](a TypedAgent[M], enableStreami
 	if err != nil {
 		return nil, fmt.Errorf("failed to load from checkpoint: %w", err)
 	}
+
+	// Resume uses the streaming mode persisted in the checkpoint, not the value the
+	// caller passed when constructing the runner. This is the runner's own invariant:
+	// the checkpoint is the source of truth for what mode the original execution was
+	// running in, and any new checkpoint written during this resume must preserve it.
+	enableStreaming := resumeInfo.EnableStreaming
 
 	o := getCommonOptions(nil, opts...)
 	if o.sharedParentSession {

--- a/adk/turn_loop.go
+++ b/adk/turn_loop.go
@@ -693,14 +693,13 @@ type GenResumeResult[T any, M MessageType] struct {
 }
 
 type turnRunSpec[T any, M MessageType] struct {
-	runCtx                context.Context
-	input                 *TypedAgentInput[M]
-	runOpts               []AgentRunOption
-	resumeParams          *ResumeParams
-	resumeEnableStreaming bool
-	isResume              bool
-	consumed              []T
-	resumeBytes           []byte
+	runCtx       context.Context
+	input        *TypedAgentInput[M]
+	runOpts      []AgentRunOption
+	resumeParams *ResumeParams
+	isResume     bool
+	consumed     []T
+	resumeBytes  []byte
 }
 
 type turnPlan[T any, M MessageType] struct {
@@ -762,13 +761,12 @@ func (l *TurnLoop[T, M]) planTurn(
 		turnCtx:   turnCtx,
 		remaining: resumeResult.Remaining,
 		spec: &turnRunSpec[T, M]{
-			runCtx:                resumeResult.RunCtx,
-			runOpts:               resumeResult.RunOpts,
-			resumeParams:          resumeResult.ResumeParams,
-			resumeEnableStreaming: pr.runnerEnableStreaming,
-			isResume:              true,
-			consumed:              resumeResult.Consumed,
-			resumeBytes:           pr.resumeBytes,
+			runCtx:       resumeResult.RunCtx,
+			runOpts:      resumeResult.RunOpts,
+			resumeParams: resumeResult.ResumeParams,
+			isResume:     true,
+			consumed:     resumeResult.Consumed,
+			resumeBytes:  pr.resumeBytes,
 		},
 	}, nil
 }
@@ -917,10 +915,9 @@ type TurnLoop[T any, M MessageType] struct {
 
 	interruptedItems []T
 
-	checkPointRunnerBytes           []byte
-	checkPointRunnerEnableStreaming bool
-	interruptContexts               []*InterruptCtx
-	capturedCancelErr               *CancelError
+	checkPointRunnerBytes []byte
+	interruptContexts     []*InterruptCtx
+	capturedCancelErr     *CancelError
 
 	pendingResume *turnLoopPendingResume[T]
 
@@ -947,10 +944,9 @@ type turnLoopCheckpoint[T any] struct {
 	// HasRunnerState reports whether RunnerCheckpoint contains resumable runner state.
 	// It is false for "between turns" checkpoints where no agent execution was
 	// interrupted (e.g. Stop() before the first turn or between turns).
-	HasRunnerState        bool
-	UnhandledItems        []T
-	CanceledItems         []T // gob-compat: kept as CanceledItems for deserialization of existing checkpoints
-	RunnerEnableStreaming bool
+	HasRunnerState bool
+	UnhandledItems []T
+	CanceledItems  []T // gob-compat: kept as CanceledItems for deserialization of existing checkpoints
 }
 
 func marshalTurnLoopCheckpoint[T any](c *turnLoopCheckpoint[T]) ([]byte, error) {
@@ -1023,11 +1019,10 @@ func (l *TurnLoop[T, M]) tryLoadCheckpoint(ctx context.Context) error {
 			return fmt.Errorf("checkpoint[%s] has runner state but bytes are empty", checkPointID)
 		}
 		l.pendingResume = &turnLoopPendingResume[T]{
-			interrupted:           append([]T{}, cp.CanceledItems...),
-			unhandled:             append([]T{}, cp.UnhandledItems...),
-			newItems:              append([]T{}, newItems...),
-			resumeBytes:           append([]byte{}, cp.RunnerCheckpoint...),
-			runnerEnableStreaming: cp.RunnerEnableStreaming,
+			interrupted: append([]T{}, cp.CanceledItems...),
+			unhandled:   append([]T{}, cp.UnhandledItems...),
+			newItems:    append([]T{}, newItems...),
+			resumeBytes: append([]byte{}, cp.RunnerCheckpoint...),
 		}
 	} else {
 		items := make([]T, 0, len(cp.UnhandledItems)+len(newItems))
@@ -1040,11 +1035,10 @@ func (l *TurnLoop[T, M]) tryLoadCheckpoint(ctx context.Context) error {
 }
 
 type turnLoopPendingResume[T any] struct {
-	interrupted           []T
-	unhandled             []T
-	newItems              []T
-	resumeBytes           []byte
-	runnerEnableStreaming bool
+	interrupted []T
+	unhandled   []T
+	newItems    []T
+	resumeBytes []byte
 }
 
 // SafePoint describes at which boundary the agent may be cancelled.
@@ -1820,7 +1814,6 @@ func (l *TurnLoop[T, M]) runAgentAndHandleEvents(
 	l.interruptContexts = nil
 	l.capturedCancelErr = nil
 	l.checkPointRunnerBytes = nil
-	l.checkPointRunnerEnableStreaming = false
 
 	var iter *AsyncIterator[*TypedAgentEvent[M]]
 
@@ -1833,13 +1826,13 @@ func (l *TurnLoop[T, M]) runAgentAndHandleEvents(
 	cancelOpt, agentCancelFunc := WithCancel()
 	runOpts = append(runOpts, cancelOpt)
 
+	// For Run path the streaming mode comes from the input. For Resume path the
+	// runner reads the streaming mode persisted in the checkpoint, so the value we
+	// pass here is irrelevant.
 	enableStreaming := false
 	if spec.input != nil {
 		enableStreaming = spec.input.EnableStreaming
-	} else {
-		enableStreaming = spec.resumeEnableStreaming
 	}
-	l.checkPointRunnerEnableStreaming = enableStreaming
 	runner := NewTypedRunner(TypedRunnerConfig[M]{
 		EnableStreaming: enableStreaming,
 		Agent:           agent,
@@ -2024,16 +2017,11 @@ func (l *TurnLoop[T, M]) cleanup(ctx context.Context) {
 
 	if shouldSaveCheckpoint {
 		hasRunnerState := len(l.checkPointRunnerBytes) > 0
-		var runnerEnableStreaming bool
-		if hasRunnerState {
-			runnerEnableStreaming = l.checkPointRunnerEnableStreaming
-		}
 		cp := &turnLoopCheckpoint[T]{
-			RunnerCheckpoint:      l.checkPointRunnerBytes,
-			HasRunnerState:        hasRunnerState,
-			UnhandledItems:        unhandled,
-			CanceledItems:         l.interruptedItems,
-			RunnerEnableStreaming: runnerEnableStreaming,
+			RunnerCheckpoint: l.checkPointRunnerBytes,
+			HasRunnerState:   hasRunnerState,
+			UnhandledItems:   unhandled,
+			CanceledItems:    l.interruptedItems,
 		}
 		checkpointed = true
 		checkpointErr = l.saveTurnLoopCheckpoint(ctx, checkpointID, cp)

--- a/adk/turn_loop.go
+++ b/adk/turn_loop.go
@@ -693,13 +693,14 @@ type GenResumeResult[T any, M MessageType] struct {
 }
 
 type turnRunSpec[T any, M MessageType] struct {
-	runCtx       context.Context
-	input        *TypedAgentInput[M]
-	runOpts      []AgentRunOption
-	resumeParams *ResumeParams
-	isResume     bool
-	consumed     []T
-	resumeBytes  []byte
+	runCtx                context.Context
+	input                 *TypedAgentInput[M]
+	runOpts               []AgentRunOption
+	resumeParams          *ResumeParams
+	resumeEnableStreaming bool
+	isResume              bool
+	consumed              []T
+	resumeBytes           []byte
 }
 
 type turnPlan[T any, M MessageType] struct {
@@ -761,12 +762,13 @@ func (l *TurnLoop[T, M]) planTurn(
 		turnCtx:   turnCtx,
 		remaining: resumeResult.Remaining,
 		spec: &turnRunSpec[T, M]{
-			runCtx:       resumeResult.RunCtx,
-			runOpts:      resumeResult.RunOpts,
-			resumeParams: resumeResult.ResumeParams,
-			isResume:     true,
-			consumed:     resumeResult.Consumed,
-			resumeBytes:  pr.resumeBytes,
+			runCtx:                resumeResult.RunCtx,
+			runOpts:               resumeResult.RunOpts,
+			resumeParams:          resumeResult.ResumeParams,
+			resumeEnableStreaming: pr.runnerEnableStreaming,
+			isResume:              true,
+			consumed:              resumeResult.Consumed,
+			resumeBytes:           pr.resumeBytes,
 		},
 	}, nil
 }
@@ -915,9 +917,10 @@ type TurnLoop[T any, M MessageType] struct {
 
 	interruptedItems []T
 
-	checkPointRunnerBytes []byte
-	interruptContexts     []*InterruptCtx
-	capturedCancelErr     *CancelError
+	checkPointRunnerBytes           []byte
+	checkPointRunnerEnableStreaming bool
+	interruptContexts               []*InterruptCtx
+	capturedCancelErr               *CancelError
 
 	pendingResume *turnLoopPendingResume[T]
 
@@ -944,9 +947,10 @@ type turnLoopCheckpoint[T any] struct {
 	// HasRunnerState reports whether RunnerCheckpoint contains resumable runner state.
 	// It is false for "between turns" checkpoints where no agent execution was
 	// interrupted (e.g. Stop() before the first turn or between turns).
-	HasRunnerState bool
-	UnhandledItems []T
-	CanceledItems  []T // gob-compat: kept as CanceledItems for deserialization of existing checkpoints
+	HasRunnerState        bool
+	UnhandledItems        []T
+	CanceledItems         []T // gob-compat: kept as CanceledItems for deserialization of existing checkpoints
+	RunnerEnableStreaming bool
 }
 
 func marshalTurnLoopCheckpoint[T any](c *turnLoopCheckpoint[T]) ([]byte, error) {
@@ -1019,10 +1023,11 @@ func (l *TurnLoop[T, M]) tryLoadCheckpoint(ctx context.Context) error {
 			return fmt.Errorf("checkpoint[%s] has runner state but bytes are empty", checkPointID)
 		}
 		l.pendingResume = &turnLoopPendingResume[T]{
-			interrupted: append([]T{}, cp.CanceledItems...),
-			unhandled:   append([]T{}, cp.UnhandledItems...),
-			newItems:    append([]T{}, newItems...),
-			resumeBytes: append([]byte{}, cp.RunnerCheckpoint...),
+			interrupted:           append([]T{}, cp.CanceledItems...),
+			unhandled:             append([]T{}, cp.UnhandledItems...),
+			newItems:              append([]T{}, newItems...),
+			resumeBytes:           append([]byte{}, cp.RunnerCheckpoint...),
+			runnerEnableStreaming: cp.RunnerEnableStreaming,
 		}
 	} else {
 		items := make([]T, 0, len(cp.UnhandledItems)+len(newItems))
@@ -1035,10 +1040,11 @@ func (l *TurnLoop[T, M]) tryLoadCheckpoint(ctx context.Context) error {
 }
 
 type turnLoopPendingResume[T any] struct {
-	interrupted []T
-	unhandled   []T
-	newItems    []T
-	resumeBytes []byte
+	interrupted           []T
+	unhandled             []T
+	newItems              []T
+	resumeBytes           []byte
+	runnerEnableStreaming bool
 }
 
 // SafePoint describes at which boundary the agent may be cancelled.
@@ -1814,6 +1820,7 @@ func (l *TurnLoop[T, M]) runAgentAndHandleEvents(
 	l.interruptContexts = nil
 	l.capturedCancelErr = nil
 	l.checkPointRunnerBytes = nil
+	l.checkPointRunnerEnableStreaming = false
 
 	var iter *AsyncIterator[*TypedAgentEvent[M]]
 
@@ -1829,7 +1836,10 @@ func (l *TurnLoop[T, M]) runAgentAndHandleEvents(
 	enableStreaming := false
 	if spec.input != nil {
 		enableStreaming = spec.input.EnableStreaming
+	} else {
+		enableStreaming = spec.resumeEnableStreaming
 	}
+	l.checkPointRunnerEnableStreaming = enableStreaming
 	runner := NewTypedRunner(TypedRunnerConfig[M]{
 		EnableStreaming: enableStreaming,
 		Agent:           agent,
@@ -2013,11 +2023,17 @@ func (l *TurnLoop[T, M]) cleanup(ctx context.Context) {
 	var checkpointErr error
 
 	if shouldSaveCheckpoint {
+		hasRunnerState := len(l.checkPointRunnerBytes) > 0
+		var runnerEnableStreaming bool
+		if hasRunnerState {
+			runnerEnableStreaming = l.checkPointRunnerEnableStreaming
+		}
 		cp := &turnLoopCheckpoint[T]{
-			RunnerCheckpoint: l.checkPointRunnerBytes,
-			HasRunnerState:   len(l.checkPointRunnerBytes) > 0,
-			UnhandledItems:   unhandled,
-			CanceledItems:    l.interruptedItems,
+			RunnerCheckpoint:      l.checkPointRunnerBytes,
+			HasRunnerState:        hasRunnerState,
+			UnhandledItems:        unhandled,
+			CanceledItems:         l.interruptedItems,
+			RunnerEnableStreaming: runnerEnableStreaming,
 		}
 		checkpointed = true
 		checkpointErr = l.saveTurnLoopCheckpoint(ctx, checkpointID, cp)

--- a/adk/turn_loop.go
+++ b/adk/turn_loop.go
@@ -2016,10 +2016,9 @@ func (l *TurnLoop[T, M]) cleanup(ctx context.Context) {
 	var checkpointErr error
 
 	if shouldSaveCheckpoint {
-		hasRunnerState := len(l.checkPointRunnerBytes) > 0
 		cp := &turnLoopCheckpoint[T]{
 			RunnerCheckpoint: l.checkPointRunnerBytes,
-			HasRunnerState:   hasRunnerState,
+			HasRunnerState:   len(l.checkPointRunnerBytes) > 0,
 			UnhandledItems:   unhandled,
 			CanceledItems:    l.interruptedItems,
 		}

--- a/adk/turn_loop_test.go
+++ b/adk/turn_loop_test.go
@@ -2550,8 +2550,7 @@ func TestTurnLoop_ResumeInterruptAgain_PreservesEnableStreamingCheckpoint(t *tes
 			require.ErrorAs(t, exit1.ExitReason, new(*InterruptError))
 			require.NoError(t, exit1.CheckpointErr)
 
-			cp1, info1, runCtx1 := loadTurnLoopRunnerCheckpoint(t, store, cpID)
-			assert.Equal(t, enableStreaming, cp1.RunnerEnableStreaming)
+			info1, runCtx1 := loadTurnLoopRunnerCheckpoint(t, store, cpID)
 			assert.Equal(t, enableStreaming, info1.EnableStreaming)
 			require.NotNil(t, runCtx1.RootInput)
 			require.Len(t, runCtx1.RootInput.Messages, 1)
@@ -2587,8 +2586,7 @@ func TestTurnLoop_ResumeInterruptAgain_PreservesEnableStreamingCheckpoint(t *tes
 			require.ErrorAs(t, exit2.ExitReason, new(*InterruptError))
 			require.NoError(t, exit2.CheckpointErr)
 
-			cp2, info2, runCtx2 := loadTurnLoopRunnerCheckpoint(t, store, cpID)
-			assert.Equal(t, enableStreaming, cp2.RunnerEnableStreaming)
+			info2, runCtx2 := loadTurnLoopRunnerCheckpoint(t, store, cpID)
 			assert.Equal(t, enableStreaming, info2.EnableStreaming)
 			require.NotNil(t, runCtx2.RootInput)
 			require.Len(t, runCtx2.RootInput.Messages, 1)
@@ -2597,7 +2595,7 @@ func TestTurnLoop_ResumeInterruptAgain_PreservesEnableStreamingCheckpoint(t *tes
 	}
 }
 
-func loadTurnLoopRunnerCheckpoint(t *testing.T, store *turnLoopCheckpointStore, cpID string) (*turnLoopCheckpoint[string], *ResumeInfo, *runContext) {
+func loadTurnLoopRunnerCheckpoint(t *testing.T, store *turnLoopCheckpointStore, cpID string) (*ResumeInfo, *runContext) {
 	t.Helper()
 
 	store.mu.Lock()
@@ -2616,7 +2614,7 @@ func loadTurnLoopRunnerCheckpoint(t *testing.T, store *turnLoopCheckpointStore, 
 	require.NotNil(t, info)
 	require.NotNil(t, runCtx)
 
-	return cp, info, runCtx
+	return info, runCtx
 }
 
 func TestTurnLoop_Stop_EscalatesCancelMode(t *testing.T) {

--- a/adk/turn_loop_test.go
+++ b/adk/turn_loop_test.go
@@ -2550,12 +2550,6 @@ func TestTurnLoop_ResumeInterruptAgain_PreservesEnableStreamingCheckpoint(t *tes
 			require.ErrorAs(t, exit1.ExitReason, new(*InterruptError))
 			require.NoError(t, exit1.CheckpointErr)
 
-			info1, runCtx1 := loadTurnLoopRunnerCheckpoint(t, store, cpID)
-			assert.Equal(t, enableStreaming, info1.EnableStreaming)
-			require.NotNil(t, runCtx1.RootInput)
-			require.Len(t, runCtx1.RootInput.Messages, 1)
-			assert.Equal(t, originalMessage, runCtx1.RootInput.Messages[0].Content)
-
 			secondAgent := &myAgent{
 				resumeFn: func(ctx context.Context, info *ResumeInfo, _ ...AgentRunOption) *AsyncIterator[*AgentEvent] {
 					assert.Equal(t, enableStreaming, info.EnableStreaming)
@@ -2586,35 +2580,23 @@ func TestTurnLoop_ResumeInterruptAgain_PreservesEnableStreamingCheckpoint(t *tes
 			require.ErrorAs(t, exit2.ExitReason, new(*InterruptError))
 			require.NoError(t, exit2.CheckpointErr)
 
-			info2, runCtx2 := loadTurnLoopRunnerCheckpoint(t, store, cpID)
+			// Verify the runner-level checkpoint persisted by the second interrupt
+			// still encodes the original streaming mode. This is the invariant the PR
+			// fixes: even though loop2's TypedRunner was constructed with the
+			// resume-path placeholder (false), runner uses resumeInfo.EnableStreaming
+			// from the previous checkpoint when re-saving.
+			store.mu.Lock()
+			data, ok := store.m[cpID]
+			store.mu.Unlock()
+			require.True(t, ok)
+			cp, err := unmarshalTurnLoopCheckpoint[string](data)
+			require.NoError(t, err)
+			require.True(t, cp.HasRunnerState)
+			_, _, info2, err := runnerLoadCheckPointImpl(newResumeBridgeStore(bridgeCheckpointID, cp.RunnerCheckpoint), context.Background(), bridgeCheckpointID)
+			require.NoError(t, err)
 			assert.Equal(t, enableStreaming, info2.EnableStreaming)
-			require.NotNil(t, runCtx2.RootInput)
-			require.Len(t, runCtx2.RootInput.Messages, 1)
-			assert.Equal(t, originalMessage, runCtx2.RootInput.Messages[0].Content)
 		})
 	}
-}
-
-func loadTurnLoopRunnerCheckpoint(t *testing.T, store *turnLoopCheckpointStore, cpID string) (*ResumeInfo, *runContext) {
-	t.Helper()
-
-	store.mu.Lock()
-	data, ok := store.m[cpID]
-	store.mu.Unlock()
-	require.True(t, ok, "turn loop checkpoint should exist")
-
-	cp, err := unmarshalTurnLoopCheckpoint[string](data)
-	require.NoError(t, err)
-	require.True(t, cp.HasRunnerState)
-	require.NotEmpty(t, cp.RunnerCheckpoint)
-
-	runnerStore := newResumeBridgeStore(bridgeCheckpointID, cp.RunnerCheckpoint)
-	_, runCtx, info, err := runnerLoadCheckPointImpl(runnerStore, context.Background(), bridgeCheckpointID)
-	require.NoError(t, err)
-	require.NotNil(t, info)
-	require.NotNil(t, runCtx)
-
-	return info, runCtx
 }
 
 func TestTurnLoop_Stop_EscalatesCancelMode(t *testing.T) {

--- a/adk/turn_loop_test.go
+++ b/adk/turn_loop_test.go
@@ -2507,6 +2507,118 @@ func TestTurnLoop_ResumeWithParams(t *testing.T) {
 	_ = exit2
 }
 
+func TestTurnLoop_ResumeInterruptAgain_PreservesEnableStreamingCheckpoint(t *testing.T) {
+	for _, enableStreaming := range []bool{true, false} {
+		t.Run(fmt.Sprintf("enable_streaming_%t", enableStreaming), func(t *testing.T) {
+			ctx := context.Background()
+			store := newTestStore()
+			cpID := fmt.Sprintf("streaming-resume-%t", enableStreaming)
+			originalMessage := "msg1"
+
+			firstAgent := &myAgent{
+				runFn: func(ctx context.Context, input *AgentInput, _ ...AgentRunOption) *AsyncIterator[*AgentEvent] {
+					assert.Equal(t, enableStreaming, input.EnableStreaming)
+					assert.Len(t, input.Messages, 1)
+					assert.Equal(t, originalMessage, input.Messages[0].Content)
+
+					iter, gen := NewAsyncIteratorPair[*AgentEvent]()
+					go func() {
+						defer gen.Close()
+						gen.Send(Interrupt(ctx, "first_interrupt"))
+					}()
+					return iter
+				},
+			}
+
+			loop1 := NewTurnLoop(TurnLoopConfig[string, *schema.Message]{
+				Store:        store,
+				CheckpointID: cpID,
+				GenInput: func(_ context.Context, _ *TurnLoop[string, *schema.Message], items []string) (*GenInputResult[string, *schema.Message], error) {
+					return &GenInputResult[string, *schema.Message]{
+						Input: &AgentInput{
+							Messages:        []Message{schema.UserMessage(items[0])},
+							EnableStreaming: enableStreaming,
+						},
+						Consumed: items,
+					}, nil
+				},
+				PrepareAgent: prepareAgent(firstAgent),
+			})
+			loop1.Push(originalMessage)
+			loop1.Run(ctx)
+			exit1 := loop1.Wait()
+			require.ErrorAs(t, exit1.ExitReason, new(*InterruptError))
+			require.NoError(t, exit1.CheckpointErr)
+
+			cp1, info1, runCtx1 := loadTurnLoopRunnerCheckpoint(t, store, cpID)
+			assert.Equal(t, enableStreaming, cp1.RunnerEnableStreaming)
+			assert.Equal(t, enableStreaming, info1.EnableStreaming)
+			require.NotNil(t, runCtx1.RootInput)
+			require.Len(t, runCtx1.RootInput.Messages, 1)
+			assert.Equal(t, originalMessage, runCtx1.RootInput.Messages[0].Content)
+
+			secondAgent := &myAgent{
+				resumeFn: func(ctx context.Context, info *ResumeInfo, _ ...AgentRunOption) *AsyncIterator[*AgentEvent] {
+					assert.Equal(t, enableStreaming, info.EnableStreaming)
+
+					iter, gen := NewAsyncIteratorPair[*AgentEvent]()
+					go func() {
+						defer gen.Close()
+						gen.Send(Interrupt(ctx, "second_interrupt"))
+					}()
+					return iter
+				},
+			}
+
+			loop2 := NewTurnLoop(TurnLoopConfig[string, *schema.Message]{
+				Store:        store,
+				CheckpointID: cpID,
+				GenInput:     genInputConsumeAll,
+				GenResume: func(_ context.Context, _ *TurnLoop[string, *schema.Message], interrupted, unhandled, newItems []string) (*GenResumeResult[string, *schema.Message], error) {
+					return &GenResumeResult[string, *schema.Message]{
+						Consumed:  interrupted,
+						Remaining: append(append([]string{}, unhandled...), newItems...),
+					}, nil
+				},
+				PrepareAgent: prepareAgent(secondAgent),
+			})
+			loop2.Run(ctx)
+			exit2 := loop2.Wait()
+			require.ErrorAs(t, exit2.ExitReason, new(*InterruptError))
+			require.NoError(t, exit2.CheckpointErr)
+
+			cp2, info2, runCtx2 := loadTurnLoopRunnerCheckpoint(t, store, cpID)
+			assert.Equal(t, enableStreaming, cp2.RunnerEnableStreaming)
+			assert.Equal(t, enableStreaming, info2.EnableStreaming)
+			require.NotNil(t, runCtx2.RootInput)
+			require.Len(t, runCtx2.RootInput.Messages, 1)
+			assert.Equal(t, originalMessage, runCtx2.RootInput.Messages[0].Content)
+		})
+	}
+}
+
+func loadTurnLoopRunnerCheckpoint(t *testing.T, store *turnLoopCheckpointStore, cpID string) (*turnLoopCheckpoint[string], *ResumeInfo, *runContext) {
+	t.Helper()
+
+	store.mu.Lock()
+	data, ok := store.m[cpID]
+	store.mu.Unlock()
+	require.True(t, ok, "turn loop checkpoint should exist")
+
+	cp, err := unmarshalTurnLoopCheckpoint[string](data)
+	require.NoError(t, err)
+	require.True(t, cp.HasRunnerState)
+	require.NotEmpty(t, cp.RunnerCheckpoint)
+
+	runnerStore := newResumeBridgeStore(bridgeCheckpointID, cp.RunnerCheckpoint)
+	_, runCtx, info, err := runnerLoadCheckPointImpl(runnerStore, context.Background(), bridgeCheckpointID)
+	require.NoError(t, err)
+	require.NotNil(t, info)
+	require.NotNil(t, runCtx)
+
+	return cp, info, runCtx
+}
+
 func TestTurnLoop_Stop_EscalatesCancelMode(t *testing.T) {
 	ctx := context.Background()
 	agentStarted := make(chan *cancelContext, 1)


### PR DESCRIPTION
## Summary

| Area | Problem | Change |
| --- | --- | --- |
| `TypedRunner.Resume` | After loading the checkpoint, the runner used `r.enableStreaming` (from `NewTypedRunner` config) when re-saving the checkpoint on a subsequent interrupt — even though the checkpoint itself already encodes the original streaming mode. This made the caller responsible for knowing the persisted mode, and on a resume that interrupted again the original `EnableStreaming = true` could be silently overwritten with `false`. | The runner now uses `resumeInfo.EnableStreaming` (the value just decoded from the checkpoint) as the source of truth on the resume path, both for driving the current agent execution and for any new checkpoint written before this resume completes. |
| `TurnLoop` | Previously tracked `RunnerEnableStreaming` itself (in `turnLoopCheckpoint`, `turnRunSpec`, `turnLoopPendingResume`, and on the loop struct) so that it could pass the right `EnableStreaming` into `NewTypedRunner` on resume. With the runner now self-consistent, none of this state is necessary. | Removed all streaming-mode tracking from `TurnLoop`. The value passed to `NewTypedRunner` on the resume path is no longer used by the runner. |

## Key Insights

- The runner is the only component that has both ends of the streaming-mode contract: it decodes `EnableStreaming` from the checkpoint when invoking the agent, and it encodes `EnableStreaming` back when persisting a new checkpoint after a subsequent interrupt. Making *both* sides read from the checkpoint (rather than from the runner's construction-time config) is what makes resume idempotent under repeated interrupts.
- This also resolves a layering smell: `TurnLoop` does not own runner-internal serialization details, so it should not need to track or persist `EnableStreaming`. With the invariant moved into the runner, the field naturally drops out of `TurnLoop`'s checkpoint and in-memory state.
- No backward-compatibility shim is added for older `TurnLoop` checkpoints. Any normally-completing turn deletes the stale checkpoint, and even if an old checkpoint is resumed, the runner now reads the correct `EnableStreaming` directly from the embedded runner checkpoint — so the previous "lost streaming mode" window is closed without TurnLoop needing to know anything.

## Validation

- `go vet ./adk/...`
- `go test -race ./adk -count=1`
- Targeted regression test:
  - `go test -race ./adk -run TestTurnLoop_ResumeInterruptAgain_PreservesEnableStreamingCheckpoint`

---

## 概要

| 模块 | 问题 | 变更 |
| --- | --- | --- |
| `TypedRunner.Resume` | runner 在 resume 时会从 checkpoint 解出 `EnableStreaming` 并交给 agent 执行，但**再次 interrupt** 重新写 checkpoint 时使用的是 `r.enableStreaming`（由 `NewTypedRunner` 时传入），等于让外层调用方对持久化的 streaming 模式负责。当老 checkpoint 被 resume 后又再次中断时，原本的 `EnableStreaming = true` 可能被 `false` 静默覆盖。 | runner 在 resume 路径下统一以 `resumeInfo.EnableStreaming`（来自 checkpoint 的真值）为唯一来源，既驱动本次 agent 执行，也用于本次 resume 期间任何后续 checkpoint 的回写。 |
| `TurnLoop` | 之前为了在 resume 时把正确的 `EnableStreaming` 传给 `NewTypedRunner`，TurnLoop 自己持久化并跟踪了 `RunnerEnableStreaming`（涉及 `turnLoopCheckpoint`、`turnRunSpec`、`turnLoopPendingResume` 以及 loop 自身的状态字段）。现在 runner 自身已经自洽，这些状态全都不再需要。 | 删除 TurnLoop 中所有 streaming 模式相关的字段与逻辑。Resume 路径下传给 `NewTypedRunner` 的 `EnableStreaming` 不再被 runner 使用。 |

## 关键认知

- 只有 runner 同时持有 streaming 模式契约的两端：在调用 agent 时从 checkpoint 解出 `EnableStreaming`，在再次中断时又要把 `EnableStreaming` 写回新 checkpoint。让**两端都以 checkpoint 为准**（而不是以 runner 创建时的 config 为准），才能让 resume 在多次 interrupt 下保持幂等。
- 这同时纠正了一处分层不洁：runner 内部的序列化细节不属于 `TurnLoop` 的职责，因此 TurnLoop 不应该跟踪或持久化 `EnableStreaming`。把不变量收回到 runner 内部后，该字段自然从 `TurnLoop` 的 checkpoint 与 in-memory 状态中消失。
- 不为旧 `TurnLoop` checkpoint 加任何向后兼容补丁：任何正常完成的 turn 会删除遗留 checkpoint；即便旧 checkpoint 被 resume，runner 也会直接从内嵌 runner checkpoint 读到正确的 `EnableStreaming`，原先"丢失 streaming 模式"的窗口已经被关闭，TurnLoop 无需关心。

## 验证

- `go vet ./adk/...`
- `go test -race ./adk -count=1`
- 定向回归测试：
  - `go test -race ./adk -run TestTurnLoop_ResumeInterruptAgain_PreservesEnableStreamingCheckpoint`
