### PR TITLE
fix(adk): emit internal events from agentic sub-agents

### DIFF
--- a/adk/agent_tool.go
+++ b/adk/agent_tool.go
@@ -156,7 +156,7 @@ func (at *typedAgentTool[M]) InvokableRun(ctx context.Context, argumentsInJSON s
 		cancelCtx.markAgentToolDescendant()
 	}
 
-	gen, enableStreaming := getEmitGeneratorAndEnableStreaming(opts)
+	gen, enableStreaming := getEmitGeneratorAndEnableStreaming[M](opts)
 	var ms *bridgeStore
 	var iter *AsyncIterator[*TypedAgentEvent[M]]
 	var err error
@@ -239,17 +239,9 @@ func (at *typedAgentTool[M]) InvokableRun(ctx context.Context, argumentsInJSON s
 					rp = append(rp, event.RunPath...)
 					event.RunPath = rp
 				}
-				if msgEvent, ok := any(event).(*AgentEvent); ok {
-					tmp := copyTypedAgentEvent(msgEvent)
-					gen.Send(msgEvent)
-					event = any(tmp).(*TypedAgentEvent[M])
-				} else {
-					// Cross-message-type agent tools are not supported and will not be supported.
-					// An AgenticMessage agent cannot be used as a tool within a Message agent's
-					// event stream. The agent tool still executes correctly and returns its text
-					// result; only real-time event streaming to the parent is blocked.
-					return "", fmt.Errorf("cross-message-type agent tools are not supported: cannot use an AgenticMessage agent as a tool of a Message agent")
-				}
+				tmp := copyTypedAgentEvent(event)
+				gen.Send(event)
+				event = tmp
 			}
 		}
 
@@ -292,8 +284,14 @@ func (at *typedAgentTool[M]) InvokableRun(ctx context.Context, argumentsInJSON s
 type agentToolOptions struct {
 	agentName       string
 	opts            []AgentRunOption
-	generator       *AsyncGenerator[*AgentEvent]
 	enableStreaming bool
+}
+
+// typedAgentToolEventOptions carries the parent runner's event generator for a
+// specific message type. This keeps forwarded internal events type-compatible
+// with the parent event stream.
+type typedAgentToolEventOptions[M MessageType] struct {
+	generator *AsyncGenerator[*TypedAgentEvent[M]]
 }
 
 func withAgentToolOptions(agentName string, opts []AgentRunOption) tool.Option {
@@ -304,7 +302,11 @@ func withAgentToolOptions(agentName string, opts []AgentRunOption) tool.Option {
 }
 
 func withAgentToolEventGenerator(gen *AsyncGenerator[*AgentEvent]) tool.Option {
-	return tool.WrapImplSpecificOptFn(func(o *agentToolOptions) {
+	return withTypedAgentToolEventGenerator(gen)
+}
+
+func withTypedAgentToolEventGenerator[M MessageType](gen *AsyncGenerator[*TypedAgentEvent[M]]) tool.Option {
+	return tool.WrapImplSpecificOptFn(func(o *typedAgentToolEventOptions[M]) {
 		o.generator = gen
 	})
 }
@@ -337,13 +339,24 @@ func extractAndDeriveAgentToolCancelCtx(ctx context.Context, agentName string, o
 	return agentOpts
 }
 
-func getEmitGeneratorAndEnableStreaming(opts []tool.Option) (*AsyncGenerator[*AgentEvent], bool) {
+func getEmitGeneratorAndEnableStreaming[M MessageType](opts []tool.Option) (*AsyncGenerator[*TypedAgentEvent[M]], bool) {
 	o := tool.GetImplSpecificOptions[agentToolOptions](nil, opts...)
-	if o == nil {
+	eventOptions := tool.GetImplSpecificOptions[typedAgentToolEventOptions[M]](nil, opts...)
+	if o == nil && eventOptions == nil {
 		return nil, false
 	}
 
-	return o.generator, o.enableStreaming
+	var gen *AsyncGenerator[*TypedAgentEvent[M]]
+	if eventOptions != nil {
+		gen = eventOptions.generator
+	}
+
+	var enableStreaming bool
+	if o != nil {
+		enableStreaming = o.enableStreaming
+	}
+
+	return gen, enableStreaming
 }
 
 func getReactChatHistory(ctx context.Context, destAgentName string) ([]Message, error) {

--- a/adk/chatmodel.go
+++ b/adk/chatmodel.go
@@ -1329,6 +1329,9 @@ func (a *TypedChatModelAgent[M]) buildAgenticReActRunFunc(_ context.Context, bc 
 
 		var runOpts []compose.Option
 		runOpts = append(runOpts, ap.composeOpts...)
+		if a.toolsConfig.EmitInternalEvents {
+			runOpts = append(runOpts, compose.WithToolsNodeOption(compose.WithToolOption(withTypedAgentToolEventGenerator[*schema.AgenticMessage](ap.generator))))
+		}
 		if ap.input.EnableStreaming {
 			runOpts = append(runOpts, compose.WithToolsNodeOption(compose.WithToolOption(withAgentToolEnableStreaming(true))))
 		}

--- a/adk/prebuilt/deep/deep_test.go
+++ b/adk/prebuilt/deep/deep_test.go
@@ -19,6 +19,8 @@ package deep
 import (
 	"context"
 	"fmt"
+	"io"
+	"sync/atomic"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -28,9 +30,77 @@ import (
 	"github.com/cloudwego/eino/adk/prebuilt/planexecute"
 	"github.com/cloudwego/eino/components/model"
 	"github.com/cloudwego/eino/components/tool"
+	"github.com/cloudwego/eino/compose"
 	mockModel "github.com/cloudwego/eino/internal/mock/components/model"
 	"github.com/cloudwego/eino/schema"
 )
+
+type sequentialAgenticModel struct {
+	responses []*schema.AgenticMessage
+	callCount int32
+}
+
+func (m *sequentialAgenticModel) Generate(_ context.Context, _ []*schema.AgenticMessage, _ ...model.Option) (*schema.AgenticMessage, error) {
+	idx := atomic.AddInt32(&m.callCount, 1) - 1
+	if int(idx) >= len(m.responses) {
+		return nil, fmt.Errorf("sequentialAgenticModel: no more responses (call #%d)", idx)
+	}
+	return m.responses[idx], nil
+}
+
+func (m *sequentialAgenticModel) Stream(ctx context.Context, input []*schema.AgenticMessage, opts ...model.Option) (*schema.StreamReader[*schema.AgenticMessage], error) {
+	result, err := m.Generate(ctx, input, opts...)
+	if err != nil {
+		return nil, err
+	}
+	return schema.StreamReaderFromArray([]*schema.AgenticMessage{result}), nil
+}
+
+func agenticText(text string) *schema.AgenticMessage {
+	return &schema.AgenticMessage{
+		Role: schema.AgenticRoleTypeAssistant,
+		ContentBlocks: []*schema.ContentBlock{
+			schema.NewContentBlock(&schema.AssistantGenText{Text: text}),
+		},
+	}
+}
+
+func agenticToolCall(toolName, callID, args string) *schema.AgenticMessage {
+	return &schema.AgenticMessage{
+		Role: schema.AgenticRoleTypeAssistant,
+		ContentBlocks: []*schema.ContentBlock{
+			schema.NewContentBlock(&schema.FunctionToolCall{Name: toolName, CallID: callID, Arguments: args}),
+		},
+	}
+}
+
+func readAgenticText(msg *schema.AgenticMessage) string {
+	if msg == nil {
+		return ""
+	}
+	for _, block := range msg.ContentBlocks {
+		if block == nil {
+			continue
+		}
+		if block.AssistantGenText != nil {
+			return block.AssistantGenText.Text
+		}
+	}
+	return ""
+}
+
+type mockSearchTool struct{}
+
+func (m *mockSearchTool) Info(context.Context) (*schema.ToolInfo, error) {
+	return &schema.ToolInfo{
+		Name: "search",
+		Desc: "search latest news",
+	}, nil
+}
+
+func (m *mockSearchTool) InvokableRun(context.Context, string, ...tool.Option) (string, error) {
+	return "latest news search result", nil
+}
 
 func TestGenModelInput(t *testing.T) {
 	ctx := context.Background()
@@ -393,6 +463,85 @@ func (n *namedPlanExecuteAgent) Name(_ context.Context) string {
 
 func (n *namedPlanExecuteAgent) Description(_ context.Context) string {
 	return n.description
+}
+
+func TestAgenticDeepAgentEmitInternalEventsFromSubAgent(t *testing.T) {
+	ctx := context.Background()
+
+	subAgentModel := &sequentialAgenticModel{
+		responses: []*schema.AgenticMessage{
+			agenticToolCall("search", "search-call-1", `{"query":"latest news"}`),
+			agenticText("search result from subagent"),
+		},
+	}
+	webSearchAgent, err := adk.NewTypedChatModelAgent(ctx, &adk.TypedChatModelAgentConfig[*schema.AgenticMessage]{
+		Name:        "web_searcher",
+		Description: "agent dedicated to web search",
+		Model:       subAgentModel,
+		ToolsConfig: adk.ToolsConfig{
+			ToolsNodeConfig: compose.ToolsNodeConfig{
+				Tools: []tool.BaseTool{&mockSearchTool{}},
+			},
+		},
+	})
+	assert.NoError(t, err)
+
+	deepModel := &sequentialAgenticModel{
+		responses: []*schema.AgenticMessage{
+			agenticToolCall(taskToolName, "task-call-1", `{"subagent_type":"web_searcher","description":"search latest news"}`),
+			agenticText("deep final answer"),
+		},
+	}
+	deepAgent, err := NewTyped(ctx, &TypedConfig[*schema.AgenticMessage]{
+		Name:                   "deep",
+		Description:            "deep agent",
+		ChatModel:              deepModel,
+		SubAgents:              []adk.TypedAgent[*schema.AgenticMessage]{webSearchAgent},
+		ToolsConfig:            adk.ToolsConfig{EmitInternalEvents: true},
+		WithoutWriteTodos:      true,
+		WithoutGeneralSubAgent: true,
+	})
+	assert.NoError(t, err)
+
+	runner := adk.NewTypedRunner(adk.TypedRunnerConfig[*schema.AgenticMessage]{
+		Agent:           deepAgent,
+		EnableStreaming: true,
+	})
+	iter := runner.Run(ctx, []*schema.AgenticMessage{
+		schema.UserAgenticMessage("search latest news"),
+	})
+
+	var emittedTexts []string
+	for {
+		event, ok := iter.Next()
+		if !ok {
+			break
+		}
+		if event.Output == nil || event.Output.MessageOutput == nil {
+			continue
+		}
+		if event.Output.MessageOutput.IsStreaming {
+			stream := event.Output.MessageOutput.MessageStream
+			for {
+				chunk, err := stream.Recv()
+				if err == io.EOF {
+					break
+				}
+				assert.NoError(t, err)
+				if text := readAgenticText(chunk); text != "" {
+					emittedTexts = append(emittedTexts, fmt.Sprintf("%s:%s", event.AgentName, text))
+				}
+			}
+			continue
+		}
+		if text := readAgenticText(event.Output.MessageOutput.Message); text != "" {
+			emittedTexts = append(emittedTexts, fmt.Sprintf("%s:%s", event.AgentName, text))
+		}
+	}
+
+	t.Logf("emitted texts: %v", emittedTexts)
+	assert.Contains(t, emittedTexts, "deep:deep final answer", "expected DeepAgent final result to be emitted")
+	assert.Contains(t, emittedTexts, "web_searcher:search result from subagent", "expected DeepAgent to emit Agentic sub-agent events when EmitInternalEvents is true")
 }
 
 func TestDeepAgentOutputKey(t *testing.T) {


### PR DESCRIPTION
#### What type of PR is this?

fix

#### Check the PR title.

- [x] This PR title match the format: <type>(optional scope): <description>
- [x] The description of this PR title is user-oriented and clear enough for others to understand.
- [ ] Attach the PR updating the user documentation if the current PR requires user awareness at the usage level. [User docs repo](https://github.com/cloudwego/cloudwego.github.io)

#### (Optional) Translate the PR title into Chinese.

N/A

#### (Optional) More detailed description for this PR(en: English/zh: Chinese).

en:
When `EmitInternalEvents` is enabled for an Agentic DeepAgent, internal events from Agentic sub-agents invoked through the DeepAgent task tool are not emitted to the parent runner. The runner only receives the DeepAgent task result and final response.

This PR fixes the Agentic path by:
- wiring `EmitInternalEvents` into `buildAgenticReActRunFunc`
- forwarding typed agent-tool events as `TypedAgentEvent[M]` instead of only `AgentEvent`
- adding a regression test for an Agentic DeepAgent invoking a `web_searcher` sub-agent

Test:
```bash
go test ./adk
go test ./adk/prebuilt/deep

#### (Optional) Which issue(s) this PR fixes:

Fixes #1055

#### (optional) The PR that updates user documentation:

N/A. This fixes existing ADK behavior and does not introduce user-facing API changes.