### PR TITLE
fix(adk): copy-on-write SetMessageID to avoid concurrent map panic

### DIFF
--- a/adk/internal/message_id.go
+++ b/adk/internal/message_id.go
@@ -31,14 +31,20 @@ func GetMessageID(extra map[string]any) string {
 	return id
 }
 
-// SetMessageID sets the message ID in Extra (initializing the map if nil).
-// Returns the (possibly newly created) Extra map.
+// SetMessageID sets the message ID in Extra and returns the resulting map.
+//
+// Copy-on-write: the input map is never mutated, because a message's Extra can
+// be shared across fan-out stream readers and an in-place write would race with
+// concurrent reads (fatal "concurrent map read and map write"). Reassigning the
+// returned map to a shared Extra field is still a field-level race that cannot
+// be eliminated while Extra is exported; COW only removes the map-level panic.
 func SetMessageID(extra map[string]any, id string) map[string]any {
-	if extra == nil {
-		extra = make(map[string]any)
+	next := make(map[string]any, len(extra)+1)
+	for k, v := range extra {
+		next[k] = v
 	}
-	extra[EinoMsgIDKey] = id
-	return extra
+	next[EinoMsgIDKey] = id
+	return next
 }
 
 // EnsureMessageID assigns a UUID v4 if no message ID is present.


### PR DESCRIPTION
## Summary
- ChatModel streaming fans out the same `*schema.Message` pointers to multiple consumers inside the model body. Stamping the eino message ID into `Extra` via an **in-place map write** then races with concurrent reads of that shared map, triggering a fatal `concurrent map read and map write` panic.
- Make `internal.SetMessageID` **copy-on-write**: allocate a fresh map, copy existing entries, then set the ID. All callers already reassign the returned map (`v.Extra = SetMessageID(...)`), so the change is transparent and fixes every path at once.
- This removes the map-level panic. The field-level race on the exported `Extra` field cannot be eliminated by the framework while `Extra` is public, and is documented as a known limit in the function doc.

## Test plan
- [x] `go build ./...`
- [x] `go test -race ./adk/...` (all green, incl. 30s race run on the adk root package)

🤖 Generated with [Claude Code](https://claude.com/claude-code)