### PR TITLE
fix(adk): drop errored streams from session persistence

### DIFF
--- a/adk/runner.go
+++ b/adk/runner.go
@@ -1070,7 +1070,9 @@ func typedRunnerHandleIterImpl[M MessageType](enableStreaming bool, store CheckP
 					persistCopy := &TypedMessageVariant[M]{IsStreaming: true, MessageStream: copies[0]}
 					persistedMsg, err := persistCopy.GetMessage()
 					if err != nil {
-						setPersistErr(err)
+						// A message-stream error means this message should not enter
+						// model context. Drop only this SessionEvent; the turn and any
+						// deferred checkpoint can still commit.
 						continue
 					}
 

--- a/adk/session_extra_test.go
+++ b/adk/session_extra_test.go
@@ -519,8 +519,7 @@ func TestStreamPersistence_GetMessageError_NotEnqueued(t *testing.T) {
 			_, _ = schema.ConcatMessageStream(ev.Output.MessageOutput.MessageStream)
 		}
 	}
-	require.Error(t, lastErr, "turn must fail when persisted-stream materialization errors")
-	assert.Contains(t, lastErr.Error(), "failed to persist session events")
+	require.NoError(t, lastErr, "stream materialization errors should drop only the message event")
 
 	// Verify no assistant SessionEvent is in the log.
 	for _, ep := range store.events {
@@ -572,8 +571,7 @@ func TestStreamPersistence_GetMessageErrorSurfacesAfterLiveStreaming(t *testing.
 			sawOutput = true
 		}
 	}
-	require.Error(t, lastErr)
-	assert.Contains(t, lastErr.Error(), "failed to persist session events")
+	require.NoError(t, lastErr)
 	assert.True(t, sawOutput, "streaming output may already be live before materialization fails")
 
 	for _, ep := range store.events {

--- a/adk/session_test.go
+++ b/adk/session_test.go
@@ -21,6 +21,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"io"
 	"strings"
 	"sync"
 	"sync/atomic"
@@ -293,6 +294,41 @@ func (a *streamingSessionAgent) Run(_ context.Context, _ *AgentInput, _ ...Agent
 				},
 			},
 		})
+	}()
+	return iter
+}
+
+type erroredStreamingInterruptAgent struct {
+	streamErr error
+}
+
+func (a *erroredStreamingInterruptAgent) Name(_ context.Context) string {
+	return "errored-streaming-interrupt-agent"
+}
+
+func (a *erroredStreamingInterruptAgent) Description(_ context.Context) string {
+	return "errored streaming interrupt agent"
+}
+
+func (a *erroredStreamingInterruptAgent) Run(ctx context.Context, _ *AgentInput, _ ...AgentRunOption) *AsyncIterator[*AgentEvent] {
+	iter, gen := NewAsyncIteratorPair[*AgentEvent]()
+	sr, sw := schema.Pipe[*schema.Message](2)
+	streamErr := a.streamErr
+	if streamErr == nil {
+		streamErr = errors.New("stream failed")
+	}
+	go func() {
+		defer gen.Close()
+		sw.Send(schema.AssistantMessage("partial", nil), nil)
+		sw.Send(nil, streamErr)
+		sw.Close()
+		gen.Send(&AgentEvent{
+			AgentName: a.Name(ctx),
+			Output: &AgentOutput{
+				MessageOutput: &MessageVariant{IsStreaming: true, MessageStream: sr, Role: schema.Assistant},
+			},
+		})
+		gen.Send(Interrupt(ctx, "checkpoint after errored stream"))
 	}()
 	return iter
 }
@@ -1053,6 +1089,73 @@ func TestRunnerSessionStreamingDoesNotBlockLiveEvent(t *testing.T) {
 
 	release()
 	drainSessionEvents(t, iter)
+}
+
+func TestRunnerSessionDropsErroredStreamingMessageBeforeCheckpoint(t *testing.T) {
+	ctx := context.Background()
+
+	tests := []struct {
+		name      string
+		streamErr error
+	}{
+		{name: "stream canceled", streamErr: ErrStreamCanceled},
+		{name: "will retry", streamErr: &WillRetryError{ErrStr: "retry", RetryAttempt: 1}},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			store := newSessionHelperStore()
+			agent := &erroredStreamingInterruptAgent{streamErr: tt.streamErr}
+			checkpointID := "errored-stream-checkpoint-" + strings.ReplaceAll(tt.name, " ", "-")
+			runner := NewRunner(ctx, RunnerConfig{
+				Agent:           agent,
+				EnableStreaming: true,
+				SessionID:       "errored-stream-session-" + tt.name,
+				SessionStore:    store,
+				CheckPointStore: store,
+			})
+
+			iter := runner.Query(ctx, "start", WithCheckPointID(checkpointID))
+			var sawInterrupt bool
+			var sawStreamErr bool
+			for {
+				event, ok := iter.Next()
+				if !ok {
+					break
+				}
+				require.NoError(t, event.Err)
+				if event.Output != nil && event.Output.MessageOutput != nil &&
+					event.Output.MessageOutput.IsStreaming {
+					for {
+						_, err := event.Output.MessageOutput.MessageStream.Recv()
+						if err == nil {
+							continue
+						}
+						require.NotEqual(t, io.EOF, err)
+						sawStreamErr = true
+						break
+					}
+				}
+				if event.Action != nil && event.Action.Interrupted != nil {
+					sawInterrupt = true
+				}
+			}
+
+			require.True(t, sawStreamErr)
+			require.True(t, sawInterrupt)
+			_, exists, err := store.Get(ctx, checkpointID)
+			require.NoError(t, err)
+			require.True(t, exists, "checkpoint should still be saved after dropping errored message stream")
+
+			persistedPartialMessages := filterStoredSessionEvents(t, store.events, func(se *SessionEvent[*schema.Message]) bool {
+				return se.Kind == SessionEventMessage &&
+					se.Message != nil &&
+					se.Message.Role == schema.Assistant &&
+					se.Message.Content == "partial"
+			})
+			assert.Empty(t, persistedPartialMessages)
+		})
+	}
 }
 
 func drainSessionEvents(t *testing.T, iter *AsyncIterator[*AgentEvent]) {


### PR DESCRIPTION
Problem: message stream errors such as ErrStreamCanceled or WillRetryError mean the message should not enter future model context, but the runner was treating materialization failure as SessionEventStore persistence failure and then skipping deferred checkpoint save. Solution: when materializing the persistence copy of a streaming message fails, drop only that SessionEventMessage and keep session boundary persistence healthy. This PR intentionally does not change checkpoint gob encoding behavior. 问题：Message Stream error 表示这条 message 不应该进入后续 model context，但 Runner 之前会把 materialization failure 当成 SessionEventStore persistence failure，进而跳过延迟 checkpoint 保存。方案：streaming message 的持久化副本 materialization 失败时，只丢弃对应的 SessionEventMessage，不改变 checkpoint gob encoding 行为。