### PR TITLE
fix(adk): wire ModelFailoverConfig into agentic ReAct path

### DIFF
--- a/adk/agentic_test.go
+++ b/adk/agentic_test.go
@@ -1681,3 +1681,65 @@ func TestAgenticFailoverStream_MidStreamError(t *testing.T) {
 	assert.Equal(t, int32(1), atomic.LoadInt32(&m2Calls))
 	assert.NotNil(t, capturedLastOutput, "failoverCtx.LastOutputMessage should contain partial stream from m1")
 }
+
+// TestAgenticFailoverGenerate_WithTools verifies that ModelFailoverConfig is
+// honored on the ReAct (with-tools) path for *schema.AgenticMessage. This
+// guards against the regression where buildAgenticReActRunFunc dropped the
+// failover config, leaving ModelFailoverConfig as a no-op for typed agents
+// that have any tools configured.
+func TestAgenticFailoverGenerate_WithTools(t *testing.T) {
+	ctx := context.Background()
+
+	m1Err := errors.New("m1 generate failed")
+	var m1Calls, m2Calls, getFailoverCalls int32
+
+	m1 := &mockAgenticModel{
+		generateFn: func(_ context.Context, _ []*schema.AgenticMessage, _ ...model.Option) (*schema.AgenticMessage, error) {
+			atomic.AddInt32(&m1Calls, 1)
+			return nil, m1Err
+		},
+	}
+	m2 := &mockAgenticModel{
+		generateFn: func(_ context.Context, _ []*schema.AgenticMessage, _ ...model.Option) (*schema.AgenticMessage, error) {
+			atomic.AddInt32(&m2Calls, 1)
+			return agenticMsg("failover ok with tools"), nil
+		},
+	}
+
+	dummyTool := newSlowTool("dummy_tool", 0, "ok")
+
+	agent, err := NewTypedChatModelAgent(ctx, &TypedChatModelAgentConfig[*schema.AgenticMessage]{
+		Name:        "failover-react-agent",
+		Description: "test failover on ReAct path",
+		Model:       m1,
+		ToolsConfig: ToolsConfig{
+			ToolsNodeConfig: compose.ToolsNodeConfig{
+				Tools: []tool.BaseTool{dummyTool},
+			},
+		},
+		ModelFailoverConfig: &ModelFailoverConfig[*schema.AgenticMessage]{
+			MaxRetries: 1,
+			ShouldFailover: func(_ context.Context, _ *schema.AgenticMessage, err error) bool {
+				return err != nil
+			},
+			GetFailoverModel: func(_ context.Context, failoverCtx *FailoverContext[*schema.AgenticMessage]) (model.BaseModel[*schema.AgenticMessage], []*schema.AgenticMessage, error) {
+				atomic.AddInt32(&getFailoverCalls, 1)
+				assert.Equal(t, uint(1), failoverCtx.FailoverAttempt)
+				assert.ErrorIs(t, failoverCtx.LastErr, m1Err)
+				return m2, nil, nil
+			},
+		},
+	})
+	require.NoError(t, err)
+
+	runner := NewTypedRunner(TypedRunnerConfig[*schema.AgenticMessage]{Agent: agent})
+	iter := runner.Run(ctx, []*schema.AgenticMessage{schema.UserAgenticMessage("hello")})
+
+	msg := drainTypedAgenticEvents(t, iter)
+	require.NotNil(t, msg)
+	assert.Equal(t, "failover ok with tools", agenticTextContent(msg))
+	assert.Equal(t, int32(1), atomic.LoadInt32(&m1Calls))
+	assert.Equal(t, int32(1), atomic.LoadInt32(&m2Calls))
+	assert.Equal(t, int32(1), atomic.LoadInt32(&getFailoverCalls),
+		"GetFailoverModel must be invoked on the ReAct path; if zero, the failover config was dropped by buildAgenticReActRunFunc")
+}

--- a/adk/chatmodel.go
+++ b/adk/chatmodel.go
@@ -1241,10 +1241,11 @@ func (a *TypedChatModelAgent[M]) buildAgenticReActRunFunc(_ context.Context, bc 
 		model:       agenticModel,
 		toolsConfig: &bc.toolsNodeConf,
 		modelWrapperConf: &typedModelWrapperConfig[*schema.AgenticMessage]{
-			handlers:    agenticHandlers,
-			middlewares: a.middlewares,
-			retryConfig: any(a.modelRetryConfig).(*TypedModelRetryConfig[*schema.AgenticMessage]),
-			toolInfos:   bc.toolInfos,
+			handlers:       agenticHandlers,
+			middlewares:    a.middlewares,
+			retryConfig:    any(a.modelRetryConfig).(*TypedModelRetryConfig[*schema.AgenticMessage]),
+			failoverConfig: any(a.modelFailoverConfig).(*ModelFailoverConfig[*schema.AgenticMessage]),
+			toolInfos:      bc.toolInfos,
 		},
 		toolsReturnDirectly: bc.returnDirectly,
 		agentName:           a.name,
@@ -1307,10 +1308,11 @@ func (a *TypedChatModelAgent[M]) buildAgenticReActRunFunc(_ context.Context, bc 
 		}
 
 		ctx = withTypedChatModelAgentExecCtx(ctx, &typedChatModelAgentExecCtx[*schema.AgenticMessage]{
-			runtimeReturnDirectly: ap.returnDirectly,
-			generator:             ap.generator,
-			cancelCtx:             cancelCtx,
-			afterToolCallsHook:    ap.afterToolCallsHook,
+			runtimeReturnDirectly:    ap.returnDirectly,
+			generator:                ap.generator,
+			cancelCtx:                cancelCtx,
+			failoverLastSuccessModel: agenticModel,
+			afterToolCallsHook:       ap.afterToolCallsHook,
 		})
 
 		// Pre-execution cancel check


### PR DESCRIPTION
## Summary

| Problem | Resolution |
| --- | --- |
| `ModelFailoverConfig` was a no-op for `TypedChatModelAgent[*schema.AgenticMessage]` once any tool was configured: after retries were exhausted the caller received `*RetryExhaustedError` and `GetFailoverModel` was never invoked. | `buildAgenticReActRunFunc` now forwards `failoverConfig` into `typedModelWrapperConfig` and propagates `failoverLastSuccessModel` through the exec context, mirroring the `*schema.Message` ReAct path. |

## Why

The bug surfaces only on the agentic-with-tools path. Two parallel paths build the model wrapper:

- `buildMessageReActRunFunc` (`*schema.Message`) wires both `retryConfig` and `failoverConfig`, and seeds `failoverLastSuccessModel` on the exec context.
- `buildAgenticReActRunFunc` (`*schema.AgenticMessage`) only wired `retryConfig` and never seeded `failoverLastSuccessModel`.

`buildModelWrappersImpl` only installs the failover wrapper when `config.failoverConfig != nil` — so on the agentic ReAct path the wrapper was simply absent, and the user-supplied `ModelFailoverConfig` had no effect at runtime. `ModelRetryConfig` worked, which is what made the gap easy to miss.

The no-tools agentic path (`buildNoToolsRunFunc`) was already correct because it uses the unified generic builder with both fields populated.

## Key Insight

This is a wiring gap, not a behavior change. `ModelFailoverConfig` validation, the failover wrapper, and the underlying state machine were all already type-parametric over `M`. The only fix needed was to plumb the config and last-success-model through on the agentic ReAct branch, so we now have one behavior contract for both `M = *schema.Message` and `M = *schema.AgenticMessage` regardless of whether tools are present.

## Reproduction & Test

`TestAgenticFailoverGenerate_WithTools` exercises the agentic ReAct path with a primary model that always errors, a fallback model that succeeds, and a non-empty `ToolsConfig`. It asserts:

- the primary model is called exactly once,
- `GetFailoverModel` is invoked with `FailoverAttempt == 1` and the original primary error,
- the fallback model produces the final message.

Without the fix, the test fails at the assertion that `GetFailoverModel` was called (it observes `getFailoverCalls == 0` and the surfaced primary error). With the fix, the test passes. The existing `TestAgenticFailoverGenerate` and `TestAgenticFailoverStream_MidStreamError` (no-tools path) continue to pass.

## Scope

- `adk/chatmodel.go`: forward `failoverConfig` and `failoverLastSuccessModel` in `buildAgenticReActRunFunc`.
- `adk/agentic_test.go`: add focused regression test for the agentic ReAct path.

No public API or behavior change for users who do not set `ModelFailoverConfig`.

---

## 概要

| 问题 | 修复 |
| --- | --- |
| 当为 `TypedChatModelAgent[*schema.AgenticMessage]` 配置工具后，`ModelFailoverConfig` 实际不生效：重试用尽后调用方收到 `*RetryExhaustedError`，`GetFailoverModel` 从未被调用。 | `buildAgenticReActRunFunc` 现在会向 `typedModelWrapperConfig` 传递 `failoverConfig`，并通过 exec context 传递 `failoverLastSuccessModel`，与 `*schema.Message` 的 ReAct 路径保持一致。 |

## 原因

模型 wrapper 由两条并列路径构建：

- `buildMessageReActRunFunc`（`*schema.Message`）同时连接了 `retryConfig` 与 `failoverConfig`，并在 exec context 中设置 `failoverLastSuccessModel`。
- `buildAgenticReActRunFunc`（`*schema.AgenticMessage`）只连接了 `retryConfig`，且未设置 `failoverLastSuccessModel`。

`buildModelWrappersImpl` 仅在 `config.failoverConfig != nil` 时才安装 failover wrapper，因此 agentic ReAct 路径上 wrapper 直接缺失，用户配置的 `ModelFailoverConfig` 在运行时不生效。由于 `ModelRetryConfig` 仍然工作，这个差距很容易被忽略。

无工具的 agentic 路径（`buildNoToolsRunFunc`）一直正确，因为它使用统一的泛型构建器，两个字段都已传入。

## 关键认识

这是一处线缆缺失，而非行为变更。`ModelFailoverConfig` 校验、failover wrapper 与底层状态机原本就已对 `M` 做了类型参数化，本次只需在 agentic ReAct 分支上把配置与上次成功模型透传过去，即可让 `M = *schema.Message` 与 `M = *schema.AgenticMessage` 在有无工具的所有组合下保持一致的行为契约。

## 复现与测试

`TestAgenticFailoverGenerate_WithTools` 在 agentic ReAct 路径上构造了：必然失败的主模型、必然成功的备用模型，以及非空的 `ToolsConfig`，并断言：

- 主模型仅被调用一次；
- `GetFailoverModel` 收到 `FailoverAttempt == 1` 和原始主模型错误；
- 备用模型产出最终消息。

修复前该测试在 `getFailoverCalls == 0`、并向上抛出主模型错误时失败；修复后通过。已有的 `TestAgenticFailoverGenerate` 与 `TestAgenticFailoverStream_MidStreamError`（无工具路径）继续通过。

## 改动范围

- `adk/chatmodel.go`：在 `buildAgenticReActRunFunc` 中传递 `failoverConfig` 与 `failoverLastSuccessModel`。
- `adk/agentic_test.go`：补充覆盖 agentic ReAct 路径的回归测试。

对未设置 `ModelFailoverConfig` 的用户无任何公开 API 或行为变更。
