### PR TITLE
fix(adk): preserve agentic role when copying events

### DIFF
--- a/adk/agentic_test.go
+++ b/adk/agentic_test.go
@@ -1206,7 +1206,8 @@ func TestCoverage_CopyAgenticEvent(t *testing.T) {
 		RunPath:   []RunStep{{agentName: "root"}, {agentName: "agent1"}},
 		Output: &TypedAgentOutput[*schema.AgenticMessage]{
 			MessageOutput: &TypedMessageVariant[*schema.AgenticMessage]{
-				Message: agenticMsg("hello"),
+				Message:     agenticMsg("hello"),
+				AgenticRole: schema.AgenticRoleTypeAssistant,
 			},
 		},
 		Action: &AgentAction{
@@ -1218,6 +1219,7 @@ func TestCoverage_CopyAgenticEvent(t *testing.T) {
 	assert.Equal(t, original.AgentName, copied.AgentName)
 	assert.Equal(t, len(original.RunPath), len(copied.RunPath))
 	assert.Equal(t, original.Action, copied.Action)
+	assert.Equal(t, schema.AgenticRoleTypeAssistant, copied.Output.MessageOutput.AgenticRole)
 
 	copied.RunPath[0].agentName = "mutated"
 	assert.NotEqual(t, original.RunPath[0].agentName, copied.RunPath[0].agentName)
@@ -1506,7 +1508,7 @@ func TestAgenticRetryWithShouldRetry_Stream(t *testing.T) {
 	require.NoError(t, err)
 
 	runner := NewTypedRunner(TypedRunnerConfig[*schema.AgenticMessage]{
-		Agent:          agent,
+		Agent:           agent,
 		EnableStreaming: true,
 	})
 	iter := runner.Run(ctx, []*schema.AgenticMessage{schema.UserAgenticMessage("hello")})
@@ -1639,7 +1641,7 @@ func TestAgenticFailoverStream_MidStreamError(t *testing.T) {
 	require.NoError(t, err)
 
 	runner := NewTypedRunner(TypedRunnerConfig[*schema.AgenticMessage]{
-		Agent:          agent,
+		Agent:           agent,
 		EnableStreaming: true,
 	})
 	iter := runner.Run(ctx, []*schema.AgenticMessage{schema.UserAgenticMessage("hello")})

--- a/adk/utils.go
+++ b/adk/utils.go
@@ -261,6 +261,7 @@ func copyTypedAgentEvent[M MessageType](ae *TypedAgentEvent[M]) *TypedAgentEvent
 	copied.Output.MessageOutput = &TypedMessageVariant[M]{
 		IsStreaming: mv.IsStreaming,
 		Role:        mv.Role,
+		AgenticRole: mv.AgenticRole,
 		ToolName:    mv.ToolName,
 	}
 	if mv.IsStreaming {


### PR DESCRIPTION
#### What type of PR is this?

fix

#### Check the PR title.

- [x] This PR title match the format: <type>(optional scope): <description>
- [x] The description of this PR title is user-oriented and clear enough for others to understand.
- [ ] Attach the PR updating the user documentation if the current PR requires user awareness at the usage level. [User docs repo](https://github.com/cloudwego/cloudwego.github.io)

#### (Optional) Translate the PR title into Chinese.

修复 ADK 复制 Agentic 事件时丢失 AgenticRole 的问题

#### (Optional) More detailed description for this PR(en: English/zh: Chinese).

en:
`copyTypedAgentEvent` copies message event metadata such as `Role` and `ToolName`, but it did not preserve `AgenticRole`. For `*schema.AgenticMessage` events, `AgenticRole` is the meaningful role metadata, especially for streaming events where consumers may need to inspect the role before consuming the stream.

This PR fixes the copy path by preserving `AgenticRole` and extends the existing Agentic event-copy test to cover the field.

Test:
```bash
GOWORK=off go test ./adk -run TestCoverage_CopyAgenticEvent -count=1
GOWORK=off go test ./adk -count=1
```

Note: plain `go test ./adk` currently fails in this checkout before package loading because `go.work` references `examples/flow/agent/deer-go` requiring Go >= 1.25.5 while `go.work` lists 1.24.9, so validation was run with `GOWORK=off` against the root module.

#### (Optional) Which issue(s) this PR fixes:

N/A

#### (optional) The PR that updates user documentation:

N/A. This fixes internal event metadata preservation and does not introduce user-facing API changes.
