### PR TITLE
refactor(adk): drop AgentInterruptCause classification

### DIFF
--- a/adk/middlewares/permission/permission_test.go
+++ b/adk/middlewares/permission/permission_test.go
@@ -1117,7 +1117,6 @@ func TestPermissionGate_PersistedAgentInterruptOmitsPrivateInfo(t *testing.T) {
 			require.Len(t, interrupt.AgentInterrupt.Contexts, 1)
 
 			ctx0 := interrupt.AgentInterrupt.Contexts[0]
-			assert.Equal(t, adk.AgentInterruptCauseToolPermission, ctx0.Cause)
 			assert.Equal(t, "permission_call", ctx0.ToolUseID)
 
 			infoJSON, err := json.Marshal(ctx0.Info)

--- a/adk/runner.go
+++ b/adk/runner.go
@@ -1214,12 +1214,10 @@ func buildAgentInterruptEvent(
 			continue
 		}
 		aic := &AgentInterruptContext{
-			Cause:       AgentInterruptCauseGeneric,
 			InterruptID: ctx.ID,
 			Info:        ctx.Info,
 		}
 		if toolUseID := extractToolUseID(ctx); toolUseID != "" {
-			aic.Cause = AgentInterruptCauseToolPermission
 			aic.ToolUseID = toolUseID
 		}
 		event.Contexts = append(event.Contexts, aic)

--- a/adk/session.go
+++ b/adk/session.go
@@ -452,18 +452,6 @@ type UserInterruptEvent struct {
 	Reason string `json:"reason,omitempty"`
 }
 
-// AgentInterruptCause identifies why the agent paused execution.
-type AgentInterruptCause string
-
-const (
-	// AgentInterruptCauseToolPermission indicates a tool call required user approval.
-	AgentInterruptCauseToolPermission AgentInterruptCause = "tool_permission"
-	// AgentInterruptCauseCustomTool indicates a custom or external tool requires a user-provided result.
-	AgentInterruptCauseCustomTool AgentInterruptCause = "custom_tool"
-	// AgentInterruptCauseGeneric indicates a generic interrupt from any component.
-	AgentInterruptCauseGeneric AgentInterruptCause = "generic"
-)
-
 // AgentInterruptEvent records a business interrupt in the durable session timeline.
 type AgentInterruptEvent struct {
 	// Contexts is the set of interrupt contexts that caused the agent to pause.
@@ -473,14 +461,18 @@ type AgentInterruptEvent struct {
 
 // AgentInterruptContext describes a single interrupt point within a batch.
 type AgentInterruptContext struct {
-	// Cause categorizes why this particular interrupt happened.
-	Cause AgentInterruptCause `json:"cause,omitempty"`
 	// InterruptID is the fully-qualified address of the interrupt point
 	// (e.g. "agent:A;tool:lookup:call_1"). Use this as the key in ResumeParams.Targets.
 	InterruptID string `json:"interrupt_id,omitempty"`
-	// Info is the user-facing information associated with the interrupt.
+	// Info is the business-defined payload describing the interrupt, provided by
+	// the component that triggered it (e.g. a middleware or a custom tool).
+	// ADK treats it as opaque; consumers type-assert it to the concrete type the
+	// triggering component documents (e.g. *permission.AskInfo) to determine how
+	// to handle the interrupt.
 	Info any `json:"info,omitempty"`
-	// ToolUseID is set when the interrupt source is a specific tool call.
+	// ToolUseID is set when the interrupt source is a specific tool call. It is
+	// structural metadata derived from the interrupt address, identifying which
+	// tool call paused; it carries no business semantics.
 	ToolUseID string `json:"tool_use_id,omitempty"`
 }
 

--- a/adk/session_test.go
+++ b/adk/session_test.go
@@ -3156,7 +3156,6 @@ func TestAttack_InFlightTurnIDRecoveryWithoutCommittedTurnEnd(t *testing.T) {
 		{EventID: uuid.NewString(), Kind: SessionEventAgentInterrupt, TurnID: "turn-interrupted", AgentInterrupt: &AgentInterruptEvent{
 			Contexts: []*AgentInterruptContext{
 				{
-					Cause:       AgentInterruptCauseGeneric,
 					InterruptID: "agent:InterruptAgent",
 					Info:        "approval_needed",
 				},

--- a/adk/session_timeline_test.go
+++ b/adk/session_timeline_test.go
@@ -111,7 +111,6 @@ func TestSessionTimeline_ClassifyAndSerializeVariants(t *testing.T) {
 			se: &SessionEvent[*schema.Message]{AgentInterrupt: &AgentInterruptEvent{
 				Contexts: []*AgentInterruptContext{
 					{
-						Cause:       AgentInterruptCauseGeneric,
 						InterruptID: "agent:timeline-agent",
 						Info:        "confirm?",
 					},
@@ -231,7 +230,6 @@ func TestSessionTimeline_ReconstructionIgnoresNonContextVariants(t *testing.T) {
 		{EventID: uuid.NewString(), Kind: SessionEventAgentInterrupt, AgentInterrupt: &AgentInterruptEvent{
 			Contexts: []*AgentInterruptContext{
 				{
-					Cause:       AgentInterruptCauseGeneric,
 					InterruptID: "agent:timeline-agent",
 					Info:        "confirm?",
 				},
@@ -259,7 +257,6 @@ func TestSessionTimeline_AgentInterruptRoundTripPreservesContexts(t *testing.T) 
 		AgentInterrupt: &AgentInterruptEvent{
 			Contexts: []*AgentInterruptContext{
 				{
-					Cause:       AgentInterruptCauseToolPermission,
 					InterruptID: "agent:timeline-agent;tool:lookup:call_1",
 					Info:        "tool info",
 					ToolUseID:   "call_1",
@@ -278,13 +275,12 @@ func TestSessionTimeline_AgentInterruptRoundTripPreservesContexts(t *testing.T) 
 	assert.Equal(t, SessionEventAgentInterrupt, decoded.Kind)
 	require.Len(t, decoded.AgentInterrupt.Contexts, 1)
 	ctx0 := decoded.AgentInterrupt.Contexts[0]
-	assert.Equal(t, AgentInterruptCauseToolPermission, ctx0.Cause)
 	assert.Equal(t, "agent:timeline-agent;tool:lookup:call_1", ctx0.InterruptID)
 	assert.Equal(t, "tool info", ctx0.Info)
 	assert.Equal(t, "call_1", ctx0.ToolUseID)
 }
 
-func TestBuildAgentInterruptEvent_ToolCauseAndToolUseID(t *testing.T) {
+func TestBuildAgentInterruptEvent_ToolUseID(t *testing.T) {
 	contexts := []*InterruptCtx{
 		{
 			ID: "agent:timeline-agent;tool:lookup:call_1",
@@ -300,7 +296,6 @@ func TestBuildAgentInterruptEvent_ToolCauseAndToolUseID(t *testing.T) {
 	event := buildAgentInterruptEvent(contexts)
 	require.NotNil(t, event)
 	require.Len(t, event.Contexts, 1)
-	assert.Equal(t, AgentInterruptCauseToolPermission, event.Contexts[0].Cause)
 	assert.Equal(t, "agent:timeline-agent;tool:lookup:call_1", event.Contexts[0].InterruptID)
 	assert.Equal(t, "tool info", event.Contexts[0].Info)
 	assert.Equal(t, "call_1", event.Contexts[0].ToolUseID)
@@ -360,7 +355,6 @@ func TestRunner_PersistsAgentInterruptSessionEvent(t *testing.T) {
 	require.NotNil(t, interrupts[0].AgentInterrupt)
 	require.Len(t, interrupts[0].AgentInterrupt.Contexts, 1)
 	ctx0 := interrupts[0].AgentInterrupt.Contexts[0]
-	assert.Equal(t, AgentInterruptCauseGeneric, ctx0.Cause)
 	assert.Equal(t, liveInterruptContexts[0].ID, ctx0.InterruptID)
 	assert.Equal(t, liveInterruptContexts[0].Info, ctx0.Info)
 	requireStoredIdleStopReason(t, store.events, "interrupted")


### PR DESCRIPTION
## Summary

Removes the `AgentInterruptCause` enum and the `AgentInterruptContext.Cause` field. Interrupt semantics are now carried entirely on `AgentInterruptContext.Info` (`any`), populated by the component that triggered the interrupt (e.g. `*permission.AskInfo` from the permission middleware, or a custom-tool-defined type).

| Before | After |
|--------|-------|
| ADK classified interrupts via three constants (`tool_permission`, `custom_tool`, `generic`) | ADK is content-agnostic: triggering component owns the payload type |
| Consumers branched on `Cause` first, then type-asserted `Info` | Consumers type-assert `Info` directly to the documented concrete type |
| `AgentInterruptContext` had two overlapping fields (`Cause` vs `Info`) | Single source of truth: `Info` |

## Why

The classification served no role inside ADK — it was set by `buildAgentInterruptEvent` based on the address shape (tool segment present ⇒ `tool_permission`, otherwise `generic`), and never read internally. Consumers who wanted real semantics still had to type-assert `Info` to the concrete payload anyway. Two parallel hints (address+`Cause` vs `Info`'s concrete type) were always at risk of disagreeing. Letting the triggering component own the payload type removes that ambiguity and keeps ADK from imposing taxonomy on business interrupts it knows nothing about.

## Key Insights

- **Address already encodes the structural distinction.** `AgentInterruptContext.ToolUseID` (derived from the address) tells consumers whether a specific tool call paused. `Cause` was a less-precise restatement of the same information.
- **Backward compatibility is safe at the wire level.** Both `encoding/json` and `encoding/gob` silently ignore unknown fields on decode, so previously-persisted `AgentInterruptEvent` blobs with `"cause":"..."` still decode cleanly into the new struct. The breaking change is at the Go source level (callers reading `ctx.Cause`) and is the explicit semantic intent.
- **Layering.** Classification belongs to the component that emitted the interrupt; ADK's role is only to deliver the opaque payload through the timeline and resume path.

## Changes

| File | Change |
|------|--------|
| `adk/session.go` | Delete `AgentInterruptCause` type + 3 constants; delete `AgentInterruptContext.Cause`; expand doc comments on `Info` and `ToolUseID` to make opaqueness explicit. |
| `adk/runner.go` | Drop both `Cause` assignments inside `buildAgentInterruptEvent`. |
| `adk/middlewares/permission/permission_test.go` | Drop one `Cause` assertion. |
| `adk/session_test.go` | Drop `Cause` from one fixture. |
| `adk/session_timeline_test.go` | Drop `Cause` from three fixtures and one assertion; rename `TestBuildAgentInterruptEvent_ToolCauseAndToolUseID` → `TestBuildAgentInterruptEvent_ToolUseID`. |

5 files, +9 / -27.

## Verification

- `go build ./...` ✅
- `go test ./adk/...` ✅
- No remaining references to `AgentInterruptCause*` in the repository.

---

## 概述

移除 `AgentInterruptCause` 枚举与 `AgentInterruptContext.Cause` 字段。中断语义改为完全由 `AgentInterruptContext.Info`（`any`）承载，由触发中断的组件填充（例如 permission 中间件设置 `*permission.AskInfo`，自定义工具设置自身定义的类型）。

## 动机

`Cause` 在 ADK 内部并未驱动任何逻辑：它由 `buildAgentInterruptEvent` 根据 address 形状机械设置（包含 tool 段则为 `tool_permission`，否则为 `generic`），消费方拿到后仍需对 `Info` 做类型断言才能取到真实业务语义。两套并行的提示（address + `Cause` vs `Info` 的具体类型）始终存在不一致风险。让触发组件独占 payload 类型，可消除这种二义性，也避免 ADK 对它并不理解的业务中断强加分类。

## 关键认知

- **address 已经编码了结构性区分。** `ToolUseID` 由 address 提取，能精确告诉消费方是否是某次工具调用暂停。`Cause` 只是其低精度重述。
- **持久化层向后兼容安全。** JSON 与 gob 解码都会静默忽略未知字段，已持久化、含 `"cause":"..."` 的旧 `AgentInterruptEvent` 仍可正确解码。源码级别的破坏性变更（读 `ctx.Cause` 的代码）正是本次改动的语义目的。
- **分层。** 分类应由触发中断的组件负责；ADK 仅承担在 timeline 与 resume 路径中透传不透明 payload 的角色。

## 验证

- `go build ./...` ✅
- `go test ./adk/...` ✅
- 仓库中不再存在任何 `AgentInterruptCause*` 引用。
