### PR TITLE
fix(schema): preserve empty params map across ToolInfo JSON roundtrip

### DIFF
--- a/schema/tool.go
+++ b/schema/tool.go
@@ -187,6 +187,13 @@ func (t *ToolInfo) UnmarshalJSON(data []byte) error {
 			params:     tmp.Params,
 			jsonschema: tmp.JSONSchema,
 		}
+		// An empty-but-non-nil params map is dropped by `omitempty` during
+		// marshaling. When jsonschema is also absent, the params form was the
+		// chosen representation, so restore the empty map to preserve the
+		// roundtrip invariant.
+		if t.ParamsOneOf.params == nil && t.ParamsOneOf.jsonschema == nil {
+			t.ParamsOneOf.params = map[string]*ParameterInfo{}
+		}
 	}
 	return nil
 }

--- a/schema/tool_test.go
+++ b/schema/tool_test.go
@@ -181,6 +181,20 @@ func TestToolInfoSerialization(t *testing.T) {
 	err = gob.NewDecoder(buf).Decode(result)
 	assert.NoError(t, err)
 	assert.Equal(t, ti2, result)
+
+	// json roundtrip with empty-but-non-nil params map: must not collapse to nil,
+	// otherwise the params form is silently dropped.
+	tiEmpty := &ToolInfo{
+		ParamsOneOf: NewParamsOneOfByParams(map[string]*ParameterInfo{}),
+	}
+	b, err = json.Marshal(tiEmpty)
+	assert.NoError(t, err)
+	result = &ToolInfo{}
+	err = json.Unmarshal(b, result)
+	assert.NoError(t, err)
+	assert.NotNil(t, result.ParamsOneOf)
+	assert.NotNil(t, result.ParamsOneOf.params)
+	assert.Equal(t, tiEmpty, result)
 }
 
 func TestMCPToolResult_NilErrorCode(t *testing.T) {


### PR DESCRIPTION
## Problem

`ToolInfo` constructed via `NewParamsOneOfByParams(map[string]*ParameterInfo{})` — i.e. with an **empty-but-non-nil** params map — does not survive a JSON marshal/unmarshal roundtrip. After the roundtrip, `ParamsOneOf.params` becomes `nil`, silently dropping the "params form" representation.

| | `params` field before | `params` field after roundtrip |
|---|---|---|
| `params: nil` | `nil` | `nil` (correct) |
| `params: {"a": ...}` | `{"a": ...}` | `{"a": ...}` (correct) |
| `params: {}` | `{}` | `nil` (**bug**) |

## Root Cause

[toolInfoForJSON](file:///Users/bytedance/github/eino/schema/tool.go#L145-L152) declares `Params` with `json:"params,omitempty"`. `encoding/json` treats an empty map as "empty" under `omitempty`, so it's elided on marshal. On unmarshal, an absent JSON field leaves the destination map `nil`. The empty-map vs nil-map distinction is therefore lost across the wire.

This matters because `ParamsOneOf` enforces an "exactly one of `params` or `jsonschema` is set" invariant; collapsing an empty map to nil flips the tool from the params form to "no parameters specified" semantics.

## Fix

In [UnmarshalJSON](file:///Users/bytedance/github/eino/schema/tool.go#L177-L199): when `HasParamsOneOf` is true and **neither** `Params` nor `JSONSchema` is present, the `params` form must have been the chosen representation, so restore an empty map.

This keeps the wire format unchanged (no breaking change for already-serialized payloads) and confines the fix to the unmarshal side, where the invariant is recoverable.

Gob is unaffected — `encoding/gob` preserves empty-map vs nil-map natively.

## Key Insight

`omitempty` on a map field destroys information at the JSON boundary: it cannot distinguish "absent" from "empty". When the surrounding type carries a discriminator (here, `HasParamsOneOf` plus the `params` / `jsonschema` "exactly one of" invariant), the discriminator is the right place to recover the lost distinction — not the wire format.

## Summary

| Problem | Fix |
|---|---|
| `ParamsOneOf{params: {}}` becomes `ParamsOneOf{params: nil}` after JSON roundtrip, silently changing tool-call semantics | In `ToolInfo.UnmarshalJSON`, when `HasParamsOneOf == true` and both `Params` and `JSONSchema` are absent, restore `params` to an empty map |

Added a regression assertion to `TestToolInfoSerialization` covering the empty-map roundtrip.

---

## 问题

通过 `NewParamsOneOfByParams(map[string]*ParameterInfo{})` 构造的 `ToolInfo`（即 params 是 **空但非 nil** 的 map）在 JSON marshal/unmarshal 往返后无法保持原状：往返后 `ParamsOneOf.params` 变为 `nil`，"params 形式" 表征被静默丢弃。

## 根因

[toolInfoForJSON](file:///Users/bytedance/github/eino/schema/tool.go#L145-L152) 中 `Params` 字段标注了 `json:"params,omitempty"`。`encoding/json` 在 `omitempty` 下会把空 map 视为 "空" 并在 marshal 时省略；unmarshal 时，缺失的 JSON 字段会让目标 map 保持 `nil`。空 map 与 nil map 的区别因此在 wire 上丢失。

由于 `ParamsOneOf` 强制 "params 与 jsonschema 二选一" 的不变量，把空 map 折叠为 nil 实际上是把 "params 形式" 转成了 "无参数" 语义。

## 修复

在 [UnmarshalJSON](file:///Users/bytedance/github/eino/schema/tool.go#L177-L199) 中：当 `HasParamsOneOf` 为 true 且 `Params` 与 `JSONSchema` 均不存在时，原始表征只可能是 params 形式，因此恢复为空 map。

wire 格式保持不变（兼容已有序列化数据），修复仅落在 unmarshal 侧，因为不变量只能在反序列化端恢复。

Gob 不受影响 —— `encoding/gob` 原生区分空 map 与 nil map。

## 关键洞察

map 字段上的 `omitempty` 会在 JSON 边界丢失信息：它无法区分 "字段缺失" 与 "字段为空"。当外层类型本身带有判别位（这里是 `HasParamsOneOf` 加上 `params` / `jsonschema` "二选一" 不变量），就应该用判别位在反序列化侧恢复信息，而不是改 wire 格式。

fixes: https://github.com/cloudwego/eino/issues/1069
