### PR TITLE
chore: ensure that tool calls match tool results and correct comments

### DIFF
--- a/adk/middlewares/reduction/reduction.go
+++ b/adk/middlewares/reduction/reduction.go
@@ -641,7 +641,7 @@ func (t *typedToolReductionMiddleware[M]) beforeModelRewriteStateGeneric(ctx con
 		return ctx, state, err
 	}
 
-	if estimatedTokens <= t.config.MaxTokensForClear {
+	if estimatedTokens < t.config.MaxTokensForClear {
 		return ctx, state, nil
 	}
 

--- a/adk/middlewares/reduction/reduction.go
+++ b/adk/middlewares/reduction/reduction.go
@@ -97,15 +97,22 @@ type TypedConfig[M adk.MessageType] struct {
 
 	// TokenCounter is used to count the number of tokens in the conversation messages.
 	// It is used to determine when to trigger clearing based on token usage, and token usage after clearing.
-	// Required.
+	// Optional. If not provided, a default token counter will be used, which estimates tokens by counting 1 token per 4 characters.
 	TokenCounter func(ctx context.Context, msg []M, tools []*schema.ToolInfo) (int64, error)
 
 	// MaxTokensForClear is the maximum number of tokens allowed in the conversation before clearing is attempted.
 	// Required. Default is 160000.
 	MaxTokensForClear int64
 
-	// ClearRetentionSuffixLimit is the number of most recent messages to retain without clearing.
-	// This ensures the model has some immediate context.
+	// ClearRetentionSuffixLimit is the number of most recent tool-call rounds to retain without clearing.
+	// A round consists of one assistant message (which may contain multiple tool calls) and its corresponding tool-result messages.
+	// This ensures the model has immediate context to process pending tool results.
+	//
+	// Example with ClearRetentionSuffixLimit = 2, the retained suffix looks like:
+	//   Round 2: assistant [call_A, call_B] → result_A, result_B
+	//   Round 1: assistant [call_C] → result_C
+	// (Round 1 is the most recent, closest to the end of the message list.)
+	//
 	// Optional. Default is 1.
 	ClearRetentionSuffixLimit int
 
@@ -634,7 +641,7 @@ func (t *typedToolReductionMiddleware[M]) beforeModelRewriteStateGeneric(ctx con
 		return ctx, state, err
 	}
 
-	if estimatedTokens < t.config.MaxTokensForClear {
+	if estimatedTokens <= t.config.MaxTokensForClear {
 		return ctx, state, nil
 	}
 
@@ -681,16 +688,14 @@ func (t *typedToolReductionMiddleware[M]) beforeModelRewriteStateGeneric(ctx con
 		toolCallMsg := editTarget[toolCallMsgIndex]
 		toolCalls := getToolCallsGeneric(toolCallMsg)
 		if isAssistantMsg(toolCallMsg) && len(toolCalls) > 0 {
-			toolMsgIndex := toolCallMsgIndex
 			for _, tc := range toolCalls {
-				toolMsgIndex++
-				if toolMsgIndex >= end {
-					break
+				// Find the corresponding tool-result message by callID
+				resultMsgIndex, found := findToolResultByCallID(editTarget, toolCallMsgIndex+1, toolCallMsgIndex+1+len(toolCalls), tc.CallID)
+				if !found {
+					continue // No corresponding tool result found, skip
 				}
-				resultMsg := editTarget[toolMsgIndex]
-				if !isToolResultMsg(resultMsg) { // unexpected
-					break
-				}
+				resultMsg := editTarget[resultMsgIndex]
+
 				if _, found := t.excludeClearTools[tc.Name]; found {
 					continue
 				}
@@ -847,6 +852,51 @@ func (t *typedToolReductionMiddleware[M]) applyClearRewriteGeneric(ctx context.C
 	}
 
 	return editTarget, end, nil
+}
+
+func agenticResultCallID(block *schema.ContentBlock) (string, bool) {
+	if block == nil {
+		return "", false
+	}
+	if block.Type == schema.ContentBlockTypeFunctionToolResult && block.FunctionToolResult != nil {
+		return block.FunctionToolResult.CallID, true
+	}
+	if block.Type == schema.ContentBlockTypeToolSearchResult && block.ToolSearchFunctionToolResult != nil {
+		return block.ToolSearchFunctionToolResult.CallID, true
+	}
+	return "", false
+}
+
+func findToolResultByCallID[M adk.MessageType](messages []M, startIndex, endIndex int, callID string) (int, bool) {
+	for i := startIndex; i < endIndex; i++ {
+		msg := messages[i]
+		if isToolResultMsg(msg) {
+			if getToolResultCallID(msg) == callID {
+				return i, true
+			}
+		} else {
+			return -1, false
+		}
+	}
+	return -1, false
+}
+
+func getToolResultCallID[M adk.MessageType](msg M) string {
+	switch m := any(msg).(type) {
+	case *schema.Message:
+		if m.Role == schema.Tool {
+			return m.ToolCallID
+		}
+	case *schema.AgenticMessage:
+		if m.Role == schema.AgenticRoleTypeUser {
+			for _, block := range m.ContentBlocks {
+				if callID, ok := agenticResultCallID(block); ok {
+					return callID
+				}
+			}
+		}
+	}
+	return ""
 }
 
 type offloadStashItem struct {

--- a/adk/middlewares/reduction/reduction_generic_test.go
+++ b/adk/middlewares/reduction/reduction_generic_test.go
@@ -296,6 +296,49 @@ func testHelperFunctions[M adk.MessageType](t *testing.T) {
 		copiedTCs := getToolCallsGeneric(copied[0])
 		assert.Equal(t, `{"modified":"true"}`, copiedTCs[0].Arguments)
 	})
+
+	t.Run("getToolResultCallID", func(t *testing.T) {
+		// Tool result message with matching callID
+		tr := makeToolResultMsgG[M]("result content", "call_123", "my_tool")
+		assert.Equal(t, "call_123", getToolResultCallID(tr))
+
+		// Non-tool-result message should return empty string
+		user := makeUserMsgG[M]("hello")
+		assert.Equal(t, "", getToolResultCallID(user))
+	})
+
+	t.Run("findToolResultByCallID", func(t *testing.T) {
+		messages := []M{
+			makeAssistantMsgWithToolCallsG[M]([]testToolCall{
+				{ID: "call_1", Name: "tool1", Arguments: `{}`},
+			}),
+			makeToolResultMsgG[M]("result 1", "call_1", "tool1"),
+			makeToolResultMsgG[M]("result 2", "call_2", "tool2"),
+		}
+
+		// Find existing tool result
+		idx, found := findToolResultByCallID(messages, 1, 3, "call_2")
+		assert.True(t, found)
+		assert.Equal(t, 2, idx)
+
+		// Find non-existent tool result
+		idx, found = findToolResultByCallID(messages, 1, 3, "call_999")
+		assert.False(t, found)
+		assert.Equal(t, -1, idx)
+
+		// Stop searching when encountering a non-tool-result message
+		messages2 := []M{
+			makeAssistantMsgWithToolCallsG[M]([]testToolCall{
+				{ID: "call_3", Name: "tool3", Arguments: `{}`},
+			}),
+			makeToolResultMsgG[M]("result 3", "call_3", "tool3"),
+			makeUserMsgG[M]("not a tool result"),
+			makeToolResultMsgG[M]("result 4", "call_4", "tool4"),
+		}
+		idx, found = findToolResultByCallID(messages2, 1, 4, "call_4")
+		assert.False(t, found)
+		assert.Equal(t, -1, idx)
+	})
 }
 
 // ---------------------------------------------------------------------------

--- a/adk/middlewares/reduction/reduction_test.go
+++ b/adk/middlewares/reduction/reduction_test.go
@@ -353,7 +353,7 @@ func TestReductionMiddlewareClear(t *testing.T) {
 						Function: schema.FunctionCall{Name: "get_weather", Arguments: `{"location": "London, UK", "unit": "c"}`},
 					},
 				}),
-				schema.ToolMessage("Sunny", "call_123456789"),
+				schema.ToolMessage("Sunny", "call_987654321"),
 				schema.AssistantMessage("", []schema.ToolCall{
 					{
 						ID:       "call_123456789",
@@ -460,7 +460,7 @@ func TestReductionMiddlewareClear(t *testing.T) {
 						Function: schema.FunctionCall{Name: "get_weather", Arguments: `{"location": "London, UK", "unit": "c"}`},
 					},
 				}),
-				schema.ToolMessage("Sunny", "call_123456789"),
+				schema.ToolMessage("Sunny", "call_987654321"),
 				schema.AssistantMessage("", []schema.ToolCall{
 					{
 						ID:       "call_123456789",
@@ -489,6 +489,74 @@ func TestReductionMiddlewareClear(t *testing.T) {
 			},
 		}, s.Messages[4].ToolCalls)
 		assert.Equal(t, "[Old tool result content cleared]", s.Messages[3].Content)
+	})
+
+	t.Run("test clear with reordered tool results", func(t *testing.T) {
+		backend := filesystem.NewInMemoryBackend()
+		config := &Config{
+			SkipTruncation:            true,
+			TokenCounter:              defaultTokenCounter,
+			MaxTokensForClear:         20,
+			ClearRetentionSuffixLimit: 0,
+			ToolConfig: map[string]*ToolReductionConfig{
+				"get_weather": {
+					Backend:      backend,
+					SkipClear:    false,
+					ClearHandler: defaultClearHandler(testClearOffloadPath("/tmp"), true, "read_file"),
+				},
+			},
+		}
+
+		mw, err := New(ctx, config)
+		assert.NoError(t, err)
+		_, s, err := mw.BeforeModelRewriteState(ctx, &adk.ChatModelAgentState{
+			Messages: []adk.Message{
+				schema.SystemMessage("you are a helpful assistant"),
+				schema.UserMessage("get weather for two cities"),
+				// Assistant message with two tool calls
+				schema.AssistantMessage("", []schema.ToolCall{
+					{
+						ID:       "two_call_one",
+						Type:     "function",
+						Function: schema.FunctionCall{Name: "get_weather", Arguments: `{"location": "London"}`},
+					},
+					{
+						ID:       "two_call_two",
+						Type:     "function",
+						Function: schema.FunctionCall{Name: "get_weather", Arguments: `{"location": "Paris"}`},
+					},
+				}),
+				// Intentionally put tool result two BEFORE tool result one
+				schema.ToolMessage("Cloudy in Paris", "two_call_two"),
+				schema.ToolMessage("Sunny in London", "two_call_one"),
+				schema.AssistantMessage("", []schema.ToolCall{{ID: "dummy", Type: "function", Function: schema.FunctionCall{Name: "dummy_tool"}}}),
+			},
+		}, &adk.ModelContext{
+			Tools: toolsInfo,
+		})
+		assert.NoError(t, err)
+
+		// Verify tool call arguments are preserved (not offloaded since offload is true)
+		assert.Equal(t, `{"location": "London"}`, s.Messages[2].ToolCalls[0].Function.Arguments)
+		assert.Equal(t, `{"location": "Paris"}`, s.Messages[2].ToolCalls[1].Function.Arguments)
+
+		// Verify tool result two is correctly matched and offloaded (it's at index 3)
+		assert.Equal(t, "<persisted-output>Tool result saved to: /tmp/clear/two_call_two\nUse read_file to view</persisted-output>", s.Messages[3].Content)
+		fileContent2, err := backend.Read(ctx, &filesystem.ReadRequest{
+			FilePath: "/tmp/clear/two_call_two",
+		})
+		assert.NoError(t, err)
+		fileContentStr2 := strings.TrimPrefix(strings.TrimSpace(fileContent2.Content), "1\t")
+		assert.Equal(t, "Cloudy in Paris", fileContentStr2)
+
+		// Verify tool result one is correctly matched and offloaded (it's at index 4)
+		assert.Equal(t, "<persisted-output>Tool result saved to: /tmp/clear/two_call_one\nUse read_file to view</persisted-output>", s.Messages[4].Content)
+		fileContent1, err := backend.Read(ctx, &filesystem.ReadRequest{
+			FilePath: "/tmp/clear/two_call_one",
+		})
+		assert.NoError(t, err)
+		fileContentStr1 := strings.TrimPrefix(strings.TrimSpace(fileContent1.Content), "1\t")
+		assert.Equal(t, "Sunny in London", fileContentStr1)
 	})
 
 	t.Run("test clear", func(t *testing.T) {
@@ -547,7 +615,7 @@ func TestReductionMiddlewareClear(t *testing.T) {
 						Function: schema.FunctionCall{Name: "get_weather", Arguments: `{"location": "London, UK", "unit": "c"}`},
 					},
 				}),
-				schema.ToolMessage("Sunny", "call_123456789"),
+				schema.ToolMessage("Sunny", "call_987654321"),
 				schema.AssistantMessage("", []schema.ToolCall{
 					{
 						ID:       "call_123456789",
@@ -621,7 +689,7 @@ func TestReductionMiddlewareClear(t *testing.T) {
 					Function: schema.FunctionCall{Name: "get_weather", Arguments: `{"location": "London, UK", "unit": "c"}`},
 				},
 			}),
-			schema.ToolMessage("Sunny", "call_123456789"),
+			schema.ToolMessage("Sunny", "call_987654321"),
 			schema.AssistantMessage("", []schema.ToolCall{
 				{
 					ID:       "call_123456789",
@@ -872,7 +940,7 @@ func TestReductionMiddlewareClear(t *testing.T) {
 					Function: schema.FunctionCall{Name: "get_weather", Arguments: `{"location": "London, UK", "unit": "c"}`},
 				},
 			}),
-			schema.ToolMessage("Sunny Sunny Sunny Sunny Sunny Sunny Sunny Sunny Sunny Sunny Sunny Sunny Sunny", "call_123456789"),
+			schema.ToolMessage("Sunny Sunny Sunny Sunny Sunny Sunny Sunny Sunny Sunny Sunny Sunny Sunny Sunny", "call_987654321"),
 			schema.AssistantMessage("", []schema.ToolCall{
 				{
 					ID:       "call_123456789",


### PR DESCRIPTION
## 修复 `reduction middleware` 中相关问题
### 1. 工具响应结果和保存文件不匹配

`clear` 时，若 `message list`为
```
[tool_call_1, too_call_2]
[tool_result_2] 
[tool_result_1]
```
则文件 `clear/tool_call_1` 中保存的是 `tool_result_2`, 
文件` clear/tool_call_2` 中保存的是 `tool_result_1`
问题在于 `tool_call`和`tool_result`没有根据`tool_call_id`严格匹配。

### 2. 修复注释