### PR TITLE
fix(adk): preserve streaming tool output during reduction

### DIFF
--- a/adk/middlewares/reduction/consts.go
+++ b/adk/middlewares/reduction/consts.go
@@ -41,6 +41,15 @@ Preview (last {preview_size}):
 )
 
 const (
+	streamTruncFmt = `<persisted-output>
+Output truncated after {preview_size} bytes were streamed. Full output saved to: {file_path}
+</persisted-output>`
+	streamTruncFmtZh = `<persisted-output>
+输出结果在流式传输 {preview_size} 字节后被截断。完整输出保存到: {file_path}
+</persisted-output>`
+)
+
+const (
 	clearWithOffloadingFmt = `<persisted-output>Tool result saved to: {file_path}
 Use {read_tool_name} to view</persisted-output>`
 	clearWithOffloadingFmtZh = `<persisted-output>工具结果已保存至: {file_path}
@@ -58,6 +67,13 @@ func getTruncFmt() string {
 	return internal.SelectPrompt(internal.I18nPrompts{
 		English: truncFmt,
 		Chinese: truncFmtZh,
+	})
+}
+
+func getStreamTruncFmt() string {
+	return internal.SelectPrompt(internal.I18nPrompts{
+		English: streamTruncFmt,
+		Chinese: streamTruncFmtZh,
 	})
 }
 

--- a/adk/middlewares/reduction/consts.go
+++ b/adk/middlewares/reduction/consts.go
@@ -17,7 +17,11 @@
 // Package reduction provides middlewares to trim context and clear tool results.
 package reduction
 
-import "github.com/cloudwego/eino/adk/internal"
+import (
+	"fmt"
+
+	"github.com/cloudwego/eino/adk/internal"
+)
 
 const (
 	truncFmt = `<persisted-output>
@@ -42,10 +46,10 @@ Preview (last {preview_size}):
 
 const (
 	streamTruncFmt = `<persisted-output>
-Output truncated after {preview_size} bytes were streamed. Full output saved to: {file_path}
+Output truncated after {preview_size} bytes were streamed. {offload_notify} {error_msg_notify}
 </persisted-output>`
 	streamTruncFmtZh = `<persisted-output>
-输出结果在流式传输 {preview_size} 字节后被截断。完整输出保存到: {file_path}
+输出结果在流式传输 {preview_size} 字节后被截断。{offload_notify} {error_msg_notify}
 </persisted-output>`
 )
 
@@ -75,6 +79,23 @@ func getStreamTruncFmt() string {
 		English: streamTruncFmt,
 		Chinese: streamTruncFmtZh,
 	})
+}
+
+func formatStreamOffloadSavedNotify(filePath string) string {
+	return fmt.Sprintf(internal.SelectPrompt(internal.I18nPrompts{
+		English: "Full output saved to: %s.",
+		Chinese: "完整输出保存到: %s。",
+	}), filePath)
+}
+
+func formatStreamOffloadFailedNotify(err error) string {
+	if err == nil {
+		return ""
+	}
+	return fmt.Sprintf(internal.SelectPrompt(internal.I18nPrompts{
+		English: "Failed to save full output: %v.",
+		Chinese: "完整输出保存失败: %v。",
+	}), err)
 }
 
 func getClearWithOffloadingFmt() string {

--- a/adk/middlewares/reduction/reduction.go
+++ b/adk/middlewares/reduction/reduction.go
@@ -533,95 +533,135 @@ func (t *typedToolReductionMiddleware[M]) wrapDefaultStreamableTruncation(
 	argumentsInJSON string,
 	output *schema.StreamReader[string],
 ) *schema.StreamReader[string] {
-	sr, sw := schema.Pipe[string](1)
-	go func() {
-		defer sw.Close()
-		defer output.Close()
+	var (
+		fullOutput             strings.Builder
+		curSize                int
+		reachedLimit           bool
+		truncTextPrefix        string
+		truncTriggeredFullText string
+		sourceErr              error
+	)
 
-		var fullOutput strings.Builder
-		truncating := false
-		filePath := ""
-		for {
-			chunk, recvErr := output.Recv()
-			if recvErr != nil {
-				if recvErr != io.EOF {
-					var zero string
-					sw.Send(zero, recvErr)
-					return
-				}
-				break
-			}
-
-			fullOutput.WriteString(chunk)
-			if truncating {
-				continue
-			}
-			if fullOutput.Len() <= t.config.MaxLengthForTrunc {
-				if sw.Send(chunk, nil) {
-					return
-				}
-				continue
-			}
-
-			remaining := t.config.MaxLengthForTrunc - (fullOutput.Len() - len(chunk))
-			if remaining > 0 {
-				prefix := clampPrefixToUTF8Boundary(chunk, remaining)
-				if prefix != "" {
-					if sw.Send(prefix, nil) {
-						return
-					}
-				}
-			}
-
-			detail := &ToolDetail{
-				ToolContext: tCtx,
-				ToolArgument: &schema.ToolArgument{
-					Text: argumentsInJSON,
-				},
-				ToolResult: &schema.ToolResult{
-					Parts: []schema.ToolOutputPart{
-						{Type: schema.ToolPartTypeText, Text: fullOutput.String()},
-					},
-				},
-			}
-			var err error
-			filePath, err = t.config.GenTruncOffloadFilePath(ctx, detail)
-			if err != nil {
-				var zero string
-				sw.Send(zero, err)
-				return
-			}
-			if cfg.Backend == nil {
-				var zero string
-				sw.Send(zero, fmt.Errorf("truncation: no backend for offload"))
-				return
-			}
-			notice, err := formatStreamTruncNotice(filePath, t.config.MaxLengthForTrunc)
-			if err != nil {
-				var zero string
-				sw.Send(zero, err)
-				return
-			}
-			if sw.Send(notice, nil) {
-				return
-			}
-			truncating = true
+	// Chunk mapping:
+	//
+	// Normal EOF:
+	//   input : C1 -------- C2(crosses limit) -------- C3 -------- EOF
+	//   output: C1 -------- [swallow C2,C3] ---------- prefix(C2)+notice
+	//
+	// Source error after truncation:
+	//   input : C1 -------- C2(crosses limit) -------- C3 -------- ERR
+	//   output: C1 -------- [swallow C2,C3] ---------- replay(C2+C3 tail) -- ERR
+	//
+	// Before truncation, chunks are forwarded unchanged. Once the limit is reached,
+	// the wrapper keeps reading and accumulating full output but suppresses chunks.
+	// On clean EOF, it offloads full output and emits one final truncation notice.
+	// On source error, it replays the original content swallowed since the truncation
+	// point, then surfaces the original source error via the outer convert layer.
+	convertHandler := func(chunk string) (string, error) {
+		if chunk == "" {
+			return "", schema.ErrNoValue
+		}
+		fullOutput.WriteString(chunk)
+		if reachedLimit {
+			return "", schema.ErrNoValue
 		}
 
-		if !truncating {
-			return
+		chunkSize := len(chunk)
+		if curSize+chunkSize < t.config.MaxLengthForTrunc {
+			curSize += chunkSize
+			return chunk, nil
 		}
 
-		if err := cfg.Backend.Write(ctx, &filesystem.WriteRequest{
+		reachedLimit = true
+		truncTriggeredFullText = fullOutput.String()
+
+		leftSize := t.config.MaxLengthForTrunc - curSize
+		if leftSize > 0 {
+			truncTextPrefix = clampPrefixToUTF8Boundary(chunk, leftSize)
+		}
+		return "", schema.ErrNoValue
+	}
+
+	errHandler := func(err error) error {
+		if reachedLimit {
+			sourceErr = err
+			return nil
+		}
+		return err
+	}
+
+	eofHandler := func() (any, error) {
+		if sourceErr != nil {
+			if fullOutput.Len() > curSize {
+				return fullOutput.String()[curSize:], nil
+			}
+			return nil, io.EOF
+		}
+		if !reachedLimit {
+			return nil, io.EOF
+		}
+		detail := &ToolDetail{
+			ToolContext: tCtx,
+			ToolArgument: &schema.ToolArgument{
+				Text: argumentsInJSON,
+			},
+			ToolResult: &schema.ToolResult{
+				Parts: []schema.ToolOutputPart{
+					{Type: schema.ToolPartTypeText, Text: truncTriggeredFullText},
+				},
+			},
+		}
+
+		var (
+			offloadNotify string
+			errorNotify   string
+		)
+		filePath, err := t.config.GenTruncOffloadFilePath(ctx, detail)
+		if err != nil {
+			errorNotify = formatStreamOffloadFailedNotify(err)
+		} else if cfg.Backend == nil {
+			errorNotify = formatStreamOffloadFailedNotify(fmt.Errorf("truncation: no backend for offload"))
+		} else if err = cfg.Backend.Write(ctx, &filesystem.WriteRequest{
 			FilePath: filePath,
 			Content:  fullOutput.String(),
 		}); err != nil {
-			var zero string
-			sw.Send(zero, err)
-			return
+			errorNotify = formatStreamOffloadFailedNotify(err)
+		} else {
+			offloadNotify = formatStreamOffloadSavedNotify(filePath)
 		}
-	}()
-	return sr
+
+		notice, err := formatStreamTruncNotice(t.config.MaxLengthForTrunc, offloadNotify, errorNotify)
+		if err != nil {
+			return nil, err
+		}
+		return truncTextPrefix + notice, nil
+	}
+
+	truncatedStream := schema.StreamReaderWithConvert(
+		output,
+		convertHandler,
+		schema.WithErrWrapper(errHandler),
+		schema.WithOnEOF(eofHandler),
+	)
+
+	// StreamReaderWithConvert's WithOnEOF can inject only one value or one error.
+	// The source-error fallback needs two Recv results:
+	//   1. replay swallowed original output,
+	//   2. surface the original source error.
+	// The inner reader emits the replay value, and this outer reader emits the
+	// original error when the inner reader reaches EOF after replay.
+	return schema.StreamReaderWithConvert(
+		truncatedStream,
+		func(chunk string) (string, error) {
+			return chunk, nil
+		},
+		schema.WithOnEOF(func() (any, error) {
+			if sourceErr != nil {
+				return nil, sourceErr
+			}
+			return nil, io.EOF
+		}),
+	)
 }
 
 func (t *typedToolReductionMiddleware[M]) WrapEnhancedInvokableToolCall(_ context.Context, endpoint adk.EnhancedInvokableToolCallEndpoint, tCtx *adk.ToolContext) (adk.EnhancedInvokableToolCallEndpoint, error) {
@@ -725,109 +765,134 @@ func (t *typedToolReductionMiddleware[M]) wrapDefaultEnhancedStreamableTruncatio
 	toolArgument *schema.ToolArgument,
 	output *schema.StreamReader[*schema.ToolResult],
 ) *schema.StreamReader[*schema.ToolResult] {
-	sr, sw := schema.Pipe[*schema.ToolResult](1)
-	go func() {
-		defer sw.Close()
-		defer output.Close()
+	var (
+		chunks                   []*schema.ToolResult
+		replayChunks             []*schema.ToolResult
+		fullLength               int
+		reachedLimit             bool
+		truncTextPrefix          *schema.ToolResult
+		truncTriggeredToolResult *schema.ToolResult
+		sourceErr                error
+	)
 
-		var chunks []*schema.ToolResult
-		fullLength := 0
-		truncating := false
-		filePath := ""
-		for {
-			chunk, recvErr := output.Recv()
-			if recvErr != nil {
-				if recvErr != io.EOF {
-					var zero *schema.ToolResult
-					sw.Send(zero, recvErr)
-					return
-				}
-				break
-			}
-
-			chunks = append(chunks, chunk)
-			chunkLength := toolResultTextLength(chunk)
-			if truncating {
-				fullLength += chunkLength
-				continue
-			}
-			if fullLength+chunkLength <= t.config.MaxLengthForTrunc {
-				fullLength += chunkLength
-				if sw.Send(chunk, nil) {
-					return
-				}
-				continue
-			}
-
-			remaining := t.config.MaxLengthForTrunc - fullLength
-			prefix := toolResultTextPrefix(chunk, remaining)
-			if prefix != nil {
-				if sw.Send(prefix, nil) {
-					return
-				}
-			}
+	// Chunk mapping:
+	//
+	// Normal EOF:
+	//   input : C1 -------- C2(crosses limit) -------- C3 -------- EOF
+	//   output: C1 -------- [swallow C2,C3] ---------- prefix(C2)+notice
+	//
+	// Source error after truncation:
+	//   input : C1 -------- C2(crosses limit) -------- C3 -------- ERR
+	//   output: C1 -------- [swallow C2,C3] ---------- replay(C2+C3) -- ERR
+	//
+	// Replay uses one merged ToolResult because WithOnEOF can inject only one
+	// value. As in the string stream wrapper, the outer convert layer surfaces
+	// the original source error on the following Recv.
+	convertHandler := func(chunk *schema.ToolResult) (*schema.ToolResult, error) {
+		chunks = append(chunks, chunk)
+		chunkLength := toolResultTextLength(chunk)
+		if reachedLimit {
 			fullLength += chunkLength
-
-			toolResult, err := schema.ConcatToolResults(chunks)
-			if err != nil {
-				var zero *schema.ToolResult
-				sw.Send(zero, err)
-				return
-			}
-			detail := &ToolDetail{
-				ToolContext:  tCtx,
-				ToolArgument: toolArgument,
-				ToolResult:   toolResult,
-			}
-			filePath, err = t.config.GenTruncOffloadFilePath(ctx, detail)
-			if err != nil {
-				var zero *schema.ToolResult
-				sw.Send(zero, err)
-				return
-			}
-			if cfg.Backend == nil {
-				var zero *schema.ToolResult
-				sw.Send(zero, fmt.Errorf("truncation: no backend for offload"))
-				return
-			}
-			notice, err := formatStreamTruncNotice(filePath, t.config.MaxLengthForTrunc)
-			if err != nil {
-				var zero *schema.ToolResult
-				sw.Send(zero, err)
-				return
-			}
-			if sw.Send(&schema.ToolResult{Parts: []schema.ToolOutputPart{{Type: schema.ToolPartTypeText, Text: notice}}}, nil) {
-				return
-			}
-			truncating = true
+			replayChunks = append(replayChunks, chunk)
+			return nil, schema.ErrNoValue
+		}
+		if fullLength+chunkLength < t.config.MaxLengthForTrunc {
+			fullLength += chunkLength
+			return chunk, nil
 		}
 
-		if !truncating {
-			return
+		reachedLimit = true
+		replayChunks = append(replayChunks, chunk)
+		truncTextPrefix = toolResultTextPrefix(chunk, t.config.MaxLengthForTrunc-fullLength)
+		fullLength += chunkLength
+		truncTriggeredToolResult = &schema.ToolResult{Parts: flattenToolResultParts(chunks)}
+		return nil, schema.ErrNoValue
+	}
+
+	errHandler := func(err error) error {
+		if reachedLimit {
+			sourceErr = err
+			return nil
+		}
+		return err
+	}
+
+	eofHandler := func() (any, error) {
+		if sourceErr != nil {
+			replay := &schema.ToolResult{Parts: flattenToolResultParts(replayChunks)}
+			if len(replay.Parts) > 0 {
+				return replay, nil
+			}
+			return nil, io.EOF
+		}
+		if !reachedLimit {
+			return nil, io.EOF
 		}
 
-		toolResult, err := schema.ConcatToolResults(chunks)
+		fullToolResult := &schema.ToolResult{Parts: flattenToolResultParts(chunks)}
+		detail := &ToolDetail{
+			ToolContext:  tCtx,
+			ToolArgument: toolArgument,
+			ToolResult:   truncTriggeredToolResult,
+		}
+
+		var (
+			offloadNotify string
+			errorNotify   string
+		)
+		filePath, err := t.config.GenTruncOffloadFilePath(ctx, detail)
 		if err != nil {
-			var zero *schema.ToolResult
-			sw.Send(zero, err)
-			return
-		}
-		if err = cfg.Backend.Write(ctx, &filesystem.WriteRequest{
+			errorNotify = formatStreamOffloadFailedNotify(err)
+		} else if cfg.Backend == nil {
+			errorNotify = formatStreamOffloadFailedNotify(fmt.Errorf("truncation: no backend for offload"))
+		} else if err = cfg.Backend.Write(ctx, &filesystem.WriteRequest{
 			FilePath: filePath,
-			Content:  stringifyToolOutputParts(toolResult.Parts),
+			Content:  stringifyToolOutputParts(fullToolResult.Parts),
 		}); err != nil {
-			var zero *schema.ToolResult
-			sw.Send(zero, err)
-			return
+			errorNotify = formatStreamOffloadFailedNotify(err)
+		} else {
+			offloadNotify = formatStreamOffloadSavedNotify(filePath)
 		}
-	}()
-	return sr
+
+		notice, err := formatStreamTruncNotice(t.config.MaxLengthForTrunc, offloadNotify, errorNotify)
+		if err != nil {
+			return nil, err
+		}
+
+		parts := make([]schema.ToolOutputPart, 0, 1)
+		if truncTextPrefix != nil {
+			parts = append(parts, truncTextPrefix.Parts...)
+		}
+		parts = append(parts, schema.ToolOutputPart{Type: schema.ToolPartTypeText, Text: notice})
+		return &schema.ToolResult{Parts: parts}, nil
+	}
+
+	truncatedStream := schema.StreamReaderWithConvert(
+		output,
+		convertHandler,
+		schema.WithErrWrapper(errHandler),
+		schema.WithOnEOF(eofHandler),
+	)
+
+	return schema.StreamReaderWithConvert(
+		truncatedStream,
+		func(chunk *schema.ToolResult) (*schema.ToolResult, error) {
+			return chunk, nil
+		},
+		schema.WithOnEOF(func() (any, error) {
+			if sourceErr != nil {
+				return nil, sourceErr
+			}
+			return nil, io.EOF
+		}),
+	)
 }
 
-func formatStreamTruncNotice(filePath string, previewSize int) (string, error) {
+func formatStreamTruncNotice(previewSize int, offloadNotify, errorMsgNotify string) (string, error) {
 	return pyfmt.Fmt(getStreamTruncFmt(), map[string]any{
-		"file_path":    filePath,
-		"preview_size": previewSize,
+		"preview_size":     previewSize,
+		"offload_notify":   offloadNotify,
+		"error_msg_notify": errorMsgNotify,
 	})
 }
 
@@ -876,6 +941,17 @@ func toolResultTextLength(result *schema.ToolResult) int {
 		}
 	}
 	return length
+}
+
+func flattenToolResultParts(chunks []*schema.ToolResult) []schema.ToolOutputPart {
+	var parts []schema.ToolOutputPart
+	for _, chunk := range chunks {
+		if chunk == nil || len(chunk.Parts) == 0 {
+			continue
+		}
+		parts = append(parts, chunk.Parts...)
+	}
+	return parts
 }
 
 func writeTruncOffload(ctx context.Context, cfg *ToolReductionConfig, truncResult *TruncResult) error {

--- a/adk/middlewares/reduction/reduction.go
+++ b/adk/middlewares/reduction/reduction.go
@@ -477,6 +477,9 @@ func (t *typedToolReductionMiddleware[M]) WrapStreamableToolCall(_ context.Conte
 		if err != nil {
 			return nil, err
 		}
+		if cfg == t.defaultConfig {
+			return t.wrapDefaultStreamableTruncation(ctx, cfg, tCtx, argumentsInJSON, output), nil
+		}
 
 		readers := output.Copy(2)
 		output = readers[0]
@@ -521,6 +524,104 @@ func (t *typedToolReductionMiddleware[M]) WrapStreamableToolCall(_ context.Conte
 		})
 		return sr, nil
 	}, nil
+}
+
+func (t *typedToolReductionMiddleware[M]) wrapDefaultStreamableTruncation(
+	ctx context.Context,
+	cfg *ToolReductionConfig,
+	tCtx *adk.ToolContext,
+	argumentsInJSON string,
+	output *schema.StreamReader[string],
+) *schema.StreamReader[string] {
+	sr, sw := schema.Pipe[string](1)
+	go func() {
+		defer sw.Close()
+		defer output.Close()
+
+		var fullOutput strings.Builder
+		truncating := false
+		filePath := ""
+		for {
+			chunk, recvErr := output.Recv()
+			if recvErr != nil {
+				if recvErr != io.EOF {
+					var zero string
+					sw.Send(zero, recvErr)
+					return
+				}
+				break
+			}
+
+			fullOutput.WriteString(chunk)
+			if truncating {
+				continue
+			}
+			if fullOutput.Len() <= t.config.MaxLengthForTrunc {
+				if sw.Send(chunk, nil) {
+					return
+				}
+				continue
+			}
+
+			remaining := t.config.MaxLengthForTrunc - (fullOutput.Len() - len(chunk))
+			if remaining > 0 {
+				prefix := clampPrefixToUTF8Boundary(chunk, remaining)
+				if prefix != "" {
+					if sw.Send(prefix, nil) {
+						return
+					}
+				}
+			}
+
+			detail := &ToolDetail{
+				ToolContext: tCtx,
+				ToolArgument: &schema.ToolArgument{
+					Text: argumentsInJSON,
+				},
+				ToolResult: &schema.ToolResult{
+					Parts: []schema.ToolOutputPart{
+						{Type: schema.ToolPartTypeText, Text: fullOutput.String()},
+					},
+				},
+			}
+			var err error
+			filePath, err = t.config.GenTruncOffloadFilePath(ctx, detail)
+			if err != nil {
+				var zero string
+				sw.Send(zero, err)
+				return
+			}
+			if cfg.Backend == nil {
+				var zero string
+				sw.Send(zero, fmt.Errorf("truncation: no backend for offload"))
+				return
+			}
+			notice, err := formatStreamTruncNotice(filePath, t.config.MaxLengthForTrunc)
+			if err != nil {
+				var zero string
+				sw.Send(zero, err)
+				return
+			}
+			if sw.Send(notice, nil) {
+				return
+			}
+			truncating = true
+		}
+
+		if !truncating {
+			return
+		}
+
+		if err := cfg.Backend.Write(ctx, &filesystem.WriteRequest{
+			FilePath: filePath,
+			Content:  fullOutput.String(),
+		}); err != nil {
+			var zero string
+			sw.Send(zero, err)
+			return
+		}
+	}()
+	return sr
 }
 
 func (t *typedToolReductionMiddleware[M]) WrapEnhancedInvokableToolCall(_ context.Context, endpoint adk.EnhancedInvokableToolCallEndpoint, tCtx *adk.ToolContext) (adk.EnhancedInvokableToolCallEndpoint, error) {
@@ -578,6 +679,9 @@ func (t *typedToolReductionMiddleware[M]) WrapEnhancedStreamableToolCall(_ conte
 		if err != nil {
 			return nil, err
 		}
+		if cfg == t.defaultConfig {
+			return t.wrapDefaultEnhancedStreamableTruncation(ctx, cfg, tCtx, toolArgument, output), nil
+		}
 
 		readers := output.Copy(2)
 		output = readers[0]
@@ -612,6 +716,179 @@ func (t *typedToolReductionMiddleware[M]) WrapEnhancedStreamableToolCall(_ conte
 
 		return truncResult.StreamToolResult, nil
 	}, nil
+}
+
+func (t *typedToolReductionMiddleware[M]) wrapDefaultEnhancedStreamableTruncation(
+	ctx context.Context,
+	cfg *ToolReductionConfig,
+	tCtx *adk.ToolContext,
+	toolArgument *schema.ToolArgument,
+	output *schema.StreamReader[*schema.ToolResult],
+) *schema.StreamReader[*schema.ToolResult] {
+	sr, sw := schema.Pipe[*schema.ToolResult](1)
+	go func() {
+		defer sw.Close()
+		defer output.Close()
+
+		var chunks []*schema.ToolResult
+		fullLength := 0
+		truncating := false
+		filePath := ""
+		for {
+			chunk, recvErr := output.Recv()
+			if recvErr != nil {
+				if recvErr != io.EOF {
+					var zero *schema.ToolResult
+					sw.Send(zero, recvErr)
+					return
+				}
+				break
+			}
+
+			chunks = append(chunks, chunk)
+			chunkLength := toolResultTextLength(chunk)
+			if truncating {
+				fullLength += chunkLength
+				continue
+			}
+			if fullLength+chunkLength <= t.config.MaxLengthForTrunc {
+				fullLength += chunkLength
+				if sw.Send(chunk, nil) {
+					return
+				}
+				continue
+			}
+
+			remaining := t.config.MaxLengthForTrunc - fullLength
+			prefix := toolResultTextPrefix(chunk, remaining)
+			if prefix != nil {
+				if sw.Send(prefix, nil) {
+					return
+				}
+			}
+			fullLength += chunkLength
+
+			toolResult, err := schema.ConcatToolResults(chunks)
+			if err != nil {
+				var zero *schema.ToolResult
+				sw.Send(zero, err)
+				return
+			}
+			detail := &ToolDetail{
+				ToolContext:  tCtx,
+				ToolArgument: toolArgument,
+				ToolResult:   toolResult,
+			}
+			filePath, err = t.config.GenTruncOffloadFilePath(ctx, detail)
+			if err != nil {
+				var zero *schema.ToolResult
+				sw.Send(zero, err)
+				return
+			}
+			if cfg.Backend == nil {
+				var zero *schema.ToolResult
+				sw.Send(zero, fmt.Errorf("truncation: no backend for offload"))
+				return
+			}
+			notice, err := formatStreamTruncNotice(filePath, t.config.MaxLengthForTrunc)
+			if err != nil {
+				var zero *schema.ToolResult
+				sw.Send(zero, err)
+				return
+			}
+			if sw.Send(&schema.ToolResult{Parts: []schema.ToolOutputPart{{Type: schema.ToolPartTypeText, Text: notice}}}, nil) {
+				return
+			}
+			truncating = true
+		}
+
+		if !truncating {
+			return
+		}
+
+		toolResult, err := schema.ConcatToolResults(chunks)
+		if err != nil {
+			var zero *schema.ToolResult
+			sw.Send(zero, err)
+			return
+		}
+		if err = cfg.Backend.Write(ctx, &filesystem.WriteRequest{
+			FilePath: filePath,
+			Content:  stringifyToolOutputParts(toolResult.Parts),
+		}); err != nil {
+			var zero *schema.ToolResult
+			sw.Send(zero, err)
+			return
+		}
+	}()
+	return sr
+}
+
+func formatStreamTruncNotice(filePath string, previewSize int) (string, error) {
+	return pyfmt.Fmt(getStreamTruncFmt(), map[string]any{
+		"file_path":    filePath,
+		"preview_size": previewSize,
+	})
+}
+
+func toolResultTextPrefix(result *schema.ToolResult, maxLength int) *schema.ToolResult {
+	if result == nil || maxLength <= 0 {
+		return nil
+	}
+	var (
+		length int
+		parts  []schema.ToolOutputPart
+	)
+	for _, part := range result.Parts {
+		if part.Type != schema.ToolPartTypeText {
+			parts = append(parts, part)
+			continue
+		}
+		remaining := maxLength - length
+		if remaining <= 0 {
+			break
+		}
+		if len(part.Text) <= remaining {
+			parts = append(parts, part)
+			length += len(part.Text)
+			continue
+		}
+		part.Text = clampPrefixToUTF8Boundary(part.Text, remaining)
+		if part.Text != "" {
+			parts = append(parts, part)
+		}
+		break
+	}
+	if len(parts) == 0 {
+		return nil
+	}
+	return &schema.ToolResult{Parts: parts}
+}
+
+func toolResultTextLength(result *schema.ToolResult) int {
+	if result == nil {
+		return 0
+	}
+	var length int
+	for _, part := range result.Parts {
+		if part.Type == schema.ToolPartTypeText {
+			length += len(part.Text)
+		}
+	}
+	return length
+}
+
+func writeTruncOffload(ctx context.Context, cfg *ToolReductionConfig, truncResult *TruncResult) error {
+	if !truncResult.NeedOffload {
+		return nil
+	}
+	if cfg.Backend == nil {
+		return fmt.Errorf("truncation: no backend for offload")
+	}
+	return cfg.Backend.Write(ctx, &filesystem.WriteRequest{
+		FilePath: truncResult.OffloadFilePath,
+		Content:  truncResult.OffloadContent,
+	})
 }
 
 func (t *typedToolReductionMiddleware[M]) BeforeModelRewriteState(ctx context.Context, state *adk.TypedChatModelAgentState[M], mc *adk.TypedModelContext[M]) (
@@ -1274,8 +1551,9 @@ func defaultTokenCounter(_ context.Context, msgs []*schema.Message, tools []*sch
 	return tokens, nil
 }
 
-// defaultTruncHandler applies the same truncation strategy to both non-streaming
-// and streaming tool outputs.
+// defaultTruncHandler applies the shared buffered truncation strategy. The
+// built-in default streaming wrappers bypass it so they can truncate
+// incrementally with a streaming-specific notice.
 //
 // Processing steps:
 //  1. Read and join tool output into a complete result:
@@ -1295,7 +1573,8 @@ func defaultTokenCounter(_ context.Context, msgs []*schema.Message, tools []*sch
 //   - When truncation is applied to a streaming tool result, output is re-emitted as a
 //     buffered single-result stream (not original chunk-by-chunk streaming semantics).
 //
-// If a tool requires strict incremental streaming behavior, provide a custom TruncHandler for that tool.
+// Tool-specific configurations that install this handler for streaming outputs
+// keep the buffered behavior below.
 func defaultTruncHandler(
 	genOffloadFilePathFn func(ctx context.Context, toolDetail *ToolDetail) (filePath string, err error),
 	truncMaxLength int,

--- a/adk/middlewares/reduction/reduction_test.go
+++ b/adk/middlewares/reduction/reduction_test.go
@@ -262,52 +262,45 @@ hello worldhello worldhello worldhello worldhello worldhello worldhello worldhel
 		assert.Equal(t, "first chunk", first)
 
 		close(releaseOverflow)
-		var remaining strings.Builder
 		noticeCh := make(chan string, 1)
 		noticeErrCh := make(chan error, 1)
 		go func() {
-			for {
-				chunk, recvErr := resp.Recv()
-				if recvErr != nil {
-					noticeErrCh <- recvErr
-					return
-				}
-				remaining.WriteString(chunk)
-				if strings.Contains(remaining.String(), "persisted-output") {
-					noticeCh <- remaining.String()
-					return
-				}
+			chunk, recvErr := resp.Recv()
+			if recvErr != nil {
+				noticeErrCh <- recvErr
+				return
 			}
+			noticeCh <- chunk
 		}()
 
 		select {
 		case got := <-noticeCh:
-			assert.Contains(t, got, "Output truncated after")
-			assert.NotContains(t, got, "Preview (first")
-			assert.NotContains(t, got, "Preview (last")
+			close(releaseEOF)
+			assert.Failf(t, "streamable truncation notice returned before source EOF", "got %q", got)
+			return
 		case recvErr := <-noticeErrCh:
 			close(releaseEOF)
 			assert.NoError(t, recvErr)
 			return
-		case <-time.After(2 * time.Second):
-			close(releaseEOF)
-			assert.Fail(t, "streamable truncation notice blocked until source EOF")
-			return
+		case <-time.After(100 * time.Millisecond):
 		}
 
 		close(releaseEOF)
-		for {
-			chunk, recvErr := resp.Recv()
-			if recvErr != nil {
-				if recvErr == io.EOF {
-					break
-				}
-				assert.NoError(t, recvErr)
-				return
-			}
-			remaining.WriteString(chunk)
+		var remaining string
+		select {
+		case remaining = <-noticeCh:
+		case recvErr := <-noticeErrCh:
+			assert.NoError(t, recvErr)
+			return
+		case <-time.After(2 * time.Second):
+			assert.Fail(t, "streamable truncation notice blocked after source EOF")
+			return
 		}
-		assert.Contains(t, remaining.String(), "persisted-output")
+		assert.Contains(t, remaining, "Output truncated after")
+		assert.NotContains(t, remaining, "Preview (first")
+		assert.NotContains(t, remaining, "Preview (last")
+		_, err = resp.Recv()
+		assert.Equal(t, io.EOF, err)
 
 		content, err := backend.Read(ctx, &filesystem.ReadRequest{FilePath: "/tmp/trunc/stream_nonblocking"})
 		assert.NoError(t, err)
@@ -374,64 +367,50 @@ hello worldhello worldhello worldhello worldhello worldhello worldhello worldhel
 		assert.Equal(t, "first chunk", first.Parts[0].Text)
 
 		close(releaseOverflow)
-		var remaining strings.Builder
 		noticeCh := make(chan string, 1)
 		noticeErrCh := make(chan error, 1)
 		go func() {
-			for {
-				chunk, recvErr := resp.Recv()
-				if recvErr != nil {
-					noticeErrCh <- recvErr
-					return
-				}
-				for _, part := range chunk.Parts {
-					if part.Type == schema.ToolPartTypeText {
-						remaining.WriteString(part.Text)
-					}
-				}
-				if strings.Contains(remaining.String(), "persisted-output") {
-					noticeCh <- remaining.String()
-					return
-				}
+			chunk, recvErr := resp.Recv()
+			if recvErr != nil {
+				noticeErrCh <- recvErr
+				return
 			}
+			noticeCh <- stringifyToolOutputParts(chunk.Parts)
 		}()
 
 		select {
 		case got := <-noticeCh:
-			assert.Contains(t, got, "Output truncated after")
-			assert.NotContains(t, got, "Preview (first")
-			assert.NotContains(t, got, "Preview (last")
+			close(releaseEOF)
+			assert.Failf(t, "enhanced streamable truncation notice returned before source EOF", "got %q", got)
+			return
 		case recvErr := <-noticeErrCh:
 			close(releaseEOF)
 			assert.NoError(t, recvErr)
 			return
-		case <-time.After(2 * time.Second):
-			close(releaseEOF)
-			assert.Fail(t, "enhanced streamable truncation notice blocked until source EOF")
-			return
+		case <-time.After(100 * time.Millisecond):
 		}
 
 		close(releaseEOF)
-		for {
-			chunk, recvErr := resp.Recv()
-			if recvErr != nil {
-				if recvErr == io.EOF {
-					break
-				}
-				assert.NoError(t, recvErr)
-				return
-			}
-			for _, part := range chunk.Parts {
-				if part.Type == schema.ToolPartTypeText {
-					remaining.WriteString(part.Text)
-				}
-			}
+		var remaining string
+		select {
+		case remaining = <-noticeCh:
+		case recvErr := <-noticeErrCh:
+			assert.NoError(t, recvErr)
+			return
+		case <-time.After(2 * time.Second):
+			assert.Fail(t, "enhanced streamable truncation notice blocked after source EOF")
+			return
 		}
-		assert.Contains(t, remaining.String(), "persisted-output")
+		assert.Contains(t, remaining, "Output truncated after")
+		assert.NotContains(t, remaining, "Preview (first")
+		assert.NotContains(t, remaining, "Preview (last")
+		_, err = resp.Recv()
+		assert.Equal(t, io.EOF, err)
 
 		content, err := backend.Read(ctx, &filesystem.ReadRequest{FilePath: "/tmp/trunc/enhanced_stream_nonblocking"})
 		assert.NoError(t, err)
-		assert.Equal(t, "first chunk"+strings.Repeat("x", 80), content.Content)
+		assert.Contains(t, content.Content, `"text": "first chunk"`)
+		assert.Contains(t, content.Content, fmt.Sprintf(`"text": "%s"`, strings.Repeat("x", 80)))
 	})
 
 	t.Run("test default streamable truncation terminal cases", func(t *testing.T) {
@@ -469,7 +448,7 @@ hello worldhello worldhello worldhello worldhello worldhello worldhello worldhel
 			assert.Equal(t, wantErr, err)
 		})
 
-		t.Run("path generation error is forwarded", func(t *testing.T) {
+		t.Run("path generation error is rendered in truncation notice", func(t *testing.T) {
 			wantErr := errors.New("path generation error")
 			mwWithPathErr := &typedToolReductionMiddleware[*schema.Message]{
 				config: &TypedConfig[*schema.Message]{
@@ -485,36 +464,39 @@ hello worldhello worldhello worldhello worldhello worldhello worldhello worldhel
 
 			got, err := resp.Recv()
 			assert.NoError(t, err)
-			assert.Equal(t, strings.Repeat("x", 10), got)
+			assert.Contains(t, got, strings.Repeat("x", 10))
+			assert.Contains(t, got, "Output truncated after 10 bytes were streamed")
+			assert.Contains(t, got, "Failed to save full output: path generation error.")
 			_, err = resp.Recv()
-			assert.Equal(t, wantErr, err)
+			assert.Equal(t, io.EOF, err)
 		})
 
-		t.Run("missing backend error is forwarded", func(t *testing.T) {
+		t.Run("missing backend error is rendered in truncation notice", func(t *testing.T) {
 			cfg := &ToolReductionConfig{}
 			resp := mw.wrapDefaultStreamableTruncation(ctx, cfg, tCtx, `{}`, stringStream(strings.Repeat("x", 20)))
 			defer resp.Close()
 
 			got, err := resp.Recv()
 			assert.NoError(t, err)
-			assert.Equal(t, strings.Repeat("x", 10), got)
+			assert.Contains(t, got, strings.Repeat("x", 10))
+			assert.Contains(t, got, "Output truncated after 10 bytes were streamed")
+			assert.Contains(t, got, "Failed to save full output: truncation: no backend for offload.")
 			_, err = resp.Recv()
-			assert.EqualError(t, err, "truncation: no backend for offload")
+			assert.Equal(t, io.EOF, err)
 		})
 
-		t.Run("truncates incrementally and writes full output", func(t *testing.T) {
+		t.Run("truncates on source EOF and writes full output", func(t *testing.T) {
 			cfg := &ToolReductionConfig{Backend: backend}
 			resp := mw.wrapDefaultStreamableTruncation(ctx, cfg, tCtx, `{}`, stringStream(strings.Repeat("x", 20), "tail"))
 			defer resp.Close()
 
 			got, err := resp.Recv()
 			assert.NoError(t, err)
-			assert.Equal(t, strings.Repeat("x", 10), got)
-			notice, err := resp.Recv()
-			assert.NoError(t, err)
-			assert.Contains(t, notice, "Output truncated after 10 bytes were streamed")
-			assert.NotContains(t, notice, "Preview (first")
-			assert.NotContains(t, notice, "Preview (last")
+			assert.Contains(t, got, strings.Repeat("x", 10))
+			assert.Contains(t, got, "Output truncated after 10 bytes were streamed")
+			assert.Contains(t, got, "Full output saved to: /tmp/trunc/stream_branches.")
+			assert.NotContains(t, got, "Preview (first")
+			assert.NotContains(t, got, "Preview (last")
 			_, err = resp.Recv()
 			assert.Equal(t, io.EOF, err)
 
@@ -523,7 +505,7 @@ hello worldhello worldhello worldhello worldhello worldhello worldhello worldhel
 			assert.Equal(t, strings.Repeat("x", 20)+"tail", content.Content)
 		})
 
-		t.Run("write error is forwarded after source EOF", func(t *testing.T) {
+		t.Run("write error is rendered in truncation notice after source EOF", func(t *testing.T) {
 			wantErr := errors.New("stream write error")
 			cfg := &ToolReductionConfig{
 				Backend: &writeFailBackend{
@@ -536,60 +518,31 @@ hello worldhello worldhello worldhello worldhello worldhello worldhello worldhel
 
 			got, err := resp.Recv()
 			assert.NoError(t, err)
-			assert.Equal(t, strings.Repeat("x", 10), got)
-			notice, err := resp.Recv()
-			assert.NoError(t, err)
-			assert.Contains(t, notice, "Output truncated after 10 bytes were streamed")
+			assert.Contains(t, got, strings.Repeat("x", 10))
+			assert.Contains(t, got, "Output truncated after 10 bytes were streamed")
+			assert.Contains(t, got, "Failed to save full output: stream write error.")
 			_, err = resp.Recv()
-			assert.Equal(t, wantErr, err)
+			assert.Equal(t, io.EOF, err)
 		})
 
-		t.Run("stops when consumer closes before short chunk", func(t *testing.T) {
-			cfg := &ToolReductionConfig{}
-			input, inputW := schema.Pipe[string](0)
-			resp := mw.wrapDefaultStreamableTruncation(ctx, cfg, tCtx, `{}`, input)
-
-			resp.Close()
-			closed := sendStreamChunk(t, inputW, "short")
-			inputW.Close()
-
-			assert.False(t, closed)
-		})
-
-		t.Run("stops when consumer closes before prefix", func(t *testing.T) {
+		t.Run("source error after truncation replays swallowed chunks before error", func(t *testing.T) {
+			wantErr := errors.New("stream source error after truncation")
 			cfg := &ToolReductionConfig{Backend: backend}
-			input, inputW := schema.Pipe[string](0)
-			resp := mw.wrapDefaultStreamableTruncation(ctx, cfg, tCtx, `{}`, input)
+			resp := mw.wrapDefaultStreamableTruncation(ctx, cfg, tCtx, `{}`, stringStreamWithError(
+				[]string{"abc", "defghijklmnop", "tail"},
+				wantErr,
+			))
+			defer resp.Close()
 
-			closed := sendStreamChunk(t, inputW, "abc")
-			assert.False(t, closed)
 			got, err := resp.Recv()
 			assert.NoError(t, err)
 			assert.Equal(t, "abc", got)
 
-			resp.Close()
-			closed = sendStreamChunk(t, inputW, strings.Repeat("x", 20))
-			inputW.Close()
-
-			assert.False(t, closed)
-		})
-
-		t.Run("stops when consumer closes before notice", func(t *testing.T) {
-			cfg := &ToolReductionConfig{Backend: backend}
-			input, inputW := schema.Pipe[string](0)
-			resp := mw.wrapDefaultStreamableTruncation(ctx, cfg, tCtx, `{}`, input)
-
-			closed := sendStreamChunk(t, inputW, strings.Repeat("x", 10))
-			assert.False(t, closed)
-			got, err := resp.Recv()
+			replayed, err := resp.Recv()
 			assert.NoError(t, err)
-			assert.Equal(t, strings.Repeat("x", 10), got)
-
-			resp.Close()
-			closed = sendStreamChunk(t, inputW, "overflow")
-			inputW.Close()
-
-			assert.False(t, closed)
+			assert.Equal(t, "defghijklmnoptail", replayed)
+			_, err = resp.Recv()
+			assert.Equal(t, wantErr, err)
 		})
 	})
 
@@ -635,7 +588,7 @@ hello worldhello worldhello worldhello worldhello worldhello worldhello worldhel
 			assert.Equal(t, wantErr, err)
 		})
 
-		t.Run("concat error is forwarded", func(t *testing.T) {
+		t.Run("conflicting media parts do not prevent truncation notice", func(t *testing.T) {
 			audioA := "YXVkaW8x"
 			audioB := "YXVkaW8y"
 			cfg := &ToolReductionConfig{Backend: backend}
@@ -653,15 +606,12 @@ hello worldhello worldhello worldhello worldhello worldhello worldhello worldhel
 			got, err := resp.Recv()
 			assert.NoError(t, err)
 			assert.Equal(t, strings.Repeat("x", 10), got.Parts[0].Text)
-			notice, err := resp.Recv()
-			assert.NoError(t, err)
-			assert.Contains(t, notice.Parts[0].Text, "Output truncated after 10 bytes were streamed")
+			assert.Contains(t, stringifyToolOutputParts(got.Parts), "Output truncated after 10 bytes were streamed")
 			_, err = resp.Recv()
-			assert.Error(t, err)
-			assert.Contains(t, err.Error(), "conflicting")
+			assert.Equal(t, io.EOF, err)
 		})
 
-		t.Run("concat error before notice is forwarded", func(t *testing.T) {
+		t.Run("conflicting media parts after forwarded chunk do not prevent truncation notice", func(t *testing.T) {
 			audioA := "YXVkaW8x"
 			audioB := "YXVkaW8y"
 			cfg := &ToolReductionConfig{Backend: backend}
@@ -680,15 +630,15 @@ hello worldhello worldhello worldhello worldhello worldhello worldhello worldhel
 			got, err := resp.Recv()
 			assert.NoError(t, err)
 			assert.Equal(t, "ok", got.Parts[0].Text)
-			prefix, err := resp.Recv()
+			notice, err := resp.Recv()
 			assert.NoError(t, err)
-			assert.Equal(t, strings.Repeat("x", 8), prefix.Parts[0].Text)
+			assert.Equal(t, strings.Repeat("x", 8), notice.Parts[0].Text)
+			assert.Contains(t, stringifyToolOutputParts(notice.Parts), "Output truncated after 10 bytes were streamed")
 			_, err = resp.Recv()
-			assert.Error(t, err)
-			assert.Contains(t, err.Error(), "conflicting")
+			assert.Equal(t, io.EOF, err)
 		})
 
-		t.Run("path generation error is forwarded", func(t *testing.T) {
+		t.Run("path generation error is rendered in truncation notice", func(t *testing.T) {
 			wantErr := errors.New("enhanced path generation error")
 			mwWithPathErr := &typedToolReductionMiddleware[*schema.Message]{
 				config: &TypedConfig[*schema.Message]{
@@ -705,11 +655,13 @@ hello worldhello worldhello worldhello worldhello worldhello worldhello worldhel
 			got, err := resp.Recv()
 			assert.NoError(t, err)
 			assert.Equal(t, strings.Repeat("x", 10), got.Parts[0].Text)
+			assert.Contains(t, stringifyToolOutputParts(got.Parts), "Output truncated after 10 bytes were streamed")
+			assert.Contains(t, stringifyToolOutputParts(got.Parts), "Failed to save full output: enhanced path generation error.")
 			_, err = resp.Recv()
-			assert.Equal(t, wantErr, err)
+			assert.Equal(t, io.EOF, err)
 		})
 
-		t.Run("missing backend error is forwarded", func(t *testing.T) {
+		t.Run("missing backend error is rendered in truncation notice", func(t *testing.T) {
 			cfg := &ToolReductionConfig{}
 			resp := mw.wrapDefaultEnhancedStreamableTruncation(ctx, cfg, tCtx, toolArg, toolResultStream(longResult))
 			defer resp.Close()
@@ -717,11 +669,13 @@ hello worldhello worldhello worldhello worldhello worldhello worldhello worldhel
 			got, err := resp.Recv()
 			assert.NoError(t, err)
 			assert.Equal(t, strings.Repeat("x", 10), got.Parts[0].Text)
+			assert.Contains(t, stringifyToolOutputParts(got.Parts), "Output truncated after 10 bytes were streamed")
+			assert.Contains(t, stringifyToolOutputParts(got.Parts), "Failed to save full output: truncation: no backend for offload.")
 			_, err = resp.Recv()
-			assert.EqualError(t, err, "truncation: no backend for offload")
+			assert.Equal(t, io.EOF, err)
 		})
 
-		t.Run("truncates incrementally and writes full output", func(t *testing.T) {
+		t.Run("truncates on source EOF and writes full output", func(t *testing.T) {
 			cfg := &ToolReductionConfig{Backend: backend}
 			resp := mw.wrapDefaultEnhancedStreamableTruncation(ctx, cfg, tCtx, toolArg, toolResultStream(
 				longResult,
@@ -732,20 +686,21 @@ hello worldhello worldhello worldhello worldhello worldhello worldhello worldhel
 			got, err := resp.Recv()
 			assert.NoError(t, err)
 			assert.Equal(t, strings.Repeat("x", 10), got.Parts[0].Text)
-			notice, err := resp.Recv()
-			assert.NoError(t, err)
-			assert.Contains(t, notice.Parts[0].Text, "Output truncated after 10 bytes were streamed")
-			assert.NotContains(t, notice.Parts[0].Text, "Preview (first")
-			assert.NotContains(t, notice.Parts[0].Text, "Preview (last")
+			gotText := stringifyToolOutputParts(got.Parts)
+			assert.Contains(t, gotText, "Output truncated after 10 bytes were streamed")
+			assert.Contains(t, gotText, "Full output saved to: /tmp/trunc/enhanced_stream_branches.")
+			assert.NotContains(t, gotText, "Preview (first")
+			assert.NotContains(t, gotText, "Preview (last")
 			_, err = resp.Recv()
 			assert.Equal(t, io.EOF, err)
 
 			content, err := backend.Read(ctx, &filesystem.ReadRequest{FilePath: "/tmp/trunc/enhanced_stream_branches"})
 			assert.NoError(t, err)
-			assert.Equal(t, strings.Repeat("x", 20)+"tail", content.Content)
+			assert.Contains(t, content.Content, fmt.Sprintf(`"text": "%s"`, strings.Repeat("x", 20)))
+			assert.Contains(t, content.Content, `"text": "tail"`)
 		})
 
-		t.Run("write error is forwarded after source EOF", func(t *testing.T) {
+		t.Run("write error is rendered in truncation notice after source EOF", func(t *testing.T) {
 			wantErr := errors.New("enhanced write error")
 			cfg := &ToolReductionConfig{
 				Backend: &writeFailBackend{
@@ -759,59 +714,35 @@ hello worldhello worldhello worldhello worldhello worldhello worldhello worldhel
 			got, err := resp.Recv()
 			assert.NoError(t, err)
 			assert.Equal(t, strings.Repeat("x", 10), got.Parts[0].Text)
-			notice, err := resp.Recv()
-			assert.NoError(t, err)
-			assert.Contains(t, notice.Parts[0].Text, "Output truncated after 10 bytes were streamed")
+			assert.Contains(t, stringifyToolOutputParts(got.Parts), "Output truncated after 10 bytes were streamed")
+			assert.Contains(t, stringifyToolOutputParts(got.Parts), "Failed to save full output: enhanced write error.")
 			_, err = resp.Recv()
-			assert.Equal(t, wantErr, err)
+			assert.Equal(t, io.EOF, err)
 		})
 
-		t.Run("stops when consumer closes before short chunk", func(t *testing.T) {
-			cfg := &ToolReductionConfig{}
-			input, inputW := schema.Pipe[*schema.ToolResult](0)
-			resp := mw.wrapDefaultEnhancedStreamableTruncation(ctx, cfg, tCtx, toolArg, input)
-
-			resp.Close()
-			closed := sendStreamChunk(t, inputW, &schema.ToolResult{Parts: []schema.ToolOutputPart{{Type: schema.ToolPartTypeText, Text: "short"}}})
-			inputW.Close()
-
-			assert.False(t, closed)
-		})
-
-		t.Run("stops when consumer closes before prefix", func(t *testing.T) {
+		t.Run("source error after truncation replays swallowed chunks before error", func(t *testing.T) {
+			wantErr := errors.New("enhanced source stream error after truncation")
 			cfg := &ToolReductionConfig{Backend: backend}
-			input, inputW := schema.Pipe[*schema.ToolResult](0)
-			resp := mw.wrapDefaultEnhancedStreamableTruncation(ctx, cfg, tCtx, toolArg, input)
+			resp := mw.wrapDefaultEnhancedStreamableTruncation(ctx, cfg, tCtx, toolArg, toolResultStreamWithError(
+				[]*schema.ToolResult{
+					{Parts: []schema.ToolOutputPart{{Type: schema.ToolPartTypeText, Text: "abc"}}},
+					{Parts: []schema.ToolOutputPart{{Type: schema.ToolPartTypeText, Text: "defghijklmnop"}}},
+					{Parts: []schema.ToolOutputPart{{Type: schema.ToolPartTypeText, Text: "tail"}}},
+				},
+				wantErr,
+			))
+			defer resp.Close()
 
-			closed := sendStreamChunk(t, inputW, &schema.ToolResult{Parts: []schema.ToolOutputPart{{Type: schema.ToolPartTypeText, Text: "abc"}}})
-			assert.False(t, closed)
 			got, err := resp.Recv()
 			assert.NoError(t, err)
 			assert.Equal(t, "abc", got.Parts[0].Text)
 
-			resp.Close()
-			closed = sendStreamChunk(t, inputW, longResult)
-			inputW.Close()
-
-			assert.False(t, closed)
-		})
-
-		t.Run("stops when consumer closes before notice", func(t *testing.T) {
-			cfg := &ToolReductionConfig{Backend: backend}
-			input, inputW := schema.Pipe[*schema.ToolResult](0)
-			resp := mw.wrapDefaultEnhancedStreamableTruncation(ctx, cfg, tCtx, toolArg, input)
-
-			closed := sendStreamChunk(t, inputW, &schema.ToolResult{Parts: []schema.ToolOutputPart{{Type: schema.ToolPartTypeText, Text: strings.Repeat("x", 10)}}})
-			assert.False(t, closed)
-			got, err := resp.Recv()
+			replayed, err := resp.Recv()
 			assert.NoError(t, err)
-			assert.Equal(t, strings.Repeat("x", 10), got.Parts[0].Text)
-
-			resp.Close()
-			closed = sendStreamChunk(t, inputW, &schema.ToolResult{Parts: []schema.ToolOutputPart{{Type: schema.ToolPartTypeText, Text: "overflow"}}})
-			inputW.Close()
-
-			assert.False(t, closed)
+			assert.Equal(t, "defghijklmnop", replayed.Parts[0].Text)
+			assert.Equal(t, "tail", replayed.Parts[1].Text)
+			_, err = resp.Recv()
+			assert.Equal(t, wantErr, err)
 		})
 	})
 

--- a/adk/middlewares/reduction/reduction_test.go
+++ b/adk/middlewares/reduction/reduction_test.go
@@ -103,6 +103,32 @@ func toolResultStreamWithError(chunks []*schema.ToolResult, err error) *schema.S
 	return sr
 }
 
+func sendStreamChunk[T any](t *testing.T, sw *schema.StreamWriter[T], chunk T) bool {
+	t.Helper()
+
+	done := make(chan bool, 1)
+	go func() {
+		done <- sw.Send(chunk, nil)
+	}()
+
+	select {
+	case closed := <-done:
+		return closed
+	case <-time.After(2 * time.Second):
+		t.Fatal("timed out sending stream chunk")
+		return true
+	}
+}
+
+type writeFailBackend struct {
+	filesystem.Backend
+	err error
+}
+
+func (b *writeFailBackend) Write(context.Context, *filesystem.WriteRequest) error {
+	return b.err
+}
+
 func TestReductionMiddlewareTrunc(t *testing.T) {
 	ctx := context.Background()
 	it := mockInvokableTool()
@@ -478,7 +504,7 @@ hello worldhello worldhello worldhello worldhello worldhello worldhello worldhel
 
 		t.Run("truncates incrementally and writes full output", func(t *testing.T) {
 			cfg := &ToolReductionConfig{Backend: backend}
-			resp := mw.wrapDefaultStreamableTruncation(ctx, cfg, tCtx, `{}`, stringStream(strings.Repeat("x", 20)))
+			resp := mw.wrapDefaultStreamableTruncation(ctx, cfg, tCtx, `{}`, stringStream(strings.Repeat("x", 20), "tail"))
 			defer resp.Close()
 
 			got, err := resp.Recv()
@@ -494,7 +520,76 @@ hello worldhello worldhello worldhello worldhello worldhello worldhello worldhel
 
 			content, err := backend.Read(ctx, &filesystem.ReadRequest{FilePath: "/tmp/trunc/stream_branches"})
 			assert.NoError(t, err)
-			assert.Equal(t, strings.Repeat("x", 20), content.Content)
+			assert.Equal(t, strings.Repeat("x", 20)+"tail", content.Content)
+		})
+
+		t.Run("write error is forwarded after source EOF", func(t *testing.T) {
+			wantErr := errors.New("stream write error")
+			cfg := &ToolReductionConfig{
+				Backend: &writeFailBackend{
+					Backend: filesystem.NewInMemoryBackend(),
+					err:     wantErr,
+				},
+			}
+			resp := mw.wrapDefaultStreamableTruncation(ctx, cfg, tCtx, `{}`, stringStream(strings.Repeat("x", 20)))
+			defer resp.Close()
+
+			got, err := resp.Recv()
+			assert.NoError(t, err)
+			assert.Equal(t, strings.Repeat("x", 10), got)
+			notice, err := resp.Recv()
+			assert.NoError(t, err)
+			assert.Contains(t, notice, "Output truncated after 10 bytes were streamed")
+			_, err = resp.Recv()
+			assert.Equal(t, wantErr, err)
+		})
+
+		t.Run("stops when consumer closes before short chunk", func(t *testing.T) {
+			cfg := &ToolReductionConfig{}
+			input, inputW := schema.Pipe[string](0)
+			resp := mw.wrapDefaultStreamableTruncation(ctx, cfg, tCtx, `{}`, input)
+
+			resp.Close()
+			closed := sendStreamChunk(t, inputW, "short")
+			inputW.Close()
+
+			assert.False(t, closed)
+		})
+
+		t.Run("stops when consumer closes before prefix", func(t *testing.T) {
+			cfg := &ToolReductionConfig{Backend: backend}
+			input, inputW := schema.Pipe[string](0)
+			resp := mw.wrapDefaultStreamableTruncation(ctx, cfg, tCtx, `{}`, input)
+
+			closed := sendStreamChunk(t, inputW, "abc")
+			assert.False(t, closed)
+			got, err := resp.Recv()
+			assert.NoError(t, err)
+			assert.Equal(t, "abc", got)
+
+			resp.Close()
+			closed = sendStreamChunk(t, inputW, strings.Repeat("x", 20))
+			inputW.Close()
+
+			assert.False(t, closed)
+		})
+
+		t.Run("stops when consumer closes before notice", func(t *testing.T) {
+			cfg := &ToolReductionConfig{Backend: backend}
+			input, inputW := schema.Pipe[string](0)
+			resp := mw.wrapDefaultStreamableTruncation(ctx, cfg, tCtx, `{}`, input)
+
+			closed := sendStreamChunk(t, inputW, strings.Repeat("x", 10))
+			assert.False(t, closed)
+			got, err := resp.Recv()
+			assert.NoError(t, err)
+			assert.Equal(t, strings.Repeat("x", 10), got)
+
+			resp.Close()
+			closed = sendStreamChunk(t, inputW, "overflow")
+			inputW.Close()
+
+			assert.False(t, closed)
 		})
 	})
 
@@ -566,6 +661,33 @@ hello worldhello worldhello worldhello worldhello worldhello worldhello worldhel
 			assert.Contains(t, err.Error(), "conflicting")
 		})
 
+		t.Run("concat error before notice is forwarded", func(t *testing.T) {
+			audioA := "YXVkaW8x"
+			audioB := "YXVkaW8y"
+			cfg := &ToolReductionConfig{Backend: backend}
+			resp := mw.wrapDefaultEnhancedStreamableTruncation(ctx, cfg, tCtx, toolArg, toolResultStream(
+				&schema.ToolResult{Parts: []schema.ToolOutputPart{
+					{Type: schema.ToolPartTypeText, Text: "ok"},
+					{Type: schema.ToolPartTypeAudio, Audio: &schema.ToolOutputAudio{MessagePartCommon: schema.MessagePartCommon{Base64Data: &audioA}}},
+				}},
+				&schema.ToolResult{Parts: []schema.ToolOutputPart{
+					{Type: schema.ToolPartTypeText, Text: strings.Repeat("x", 20)},
+					{Type: schema.ToolPartTypeAudio, Audio: &schema.ToolOutputAudio{MessagePartCommon: schema.MessagePartCommon{Base64Data: &audioB}}},
+				}},
+			))
+			defer resp.Close()
+
+			got, err := resp.Recv()
+			assert.NoError(t, err)
+			assert.Equal(t, "ok", got.Parts[0].Text)
+			prefix, err := resp.Recv()
+			assert.NoError(t, err)
+			assert.Equal(t, strings.Repeat("x", 8), prefix.Parts[0].Text)
+			_, err = resp.Recv()
+			assert.Error(t, err)
+			assert.Contains(t, err.Error(), "conflicting")
+		})
+
 		t.Run("path generation error is forwarded", func(t *testing.T) {
 			wantErr := errors.New("enhanced path generation error")
 			mwWithPathErr := &typedToolReductionMiddleware[*schema.Message]{
@@ -601,7 +723,10 @@ hello worldhello worldhello worldhello worldhello worldhello worldhello worldhel
 
 		t.Run("truncates incrementally and writes full output", func(t *testing.T) {
 			cfg := &ToolReductionConfig{Backend: backend}
-			resp := mw.wrapDefaultEnhancedStreamableTruncation(ctx, cfg, tCtx, toolArg, toolResultStream(longResult))
+			resp := mw.wrapDefaultEnhancedStreamableTruncation(ctx, cfg, tCtx, toolArg, toolResultStream(
+				longResult,
+				&schema.ToolResult{Parts: []schema.ToolOutputPart{{Type: schema.ToolPartTypeText, Text: "tail"}}},
+			))
 			defer resp.Close()
 
 			got, err := resp.Recv()
@@ -617,7 +742,76 @@ hello worldhello worldhello worldhello worldhello worldhello worldhello worldhel
 
 			content, err := backend.Read(ctx, &filesystem.ReadRequest{FilePath: "/tmp/trunc/enhanced_stream_branches"})
 			assert.NoError(t, err)
-			assert.Equal(t, strings.Repeat("x", 20), content.Content)
+			assert.Equal(t, strings.Repeat("x", 20)+"tail", content.Content)
+		})
+
+		t.Run("write error is forwarded after source EOF", func(t *testing.T) {
+			wantErr := errors.New("enhanced write error")
+			cfg := &ToolReductionConfig{
+				Backend: &writeFailBackend{
+					Backend: filesystem.NewInMemoryBackend(),
+					err:     wantErr,
+				},
+			}
+			resp := mw.wrapDefaultEnhancedStreamableTruncation(ctx, cfg, tCtx, toolArg, toolResultStream(longResult))
+			defer resp.Close()
+
+			got, err := resp.Recv()
+			assert.NoError(t, err)
+			assert.Equal(t, strings.Repeat("x", 10), got.Parts[0].Text)
+			notice, err := resp.Recv()
+			assert.NoError(t, err)
+			assert.Contains(t, notice.Parts[0].Text, "Output truncated after 10 bytes were streamed")
+			_, err = resp.Recv()
+			assert.Equal(t, wantErr, err)
+		})
+
+		t.Run("stops when consumer closes before short chunk", func(t *testing.T) {
+			cfg := &ToolReductionConfig{}
+			input, inputW := schema.Pipe[*schema.ToolResult](0)
+			resp := mw.wrapDefaultEnhancedStreamableTruncation(ctx, cfg, tCtx, toolArg, input)
+
+			resp.Close()
+			closed := sendStreamChunk(t, inputW, &schema.ToolResult{Parts: []schema.ToolOutputPart{{Type: schema.ToolPartTypeText, Text: "short"}}})
+			inputW.Close()
+
+			assert.False(t, closed)
+		})
+
+		t.Run("stops when consumer closes before prefix", func(t *testing.T) {
+			cfg := &ToolReductionConfig{Backend: backend}
+			input, inputW := schema.Pipe[*schema.ToolResult](0)
+			resp := mw.wrapDefaultEnhancedStreamableTruncation(ctx, cfg, tCtx, toolArg, input)
+
+			closed := sendStreamChunk(t, inputW, &schema.ToolResult{Parts: []schema.ToolOutputPart{{Type: schema.ToolPartTypeText, Text: "abc"}}})
+			assert.False(t, closed)
+			got, err := resp.Recv()
+			assert.NoError(t, err)
+			assert.Equal(t, "abc", got.Parts[0].Text)
+
+			resp.Close()
+			closed = sendStreamChunk(t, inputW, longResult)
+			inputW.Close()
+
+			assert.False(t, closed)
+		})
+
+		t.Run("stops when consumer closes before notice", func(t *testing.T) {
+			cfg := &ToolReductionConfig{Backend: backend}
+			input, inputW := schema.Pipe[*schema.ToolResult](0)
+			resp := mw.wrapDefaultEnhancedStreamableTruncation(ctx, cfg, tCtx, toolArg, input)
+
+			closed := sendStreamChunk(t, inputW, &schema.ToolResult{Parts: []schema.ToolOutputPart{{Type: schema.ToolPartTypeText, Text: strings.Repeat("x", 10)}}})
+			assert.False(t, closed)
+			got, err := resp.Recv()
+			assert.NoError(t, err)
+			assert.Equal(t, strings.Repeat("x", 10), got.Parts[0].Text)
+
+			resp.Close()
+			closed = sendStreamChunk(t, inputW, &schema.ToolResult{Parts: []schema.ToolOutputPart{{Type: schema.ToolPartTypeText, Text: "overflow"}}})
+			inputW.Close()
+
+			assert.False(t, closed)
 		})
 	})
 

--- a/adk/middlewares/reduction/reduction_test.go
+++ b/adk/middlewares/reduction/reduction_test.go
@@ -24,6 +24,7 @@ import (
 	"io"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 
@@ -52,6 +53,54 @@ func testClearOffloadPath(root string) func(context.Context, *ToolDetail) (strin
 		}
 		return fmt.Sprintf("%s/clear/%s", root, callID), nil
 	}
+}
+
+func stringStream(chunks ...string) *schema.StreamReader[string] {
+	sr, sw := schema.Pipe[string](len(chunks))
+	go func() {
+		defer sw.Close()
+		for _, chunk := range chunks {
+			sw.Send(chunk, nil)
+		}
+	}()
+	return sr
+}
+
+func stringStreamWithError(chunks []string, err error) *schema.StreamReader[string] {
+	sr, sw := schema.Pipe[string](len(chunks) + 1)
+	go func() {
+		defer sw.Close()
+		for _, chunk := range chunks {
+			sw.Send(chunk, nil)
+		}
+		var zero string
+		sw.Send(zero, err)
+	}()
+	return sr
+}
+
+func toolResultStream(chunks ...*schema.ToolResult) *schema.StreamReader[*schema.ToolResult] {
+	sr, sw := schema.Pipe[*schema.ToolResult](len(chunks))
+	go func() {
+		defer sw.Close()
+		for _, chunk := range chunks {
+			sw.Send(chunk, nil)
+		}
+	}()
+	return sr
+}
+
+func toolResultStreamWithError(chunks []*schema.ToolResult, err error) *schema.StreamReader[*schema.ToolResult] {
+	sr, sw := schema.Pipe[*schema.ToolResult](len(chunks) + 1)
+	go func() {
+		defer sw.Close()
+		for _, chunk := range chunks {
+			sw.Send(chunk, nil)
+		}
+		var zero *schema.ToolResult
+		sw.Send(zero, err)
+	}()
+	return sr
 }
 
 func TestReductionMiddlewareTrunc(t *testing.T) {
@@ -125,6 +174,451 @@ hello worldhello worldhello worldhello worldhello worldhello worldhello worldhel
 		expOrigContent := `hello worldhello worldhello worldhello worldhello worldhello worldhello worldhello worldhello worldhello world
 hello worldhello worldhello worldhello worldhello worldhello worldhello worldhello world`
 		assert.Equal(t, expOrigContent, content.Content)
+	})
+
+	t.Run("test streamable default truncation is nonblocking before source EOF", func(t *testing.T) {
+		tCtx := &adk.ToolContext{
+			Name:   "mock_streamable_tool",
+			CallID: "stream_nonblocking",
+		}
+		backend := filesystem.NewInMemoryBackend()
+		config := &Config{
+			Backend:           backend,
+			MaxLengthForTrunc: 30,
+		}
+		mw, err := New(ctx, config)
+		assert.NoError(t, err)
+
+		releaseOverflow := make(chan struct{})
+		releaseEOF := make(chan struct{})
+		endpoint := func(_ context.Context, _ string, _ ...tool.Option) (*schema.StreamReader[string], error) {
+			sr, sw := schema.Pipe[string](0)
+			go func() {
+				sw.Send("first chunk", nil)
+				<-releaseOverflow
+				sw.Send(strings.Repeat("x", 80), nil)
+				<-releaseEOF
+				sw.Close()
+			}()
+			return sr, nil
+		}
+
+		edp, err := mw.WrapStreamableToolCall(ctx, endpoint, tCtx)
+		assert.NoError(t, err)
+
+		respCh := make(chan *schema.StreamReader[string], 1)
+		errCh := make(chan error, 1)
+		go func() {
+			resp, runErr := edp(ctx, `{"value":"asd"}`)
+			if runErr != nil {
+				errCh <- runErr
+				return
+			}
+			respCh <- resp
+		}()
+
+		var resp *schema.StreamReader[string]
+		select {
+		case runErr := <-errCh:
+			close(releaseEOF)
+			assert.NoError(t, runErr)
+			return
+		case resp = <-respCh:
+		case <-time.After(2 * time.Second):
+			close(releaseEOF)
+			assert.Fail(t, "streamable truncation wrapper blocked until source EOF")
+			return
+		}
+		defer resp.Close()
+
+		first, err := resp.Recv()
+		assert.NoError(t, err)
+		assert.Equal(t, "first chunk", first)
+
+		close(releaseOverflow)
+		var remaining strings.Builder
+		noticeCh := make(chan string, 1)
+		noticeErrCh := make(chan error, 1)
+		go func() {
+			for {
+				chunk, recvErr := resp.Recv()
+				if recvErr != nil {
+					noticeErrCh <- recvErr
+					return
+				}
+				remaining.WriteString(chunk)
+				if strings.Contains(remaining.String(), "persisted-output") {
+					noticeCh <- remaining.String()
+					return
+				}
+			}
+		}()
+
+		select {
+		case got := <-noticeCh:
+			assert.Contains(t, got, "Output truncated after")
+			assert.NotContains(t, got, "Preview (first")
+			assert.NotContains(t, got, "Preview (last")
+		case recvErr := <-noticeErrCh:
+			close(releaseEOF)
+			assert.NoError(t, recvErr)
+			return
+		case <-time.After(2 * time.Second):
+			close(releaseEOF)
+			assert.Fail(t, "streamable truncation notice blocked until source EOF")
+			return
+		}
+
+		close(releaseEOF)
+		for {
+			chunk, recvErr := resp.Recv()
+			if recvErr != nil {
+				if recvErr == io.EOF {
+					break
+				}
+				assert.NoError(t, recvErr)
+				return
+			}
+			remaining.WriteString(chunk)
+		}
+		assert.Contains(t, remaining.String(), "persisted-output")
+
+		content, err := backend.Read(ctx, &filesystem.ReadRequest{FilePath: "/tmp/trunc/stream_nonblocking"})
+		assert.NoError(t, err)
+		assert.Equal(t, "first chunk"+strings.Repeat("x", 80), content.Content)
+	})
+
+	t.Run("test enhanced streamable default truncation is nonblocking before source EOF", func(t *testing.T) {
+		tCtx := &adk.ToolContext{
+			Name:   "mock_enhanced_streamable_tool",
+			CallID: "enhanced_stream_nonblocking",
+		}
+		backend := filesystem.NewInMemoryBackend()
+		config := &Config{
+			Backend:           backend,
+			MaxLengthForTrunc: 30,
+		}
+		mw, err := New(ctx, config)
+		assert.NoError(t, err)
+
+		releaseOverflow := make(chan struct{})
+		releaseEOF := make(chan struct{})
+		endpoint := func(_ context.Context, _ *schema.ToolArgument, _ ...tool.Option) (*schema.StreamReader[*schema.ToolResult], error) {
+			sr, sw := schema.Pipe[*schema.ToolResult](0)
+			go func() {
+				sw.Send(&schema.ToolResult{Parts: []schema.ToolOutputPart{{Type: schema.ToolPartTypeText, Text: "first chunk"}}}, nil)
+				<-releaseOverflow
+				sw.Send(&schema.ToolResult{Parts: []schema.ToolOutputPart{{Type: schema.ToolPartTypeText, Text: strings.Repeat("x", 80)}}}, nil)
+				<-releaseEOF
+				sw.Close()
+			}()
+			return sr, nil
+		}
+
+		edp, err := mw.WrapEnhancedStreamableToolCall(ctx, endpoint, tCtx)
+		assert.NoError(t, err)
+
+		respCh := make(chan *schema.StreamReader[*schema.ToolResult], 1)
+		errCh := make(chan error, 1)
+		go func() {
+			resp, runErr := edp(ctx, &schema.ToolArgument{Text: `{"value":"asd"}`})
+			if runErr != nil {
+				errCh <- runErr
+				return
+			}
+			respCh <- resp
+		}()
+
+		var resp *schema.StreamReader[*schema.ToolResult]
+		select {
+		case runErr := <-errCh:
+			close(releaseEOF)
+			assert.NoError(t, runErr)
+			return
+		case resp = <-respCh:
+		case <-time.After(2 * time.Second):
+			close(releaseEOF)
+			assert.Fail(t, "enhanced streamable truncation wrapper blocked until source EOF")
+			return
+		}
+		defer resp.Close()
+
+		first, err := resp.Recv()
+		assert.NoError(t, err)
+		assert.Equal(t, "first chunk", first.Parts[0].Text)
+
+		close(releaseOverflow)
+		var remaining strings.Builder
+		noticeCh := make(chan string, 1)
+		noticeErrCh := make(chan error, 1)
+		go func() {
+			for {
+				chunk, recvErr := resp.Recv()
+				if recvErr != nil {
+					noticeErrCh <- recvErr
+					return
+				}
+				for _, part := range chunk.Parts {
+					if part.Type == schema.ToolPartTypeText {
+						remaining.WriteString(part.Text)
+					}
+				}
+				if strings.Contains(remaining.String(), "persisted-output") {
+					noticeCh <- remaining.String()
+					return
+				}
+			}
+		}()
+
+		select {
+		case got := <-noticeCh:
+			assert.Contains(t, got, "Output truncated after")
+			assert.NotContains(t, got, "Preview (first")
+			assert.NotContains(t, got, "Preview (last")
+		case recvErr := <-noticeErrCh:
+			close(releaseEOF)
+			assert.NoError(t, recvErr)
+			return
+		case <-time.After(2 * time.Second):
+			close(releaseEOF)
+			assert.Fail(t, "enhanced streamable truncation notice blocked until source EOF")
+			return
+		}
+
+		close(releaseEOF)
+		for {
+			chunk, recvErr := resp.Recv()
+			if recvErr != nil {
+				if recvErr == io.EOF {
+					break
+				}
+				assert.NoError(t, recvErr)
+				return
+			}
+			for _, part := range chunk.Parts {
+				if part.Type == schema.ToolPartTypeText {
+					remaining.WriteString(part.Text)
+				}
+			}
+		}
+		assert.Contains(t, remaining.String(), "persisted-output")
+
+		content, err := backend.Read(ctx, &filesystem.ReadRequest{FilePath: "/tmp/trunc/enhanced_stream_nonblocking"})
+		assert.NoError(t, err)
+		assert.Equal(t, "first chunk"+strings.Repeat("x", 80), content.Content)
+	})
+
+	t.Run("test default streamable truncation terminal cases", func(t *testing.T) {
+		tCtx := &adk.ToolContext{Name: "mock_streamable_tool", CallID: "stream_branches"}
+		backend := filesystem.NewInMemoryBackend()
+		mw := &typedToolReductionMiddleware[*schema.Message]{
+			config: &TypedConfig[*schema.Message]{
+				MaxLengthForTrunc:       10,
+				GenTruncOffloadFilePath: testTruncOffloadPath("/tmp"),
+			},
+		}
+
+		t.Run("short output forwards and does not truncate", func(t *testing.T) {
+			cfg := &ToolReductionConfig{}
+			resp := mw.wrapDefaultStreamableTruncation(ctx, cfg, tCtx, `{}`, stringStream("short"))
+			defer resp.Close()
+
+			got, err := resp.Recv()
+			assert.NoError(t, err)
+			assert.Equal(t, "short", got)
+			_, err = resp.Recv()
+			assert.Equal(t, io.EOF, err)
+		})
+
+		t.Run("source error is forwarded", func(t *testing.T) {
+			wantErr := errors.New("source stream error")
+			cfg := &ToolReductionConfig{}
+			resp := mw.wrapDefaultStreamableTruncation(ctx, cfg, tCtx, `{}`, stringStreamWithError([]string{"ok"}, wantErr))
+			defer resp.Close()
+
+			got, err := resp.Recv()
+			assert.NoError(t, err)
+			assert.Equal(t, "ok", got)
+			_, err = resp.Recv()
+			assert.Equal(t, wantErr, err)
+		})
+
+		t.Run("path generation error is forwarded", func(t *testing.T) {
+			wantErr := errors.New("path generation error")
+			mwWithPathErr := &typedToolReductionMiddleware[*schema.Message]{
+				config: &TypedConfig[*schema.Message]{
+					MaxLengthForTrunc: 10,
+					GenTruncOffloadFilePath: func(context.Context, *ToolDetail) (string, error) {
+						return "", wantErr
+					},
+				},
+			}
+			cfg := &ToolReductionConfig{Backend: backend}
+			resp := mwWithPathErr.wrapDefaultStreamableTruncation(ctx, cfg, tCtx, `{}`, stringStream(strings.Repeat("x", 20)))
+			defer resp.Close()
+
+			got, err := resp.Recv()
+			assert.NoError(t, err)
+			assert.Equal(t, strings.Repeat("x", 10), got)
+			_, err = resp.Recv()
+			assert.Equal(t, wantErr, err)
+		})
+
+		t.Run("missing backend error is forwarded", func(t *testing.T) {
+			cfg := &ToolReductionConfig{}
+			resp := mw.wrapDefaultStreamableTruncation(ctx, cfg, tCtx, `{}`, stringStream(strings.Repeat("x", 20)))
+			defer resp.Close()
+
+			got, err := resp.Recv()
+			assert.NoError(t, err)
+			assert.Equal(t, strings.Repeat("x", 10), got)
+			_, err = resp.Recv()
+			assert.EqualError(t, err, "truncation: no backend for offload")
+		})
+
+		t.Run("truncates incrementally and writes full output", func(t *testing.T) {
+			cfg := &ToolReductionConfig{Backend: backend}
+			resp := mw.wrapDefaultStreamableTruncation(ctx, cfg, tCtx, `{}`, stringStream(strings.Repeat("x", 20)))
+			defer resp.Close()
+
+			got, err := resp.Recv()
+			assert.NoError(t, err)
+			assert.Equal(t, strings.Repeat("x", 10), got)
+			notice, err := resp.Recv()
+			assert.NoError(t, err)
+			assert.Contains(t, notice, "Output truncated after 10 bytes were streamed")
+			assert.NotContains(t, notice, "Preview (first")
+			assert.NotContains(t, notice, "Preview (last")
+			_, err = resp.Recv()
+			assert.Equal(t, io.EOF, err)
+
+			content, err := backend.Read(ctx, &filesystem.ReadRequest{FilePath: "/tmp/trunc/stream_branches"})
+			assert.NoError(t, err)
+			assert.Equal(t, strings.Repeat("x", 20), content.Content)
+		})
+	})
+
+	t.Run("test default enhanced streamable truncation terminal cases", func(t *testing.T) {
+		tCtx := &adk.ToolContext{Name: "mock_enhanced_streamable_tool", CallID: "enhanced_stream_branches"}
+		toolArg := &schema.ToolArgument{Text: `{}`}
+		backend := filesystem.NewInMemoryBackend()
+		mw := &typedToolReductionMiddleware[*schema.Message]{
+			config: &TypedConfig[*schema.Message]{
+				MaxLengthForTrunc:       10,
+				GenTruncOffloadFilePath: testTruncOffloadPath("/tmp"),
+			},
+		}
+		longResult := &schema.ToolResult{Parts: []schema.ToolOutputPart{{Type: schema.ToolPartTypeText, Text: strings.Repeat("x", 20)}}}
+
+		t.Run("short output forwards and does not truncate", func(t *testing.T) {
+			cfg := &ToolReductionConfig{}
+			resp := mw.wrapDefaultEnhancedStreamableTruncation(ctx, cfg, tCtx, toolArg, toolResultStream(
+				&schema.ToolResult{Parts: []schema.ToolOutputPart{{Type: schema.ToolPartTypeText, Text: "short"}}},
+			))
+			defer resp.Close()
+
+			got, err := resp.Recv()
+			assert.NoError(t, err)
+			assert.Equal(t, "short", got.Parts[0].Text)
+			_, err = resp.Recv()
+			assert.Equal(t, io.EOF, err)
+		})
+
+		t.Run("source error is forwarded", func(t *testing.T) {
+			wantErr := errors.New("enhanced source stream error")
+			cfg := &ToolReductionConfig{}
+			resp := mw.wrapDefaultEnhancedStreamableTruncation(ctx, cfg, tCtx, toolArg, toolResultStreamWithError(
+				[]*schema.ToolResult{{Parts: []schema.ToolOutputPart{{Type: schema.ToolPartTypeText, Text: "ok"}}}},
+				wantErr,
+			))
+			defer resp.Close()
+
+			got, err := resp.Recv()
+			assert.NoError(t, err)
+			assert.Equal(t, "ok", got.Parts[0].Text)
+			_, err = resp.Recv()
+			assert.Equal(t, wantErr, err)
+		})
+
+		t.Run("concat error is forwarded", func(t *testing.T) {
+			audioA := "YXVkaW8x"
+			audioB := "YXVkaW8y"
+			cfg := &ToolReductionConfig{Backend: backend}
+			resp := mw.wrapDefaultEnhancedStreamableTruncation(ctx, cfg, tCtx, toolArg, toolResultStream(
+				&schema.ToolResult{Parts: []schema.ToolOutputPart{
+					{Type: schema.ToolPartTypeText, Text: strings.Repeat("x", 20)},
+					{Type: schema.ToolPartTypeAudio, Audio: &schema.ToolOutputAudio{MessagePartCommon: schema.MessagePartCommon{Base64Data: &audioA}}},
+				}},
+				&schema.ToolResult{Parts: []schema.ToolOutputPart{
+					{Type: schema.ToolPartTypeAudio, Audio: &schema.ToolOutputAudio{MessagePartCommon: schema.MessagePartCommon{Base64Data: &audioB}}},
+				}},
+			))
+			defer resp.Close()
+
+			got, err := resp.Recv()
+			assert.NoError(t, err)
+			assert.Equal(t, strings.Repeat("x", 10), got.Parts[0].Text)
+			notice, err := resp.Recv()
+			assert.NoError(t, err)
+			assert.Contains(t, notice.Parts[0].Text, "Output truncated after 10 bytes were streamed")
+			_, err = resp.Recv()
+			assert.Error(t, err)
+			assert.Contains(t, err.Error(), "conflicting")
+		})
+
+		t.Run("path generation error is forwarded", func(t *testing.T) {
+			wantErr := errors.New("enhanced path generation error")
+			mwWithPathErr := &typedToolReductionMiddleware[*schema.Message]{
+				config: &TypedConfig[*schema.Message]{
+					MaxLengthForTrunc: 10,
+					GenTruncOffloadFilePath: func(context.Context, *ToolDetail) (string, error) {
+						return "", wantErr
+					},
+				},
+			}
+			cfg := &ToolReductionConfig{Backend: backend}
+			resp := mwWithPathErr.wrapDefaultEnhancedStreamableTruncation(ctx, cfg, tCtx, toolArg, toolResultStream(longResult))
+			defer resp.Close()
+
+			got, err := resp.Recv()
+			assert.NoError(t, err)
+			assert.Equal(t, strings.Repeat("x", 10), got.Parts[0].Text)
+			_, err = resp.Recv()
+			assert.Equal(t, wantErr, err)
+		})
+
+		t.Run("missing backend error is forwarded", func(t *testing.T) {
+			cfg := &ToolReductionConfig{}
+			resp := mw.wrapDefaultEnhancedStreamableTruncation(ctx, cfg, tCtx, toolArg, toolResultStream(longResult))
+			defer resp.Close()
+
+			got, err := resp.Recv()
+			assert.NoError(t, err)
+			assert.Equal(t, strings.Repeat("x", 10), got.Parts[0].Text)
+			_, err = resp.Recv()
+			assert.EqualError(t, err, "truncation: no backend for offload")
+		})
+
+		t.Run("truncates incrementally and writes full output", func(t *testing.T) {
+			cfg := &ToolReductionConfig{Backend: backend}
+			resp := mw.wrapDefaultEnhancedStreamableTruncation(ctx, cfg, tCtx, toolArg, toolResultStream(longResult))
+			defer resp.Close()
+
+			got, err := resp.Recv()
+			assert.NoError(t, err)
+			assert.Equal(t, strings.Repeat("x", 10), got.Parts[0].Text)
+			notice, err := resp.Recv()
+			assert.NoError(t, err)
+			assert.Contains(t, notice.Parts[0].Text, "Output truncated after 10 bytes were streamed")
+			assert.NotContains(t, notice.Parts[0].Text, "Preview (first")
+			assert.NotContains(t, notice.Parts[0].Text, "Preview (last")
+			_, err = resp.Recv()
+			assert.Equal(t, io.EOF, err)
+
+			content, err := backend.Read(ctx, &filesystem.ReadRequest{FilePath: "/tmp/trunc/enhanced_stream_branches"})
+			assert.NoError(t, err)
+			assert.Equal(t, strings.Repeat("x", 20), content.Content)
+		})
 	})
 
 	t.Run("test streamable line and bypass error", func(t *testing.T) {
@@ -902,6 +1396,62 @@ func TestReductionMiddlewareClear(t *testing.T) {
 			FilePath: "/tmp/clear/call_987654321",
 		})
 		assert.NoError(t, err)
+	})
+}
+
+func TestStreamTruncationHelpers(t *testing.T) {
+	t.Run("toolResultTextPrefix trims text and preserves leading non-text parts", func(t *testing.T) {
+		assert.Nil(t, toolResultTextPrefix(nil, 10))
+		assert.Nil(t, toolResultTextPrefix(&schema.ToolResult{}, 10))
+		assert.Nil(t, toolResultTextPrefix(&schema.ToolResult{Parts: []schema.ToolOutputPart{
+			{Type: schema.ToolPartTypeText, Text: "abc"},
+		}}, 0))
+
+		got := toolResultTextPrefix(&schema.ToolResult{Parts: []schema.ToolOutputPart{
+			{Type: schema.ToolPartTypeImage},
+			{Type: schema.ToolPartTypeText, Text: "abc"},
+			{Type: schema.ToolPartTypeText, Text: "def"},
+		}}, 5)
+		assert.NotNil(t, got)
+		assert.Equal(t, []schema.ToolOutputPart{
+			{Type: schema.ToolPartTypeImage},
+			{Type: schema.ToolPartTypeText, Text: "abc"},
+			{Type: schema.ToolPartTypeText, Text: "de"},
+		}, got.Parts)
+
+		got = toolResultTextPrefix(&schema.ToolResult{Parts: []schema.ToolOutputPart{
+			{Type: schema.ToolPartTypeText, Text: "abc"},
+			{Type: schema.ToolPartTypeText, Text: "def"},
+		}}, 3)
+		assert.NotNil(t, got)
+		assert.Equal(t, []schema.ToolOutputPart{
+			{Type: schema.ToolPartTypeText, Text: "abc"},
+		}, got.Parts)
+	})
+
+	t.Run("toolResultTextLength handles nil result", func(t *testing.T) {
+		assert.Equal(t, 0, toolResultTextLength(nil))
+	})
+
+	t.Run("writeTruncOffload handles disabled missing and successful offload", func(t *testing.T) {
+		ctx := context.Background()
+
+		err := writeTruncOffload(ctx, &ToolReductionConfig{}, &TruncResult{NeedOffload: false})
+		assert.NoError(t, err)
+
+		err = writeTruncOffload(ctx, &ToolReductionConfig{}, &TruncResult{NeedOffload: true})
+		assert.EqualError(t, err, "truncation: no backend for offload")
+
+		backend := filesystem.NewInMemoryBackend()
+		err = writeTruncOffload(ctx, &ToolReductionConfig{Backend: backend}, &TruncResult{
+			NeedOffload:     true,
+			OffloadFilePath: "/tmp/trunc/helper",
+			OffloadContent:  "full output",
+		})
+		assert.NoError(t, err)
+		content, err := backend.Read(ctx, &filesystem.ReadRequest{FilePath: "/tmp/trunc/helper"})
+		assert.NoError(t, err)
+		assert.Equal(t, "full output", content.Content)
 	})
 }
 


### PR DESCRIPTION
## Summary
- use a default streaming-specific truncation notice with no tail preview, so default streaming truncation does not wait for EOF before notifying truncation
- forward chunks only until `MaxLengthForTrunc`, emit the notice once the threshold is crossed, then drain remaining output for offload without forwarding it
- keep non-streaming and tool-specific/custom `TruncHandler` behavior unchanged
- cover streamable/enhanced streamable nonblocking behavior plus default streaming terminal, error, drain, and consumer-close paths

Fixes #1064.

## Tests
- `go test ./adk/middlewares/reduction -run 'TestReductionMiddlewareTrunc/.*default.*streamable.*(terminal cases|nonblocking)' -count=1`
- `go test ./adk/middlewares/reduction -count=1`
- `go test ./adk/middlewares/reduction -coverprofile=/tmp/eino-reduction-after2.cover -covermode=count -count=1`
- local patch coverage estimate for `adk/middlewares/reduction/reduction.go`: 217/227 coverable added lines hit, about 95.59%
- wrapper coverage: `wrapDefaultStreamableTruncation` 94.4%, `wrapDefaultEnhancedStreamableTruncation` 95.5%
- `go test ./adk/... -count=1`
- `git diff --check`

Note: the latest fork workflow runs are currently waiting for maintainer approval (`action_required`), so Codecov has not recalculated for commit `95ac44d` yet.