### PR TITLE
fix(adk): persist BeforeAgent session events

### DIFF
--- a/adk/chatmodel.go
+++ b/adk/chatmodel.go
@@ -81,6 +81,7 @@ func (e *typedChatModelAgentExecCtx[M]) send(ctx context.Context, event *TypedAg
 	if event == nil {
 		return
 	}
+	ensureTypedAgentEventMessageIDs(event)
 	if event.EventID == "" || event.SessionEvent != nil {
 		gen := sessionEventIDGeneratorFromContext[M](ctx)
 		if gen == nil {

--- a/adk/chatmodel.go
+++ b/adk/chatmodel.go
@@ -121,6 +121,43 @@ func getTypedChatModelAgentExecCtx[M MessageType](ctx context.Context) *typedCha
 	return nil
 }
 
+func newTypedChatModelAgentExecCtx[M MessageType](
+	generator *AsyncGenerator[*TypedAgentEvent[M]],
+	cancelCtx *cancelContext,
+	sessionEvents bool,
+	timelineEvents bool,
+	internalTimelineEvents bool,
+) *typedChatModelAgentExecCtx[M] {
+	return &typedChatModelAgentExecCtx[M]{
+		generator:              generator,
+		cancelCtx:              cancelCtx,
+		sessionEvents:          sessionEvents,
+		timelineEvents:         timelineEvents,
+		internalTimelineEvents: internalTimelineEvents,
+	}
+}
+
+func configureTypedChatModelAgentExecCtx[M MessageType](
+	ctx context.Context,
+	generator *AsyncGenerator[*TypedAgentEvent[M]],
+	cancelCtx *cancelContext,
+	sessionEvents bool,
+	timelineEvents bool,
+	internalTimelineEvents bool,
+) (context.Context, *typedChatModelAgentExecCtx[M]) {
+	execCtx := getTypedChatModelAgentExecCtx[M](ctx)
+	if execCtx == nil {
+		execCtx = &typedChatModelAgentExecCtx[M]{}
+		ctx = withTypedChatModelAgentExecCtx(ctx, execCtx)
+	}
+	execCtx.generator = generator
+	execCtx.cancelCtx = cancelCtx
+	execCtx.sessionEvents = sessionEvents
+	execCtx.timelineEvents = timelineEvents
+	execCtx.internalTimelineEvents = internalTimelineEvents
+	return ctx, execCtx
+}
+
 type chatModelAgentRunOptions struct {
 	chatModelOptions []model.Option
 	toolOptions      []tool.Option
@@ -1173,14 +1210,9 @@ func (a *TypedChatModelAgent[M]) buildNoToolsRunFunc(_ context.Context) (typedRu
 			return
 		}
 
-		ctx = withTypedChatModelAgentExecCtx(ctx, &typedChatModelAgentExecCtx[M]{
-			generator:                p.generator,
-			cancelCtx:                cancelCtx,
-			failoverLastSuccessModel: a.model,
-			sessionEvents:            p.sessionEvents,
-			timelineEvents:           p.timelineEvents,
-			internalTimelineEvents:   p.internalTimelineEvents,
-		})
+		var execCtx *typedChatModelAgentExecCtx[M]
+		ctx, execCtx = configureTypedChatModelAgentExecCtx(ctx, p.generator, cancelCtx, p.sessionEvents, p.timelineEvents, p.internalTimelineEvents)
+		execCtx.failoverLastSuccessModel = a.model
 
 		// Pre-execution cancel check
 		if cancelCtx != nil && cancelCtx.shouldCancel() {
@@ -1330,16 +1362,10 @@ func (a *TypedChatModelAgent[M]) buildMessageReActRunFunc(_ context.Context, bc 
 			return
 		}
 
-		ctx = withTypedChatModelAgentExecCtx(ctx, &chatModelAgentExecCtx{
-			runtimeReturnDirectly:    mp.returnDirectly,
-			generator:                mp.generator,
-			cancelCtx:                cancelCtx,
-			failoverLastSuccessModel: msgModel,
-			afterToolCallsHook:       mp.afterToolCallsHook,
-			sessionEvents:            mp.sessionEvents,
-			timelineEvents:           mp.timelineEvents,
-			internalTimelineEvents:   mp.internalTimelineEvents,
-		})
+		ctx, execCtx := configureTypedChatModelAgentExecCtx(ctx, mp.generator, cancelCtx, mp.sessionEvents, mp.timelineEvents, mp.internalTimelineEvents)
+		execCtx.runtimeReturnDirectly = mp.returnDirectly
+		execCtx.failoverLastSuccessModel = msgModel
+		execCtx.afterToolCallsHook = mp.afterToolCallsHook
 
 		// Pre-execution cancel check
 		if cancelCtx != nil && cancelCtx.shouldCancel() {
@@ -1487,15 +1513,9 @@ func (a *TypedChatModelAgent[M]) buildAgenticReActRunFunc(_ context.Context, bc 
 			return
 		}
 
-		ctx = withTypedChatModelAgentExecCtx(ctx, &typedChatModelAgentExecCtx[*schema.AgenticMessage]{
-			runtimeReturnDirectly:  ap.returnDirectly,
-			generator:              ap.generator,
-			cancelCtx:              cancelCtx,
-			afterToolCallsHook:     ap.afterToolCallsHook,
-			sessionEvents:          ap.sessionEvents,
-			timelineEvents:         ap.timelineEvents,
-			internalTimelineEvents: ap.internalTimelineEvents,
-		})
+		ctx, execCtx := configureTypedChatModelAgentExecCtx(ctx, ap.generator, cancelCtx, ap.sessionEvents, ap.timelineEvents, ap.internalTimelineEvents)
+		execCtx.runtimeReturnDirectly = ap.returnDirectly
+		execCtx.afterToolCallsHook = ap.afterToolCallsHook
 
 		// Pre-execution cancel check
 		if cancelCtx != nil && cancelCtx.shouldCancel() {
@@ -1632,6 +1652,8 @@ func (a *TypedChatModelAgent[M]) Run(ctx context.Context, input *TypedAgentInput
 
 	o := getCommonOptions(nil, opts...)
 	cancelCtx, cancelCtxOwned := resolveRunCancelContext(ctx, o)
+	ctx = withTypedChatModelAgentExecCtx(ctx,
+		newTypedChatModelAgentExecCtx(generator, cancelCtx, o.enableSessionEvents, o.enableTimelineEvents, o.enableInternalTimelineEvents))
 
 	ctx, run, bc, input, err := a.getRunFunc(ctx, input)
 	if err != nil {
@@ -1727,6 +1749,8 @@ func (a *TypedChatModelAgent[M]) Resume(ctx context.Context, info *ResumeInfo, o
 
 	o := getCommonOptions(nil, opts...)
 	cancelCtx, cancelCtxOwned := resolveRunCancelContext(ctx, o)
+	ctx = withTypedChatModelAgentExecCtx(ctx,
+		newTypedChatModelAgentExecCtx(generator, cancelCtx, o.enableSessionEvents, o.enableTimelineEvents, o.enableInternalTimelineEvents))
 
 	ctx, run, bc, _, err := a.getRunFunc(ctx, nil)
 	if err != nil {

--- a/adk/handler.go
+++ b/adk/handler.go
@@ -416,10 +416,10 @@ func DeleteRunLocalValue(ctx context.Context, key string) error {
 // canonical in-run path because Runner materializes identity, emits the live
 // event, and persists it through the ordered session event pipeline.
 //
-// Note: TypedSendEvent is a pure transport — it does NOT auto-assign message IDs.
-// Framework-created messages (model output, tool results) receive IDs automatically
-// via internal wrapper layers. If your middleware constructs its own messages, call
-// EnsureMessageID before sending to assign an ID.
+// TypedSendEvent assigns message IDs for message-bearing events before enqueueing
+// them. Middleware authors only need to call EnsureMessageID directly when they
+// need the ID before emitting the event, for example to build another event that
+// references the message by ID.
 //
 // When called outside of an agent execution context, or from a path without an
 // event generator, this function is a no-op.

--- a/adk/message_id_test.go
+++ b/adk/message_id_test.go
@@ -470,11 +470,10 @@ func TestMessageID_UserInputNoAutoID(t *testing.T) {
 	}
 }
 
-// Scenario 8: Middleware must call EnsureMessageID before SendEvent; pointer identity ensures state consistency
-// TestMessageID_SendEvent_MiddlewareMustEnsureID verifies that TypedSendEvent is a pure
-// transport and does NOT auto-assign message IDs. Middleware authors must call
-// EnsureMessageID themselves before sending.
-func TestMessageID_SendEvent_MiddlewareMustEnsureID(t *testing.T) {
+// Scenario 8: SendEvent assigns message IDs before enqueue; pointer identity ensures state consistency.
+// TestMessageID_SendEvent_AutoEnsuresID verifies that middleware-created messages
+// receive IDs at the SendEvent boundary.
+func TestMessageID_SendEvent_AutoEnsuresID(t *testing.T) {
 	ctx := context.Background()
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
@@ -498,21 +497,18 @@ func TestMessageID_SendEvent_MiddlewareMustEnsureID(t *testing.T) {
 					// Middleware creates a new message and writes the SAME pointer to both state and event
 					middlewareMsg = schema.AssistantMessage("middleware injected", nil)
 
-					// Middleware is responsible for assigning the ID before sending
-					EnsureMessageID(middlewareMsg)
-
 					// Write to state
 					state.Messages = append(state.Messages, middlewareMsg)
 
-					// Send as event — TypedSendEvent does NOT auto-assign ID
+					// Send as event — TypedSendEvent assigns ID on the shared pointer.
 					event := EventFromMessage(middlewareMsg, nil, schema.Assistant, "")
 					err := SendEvent(ctx, event)
 					if err != nil {
 						return err
 					}
 
-					// Because we called EnsureMessageID on the shared pointer,
-					// the state copy also has the ID (pointer identity)
+					// Because SendEvent ensures ID on the shared pointer, the state
+					// copy also has the ID (pointer identity).
 					stateMsgIDAfterSendEvent = internal.GetMessageID(middlewareMsg.Extra)
 
 					return nil
@@ -538,10 +534,10 @@ func TestMessageID_SendEvent_MiddlewareMustEnsureID(t *testing.T) {
 	// We expect at least 2 events: model response + middleware injected message
 	require.GreaterOrEqual(t, len(allEvents), 2)
 
-	// The middleware message pointer should have an ID (assigned by middleware via EnsureMessageID)
+	// The middleware message pointer should have an ID assigned at SendEvent time.
 	require.NotNil(t, middlewareMsg)
 	middlewareMsgID := GetMessageID(middlewareMsg)
-	assert.NotEmpty(t, middlewareMsgID, "middleware should have assigned an ID via EnsureMessageID")
+	assert.NotEmpty(t, middlewareMsgID, "SendEvent should assign an ID")
 	assert.True(t, isValidUUID(middlewareMsgID))
 
 	// The ID captured right after SendEvent (via pointer identity) should be the same

--- a/adk/middlewares/automemory/automemory.go
+++ b/adk/middlewares/automemory/automemory.go
@@ -1693,7 +1693,6 @@ func (m *middleware[M]) sendTopicMemoryEvent(ctx context.Context, msgs []M, memM
 	if len(msgs) > 0 && !isNilMessage(msgs[len(msgs)-1]) {
 		beforeID = adk.GetMessageID(msgs[len(msgs)-1])
 	}
-	adk.EnsureMessageID(memMsg)
 	if sendEventErr := adk.TypedSendEvent(ctx, &adk.TypedAgentEvent[M]{SessionEvent: &adk.SessionEvent[M]{
 		Kind: adk.SessionEventMessageInserted,
 		MessageInserted: &adk.MessageInsertedEvent[M]{

--- a/adk/middlewares/automemory/automemory.go
+++ b/adk/middlewares/automemory/automemory.go
@@ -1693,6 +1693,7 @@ func (m *middleware[M]) sendTopicMemoryEvent(ctx context.Context, msgs []M, memM
 	if len(msgs) > 0 && !isNilMessage(msgs[len(msgs)-1]) {
 		beforeID = adk.GetMessageID(msgs[len(msgs)-1])
 	}
+	adk.EnsureMessageID(memMsg)
 	if sendEventErr := adk.TypedSendEvent(ctx, &adk.TypedAgentEvent[M]{SessionEvent: &adk.SessionEvent[M]{
 		Kind: adk.SessionEventMessageInserted,
 		MessageInserted: &adk.MessageInsertedEvent[M]{

--- a/adk/middlewares/automemory/automemory_test.go
+++ b/adk/middlewares/automemory/automemory_test.go
@@ -30,6 +30,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/cloudwego/eino/adk"
+	adksession "github.com/cloudwego/eino/adk/session"
 	"github.com/cloudwego/eino/components/model"
 	"github.com/cloudwego/eino/schema"
 )
@@ -168,6 +169,62 @@ func TestMiddleware_TopicSelection_InsertsMemoryMessage(t *testing.T) {
 	require.NotNil(t, out.AgentInput.Messages[1].Extra)
 	require.NotNil(t, out.AgentInput.Messages[1].Extra["__eino_automemory__"])
 	require.Contains(t, out.AgentInput.Messages[1].Content, "Contents of /mem/debugging.md")
+}
+
+func TestMiddleware_BeforeAgent_MessageInsertedEventPersistsToSessionStore(t *testing.T) {
+	ctx := context.Background()
+	b := NewInMemoryBackend()
+	now := time.Now()
+
+	b.put("/mem/MEMORY.md", "- [debugging.md](debugging.md) - notes\n", now)
+	b.put("/mem/debugging.md", "---\nname: Debugging\ndescription: build and test commands\ntype: project\n---\n\n# Debugging\npnpm test\n", now)
+
+	mw, err := New(ctx, &Config[*schema.Message]{
+		MemoryDirectory: "/mem",
+		MemoryBackend:   b,
+		Model:           &fixedModel{out: "ok"},
+	})
+	require.NoError(t, err)
+
+	agent, err := adk.NewChatModelAgent(ctx, &adk.ChatModelAgentConfig{
+		Name:        "automemory-session-event-agent",
+		Instruction: "base",
+		Model:       &fixedModel{out: "ok"},
+		Handlers:    []adk.ChatModelAgentMiddleware{mw},
+	})
+	require.NoError(t, err)
+
+	const sessionID = "automemory-message-inserted-session"
+	store := adksession.NewInMemoryStore[*schema.Message](nil)
+	runner := adk.NewRunner(ctx, adk.RunnerConfig{
+		Agent:          agent,
+		SessionID:      sessionID,
+		SessionService: adk.NewLocalSessionService[*schema.Message](store),
+	})
+
+	iter := runner.Query(ctx, "How to run tests?")
+	for {
+		event, ok := iter.Next()
+		if !ok {
+			break
+		}
+		require.NoError(t, event.Err)
+	}
+
+	loaded, err := store.LoadEvents(ctx, &adk.LoadSessionEventsRequest{
+		SessionID: sessionID,
+		Kinds:     []adk.SessionEventKind{adk.SessionEventMessageInserted},
+	})
+	require.NoError(t, err)
+	require.Len(t, loaded.Events, 1, "AutoMemory BeforeAgent MessageInserted event should be persisted in SessionStore")
+
+	inserted := loaded.Events[0].MessageInserted
+	require.NotNil(t, inserted)
+	require.NotEmpty(t, inserted.BeforeMessageID)
+	require.NotNil(t, inserted.Message)
+	require.Contains(t, inserted.Message.Content, "<!-- automemory -->")
+	require.Contains(t, inserted.Message.Content, "Contents of /mem/debugging.md")
+	require.NotNil(t, inserted.Message.Extra[memoryExtraKey])
 }
 
 func TestMiddleware_TopicSelection_AsyncInjectsInBeforeModel(t *testing.T) {

--- a/adk/wrappers.go
+++ b/adk/wrappers.go
@@ -907,7 +907,9 @@ func GetMessageID[M MessageType](msg M) string {
 
 // EnsureMessageID assigns a UUID v4 message ID if the message doesn't have one.
 // Idempotent: if ID already set, no-op.
-// Middleware authors should call this before SendEvent if they create messages.
+// TypedSendEvent/SendEvent call this automatically for message-bearing events.
+// Middleware authors only need to call it directly when they need the ID before
+// emitting the event.
 func EnsureMessageID[M MessageType](msg M) {
 	switch v := any(msg).(type) {
 	case *schema.Message:
@@ -917,6 +919,48 @@ func EnsureMessageID[M MessageType](msg M) {
 	case *schema.AgenticMessage:
 		if internal.GetMessageID(v.Extra) == "" {
 			v.Extra = internal.EnsureMessageID(v.Extra)
+		}
+	}
+}
+
+func ensureTypedAgentEventMessageIDs[M MessageType](event *TypedAgentEvent[M]) {
+	if event == nil {
+		return
+	}
+	if event.Output != nil && event.Output.MessageOutput != nil && !isNilMessage(event.Output.MessageOutput.Message) {
+		EnsureMessageID(event.Output.MessageOutput.Message)
+	}
+	ensureSessionEventMessageIDs(event.SessionEvent)
+}
+
+func ensureSessionEventMessageIDs[M MessageType](event *SessionEvent[M]) {
+	if event == nil {
+		return
+	}
+	if !isNilMessage(event.Message) {
+		EnsureMessageID(event.Message)
+	}
+	if event.MessagesReplaced != nil {
+		for _, msg := range *event.MessagesReplaced {
+			if !isNilMessage(msg) {
+				EnsureMessageID(msg)
+			}
+		}
+	}
+	if event.MessageUpdated != nil && !isNilMessage(event.MessageUpdated.Message) {
+		msgID := GetMessageID(event.MessageUpdated.Message)
+		if msgID == "" && event.MessageUpdated.MessageID != "" {
+			typedSetMessageID(event.MessageUpdated.Message, event.MessageUpdated.MessageID)
+		}
+	}
+	if event.MessageInserted != nil && !isNilMessage(event.MessageInserted.Message) {
+		EnsureMessageID(event.MessageInserted.Message)
+	}
+	if event.TurnEnd != nil {
+		for _, msg := range event.TurnEnd.Messages {
+			if !isNilMessage(msg) {
+				EnsureMessageID(msg)
+			}
 		}
 	}
 }


### PR DESCRIPTION
## Problem
AutoMemory inserts a memory message during `BeforeAgent` and emits a `SessionEventMessageInserted` for session replay. The message is visible to the model, but the session event was not persisted because `TypedSendEvent` had no `chatModelAgentExecCtx` yet at `BeforeAgent` time.

Expected: `BeforeAgent` middleware can emit session events that Runner persists.
Actual: the event is silently dropped before the agent execution context is installed.

## Solution
Install a fresh per-agent `typedChatModelAgentExecCtx` at `Run`/`Resume` entry, before `getRunFunc` invokes `BeforeAgent`. The later no-tools/ReAct execution paths reuse and complete the same context instead of depending on a later-only installation point.

AutoMemory also assigns the inserted message ID before emitting the session event, so the event snapshot and model execution do not race on lazy message ID mutation.

## Key Insight
Runner-owned admission events already use a direct durable lane before agent execution. Middleware-emitted events use the agent event iterator lane, so that lane must exist before lifecycle hooks that are allowed to emit events. Each nested agent still needs its own fresh exec context to avoid overwriting the parent sender.

## Summary
| Problem | Solution |
|---------|----------|
| `BeforeAgent` session events were dropped | Create the agent exec context before `BeforeAgent` |
| Nested agents could share the parent sender if the context is reused incorrectly | Create a fresh exec context at each `Run`/`Resume` boundary |
| AutoMemory inserted message could be lazily mutated while Runner snapshots it | Assign the inserted message ID before event emission |

---

## 问题
AutoMemory 在 `BeforeAgent` 中插入 memory message，并发送 `SessionEventMessageInserted` 供 session replay 使用。模型可以看到这条 message，但 session event 没有持久化，因为 `BeforeAgent` 执行时 `TypedSendEvent` 还拿不到 `chatModelAgentExecCtx`。

期望：`BeforeAgent` middleware 可以发送并持久化 session event。
实际：agent execution context 尚未安装，event 被静默丢弃。

## 解决方案
在 `Run`/`Resume` 入口处安装一个新的、当前 agent 专属的 `typedChatModelAgentExecCtx`，确保它早于 `getRunFunc` 触发的 `BeforeAgent`。后续 no-tools/ReAct 执行路径复用并补全同一个 context，而不是依赖更晚的安装点。

AutoMemory 同时在发送 event 前为插入的 message 分配 message ID，避免 Runner snapshot event 时与模型执行路径的懒分配发生并发读写。

## 关键洞察
Runner 自己的 admission events 已经有一条执行前的直接持久化通道。Middleware 发送的 event 走 agent event iterator 通道，所以这个通道必须在允许发送 event 的 lifecycle hook 之前可用。嵌套 agent 仍然必须在自己的 `Run`/`Resume` 边界创建新的 exec context，避免覆盖父 agent 的 sender。

## 总结
| 问题 | 解决方案 |
|------|----------|
| `BeforeAgent` session events 被丢弃 | 在 `BeforeAgent` 前创建 agent exec context |
| 嵌套 agent 可能误复用父 agent sender | 每个 `Run`/`Resume` 边界创建新的 exec context |
| AutoMemory inserted message 可能在 snapshot 时被懒分配 message ID | 发送 event 前先分配 inserted message ID |

## Verification
- `go test -v -gcflags="all=-l -N" ./adk/middlewares/automemory -run TestMiddleware_BeforeAgent_MessageInsertedEventPersistsToSessionStore`
- `go test ./adk/middlewares/automemory ./adk`
- `go test -race ./adk/middlewares/automemory ./adk`
- `golangci-lint run --new-from-rev=origin/alpha/10 ./...`
- `go test -coverprofile=/tmp/automemory_fix_coverage.out ./adk/middlewares/automemory ./adk`