### PR TITLE
fix(adk): avoid reduction/filesystem read_file loops on large tool results

### DIFF
--- a/adk/filesystem/backend_inmemory.go
+++ b/adk/filesystem/backend_inmemory.go
@@ -19,7 +19,7 @@ package filesystem
 import (
 	"context"
 	"fmt"
-	"path/filepath"
+	pathpkg "path"
 	"regexp"
 	"strings"
 	"sync"
@@ -72,7 +72,7 @@ func (b *InMemoryBackend) LsInfo(ctx context.Context, req *LsInfoRequest) ([]Fil
 				// The path itself is a file
 				if !seen[normalizedFilePath] {
 					result = append(result, FileInfo{
-						Path:       filepath.Base(normalizedFilePath),
+						Path:       pathpkg.Base(normalizedFilePath),
 						IsDir:      false,
 						Size:       int64(len(entry.content)),
 						ModifiedAt: entry.modifiedAt.Format(time.RFC3339Nano),
@@ -378,7 +378,7 @@ func (b *InMemoryBackend) filterByGlob(files []string, searchPath string, globPa
 				matchPath = strings.TrimPrefix(filePath, searchPath+"/")
 			}
 		} else {
-			matchPath = filepath.Base(filePath)
+			matchPath = pathpkg.Base(filePath)
 		}
 
 		matched, err := doublestar.Match(globPattern, matchPath)
@@ -397,7 +397,7 @@ func (b *InMemoryBackend) filterByFileType(files []string, fileType string) []st
 	var result []string
 
 	for _, filePath := range files {
-		ext := strings.TrimPrefix(filepath.Ext(filePath), ".")
+		ext := strings.TrimPrefix(pathpkg.Ext(filePath), ".")
 		if matchFileType(ext, fileType) {
 			result = append(result, filePath)
 		}
@@ -691,13 +691,14 @@ func normalizePath(path string) string {
 	if path == "" {
 		return "/"
 	}
+	path = strings.ReplaceAll(path, "\\", "/")
 
 	// Ensure path starts with "/"
 	if !strings.HasPrefix(path, "/") {
 		path = "/" + path
 	}
 
-	return filepath.Clean(path)
+	return pathpkg.Clean(path)
 }
 
 type grepCollector struct {

--- a/adk/filesystem/backend_inmemory_test.go
+++ b/adk/filesystem/backend_inmemory_test.go
@@ -76,6 +76,26 @@ func TestInMemoryBackend_WriteAndRead(t *testing.T) {
 	}
 }
 
+func TestInMemoryBackend_NormalizePath_WindowsSeparator(t *testing.T) {
+	b := NewInMemoryBackend()
+	ctx := context.Background()
+
+	err := b.Write(ctx, &WriteRequest{
+		FilePath: "\\windows\\style\\file.txt",
+		Content:  "hello",
+	})
+	if err != nil {
+		t.Fatalf("Write failed: %v", err)
+	}
+
+	out, err := b.Read(ctx, &ReadRequest{FilePath: "/windows/style/file.txt"})
+	if err != nil {
+		t.Fatalf("Read failed: %v", err)
+	}
+	if out.Content != "hello" {
+		t.Fatalf("expected %q, got %q", "hello", out.Content)
+	}
+}
 func TestInMemoryBackend_LsInfo(t *testing.T) {
 	backend := NewInMemoryBackend()
 	ctx := context.Background()

--- a/adk/middlewares/filesystem/filesystem.go
+++ b/adk/middlewares/filesystem/filesystem.go
@@ -664,15 +664,15 @@ func formatLineNumbers(content string, startLine, columnOffset, columnLimit int)
 	var b strings.Builder
 	for i, line := range lines {
 		lineNo := startLine + i
-		line, note := sliceLineByColumns(line, lineNo, columnOffset, columnLimit)
+		slicedLine, note := sliceLineByColumns(line, lineNo, columnOffset, columnLimit)
 		if i < len(lines)-1 {
-			fmt.Fprintf(&b, "%6d\t%s", lineNo, line)
+			fmt.Fprintf(&b, "%6d\t%s", lineNo, slicedLine)
 			if note != "" {
 				fmt.Fprintf(&b, "\n[%s]", note)
 			}
 			b.WriteByte('\n')
 		} else {
-			fmt.Fprintf(&b, "%6d\t%s", lineNo, line)
+			fmt.Fprintf(&b, "%6d\t%s", lineNo, slicedLine)
 			if note != "" {
 				fmt.Fprintf(&b, "\n[%s]", note)
 			}

--- a/adk/middlewares/filesystem/filesystem.go
+++ b/adk/middlewares/filesystem/filesystem.go
@@ -48,6 +48,9 @@ const (
 
 	noFilesFound   = "No files found"
 	noMatchesFound = "No matches found"
+
+	defaultReadFileLineLimit   = 2000
+	defaultReadFileColumnLimit = 2000
 )
 
 // ToolConfig configures a filesystem tool
@@ -208,10 +211,15 @@ func NewMiddleware(ctx context.Context, config *Config) (adk.AgentMiddleware, er
 	}
 
 	if !config.WithoutLargeToolResultOffloading {
+		readFileToolName := ToolNameReadFile
+		if config.ReadFileToolConfig != nil && config.ReadFileToolConfig.Name != "" {
+			readFileToolName = config.ReadFileToolConfig.Name
+		}
 		m.WrapToolCall = newToolResultOffloading(ctx, &toolResultOffloadingConfig{
 			Backend:       config.Backend,
 			TokenLimit:    config.LargeToolResultOffloadingTokenLimit,
 			PathGenerator: config.LargeToolResultOffloadingPathGen,
+			ExcludeTools:  []string{readFileToolName},
 		})
 	}
 
@@ -592,6 +600,12 @@ type readFileArgs struct {
 
 	// Limit is the number of lines to read.
 	Limit int `json:"limit" jsonschema:"description=The number of lines to read. Only provide if the file is too large to read at once."`
+
+	// ColumnOffset is the 1-based character column to start reading from within each returned line.
+	ColumnOffset int `json:"column_offset,omitempty" jsonschema:"description=The 1-based character column to start reading from within each returned line. Use with column_limit for very long single-line files. Values less than 1 are treated as 1."`
+
+	// ColumnLimit is the maximum number of characters to read from each returned line.
+	ColumnLimit int `json:"column_limit,omitempty" jsonschema:"description=The maximum number of characters to read from each returned line. Defaults to 2000 to keep very long single-line files readable. Set to -1 to disable column limiting."`
 }
 
 // multiModalReadFileArgs extends readFileArgs with PDF-specific parameters for MultiModalReadFileTool.
@@ -609,12 +623,7 @@ func newReadFileTool(fs filesystem.Backend, name string, desc string) (tool.Base
 		return nil, err
 	}
 	return utils.InferTool(toolName, d, func(ctx context.Context, input readFileArgs) (string, error) {
-		if input.Offset <= 0 {
-			input.Offset = 1
-		}
-		if input.Limit <= 0 {
-			input.Limit = 2000
-		}
+		normalizeReadFileArgs(&input)
 
 		fileCt, err := fs.Read(ctx, &filesystem.ReadRequest{
 			FilePath: input.FilePath,
@@ -628,24 +637,92 @@ func newReadFileTool(fs filesystem.Backend, name string, desc string) (tool.Base
 			return fmt.Sprintf("No content found at path: %s", input.FilePath), nil
 		}
 
-		return formatLineNumbers(fileCt.Content, input.Offset), nil
+		return formatLineNumbers(fileCt.Content, input.Offset, input.ColumnOffset, input.ColumnLimit), nil
 	})
+}
+
+func normalizeReadFileArgs(input *readFileArgs) {
+	if input.Offset <= 0 {
+		input.Offset = 1
+	}
+	if input.Limit <= 0 {
+		input.Limit = defaultReadFileLineLimit
+	}
+	if input.ColumnOffset <= 0 {
+		input.ColumnOffset = 1
+	}
+	if input.ColumnLimit == 0 {
+		input.ColumnLimit = defaultReadFileColumnLimit
+	}
 }
 
 // formatLineNumbers prefixes each line of content with a 1-based line number
 // starting at startLine (e.g. "     1\tfoo"). startLine corresponds to the
 // line number of the first line in content (usually ReadRequest.Offset).
-func formatLineNumbers(content string, startLine int) string {
+func formatLineNumbers(content string, startLine, columnOffset, columnLimit int) string {
 	lines := strings.Split(content, "\n")
 	var b strings.Builder
 	for i, line := range lines {
+		lineNo := startLine + i
+		line, note := sliceLineByColumns(line, lineNo, columnOffset, columnLimit)
 		if i < len(lines)-1 {
-			fmt.Fprintf(&b, "%6d\t%s\n", startLine+i, line)
+			fmt.Fprintf(&b, "%6d\t%s", lineNo, line)
+			if note != "" {
+				fmt.Fprintf(&b, "\n[%s]", note)
+			}
+			b.WriteByte('\n')
 		} else {
-			fmt.Fprintf(&b, "%6d\t%s", startLine+i, line)
+			fmt.Fprintf(&b, "%6d\t%s", lineNo, line)
+			if note != "" {
+				fmt.Fprintf(&b, "\n[%s]", note)
+			}
 		}
 	}
 	return b.String()
+}
+
+func sliceLineByColumns(line string, lineNo, columnOffset, columnLimit int) (string, string) {
+	if columnOffset <= 0 {
+		columnOffset = 1
+	}
+	if columnLimit == 0 {
+		columnLimit = defaultReadFileColumnLimit
+	}
+	if columnOffset == 1 && columnLimit < 0 {
+		return line, ""
+	}
+
+	runes := []rune(line)
+	totalColumns := len(runes)
+	if totalColumns == 0 {
+		if columnOffset == 1 {
+			return "", ""
+		}
+		return "", fmt.Sprintf("Line %d has no content at column_offset=%d.", lineNo, columnOffset)
+	}
+
+	start := columnOffset - 1
+	if start >= totalColumns {
+		return "", fmt.Sprintf("Line %d has %d columns; column_offset=%d is beyond the end.", lineNo, totalColumns, columnOffset)
+	}
+
+	end := totalColumns
+	if columnLimit > 0 && start+columnLimit < end {
+		end = start + columnLimit
+	}
+
+	segment := string(runes[start:end])
+	if start == 0 && end == totalColumns {
+		return segment, ""
+	}
+	if end < totalColumns {
+		nextLimit := columnLimit
+		if nextLimit < 0 {
+			nextLimit = defaultReadFileColumnLimit
+		}
+		return segment, fmt.Sprintf("Line %d truncated: showing columns %d-%d of %d. Use column_offset=%d and column_limit=%d to continue.", lineNo, start+1, end, totalColumns, end+1, nextLimit)
+	}
+	return segment, fmt.Sprintf("Line %d starts at column %d of %d.", lineNo, start+1, totalColumns)
 }
 
 const maxPagesPerRequest = 20
@@ -697,12 +774,7 @@ func newMultiModalReadFileTool(fs filesystem.Backend, name string, desc string) 
 	}
 
 	return utils.InferEnhancedTool(toolName, d, func(ctx context.Context, input multiModalReadFileArgs) (*schema.ToolResult, error) {
-		if input.Offset <= 0 {
-			input.Offset = 1
-		}
-		if input.Limit <= 0 {
-			input.Limit = 2000
-		}
+		normalizeReadFileArgs(&input.readFileArgs)
 
 		if input.Pages != "" {
 			if err := validatePages(input.Pages); err != nil {
@@ -779,7 +851,7 @@ func newMultiModalReadFileTool(fs filesystem.Backend, name string, desc string) 
 		}
 
 		return &schema.ToolResult{
-			Parts: []schema.ToolOutputPart{{Type: schema.ToolPartTypeText, Text: formatLineNumbers(fileCt.Content, input.Offset)}},
+			Parts: []schema.ToolOutputPart{{Type: schema.ToolPartTypeText, Text: formatLineNumbers(fileCt.Content, input.Offset, input.ColumnOffset, input.ColumnLimit)}},
 		}, nil
 	})
 }

--- a/adk/middlewares/filesystem/filesystem_test.go
+++ b/adk/middlewares/filesystem/filesystem_test.go
@@ -265,6 +265,63 @@ func TestReadFileTool_LongSingleLineColumnPagination(t *testing.T) {
 	assert.Equal(t, fmt.Sprintf("     1\t%s\n[Line 1 starts at column 2501 of 3000.]", strings.Repeat("b", 500)), result)
 }
 
+func TestReadFileTool_ColumnPaginationEdgeCases(t *testing.T) {
+	backend := filesystem.NewInMemoryBackend()
+	assert.NoError(t, backend.Write(context.Background(), &filesystem.WriteRequest{
+		FilePath: "/file.txt",
+		Content:  "aaaaaaaaaa",
+	}))
+
+	readTool, err := newReadFileTool(backend, "", "")
+	assert.NoError(t, err)
+
+	r, err := invokeTool(t, readTool, `{"file_path":"/file.txt", "offset":1, "limit":1, "column_limit":-1}`)
+	assert.NoError(t, err)
+	assert.Contains(t, r, "aaaaaaaaaa")
+	assert.NotContains(t, r, "truncated")
+	assert.NotContains(t, r, "starts at column")
+
+	r, err = invokeTool(t, readTool, `{"file_path":"/file.txt", "offset":1, "limit":1, "column_offset":50, "column_limit":10}`)
+	assert.NoError(t, err)
+	assert.Contains(t, r, "column_offset=50 is beyond the end")
+
+	r, err = invokeTool(t, readTool, `{"file_path":"/file.txt", "offset":1, "limit":1, "column_offset":5, "column_limit":100}`)
+	assert.NoError(t, err)
+	assert.Contains(t, r, fmt.Sprintf("     1\t%s", "aaaaaa"))
+	assert.NotContains(t, r, "truncated")
+	assert.Contains(t, r, "Line 1 starts at column 5 of 10")
+}
+
+func TestReadFileTool_ColumnPaginationOnEmptyLine(t *testing.T) {
+	backend := filesystem.NewInMemoryBackend()
+	assert.NoError(t, backend.Write(context.Background(), &filesystem.WriteRequest{
+		FilePath: "/mixed.txt",
+		Content:  "\nhello",
+	}))
+
+	readTool, err := newReadFileTool(backend, "", "")
+	assert.NoError(t, err)
+
+	r, err := invokeTool(t, readTool, `{"file_path":"/mixed.txt", "offset":1, "limit":1, "column_offset":3, "column_limit":10}`)
+	assert.NoError(t, err)
+	assert.Contains(t, r, "Line 1 has no content at column_offset=3")
+}
+
+func TestReadFileTool_ColumnOffsetBoundary(t *testing.T) {
+	backend := filesystem.NewInMemoryBackend()
+	assert.NoError(t, backend.Write(context.Background(), &filesystem.WriteRequest{
+		FilePath: "/b.txt",
+		Content:  "abcdef",
+	}))
+
+	readTool, err := newReadFileTool(backend, "", "")
+	assert.NoError(t, err)
+
+	r, err := invokeTool(t, readTool, `{"file_path":"/b.txt", "offset":1, "limit":1, "column_offset":7, "column_limit":5}`)
+	assert.NoError(t, err)
+	assert.Contains(t, r, "column_offset=7 is beyond the end")
+}
+
 func TestWriteFileTool(t *testing.T) {
 	backend := setupTestBackend()
 	writeTool, err := newWriteFileTool(backend, "", "")

--- a/adk/middlewares/filesystem/filesystem_test.go
+++ b/adk/middlewares/filesystem/filesystem_test.go
@@ -235,6 +235,36 @@ func TestReadFileTool_DefaultLimit(t *testing.T) {
 	})
 }
 
+func TestReadFileTool_LongSingleLineColumnPagination(t *testing.T) {
+	backend := filesystem.NewInMemoryBackend()
+	longLine := strings.Repeat("a", 2500) + strings.Repeat("b", 500)
+	err := backend.Write(context.Background(), &filesystem.WriteRequest{
+		FilePath: "/long.txt",
+		Content:  longLine,
+	})
+	assert.NoError(t, err)
+
+	readTool, err := newReadFileTool(backend, "", "")
+	assert.NoError(t, err)
+
+	result, err := invokeTool(t, readTool, `{"file_path": "/long.txt", "offset": 1, "limit": 1}`)
+	assert.NoError(t, err)
+	assert.Contains(t, result, fmt.Sprintf("     1\t%s", strings.Repeat("a", 2000)))
+	assert.NotContains(t, result, strings.Repeat("a", 2001))
+	assert.Contains(t, result, "Line 1 truncated: showing columns 1-2000 of 3000")
+	assert.Contains(t, result, "column_offset=2001")
+
+	result, err = invokeTool(t, readTool, `{"file_path": "/long.txt", "offset": 1, "limit": 1, "column_offset": 2001, "column_limit": 500}`)
+	assert.NoError(t, err)
+	assert.Contains(t, result, fmt.Sprintf("     1\t%s", strings.Repeat("a", 500)))
+	assert.Contains(t, result, "Line 1 truncated: showing columns 2001-2500 of 3000")
+	assert.Contains(t, result, "column_offset=2501")
+
+	result, err = invokeTool(t, readTool, `{"file_path": "/long.txt", "offset": 1, "limit": 1, "column_offset": 2501, "column_limit": 500}`)
+	assert.NoError(t, err)
+	assert.Equal(t, fmt.Sprintf("     1\t%s\n[Line 1 starts at column 2501 of 3000.]", strings.Repeat("b", 500)), result)
+}
+
 func TestWriteFileTool(t *testing.T) {
 	backend := setupTestBackend()
 	writeTool, err := newWriteFileTool(backend, "", "")
@@ -2502,7 +2532,7 @@ func TestMultiModalReadFileTool_SchemaContainsAllFields(t *testing.T) {
 	assert.NotNil(t, js)
 	assert.NotNil(t, js.Properties, "schema should have properties")
 
-	for _, field := range []string{"file_path", "offset", "limit", "pages"} {
+	for _, field := range []string{"file_path", "offset", "limit", "column_offset", "column_limit", "pages"} {
 		_, ok := js.Properties.Get(field)
 		assert.True(t, ok, "expected JSON schema to contain field %q, schema=%+v", field, js.Properties)
 	}

--- a/adk/middlewares/filesystem/large_tool_result.go
+++ b/adk/middlewares/filesystem/large_tool_result.go
@@ -37,6 +37,7 @@ type toolResultOffloadingConfig struct {
 	Backend       filesystem.Backend
 	TokenLimit    int
 	PathGenerator func(ctx context.Context, input *compose.ToolInput) (string, error)
+	ExcludeTools  []string
 }
 
 func newToolResultOffloading(ctx context.Context, config *toolResultOffloadingConfig) compose.ToolMiddleware {
@@ -44,6 +45,10 @@ func newToolResultOffloading(ctx context.Context, config *toolResultOffloadingCo
 		backend:       config.Backend,
 		tokenLimit:    config.TokenLimit,
 		pathGenerator: config.PathGenerator,
+		excludeTools:  make(map[string]struct{}, len(config.ExcludeTools)),
+	}
+	for _, toolName := range config.ExcludeTools {
+		offloading.excludeTools[toolName] = struct{}{}
 	}
 
 	if offloading.tokenLimit == 0 {
@@ -66,6 +71,7 @@ type toolResultOffloading struct {
 	backend       filesystem.Backend
 	tokenLimit    int
 	pathGenerator func(ctx context.Context, input *compose.ToolInput) (string, error)
+	excludeTools  map[string]struct{}
 }
 
 func (t *toolResultOffloading) invoke(endpoint compose.InvokableToolEndpoint) compose.InvokableToolEndpoint {
@@ -101,6 +107,11 @@ func (t *toolResultOffloading) stream(endpoint compose.StreamableToolEndpoint) c
 }
 
 func (t *toolResultOffloading) handleResult(ctx context.Context, result string, input *compose.ToolInput) (string, error) {
+	if input != nil {
+		if _, excluded := t.excludeTools[input.Name]; excluded {
+			return result, nil
+		}
+	}
 	if len(result) > t.tokenLimit*4 {
 		path, err := t.pathGenerator(ctx, input)
 		if err != nil {

--- a/adk/middlewares/filesystem/large_tool_result_test.go
+++ b/adk/middlewares/filesystem/large_tool_result_test.go
@@ -24,6 +24,8 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/stretchr/testify/assert"
+
 	"github.com/cloudwego/eino/compose"
 	"github.com/cloudwego/eino/schema"
 )
@@ -576,6 +578,31 @@ func TestToolResultOffloading_BackendWriteError(t *testing.T) {
 	if !strings.Contains(err.Error(), "write failed") {
 		t.Errorf("expected 'write failed' error, got %v", err)
 	}
+}
+
+func TestToolResultOffloading_ExcludeTools(t *testing.T) {
+	ctx := context.Background()
+	backend := newMockBackend()
+
+	middleware := newToolResultOffloading(ctx, &toolResultOffloadingConfig{
+		Backend:      backend,
+		TokenLimit:   10,
+		ExcludeTools: []string{ToolNameReadFile},
+	})
+
+	largeResult := strings.Repeat("x", 100)
+	mockEndpoint := func(ctx context.Context, input *compose.ToolInput) (*compose.ToolOutput, error) {
+		return &compose.ToolOutput{Result: largeResult}, nil
+	}
+
+	wrappedEndpoint := middleware.Invokable(mockEndpoint)
+	output, err := wrappedEndpoint(ctx, &compose.ToolInput{
+		Name:   ToolNameReadFile,
+		CallID: "read_file_call",
+	})
+	assert.NoError(t, err)
+	assert.Equal(t, largeResult, output.Result)
+	assert.Empty(t, backend.files)
 }
 
 // failingBackend is a mock backend that can be configured to fail

--- a/adk/middlewares/filesystem/prompt.go
+++ b/adk/middlewares/filesystem/prompt.go
@@ -28,6 +28,7 @@ const (
 	tooLargeToolMessage = `Tool result too large, the result of this tool call {tool_call_id} was saved in the filesystem at this path: {file_path}
 You can read the result from the filesystem by using the read_file tool, but make sure to only read part of the result at a time.
 You can do this by specifying an offset and limit in the read_file tool call.
+If a result contains very long single-line content, specify column_offset and column_limit to read a slice of that line.
 For example, to read the first 100 lines, you can use the read_file tool with offset=0 and limit=100.
 
 Here are the first 10 lines of the result:
@@ -36,6 +37,7 @@ Here are the first 10 lines of the result:
 	tooLargeToolMessageChinese = `工具结果过大，此工具调用 {tool_call_id} 的结果已保存到文件系统的以下路径：{file_path}
 你可以使用 read_file 工具从文件系统读取结果，但请确保每次只读取部分结果。
 你可以通过在 read_file 工具调用中指定 offset 和 limit 来实现。
+如果结果包含很长的单行内容，请指定 column_offset 和 column_limit 来读取该行的一段。
 例如，要读取前 100 行，你可以使用 read_file 工具，设置 offset=0 和 limit=100。
 
 以下是结果的前 10 行：
@@ -66,8 +68,10 @@ Usage:
 - **IMPORTANT for large files and codebase exploration**: Use pagination with offset and limit parameters to avoid context overflow
 	- First scan: read_file(path, limit=100) to see file structure
 	- Read more sections: read_file(path, offset=100, limit=200) for next 200 lines
+	- For very long single-line files, use column_offset and column_limit to read the line in chunks
 	- Only omit limit (read full file) when necessary for editing
 - Specify offset and limit: read_file(path, offset=0, limit=100) reads first 100 lines
+- Specify column_offset and column_limit: read_file(path, offset=1, limit=1, column_offset=2001, column_limit=2000) reads columns 2001-4000 of line 1
 - Results are returned using cat -n format, with line numbers starting at 1
 - You have the capability to call multiple tools in a single response. It is always better to speculatively read multiple files as a batch that are potentially useful.
 - If you read a file that exists but has empty contents you will receive a system reminder warning in place of file contents.
@@ -82,8 +86,10 @@ Usage:
 - **大文件和代码库探索的重要提示**：使用 offset 和 limit 参数进行分页，以避免上下文溢出
 	- 首次扫描：read_file(path, limit=100) 查看文件结构
 	- 读取更多部分：read_file(path, offset=100, limit=200) 读取接下来的 200 行
+	- 对于很长的单行文件，使用 column_offset 和 column_limit 分块读取该行
 	- 仅在编辑必要时才省略 limit（读取完整文件）
 - 指定 offset 和 limit：read_file(path, offset=0, limit=100) 读取前 100 行
+- 指定 column_offset 和 column_limit：read_file(path, offset=1, limit=1, column_offset=2001, column_limit=2000) 读取第 1 行的第 2001-4000 列
 - 结果以 cat -n 格式返回，行号从 1 开始
 - 你可以在单个响应中调用多个工具。最好同时推测性地批量读取多个可能有用的文件
 - 如果你读取的文件存在但内容为空，你将收到系统提醒警告而不是文件内容

--- a/adk/middlewares/reduction/internal/clear_tool_result_test.go
+++ b/adk/middlewares/reduction/internal/clear_tool_result_test.go
@@ -265,6 +265,35 @@ func Test_reduceByTokens(t *testing.T) {
 	}
 }
 
+func TestNewToolResultMiddleware_ExcludesReadFileFromClear(t *testing.T) {
+	ctx := context.Background()
+	backend := newMockBackend()
+
+	mw, err := NewToolResultMiddleware(ctx, &ToolResultConfig{
+		Backend:                backend,
+		ClearingTokenThreshold: 1,
+		KeepRecentTokens:       -1,
+		OffloadingTokenLimit:   1000,
+	})
+	assert.NoError(t, err)
+	assert.NotNil(t, mw.BeforeChatModel)
+
+	readFileResult := strings.Repeat("x", 100)
+	state := &adk.ChatModelAgentState{
+		Messages: []adk.Message{
+			schema.UserMessage("read offloaded content"),
+			schema.ToolMessage(readFileResult, "read_call", schema.WithToolName("read_file")),
+			schema.ToolMessage(strings.Repeat("y", 100), "other_call", schema.WithToolName("other_tool")),
+			schema.UserMessage("tail"),
+		},
+	}
+
+	err = mw.BeforeChatModel(ctx, state)
+	assert.NoError(t, err)
+	assert.Equal(t, readFileResult, state.Messages[1].Content)
+	assert.Equal(t, "[Old tool result content cleared]", state.Messages[2].Content)
+}
+
 func Test_newClearToolResult(t *testing.T) {
 	ctx := context.Background()
 

--- a/adk/middlewares/reduction/internal/large_tool_result.go
+++ b/adk/middlewares/reduction/internal/large_tool_result.go
@@ -37,6 +37,7 @@ const (
 	tooLargeToolMessage = `Tool result too large, the result of this tool call {tool_call_id} was saved in the filesystem at this path: {file_path}
 You can read the result from the filesystem by using the '{read_file_tool_name}' tool, but make sure to only read part of the result at a time.
 You can do this by specifying an offset and limit in the '{read_file_tool_name}' tool call.
+If a result contains very long single-line content, specify column_offset and column_limit to read a slice of that line.
 For example, to read the first 100 lines, you can use the '{read_file_tool_name}' tool with offset=0 and limit=100.
 
 Here are the first 10 lines of the result:
@@ -45,6 +46,7 @@ Here are the first 10 lines of the result:
 	tooLargeToolMessageChinese = `工具结果过大，此工具调用 {tool_call_id} 的结果已保存到文件系统的以下路径：{file_path}
 你可以使用 '{read_file_tool_name}' 工具从文件系统读取结果，但请确保每次只读取部分结果。
 你可以通过在 '{read_file_tool_name}' 工具调用中指定 offset 和 limit 来实现。
+如果结果包含很长的单行内容，请在 '{read_file_tool_name}' 工具调用中指定 column_offset 和 column_limit 来读取该行的一段。
 例如，要读取前 100 行，你可以使用 '{read_file_tool_name}' 工具，设置 offset=0 和 limit=100。
 
 以下是结果的前 10 行：
@@ -133,6 +135,9 @@ func (t *toolResultOffloading) stream(endpoint compose.StreamableToolEndpoint) c
 }
 
 func (t *toolResultOffloading) handleResult(ctx context.Context, result string, input *compose.ToolInput) (string, error) {
+	if input != nil && input.Name == t.toolName {
+		return result, nil
+	}
 	if t.counter(schema.ToolMessage(result, input.CallID, schema.WithToolName(input.Name))) > t.tokenLimit*4 {
 		path, err := t.pathGenerator(ctx, input)
 		if err != nil {

--- a/adk/middlewares/reduction/internal/large_tool_result_test.go
+++ b/adk/middlewares/reduction/internal/large_tool_result_test.go
@@ -555,6 +555,35 @@ func TestToolResultOffloading_BackendWriteError(t *testing.T) {
 	}
 }
 
+func TestToolResultOffloading_SkipReadFileTool(t *testing.T) {
+	ctx := context.Background()
+	backend := newMockBackend()
+
+	config := &toolResultOffloadingConfig{
+		Backend:          backend,
+		ReadFileToolName: "read_file",
+		TokenLimit:       10,
+	}
+
+	middleware := newToolResultOffloading(ctx, config)
+	largeResult := strings.Repeat("x", 100)
+	mockEndpoint := func(ctx context.Context, input *compose.ToolInput) (*compose.ToolOutput, error) {
+		return &compose.ToolOutput{Result: largeResult}, nil
+	}
+
+	wrappedEndpoint := middleware.Invokable(mockEndpoint)
+	output, err := wrappedEndpoint(ctx, &compose.ToolInput{Name: "read_file", CallID: "read_file_call"})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if output.Result != largeResult {
+		t.Fatalf("expected read_file result to pass through unchanged")
+	}
+	if len(backend.files) != 0 {
+		t.Fatalf("expected no files to be written, got %d", len(backend.files))
+	}
+}
+
 // failingBackend is a mock backend that can be configured to fail
 type failingBackend struct {
 	writeErr error

--- a/adk/middlewares/reduction/internal/tool_result.go
+++ b/adk/middlewares/reduction/internal/tool_result.go
@@ -101,16 +101,21 @@ type ToolResultConfig struct {
 //     which provides the read_file tool automatically, OR
 //   - Implement your own read_file tool that reads from the same Backend
 func NewToolResultMiddleware(ctx context.Context, cfg *ToolResultConfig) (adk.AgentMiddleware, error) {
+	readFileToolName := cfg.ReadFileToolName
+	if readFileToolName == "" {
+		readFileToolName = "read_file"
+	}
+	excludeTools := append(append([]string{}, cfg.ExcludeTools...), readFileToolName)
 	bc := newClearToolResult(ctx, &ClearToolResultConfig{
 		ToolResultTokenThreshold:   cfg.ClearingTokenThreshold,
 		KeepRecentTokens:           cfg.KeepRecentTokens,
 		ClearToolResultPlaceholder: cfg.ClearToolResultPlaceholder,
 		TokenCounter:               cfg.TokenCounter,
-		ExcludeTools:               cfg.ExcludeTools,
+		ExcludeTools:               excludeTools,
 	})
 	tm := newToolResultOffloading(ctx, &toolResultOffloadingConfig{
 		Backend:          cfg.Backend,
-		ReadFileToolName: cfg.ReadFileToolName,
+		ReadFileToolName: readFileToolName,
 		TokenLimit:       cfg.OffloadingTokenLimit,
 		PathGenerator:    cfg.PathGenerator,
 	})

--- a/adk/middlewares/reduction/reduction.go
+++ b/adk/middlewares/reduction/reduction.go
@@ -21,7 +21,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"path/filepath"
+	pathpkg "path"
 	"strings"
 	"unicode/utf8"
 
@@ -92,6 +92,7 @@ type TypedConfig[M adk.MessageType] struct {
 	MaxLengthForTrunc int
 
 	// TruncExcludeTools is list of tool names whose tool results should never be truncated.
+	// ReadFileToolName is always excluded by default so retrieved offloaded content is not re-truncated.
 	// Optional. Default is nil.
 	TruncExcludeTools []string
 
@@ -116,6 +117,7 @@ type TypedConfig[M adk.MessageType] struct {
 	ClearAtLeastTokens int64
 
 	// ClearExcludeTools is list of tool names whose tool uses and results should never be cleared.
+	// ReadFileToolName is always excluded by default so retrieved offloaded content is not re-cleared.
 	// Optional. Default is nil.
 	ClearExcludeTools []string
 
@@ -265,7 +267,7 @@ func (t *TypedConfig[M]) copyAndFillDefaults() (*TypedConfig[M], error) {
 			if tcID == "" {
 				tcID = uuid.NewString()
 			}
-			return filepath.Join(cfg.RootDir, "trunc", tcID), nil
+			return pathpkg.Join(cfg.RootDir, "trunc", tcID), nil
 		}
 	}
 	if cfg.GenClearOffloadFilePath == nil {
@@ -274,7 +276,7 @@ func (t *TypedConfig[M]) copyAndFillDefaults() (*TypedConfig[M], error) {
 			if tcID == "" {
 				tcID = uuid.NewString()
 			}
-			return filepath.Join(cfg.RootDir, "clear", tcID), nil
+			return pathpkg.Join(cfg.RootDir, "clear", tcID), nil
 		}
 	}
 	if cfg.MaxLengthForTrunc == 0 {
@@ -328,14 +330,17 @@ func NewTyped[M adk.MessageType](_ context.Context, config *TypedConfig[M]) (adk
 	if !defaultReductionConfig.SkipClear {
 		defaultReductionConfig.ClearHandler = defaultClearHandler(config.GenClearOffloadFilePath, config.Backend != nil, config.ReadFileToolName)
 	}
-	excludeTruncTools := make(map[string]struct{}, len(config.TruncExcludeTools))
+	excludeTruncTools := make(map[string]struct{}, len(config.TruncExcludeTools)+1)
 	for _, toolName := range config.TruncExcludeTools {
 		excludeTruncTools[toolName] = struct{}{}
 	}
-	excludeClearTools := make(map[string]struct{}, len(config.ClearExcludeTools))
+	excludeTruncTools[config.ReadFileToolName] = struct{}{}
+
+	excludeClearTools := make(map[string]struct{}, len(config.ClearExcludeTools)+1)
 	for _, toolName := range config.ClearExcludeTools {
 		excludeClearTools[toolName] = struct{}{}
 	}
+	excludeClearTools[config.ReadFileToolName] = struct{}{}
 
 	return &typedToolReductionMiddleware[M]{
 		config:            config,
@@ -897,7 +902,7 @@ func isUserMsg[M adk.MessageType](msg M) bool {
 			return false
 		}
 		// A user-role agentic message that contains any FunctionToolResult block
-		// is a tool result message, not a normal user message — even if it also
+		// is a tool result message, not a normal user message, even if it also
 		// carries UserInput blocks. This ensures the clear flow's tool-call grouping
 		// remains correctly aligned.
 		for _, block := range m.ContentBlocks {

--- a/adk/middlewares/reduction/reduction_test.go
+++ b/adk/middlewares/reduction/reduction_test.go
@@ -307,6 +307,34 @@ hello worldhello worldhello worldhello worldhello worldhello worldhello worldhel
 		_, err = backend.Read(ctx, &filesystem.ReadRequest{FilePath: "/custom/trunc/custom_123"})
 		assert.NoError(t, err)
 	})
+
+	t.Run("read_file tool is not truncated by default", func(t *testing.T) {
+		tCtx := &adk.ToolContext{
+			Name:   "read_file",
+			CallID: "read_file_call",
+		}
+		backend := filesystem.NewInMemoryBackend()
+		config := &Config{
+			Backend:           backend,
+			MaxLengthForTrunc: 10,
+		}
+
+		mw, err := New(ctx, config)
+		assert.NoError(t, err)
+
+		largeReadFileResult := strings.Repeat("x", 100)
+		endpoint := func(_ context.Context, _ string, _ ...tool.Option) (string, error) {
+			return largeReadFileResult, nil
+		}
+		wrapped, err := mw.WrapInvokableToolCall(ctx, endpoint, tCtx)
+		assert.NoError(t, err)
+
+		resp, err := wrapped(ctx, `{}`)
+		assert.NoError(t, err)
+		assert.Equal(t, largeReadFileResult, resp)
+		_, err = backend.Read(ctx, &filesystem.ReadRequest{FilePath: "/tmp/trunc/read_file_call"})
+		assert.Error(t, err)
+	})
 }
 
 func TestReductionMiddlewareClear(t *testing.T) {
@@ -686,6 +714,38 @@ func TestReductionMiddlewareClear(t *testing.T) {
 		assert.NotNil(t, msgs[4].Extra[msgClearedFlag])
 		assert.Equal(t, "<persisted-output>Tool result saved to: /tmp/clear/call_987654321\nUse read_file to view</persisted-output>", s.Messages[3].Content)
 		assert.Equal(t, "<persisted-output>Tool result saved to: /tmp/clear/call_123456789\nUse read_file to view</persisted-output>", s.Messages[5].Content)
+	})
+
+	t.Run("read_file tool is not cleared by default", func(t *testing.T) {
+		backend := filesystem.NewInMemoryBackend()
+		config := &Config{
+			Backend:                   backend,
+			SkipTruncation:            true,
+			TokenCounter:              func(context.Context, []adk.Message, []*schema.ToolInfo) (int64, error) { return 100, nil },
+			MaxTokensForClear:         20,
+			ClearRetentionSuffixLimit: 0,
+		}
+
+		mw, err := New(ctx, config)
+		assert.NoError(t, err)
+
+		longReadFileResult := strings.Repeat("x", 100)
+		msgs := []adk.Message{
+			schema.UserMessage("read persisted output"),
+			schema.AssistantMessage("", []schema.ToolCall{
+				{ID: "read_call", Type: "function", Function: schema.FunctionCall{Name: "read_file", Arguments: `{"file_path":"/tmp/trunc/original"}`}},
+			}),
+			schema.ToolMessage(longReadFileResult, "read_call", schema.WithToolName("read_file")),
+			schema.AssistantMessage("", []schema.ToolCall{
+				{ID: "next_call", Type: "function", Function: schema.FunctionCall{Name: "next_tool", Arguments: `{}`}},
+			}),
+		}
+
+		_, state, err := mw.BeforeModelRewriteState(ctx, &adk.ChatModelAgentState{Messages: msgs}, &adk.ModelContext{})
+		assert.NoError(t, err)
+		assert.Equal(t, longReadFileResult, state.Messages[2].Content)
+		_, err = backend.Read(ctx, &filesystem.ReadRequest{FilePath: "/tmp/clear/read_call"})
+		assert.Error(t, err)
 	})
 
 	t.Run("test ClearExcludeTools", func(t *testing.T) {


### PR DESCRIPTION
## Summary

This fixes the conflict between reduction and filesystem middleware described in #860.

When a large tool result is truncated or offloaded and the agent uses `read_file` to fetch it back, the returned content should not be truncated, cleared, or offloaded again by default. This change also adds column-based pagination to `read_file` so very long single-line content can be read incrementally.

## What changed

- exclude `read_file` from default reduction truncation and clearing
- exclude `read_file` from legacy large tool result offloading paths
- add `column_offset` and `column_limit` to `read_file`
- paginate long single-line content with continuation hints
- update English and Chinese prompts/tool descriptions to document column-based reads
- normalize virtual in-memory/offload paths to slash-based filesystem paths across platforms

## Tests

New coverage added:
- `TestReadFileTool_LongSingleLineColumnPagination`
- `TestToolResultOffloading_ExcludeTools`
- `TestNewToolResultMiddleware_ExcludesReadFileFromClear`
- `TestToolResultOffloading_SkipReadFileTool`
- `TestReductionMiddlewareTrunc/read_file tool is not truncated by default`
- `TestReductionMiddlewareClear/read_file tool is not cleared by default`

Passed:
- `go test ./adk/middlewares/filesystem ./adk/middlewares/reduction`

Also checked:
- `gofmt` on modified files
- `git diff --check`

## Notes

A full `go test ./...` run still reports unrelated failures in other packages on this Windows environment, including:
- `adk/middlewares/agentsmd`
- `adk/middlewares/plantask`
- `adk/middlewares/skill`
- `components/document/parser`

Those failures are not introduced by this change and are outside the scope of #860.