### PR TITLE
fix(adk): skip failover when error contains interrupt info

### DIFF
--- a/adk/failover_chatmodel.go
+++ b/adk/failover_chatmodel.go
@@ -26,6 +26,7 @@ import (
 	"github.com/cloudwego/eino/callbacks"
 	"github.com/cloudwego/eino/components"
 	"github.com/cloudwego/eino/components/model"
+	"github.com/cloudwego/eino/compose"
 	"github.com/cloudwego/eino/schema"
 )
 
@@ -237,6 +238,10 @@ func newFailoverModelWrapper[M MessageType](inner model.BaseModel[M], config *Mo
 
 func (f *failoverModelWrapper[M]) needFailover(ctx context.Context, outputMessage M, outputErr error) bool {
 	if ctx.Err() != nil {
+		return false
+	}
+
+	if _, ok := compose.ExtractInterruptInfo(outputErr); ok {
 		return false
 	}
 


### PR DESCRIPTION
In `needFailover`, check for `compose.ExtractInterruptInfo` before proceeding with failover logic. Interrupt errors should not trigger failover since they represent a pause/resume flow rather than an actual failure.