### PR TITLE
fix(adk): allow business interrupt resume through permission gate

### DIFF
--- a/adk/middlewares/permission/permission.go
+++ b/adk/middlewares/permission/permission.go
@@ -177,6 +177,10 @@ func (m *Middleware[M]) permissionGate(
 	wasInterrupted, hasState, savedState := tool.GetInterruptState[*AskState](ctx)
 	isTarget, hasData, response := tool.GetResumeContext[*ResumeResponse](ctx)
 
+	if wasInterrupted && !hasState {
+		return &gateResult{allowed: true, argument: argument}, nil
+	}
+
 	if wasInterrupted && !isTarget {
 		if !hasState || savedState == nil {
 			return nil, fmt.Errorf("permission: missing AskState for resumed tool %q (call_id=%s)", tCtx.Name, tCtx.CallID)

--- a/adk/middlewares/permission/permission_test.go
+++ b/adk/middlewares/permission/permission_test.go
@@ -175,6 +175,86 @@ func TestWrapInvokableToolCall_ResumeApproveUsesSavedInterruptedArguments(t *tes
 	assert.Equal(t, `{"path":"/tmp/approved"}`, received)
 }
 
+func TestWrapInvokableToolCall_PassesThroughBusinessInterruptResume(t *testing.T) {
+	checkerCalls := 0
+	m := NewTyped[*schema.Message](func(ctx context.Context, tCtx *adk.ToolContext, args *schema.ToolArgument) (*GateCheckResult, error) {
+		checkerCalls++
+		return &GateCheckResult{Decision: GateAsk, Message: "approve tool?"}, nil
+	})
+
+	endpointCalls := 0
+	endpoint := adk.InvokableToolCallEndpoint(func(ctx context.Context, argumentsInJSON string, opts ...tool.Option) (string, error) {
+		endpointCalls++
+		wasInterrupted, hasState, state := tool.GetInterruptState[string](ctx)
+		isTarget, hasData, data := tool.GetResumeContext[string](ctx)
+		if wasInterrupted && hasState {
+			assert.Equal(t, "business-state", state)
+			require.True(t, isTarget)
+			require.True(t, hasData)
+			assert.Equal(t, "business-resume", data)
+			assert.Equal(t, `{"path":"/tmp/approved"}`, argumentsInJSON)
+			return "business resumed", nil
+		}
+		return "", tool.StatefulInterrupt(ctx, "business interrupt", "business-state")
+	})
+
+	tCtx := &adk.ToolContext{Name: "NestedTool", CallID: "call_nested_business"}
+	wrapped, err := m.WrapInvokableToolCall(context.Background(), endpoint, tCtx)
+	require.NoError(t, err)
+
+	_, err = wrapped(withAddress(context.Background()), `{"path":"/tmp/approved"}`)
+	require.Error(t, err)
+	var permissionSignal *core.InterruptSignal
+	require.True(t, errors.As(err, &permissionSignal))
+
+	_, err = wrapped(resumeContext(permissionSignal, &ResumeResponse{Action: ResumeActionApprove}), `{"path":"/tmp/ignored"}`)
+	require.Error(t, err)
+	var businessSignal *core.InterruptSignal
+	require.True(t, errors.As(err, &businessSignal))
+
+	result, err := wrapped(genericResumeContext(businessSignal, "business-resume"), `{"path":"/tmp/approved"}`)
+	require.NoError(t, err)
+	assert.Equal(t, "business resumed", result)
+	assert.Equal(t, 1, checkerCalls)
+	assert.Equal(t, 2, endpointCalls)
+}
+
+func TestAttack_BusinessInterruptNonTargetReplayPassesThrough(t *testing.T) {
+	m := NewTyped[*schema.Message](func(ctx context.Context, tCtx *adk.ToolContext, args *schema.ToolArgument) (*GateCheckResult, error) {
+		return &GateCheckResult{Decision: GateAllow}, nil
+	})
+
+	endpointCalls := 0
+	endpoint := adk.InvokableToolCallEndpoint(func(ctx context.Context, argumentsInJSON string, opts ...tool.Option) (string, error) {
+		endpointCalls++
+		wasInterrupted, hasState, state := tool.GetInterruptState[string](ctx)
+		isTarget, _, _ := tool.GetResumeContext[string](ctx)
+		if wasInterrupted {
+			require.True(t, hasState)
+			assert.Equal(t, "business-state", state)
+			require.False(t, isTarget)
+			return "", tool.StatefulInterrupt(ctx, "business interrupt", state)
+		}
+		return "", tool.StatefulInterrupt(ctx, "business interrupt", "business-state")
+	})
+
+	tCtx := &adk.ToolContext{Name: "NestedTool", CallID: "call_nested_business_nontarget"}
+	wrapped, err := m.WrapInvokableToolCall(context.Background(), endpoint, tCtx)
+	require.NoError(t, err)
+
+	_, err = wrapped(withAddress(context.Background()), `{"path":"/tmp/approved"}`)
+	require.Error(t, err)
+	var businessSignal *core.InterruptSignal
+	require.True(t, errors.As(err, &businessSignal))
+
+	_, err = wrapped(nonTargetResumeContext(businessSignal), `{"path":"/tmp/approved"}`)
+	require.Error(t, err)
+	var replayedSignal *core.InterruptSignal
+	require.True(t, errors.As(err, &replayedSignal), "non-target replay should preserve the underlying business interrupt")
+	assert.NotContains(t, err.Error(), "missing AskState")
+	assert.Equal(t, 2, endpointCalls)
+}
+
 func TestWrapInvokableToolCall_ResumeApproveWithExplicitEmptyUpdatedInput(t *testing.T) {
 	m := NewTyped[*schema.Message](func(ctx context.Context, tCtx *adk.ToolContext, args *schema.ToolArgument) (*GateCheckResult, error) {
 		return &GateCheckResult{Decision: GateAsk, Message: "approve empty override?"}, nil
@@ -1249,9 +1329,20 @@ func withAddress(ctx context.Context) context.Context {
 }
 
 func resumeContext(signal *core.InterruptSignal, response *ResumeResponse) context.Context {
+	return genericResumeContext(signal, response)
+}
+
+func genericResumeContext(signal *core.InterruptSignal, response any) context.Context {
 	id2Addr, id2State := core.SignalToPersistenceMaps(signal)
 	ctx := context.Background()
 	ctx = core.PopulateInterruptState(ctx, id2Addr, id2State)
 	ctx = core.BatchResumeWithData(ctx, map[string]any{signal.ID: response})
+	return withAddress(ctx)
+}
+
+func nonTargetResumeContext(signal *core.InterruptSignal) context.Context {
+	id2Addr, id2State := core.SignalToPersistenceMaps(signal)
+	ctx := context.Background()
+	ctx = core.PopulateInterruptState(ctx, id2Addr, id2State)
 	return withAddress(ctx)
 }

--- a/uncommitted_comprehensive_review.md
+++ b/uncommitted_comprehensive_review.md
@@ -2,84 +2,105 @@
 
 ## Overview
 
-- Scope: uncommitted changes in `adk/runner.go`, `adk/session.go`, and related ADK session tests.
-- Total iterations: Stage 1 design review: 1 fix iteration; Stage 2 attack review: 1 fix iteration; Stage 3 test audit: 1 verification iteration.
-- Files modified by this review: 2 (`adk/runner.go`, `adk/session_test.go`).
-- Cumulative diff after review: 719 insertions / 633 deletions across 8 files.
+- Total iterations: Stage 1: 1, Stage 2: 1, Stage 3: 1
+- Files modified by review: 2
+- Current diff size: +95 / -0
+- Baseline before review: `go test ./...` passed
+- Final verification: `go test ./...` passed
+
+## Scope
+
+| File | Role |
+| --- | --- |
+| `adk/middlewares/permission/permission.go` | Permission gate resume routing |
+| `adk/middlewares/permission/permission_test.go` | Resume pass-through and attack coverage |
 
 ## Stage 1: Design Review
 
-### Findings Resolved
+### Scorecard
 
-| # | Dimension | Finding | Fix Applied | Files |
-|---|-----------|---------|-------------|-------|
-| 1 | Lifecycle / resource ownership | Session handle ownership transferred to the iterator/finalizer only after preparation succeeds. Some post-open preparation errors returned without closing the handle, leaving `NewLocalSessionService` locked for that session. | Closed the handle on checkpoint-load/decode failures in run and resume preparation, on checkpoint-load failures after resume preparation, and on "agent does not support resume" errors. | `adk/runner.go` |
+| Dimension | Rating | Notes |
+| --- | --- | --- |
+| Concept Coherence | 4/5 | Passing through non-permission interrupt state is consistent with tool middleware acting as a conduit. |
+| API Usability | 5/5 | No public API changes. |
+| Minimum API Surface | 5/5 | No new exported types/functions. |
+| Backward Compatibility | 4/5 | Permission `AskState` paths remain fail-closed; business interrupt paths now resume correctly. |
+| Module Separation | 5/5 | Logic stays inside the permission middleware wrapper. |
+| Cohesion vs. Tension | 4/5 | The middleware must distinguish its own persisted state from underlying tool state. |
+| Elegance vs. Complexity | 4/5 | A single guard keeps the common pass-through path simple. |
+| Naming | 5/5 | New helper/test names describe targeted and non-target resume semantics. |
+| Readability | 4/5 | The critical branch is concise; tests document the scenario. |
+| Duplication | 4/5 | Resume-context helpers share `genericResumeContext`; one extra non-target helper is acceptable. |
+| Public API Documentation | N/A | No public API additions. |
+| Internal Comments | 4/5 | Existing tests make intent explicit; no extra production comment needed. |
 
-### Design Scorecard
+### Finding Resolved
 
-| Dimension | Before | After | Notes |
-|-----------|--------|-------|-------|
-| Concept coherence | 4/5 | 4/5 | SessionHandle ownership remains clear: prepare owns it until iterator/finalizer is installed. |
-| API usability | 4/5 | 4/5 | No public API change from this review. |
-| Minimum API surface | 4/5 | 4/5 | No additional production API surface. |
-| Backward compatibility | 4/5 | 4/5 | Fix preserves user-facing behavior except avoiding leaked busy sessions. |
-| Module layering | 4/5 | 4/5 | Handle cleanup stays in runner/session-admission layer. |
-| Cohesion | 4/5 | 4/5 | Error cleanup is colocated with the failing preparation paths. |
-| Complexity | 4/5 | 4/5 | Fix adds explicit close calls instead of introducing a broader ownership abstraction. |
-| Naming | 4/5 | 4/5 | New test helper name `publicSessionHelperStore` describes the adapter role. |
-| Readability | 4/5 | 4/5 | Preparation paths remain understandable; a future helper could reduce repeated close snippets. |
-| Duplication | 4/5 | 4/5 | Close snippets are duplicated but small and local. |
-| Public docs | 4/5 | 4/5 | No public API added. |
-| Internal comments | 4/5 | 4/5 | Existing checkpoint/finalization comments remain accurate. |
+| # | Dimension | Finding | Verdict | Fix |
+| --- | --- | --- | --- | --- |
+| 1 | Concept Coherence / Backward Compatibility | The original targeted-only pass-through let targeted business interrupts resume, but non-target replay of the same business interrupt still failed with `missing AskState` before the underlying tool could re-interrupt. | Fix | Generalized the pass-through to any resumed interrupt whose saved state is not a permission `AskState`. |
+
+### Validation and Counter-Argument
+
+| Finding | Validation | Counter-Argument | Decision |
+| --- | --- | --- | --- |
+| Business interrupt non-target replay fails | `TestAttack_BusinessInterruptNonTargetReplayPassesThrough` reproduced the failure before the production fix. | Passing through a non-`AskState` could theoretically hide corrupted permission state, but the existing change already accepts non-`AskState` for targeted business resumes. Consistent pass-through is required by the ADK explicit targeted resume contract. | Fix |
 
 ## Stage 2: Attack Review
 
 ### Attack Tests
 
-| # | Severity | Issue | Test Name | Final Status |
-|---|----------|-------|-----------|--------------|
-| 1 | High | Corrupt session-derived checkpoint leaked the active local session handle after the first failed run, causing the next run on the same session to fail with `ErrSessionBusy`. | `TestAttack_RunClosesSessionHandleWhenCheckpointDecodeFails` | Fixed and passing |
+| Test | Category | Result | Notes |
+| --- | --- | --- | --- |
+| `TestWrapInvokableToolCall_PassesThroughBusinessInterruptResume` | Feature interaction | Passed | Verifies permission approval can be followed by an underlying business interrupt and targeted business resume. |
+| `TestAttack_BusinessInterruptNonTargetReplayPassesThrough` | Conflict detection / feature interaction | Failed before fix, passed after fix | Verifies non-target replay preserves the underlying business interrupt instead of returning a permission `AskState` error. |
+| `TestAttack_InvalidRespondDoesNotPersistDecisionEvent` | Validation gap | Passed | Existing attack coverage remains green. |
 
-### Validation
+### Bug Fixed
 
-- The attack test first failed with `adk: session already has an active handle`, confirming the bug was not hypothetical.
-- After the fix, the same test passes and verifies the session can be reopened after deleting the corrupt checkpoint.
-- Existing `TestAttack_` suite also passes after the fix.
+| # | Severity | Bug | Fix | Test |
+| --- | --- | --- | --- | --- |
+| 1 | High | A permission-wrapped tool with non-permission interrupt state could not participate in sibling/non-target replay because the permission gate treated missing `AskState` as a permission error. | In `permissionGate`, return an allowed pass-through result whenever `wasInterrupted && !hasState`, allowing the underlying tool to inspect its own state and target status. | `TestAttack_BusinessInterruptNonTargetReplayPassesThrough` |
 
 ## Stage 3: Test Audit
 
-### Improvements Applied
-
-| # | Category | Change | LOC Impact |
-|---|----------|--------|------------|
-| 1 | Coverage gap | Added a regression attack test for checkpoint decode failure cleanup. | +46 LOC test |
-| 2 | Test infrastructure | Added `publicSessionHelperStore` to exercise the sealed `NewLocalSessionService` path rather than the looser in-package helper handle. | +34 LOC test helper |
-
 ### Audit Result
 
-- Assertion quality: the new test asserts the exact failure class via `ErrorContains` and then asserts the absence of follow-up errors.
-- Semantic value: the test covers a real resource-lifecycle regression that package tests did not previously catch.
-- Duplication: the helper is small and specifically adapts the existing `sessionHelperStore` to the public `SessionEventStore` contract; no broader extraction needed.
-- Coverage: `go test -coverprofile=cover.out ./adk` reports 88.9% statement coverage for `./adk`.
+| Category | Result |
+| --- | --- |
+| Duplicates | No true duplicates found in the changed tests. |
+| Assertion Quality | Assertions check target flags, resume payloads, preserved state, error type, and call counts. |
+| Boilerplate | `genericResumeContext` and `nonTargetResumeContext` keep setup explicit without over-abstracting. |
+| Logical Grouping | New tests are placed near existing invokable resume tests. |
+| Semantic Value | Both added tests cover distinct targeted and non-target business interrupt semantics. |
+| Coverage | Package coverage is 81.9%; the changed production branch is directly covered by the new tests. |
 
-## Verification
+### Coverage
 
-| Command | Result |
-|---------|--------|
-| `go test ./adk -run TestAttack_RunClosesSessionHandleWhenCheckpointDecodeFails -count=1 -v` | PASS |
-| `go test ./adk -count=1` | PASS |
-| `go test ./adk -run 'TestAttack_' -count=1 -v` | PASS |
-| `go test -coverprofile=cover.out ./adk && go tool cover -func=cover.out` | PASS, total 88.9% |
-| `go test ./...` | PASS |
+- Command: `go test -coverprofile=/tmp/eino_permission_cover.out ./adk/middlewares/permission && go tool cover -func=/tmp/eino_permission_cover.out`
+- Package coverage: 81.9% statements
+- `permissionGate`: 72.7% statements
+- Diff coverage: covered for the new `wasInterrupted && !hasState` branch
+- Remaining package-level gap: existing functions such as `publicInfo` still report low coverage, but they are outside this review's diff.
 
 ## Cumulative File Change List
 
 | File | Stage(s) | Summary |
-|------|----------|---------|
-| `adk/runner.go` | 1, 2 | Releases session handles on checkpoint preparation/load failures and unsupported-resume errors before returning. |
-| `adk/session_test.go` | 2, 3 | Adds a public-session-service adapter helper and a regression attack test for checkpoint decode failure cleanup. |
+| --- | --- | --- |
+| `adk/middlewares/permission/permission.go` | 1, 2 | Generalized resumed non-`AskState` pass-through so underlying business interrupts handle both targeted and non-target replay. |
+| `adk/middlewares/permission/permission_test.go` | 2, 3 | Added targeted business interrupt resume coverage, non-target attack coverage, and reusable resume-context helpers. |
+
+## Verification Commands
+
+| Command | Result |
+| --- | --- |
+| `go test ./...` | Passed before review |
+| `go test ./adk/middlewares/permission -run 'TestAttack_BusinessInterruptNonTargetReplayPassesThrough|TestWrapInvokableToolCall_PassesThroughBusinessInterruptResume' -v -count=1` | Passed |
+| `go test ./adk/middlewares/permission -run 'TestAttack_|TestWrapInvokableToolCall_PassesThroughBusinessInterruptResume' -v -count=1` | Passed |
+| `go test -coverprofile=/tmp/eino_permission_cover.out ./adk/middlewares/permission && go tool cover -func=/tmp/eino_permission_cover.out` | Passed, 81.9% package coverage |
+| `go test ./...` | Passed after review |
 
 ## Remaining Items
 
-- No unresolved blockers found.
-- Deferred minor cleanup: repeated `sessionHandle.close(ctx)` snippets in resume/run preparation could be centralized later if more cleanup paths are added.
+- No unresolved blockers.
+- Package-level coverage remains below the skill's 85% target, but the uncovered regions are pre-existing and outside the uncommitted diff; the changed branch is covered.


### PR DESCRIPTION
Problem: permission gate rejected resumed business interrupts without AskState before the underlying tool could handle its own state. Solution: pass through resumed interrupts that do not carry permission AskState while preserving fail-closed behavior for permission-owned state. Validation: golangci-lint, targeted permission tests, go test -race ./..., and go test -coverprofile ./... passed.