### PR TITLE
fix(adk): persist leading system messages

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -64,6 +64,7 @@ CLAUDE.md
 
 # Internal dev setup (not for public repo)
 /scripts/dev_setup_internal.sh
+/adk/decode_session_event_test.go
 
 # External working trees
 /examples/

--- a/.gitignore
+++ b/.gitignore
@@ -64,7 +64,6 @@ CLAUDE.md
 
 # Internal dev setup (not for public repo)
 /scripts/dev_setup_internal.sh
-/adk/decode_session_event_test.go
 
 # External working trees
 /examples/

--- a/adk/chatmodel.go
+++ b/adk/chatmodel.go
@@ -22,6 +22,7 @@ import (
 	"errors"
 	"fmt"
 	"math"
+	"reflect"
 	"runtime/debug"
 	"strings"
 	"sync"
@@ -322,6 +323,120 @@ func ensureGeneratedMessageIDs[M MessageType](messages []M) {
 	for _, msg := range messages {
 		EnsureMessageID(msg)
 	}
+}
+
+func leadingSystemMessage[M MessageType](messages []M) (M, bool) {
+	var zero M
+	if len(messages) == 0 || isNilMessage(messages[0]) {
+		return zero, false
+	}
+	switch msg := any(messages[0]).(type) {
+	case *schema.Message:
+		if msg.Role == schema.System {
+			return messages[0], true
+		}
+	case *schema.AgenticMessage:
+		if msg.Role == schema.AgenticRoleTypeSystem {
+			return messages[0], true
+		}
+	}
+	return zero, false
+}
+
+func sameSystemMessage[M MessageType](oldSys, newSys M) bool {
+	if isNilMessage(oldSys) || isNilMessage(newSys) {
+		return isNilMessage(oldSys) && isNilMessage(newSys)
+	}
+	switch oldMsg := any(oldSys).(type) {
+	case *schema.Message:
+		newMsg, ok := any(newSys).(*schema.Message)
+		if !ok {
+			return false
+		}
+		return oldMsg.Role == newMsg.Role &&
+			oldMsg.Content == newMsg.Content &&
+			reflect.DeepEqual(oldMsg.MultiContent, newMsg.MultiContent) &&
+			reflect.DeepEqual(oldMsg.UserInputMultiContent, newMsg.UserInputMultiContent) &&
+			reflect.DeepEqual(oldMsg.AssistantGenMultiContent, newMsg.AssistantGenMultiContent) &&
+			oldMsg.Name == newMsg.Name
+	case *schema.AgenticMessage:
+		newMsg, ok := any(newSys).(*schema.AgenticMessage)
+		return ok && oldMsg.Role == newMsg.Role &&
+			reflect.DeepEqual(oldMsg.ContentBlocks, newMsg.ContentBlocks)
+	default:
+		return false
+	}
+}
+
+func setMessageIDFromTarget[M MessageType](msg M, targetID string) {
+	if targetID == "" || isNilMessage(msg) {
+		return
+	}
+	typedSetMessageID(msg, targetID)
+}
+
+func syncLeadingSystemMessageSessionEvent[M MessageType](
+	ctx context.Context,
+	previous []M,
+	generated []M,
+) error {
+	execCtx := getTypedChatModelAgentExecCtx[M](ctx)
+	if execCtx == nil || !execCtx.sessionEvents {
+		return nil
+	}
+
+	newSys, ok := leadingSystemMessage(generated)
+	if !ok {
+		return nil
+	}
+
+	var event *TypedAgentEvent[M]
+	if oldSys, hasOldSys := leadingSystemMessage(previous); hasOldSys {
+		EnsureMessageID(oldSys)
+		oldID := GetMessageID(oldSys)
+		setMessageIDFromTarget(newSys, oldID)
+		if sameSystemMessage(oldSys, newSys) {
+			return nil
+		}
+		event = &TypedAgentEvent[M]{
+			SessionEvent: &SessionEvent[M]{
+				Kind: SessionEventMessageUpdated,
+				MessageUpdated: &MessageUpdatedEvent[M]{
+					MessageID: oldID,
+					Message:   newSys,
+				},
+			},
+		}
+	} else if len(previous) == 0 {
+		EnsureMessageID(newSys)
+		event = &TypedAgentEvent[M]{
+			SessionEvent: &SessionEvent[M]{
+				Kind:    SessionEventMessage,
+				Message: newSys,
+			},
+		}
+	} else {
+		if isNilMessage(previous[0]) {
+			return errors.New("sync leading system message: previous first message is nil")
+		}
+		EnsureMessageID(previous[0])
+		EnsureMessageID(newSys)
+		event = &TypedAgentEvent[M]{
+			SessionEvent: &SessionEvent[M]{
+				Kind: SessionEventMessageInserted,
+				MessageInserted: &MessageInsertedEvent[M]{
+					Message:         newSys,
+					BeforeMessageID: GetMessageID(previous[0]),
+				},
+			},
+		}
+	}
+
+	execCtx.send(ctx, event)
+	if event.Err != nil {
+		return event.Err
+	}
+	return nil
 }
 
 // TypedChatModelAgentState represents the state of a chat model agent during conversation.
@@ -1166,6 +1281,9 @@ func (a *TypedChatModelAgent[M]) buildNoToolsRunFunc(_ context.Context) (typedRu
 			if err != nil {
 				return nil, err
 			}
+			if err := syncLeadingSystemMessageSessionEvent(ctx, in.input.Messages, messages); err != nil {
+				return nil, err
+			}
 			if p.sessionEvents {
 				ensureGeneratedMessageIDs(messages)
 			}
@@ -1331,6 +1449,9 @@ func (a *TypedChatModelAgent[M]) buildMessageReActRunFunc(_ context.Context, bc 
 					if genErr != nil {
 						return nil, genErr
 					}
+					if genErr = syncLeadingSystemMessageSessionEvent(ctx, in.input.Messages, messages); genErr != nil {
+						return nil, genErr
+					}
 					if mp.sessionEvents {
 						ensureGeneratedMessageIDs(messages)
 					}
@@ -1480,6 +1601,9 @@ func (a *TypedChatModelAgent[M]) buildAgenticReActRunFunc(_ context.Context, bc 
 					}
 					messages, genErr := genModelInputFn(ctx, in.instruction, in.input)
 					if genErr != nil {
+						return nil, genErr
+					}
+					if genErr = syncLeadingSystemMessageSessionEvent(ctx, in.input.Messages, messages); genErr != nil {
 						return nil, genErr
 					}
 					if ap.sessionEvents {

--- a/adk/chatmodel.go
+++ b/adk/chatmodel.go
@@ -350,19 +350,10 @@ func sameSystemMessage[M MessageType](oldSys, newSys M) bool {
 	switch oldMsg := any(oldSys).(type) {
 	case *schema.Message:
 		newMsg, ok := any(newSys).(*schema.Message)
-		if !ok {
-			return false
-		}
-		return oldMsg.Role == newMsg.Role &&
-			oldMsg.Content == newMsg.Content &&
-			reflect.DeepEqual(oldMsg.MultiContent, newMsg.MultiContent) &&
-			reflect.DeepEqual(oldMsg.UserInputMultiContent, newMsg.UserInputMultiContent) &&
-			reflect.DeepEqual(oldMsg.AssistantGenMultiContent, newMsg.AssistantGenMultiContent) &&
-			oldMsg.Name == newMsg.Name
+		return ok && reflect.DeepEqual(oldMsg, newMsg)
 	case *schema.AgenticMessage:
 		newMsg, ok := any(newSys).(*schema.AgenticMessage)
-		return ok && oldMsg.Role == newMsg.Role &&
-			reflect.DeepEqual(oldMsg.ContentBlocks, newMsg.ContentBlocks)
+		return ok && reflect.DeepEqual(oldMsg, newMsg)
 	default:
 		return false
 	}

--- a/adk/chatmodel_test.go
+++ b/adk/chatmodel_test.go
@@ -118,13 +118,16 @@ func TestChatModelAgentRun(t *testing.T) {
 			events = append(events, event)
 		}
 
-		require.Len(t, events, 2)
-		require.NotNil(t, events[0].Output)
-		assert.Equal(t, "session answer", events[0].Output.MessageOutput.Message.Content)
+		require.Len(t, events, 3)
+		require.NotNil(t, events[0].SessionEvent)
+		assert.Equal(t, SessionEventMessageInserted, events[0].SessionEvent.Kind)
+		assert.Equal(t, schema.System, events[0].SessionEvent.MessageInserted.Message.Role)
+		require.NotNil(t, events[1].Output)
+		assert.Equal(t, "session answer", events[1].Output.MessageOutput.Message.Content)
 
-		require.NotNil(t, events[1].SessionEvent)
-		assert.Equal(t, SessionEventTurnEnd, events[1].SessionEvent.Kind)
-		turnEnd := events[1].SessionEvent.TurnEnd
+		require.NotNil(t, events[2].SessionEvent)
+		assert.Equal(t, SessionEventTurnEnd, events[2].SessionEvent.Kind)
+		turnEnd := events[2].SessionEvent.TurnEnd
 		require.NotNil(t, turnEnd)
 		assert.Nil(t, turnEnd.Messages)
 		assert.Equal(t, "session answer", turnEnd.SessionValues["answer"])
@@ -295,12 +298,14 @@ func TestChatModelAgentRun(t *testing.T) {
 			events = append(events, event)
 		}
 
-		require.Len(t, events, 4)
+		require.Len(t, events, 5)
 		assert.Equal(t, 2, generateCount)
-		require.NotNil(t, events[3].SessionEvent)
-		assert.Equal(t, SessionEventTurnEnd, events[3].SessionEvent.Kind)
+		require.NotNil(t, events[0].SessionEvent)
+		assert.Equal(t, SessionEventMessageInserted, events[0].SessionEvent.Kind)
+		require.NotNil(t, events[4].SessionEvent)
+		assert.Equal(t, SessionEventTurnEnd, events[4].SessionEvent.Kind)
 
-		turnEnd := events[3].SessionEvent.TurnEnd
+		turnEnd := events[4].SessionEvent.TurnEnd
 		require.NotNil(t, turnEnd)
 		assert.Nil(t, turnEnd.Messages)
 		require.Len(t, turnEnd.ToolInfos, 1)

--- a/adk/session_test.go
+++ b/adk/session_test.go
@@ -32,6 +32,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"github.com/cloudwego/eino/components/model"
 	"github.com/cloudwego/eino/schema"
 )
 
@@ -4655,6 +4656,315 @@ func TestRunnerPersists_MessageInserted_AnchorAndAppend(t *testing.T) {
 	require.NotEqual(t, -1, idxPatched)
 	assert.Less(t, idxAgentsmd, idxUser, "agentsmd must be inserted before the user message")
 	assert.Greater(t, idxPatched, idxUser, "patched tool message must be appended at the end")
+}
+
+type leadingSystemTestModel[M MessageType] struct {
+	response M
+	inputs   [][]M
+}
+
+func (m *leadingSystemTestModel[M]) Generate(_ context.Context, input []M, _ ...model.Option) (M, error) {
+	copied := append([]M{}, input...)
+	m.inputs = append(m.inputs, copied)
+	return m.response, nil
+}
+
+func (m *leadingSystemTestModel[M]) Stream(ctx context.Context, input []M, opts ...model.Option) (*schema.StreamReader[M], error) {
+	msg, err := m.Generate(ctx, input, opts...)
+	if err != nil {
+		return nil, err
+	}
+	return schema.StreamReaderFromArray([]M{msg}), nil
+}
+
+func drainAgenticSessionEvents(t *testing.T, iter *AsyncIterator[*TypedAgentEvent[*schema.AgenticMessage]]) {
+	t.Helper()
+	for {
+		event, ok := iter.Next()
+		if !ok {
+			return
+		}
+		require.NoError(t, event.Err)
+	}
+}
+
+func loadMessageSessionEvents(t *testing.T, ctx context.Context, store *sessionHelperStore, sid string) []*SessionEvent[*schema.Message] {
+	t.Helper()
+	res, err := store.LoadEventsForSession(ctx, sid, &LoadSessionEventsRequest{})
+	require.NoError(t, err)
+	return res.Events
+}
+
+func loadAgenticSessionEvents(t *testing.T, ctx context.Context, store *agenticSessionHelperStore, sid string) []*SessionEvent[*schema.AgenticMessage] {
+	t.Helper()
+	res, err := store.LoadEventsForSession(ctx, sid, &LoadSessionEventsRequest{})
+	require.NoError(t, err)
+	return res.Events
+}
+
+func TestRunnerPersists_LeadingSystemMessageInsertedBeforeUser(t *testing.T) {
+	ctx := context.Background()
+	store := newSessionHelperStore()
+	sid := "leading-system-insert"
+	model := &leadingSystemTestModel[*schema.Message]{response: schema.AssistantMessage("answer", nil)}
+	agent, err := NewChatModelAgent(ctx, &ChatModelAgentConfig{
+		Name:        "system-insert-agent",
+		Description: "test",
+		Instruction: "system v1",
+		Model:       model,
+	})
+	require.NoError(t, err)
+
+	runner := NewRunner(ctx, RunnerConfig{Agent: agent, SessionID: sid, SessionStore: store})
+	drainSessionEvents(t, runner.Run(ctx, []*schema.Message{schema.UserMessage("hello")}))
+
+	events := loadMessageSessionEvents(t, ctx, store, sid)
+	var userEvent, insertedEvent, assistantEventIndex int
+	userEvent, insertedEvent, assistantEventIndex = -1, -1, -1
+	for i, event := range events {
+		if event.Message != nil && event.Message.Role == schema.User {
+			userEvent = i
+		}
+		if event.MessageInserted != nil && event.MessageInserted.Message.Role == schema.System {
+			insertedEvent = i
+		}
+		if event.Message != nil && event.Message.Role == schema.Assistant {
+			assistantEventIndex = i
+		}
+	}
+	require.NotEqual(t, -1, userEvent)
+	require.NotEqual(t, -1, insertedEvent)
+	require.NotEqual(t, -1, assistantEventIndex)
+	assert.Equal(t, GetMessageID(events[userEvent].Message), events[insertedEvent].MessageInserted.BeforeMessageID)
+	assert.Less(t, insertedEvent, assistantEventIndex, "system mutation event must be emitted before model output")
+
+	handle := mustOpenTestSession[*schema.Message](t, ctx, store, sid)
+	result, err := reconstructSessionState[*schema.Message](ctx, handle, sid, defaultLoadPageSize)
+	require.NoError(t, err)
+	require.NoError(t, handle.close(ctx))
+	require.Len(t, result.state.Messages, 3)
+	assert.Equal(t, schema.System, result.state.Messages[0].Role)
+	assert.Equal(t, "system v1", result.state.Messages[0].Content)
+	assert.Equal(t, schema.User, result.state.Messages[1].Role)
+	assert.Equal(t, schema.Assistant, result.state.Messages[2].Role)
+}
+
+func TestRunnerPersists_LeadingSystemMessageAsMessageWithNoPreviousMessages(t *testing.T) {
+	ctx := context.Background()
+	store := newSessionHelperStore()
+	sid := "leading-system-empty"
+	model := &leadingSystemTestModel[*schema.Message]{response: schema.AssistantMessage("answer", nil)}
+	agent, err := NewChatModelAgent(ctx, &ChatModelAgentConfig{
+		Name:        "system-empty-agent",
+		Description: "test",
+		Instruction: "system only",
+		Model:       model,
+	})
+	require.NoError(t, err)
+
+	runner := NewRunner(ctx, RunnerConfig{Agent: agent, SessionID: sid, SessionStore: store})
+	drainSessionEvents(t, runner.Run(ctx, nil))
+
+	var systemMessages int
+	for _, event := range loadMessageSessionEvents(t, ctx, store, sid) {
+		if event.Kind == SessionEventMessage && event.Message != nil && event.Message.Role == schema.System {
+			systemMessages++
+			assert.Equal(t, "system only", event.Message.Content)
+		}
+	}
+	assert.Equal(t, 1, systemMessages)
+}
+
+func TestRunnerPersists_LeadingSystemMessageUpdatedOnlyWhenChanged(t *testing.T) {
+	ctx := context.Background()
+	store := newSessionHelperStore()
+	sid := "leading-system-update"
+
+	runTurn := func(instruction, user string) {
+		model := &leadingSystemTestModel[*schema.Message]{response: schema.AssistantMessage("answer "+user, nil)}
+		agent, err := NewChatModelAgent(ctx, &ChatModelAgentConfig{
+			Name:        "system-update-agent",
+			Description: "test",
+			Instruction: instruction,
+			Model:       model,
+		})
+		require.NoError(t, err)
+		runner := NewRunner(ctx, RunnerConfig{Agent: agent, SessionID: sid, SessionStore: store})
+		drainSessionEvents(t, runner.Run(ctx, []*schema.Message{schema.UserMessage(user)}))
+	}
+
+	runTurn("system v1", "one")
+	handle := mustOpenTestSession[*schema.Message](t, ctx, store, sid)
+	firstState, err := reconstructSessionState[*schema.Message](ctx, handle, sid, defaultLoadPageSize)
+	require.NoError(t, err)
+	require.NoError(t, handle.close(ctx))
+	require.NotEmpty(t, firstState.state.Messages)
+	oldSystemID := GetMessageID(firstState.state.Messages[0])
+	require.NotEmpty(t, oldSystemID)
+
+	runTurn("system v1", "two")
+	for _, event := range loadMessageSessionEvents(t, ctx, store, sid) {
+		if event.MessageUpdated != nil {
+			t.Fatalf("identical system message must not emit message_updated: %#v", event.MessageUpdated)
+		}
+	}
+
+	runTurn("system v2", "three")
+	var systemUpdates []*SessionEvent[*schema.Message]
+	for _, event := range loadMessageSessionEvents(t, ctx, store, sid) {
+		if event.MessageUpdated != nil && event.MessageUpdated.Message.Role == schema.System {
+			systemUpdates = append(systemUpdates, event)
+		}
+	}
+	require.Len(t, systemUpdates, 1)
+	update := systemUpdates[0].MessageUpdated
+	assert.Equal(t, oldSystemID, update.MessageID)
+	assert.Equal(t, oldSystemID, GetMessageID(update.Message))
+	assert.Equal(t, "system v2", update.Message.Content)
+}
+
+func TestRunnerPersists_LeadingSystemMessageFromMessagesReplacedBoundary(t *testing.T) {
+	ctx := context.Background()
+	store := newSessionHelperStore()
+	sid := "leading-system-replaced"
+
+	system := schema.SystemMessage("system v1")
+	user := schema.UserMessage("seed")
+	EnsureMessageID(system)
+	EnsureMessageID(user)
+	replaced := []*schema.Message{system, user}
+	require.NoError(t, store.AppendEventsForSession(ctx, sid, []*SessionEvent[*schema.Message]{
+		withTestEventID(&SessionEvent[*schema.Message]{
+			Kind:             SessionEventMessagesReplaced,
+			MessagesReplaced: &replaced,
+		}),
+	}))
+	oldSystemID := GetMessageID(system)
+
+	runTurn := func(instruction string) {
+		model := &leadingSystemTestModel[*schema.Message]{response: schema.AssistantMessage("answer", nil)}
+		agent, err := NewChatModelAgent(ctx, &ChatModelAgentConfig{
+			Name:        "system-replaced-agent",
+			Description: "test",
+			Instruction: instruction,
+			Model:       model,
+		})
+		require.NoError(t, err)
+		runner := NewRunner(ctx, RunnerConfig{Agent: agent, SessionID: sid, SessionStore: store})
+		drainSessionEvents(t, runner.Run(ctx, []*schema.Message{schema.UserMessage("next")}))
+	}
+
+	runTurn("system v1")
+	for _, event := range loadMessageSessionEvents(t, ctx, store, sid) {
+		if event.MessageUpdated != nil {
+			t.Fatalf("identical system message after MessagesReplaced must not emit update")
+		}
+	}
+
+	runTurn("system v2")
+	var found *MessageUpdatedEvent[*schema.Message]
+	for _, event := range loadMessageSessionEvents(t, ctx, store, sid) {
+		if event.MessageUpdated != nil && event.MessageUpdated.Message.Role == schema.System {
+			found = event.MessageUpdated
+		}
+	}
+	require.NotNil(t, found)
+	assert.Equal(t, oldSystemID, found.MessageID)
+	assert.Equal(t, oldSystemID, GetMessageID(found.Message))
+	assert.Equal(t, "system v2", found.Message.Content)
+}
+
+func TestRunnerSkipsLeadingSystemEventWhenCustomGenModelInputHasNoSystem(t *testing.T) {
+	ctx := context.Background()
+	store := newSessionHelperStore()
+	sid := "leading-system-custom-none"
+	model := &leadingSystemTestModel[*schema.Message]{response: schema.AssistantMessage("answer", nil)}
+	agent, err := NewChatModelAgent(ctx, &ChatModelAgentConfig{
+		Name:        "custom-no-system-agent",
+		Description: "test",
+		Instruction: "ignored by custom input",
+		Model:       model,
+		GenModelInput: func(_ context.Context, _ string, input *AgentInput) ([]*schema.Message, error) {
+			return append([]*schema.Message{}, input.Messages...), nil
+		},
+	})
+	require.NoError(t, err)
+
+	runner := NewRunner(ctx, RunnerConfig{Agent: agent, SessionID: sid, SessionStore: store})
+	drainSessionEvents(t, runner.Run(ctx, []*schema.Message{schema.UserMessage("hello")}))
+
+	for _, event := range loadMessageSessionEvents(t, ctx, store, sid) {
+		switch {
+		case event.Message != nil && event.Message.Role == schema.System:
+			t.Fatalf("custom GenModelInput without leading system must not persist system message")
+		case event.MessageInserted != nil && event.MessageInserted.Message.Role == schema.System:
+			t.Fatalf("custom GenModelInput without leading system must not insert system message")
+		case event.MessageUpdated != nil && event.MessageUpdated.Message.Role == schema.System:
+			t.Fatalf("custom GenModelInput without leading system must not update system message")
+		}
+	}
+	require.Len(t, model.inputs, 1)
+	require.Len(t, model.inputs[0], 1)
+	assert.Equal(t, schema.User, model.inputs[0][0].Role)
+}
+
+func TestSameSystemMessageIgnoresExtra(t *testing.T) {
+	oldMsg := schema.SystemMessage("same")
+	oldMsg.Extra = map[string]any{"_eino_msg_id": "old", "trace": "a"}
+	newMsg := schema.SystemMessage("same")
+	newMsg.Extra = map[string]any{"_eino_msg_id": "new", "trace": "b"}
+	assert.True(t, sameSystemMessage[*schema.Message](oldMsg, newMsg))
+
+	oldAgentic := schema.SystemAgenticMessage("same")
+	oldAgentic.Extra = map[string]any{"_eino_msg_id": "old", "trace": "a"}
+	newAgentic := schema.SystemAgenticMessage("same")
+	newAgentic.Extra = map[string]any{"_eino_msg_id": "new", "trace": "b"}
+	assert.True(t, sameSystemMessage[*schema.AgenticMessage](oldAgentic, newAgentic))
+}
+
+func TestRunnerPersists_LeadingSystemMessageAgenticInsertAndUpdate(t *testing.T) {
+	ctx := context.Background()
+	store := newAgenticSessionHelperStore()
+	sid := "leading-system-agentic"
+
+	runTurn := func(instruction, user string) {
+		model := &leadingSystemTestModel[*schema.AgenticMessage]{response: agenticAssistantMessage("answer " + user)}
+		agent, err := NewTypedChatModelAgent(ctx, &TypedChatModelAgentConfig[*schema.AgenticMessage]{
+			Name:        "agentic-system-agent",
+			Description: "test",
+			Instruction: instruction,
+			Model:       model,
+		})
+		require.NoError(t, err)
+		runner := NewTypedRunner(TypedRunnerConfig[*schema.AgenticMessage]{
+			Agent:        agent,
+			SessionID:    sid,
+			SessionStore: store,
+		})
+		drainAgenticSessionEvents(t, runner.Run(ctx, []*schema.AgenticMessage{schema.UserAgenticMessage(user)}))
+	}
+
+	runTurn("agentic system v1", "one")
+	var inserted *MessageInsertedEvent[*schema.AgenticMessage]
+	for _, event := range loadAgenticSessionEvents(t, ctx, store, sid) {
+		if event.MessageInserted != nil && event.MessageInserted.Message.Role == schema.AgenticRoleTypeSystem {
+			inserted = event.MessageInserted
+		}
+	}
+	require.NotNil(t, inserted)
+	oldSystemID := GetMessageID(inserted.Message)
+	require.NotEmpty(t, oldSystemID)
+
+	runTurn("agentic system v2", "two")
+	var updated *MessageUpdatedEvent[*schema.AgenticMessage]
+	for _, event := range loadAgenticSessionEvents(t, ctx, store, sid) {
+		if event.MessageUpdated != nil && event.MessageUpdated.Message.Role == schema.AgenticRoleTypeSystem {
+			updated = event.MessageUpdated
+		}
+	}
+	require.NotNil(t, updated)
+	assert.Equal(t, oldSystemID, updated.MessageID)
+	assert.Equal(t, oldSystemID, GetMessageID(updated.Message))
 }
 
 func TestRunnerPersists_MessagesDeleted_Reconstructs(t *testing.T) {

--- a/adk/session_test.go
+++ b/adk/session_test.go
@@ -4908,18 +4908,74 @@ func TestRunnerSkipsLeadingSystemEventWhenCustomGenModelInputHasNoSystem(t *test
 	assert.Equal(t, schema.User, model.inputs[0][0].Role)
 }
 
-func TestSameSystemMessageIgnoresExtra(t *testing.T) {
+func TestAttack_LeadingSystemMessageExtraChangesArePersisted(t *testing.T) {
+	ctx := context.Background()
+	store := newSessionHelperStore()
+	sid := "leading-system-extra-update"
+
+	runTurn := func(trace string) {
+		model := &leadingSystemTestModel[*schema.Message]{response: schema.AssistantMessage("answer "+trace, nil)}
+		agent, err := NewChatModelAgent(ctx, &ChatModelAgentConfig{
+			Name:        "system-extra-agent",
+			Description: "test",
+			Instruction: "ignored by custom input",
+			Model:       model,
+			GenModelInput: func(_ context.Context, _ string, input *AgentInput) ([]*schema.Message, error) {
+				system := schema.SystemMessage("same")
+				system.Extra = map[string]any{"trace": trace}
+				messages := make([]*schema.Message, 0, len(input.Messages)+1)
+				messages = append(messages, system)
+				messages = append(messages, input.Messages...)
+				return messages, nil
+			},
+		})
+		require.NoError(t, err)
+		runner := NewRunner(ctx, RunnerConfig{Agent: agent, SessionID: sid, SessionStore: store})
+		drainSessionEvents(t, runner.Run(ctx, []*schema.Message{schema.UserMessage(trace)}))
+	}
+
+	runTurn("a")
+	runTurn("b")
+
+	var update *MessageUpdatedEvent[*schema.Message]
+	for _, event := range loadMessageSessionEvents(t, ctx, store, sid) {
+		if event.MessageUpdated != nil && event.MessageUpdated.Message.Role == schema.System {
+			update = event.MessageUpdated
+		}
+	}
+	require.NotNil(t, update, "system Extra changes must be persisted as message_updated")
+	assert.Equal(t, "b", update.Message.Extra["trace"])
+
+	handle := mustOpenTestSession[*schema.Message](t, ctx, store, sid)
+	result, err := reconstructSessionState[*schema.Message](ctx, handle, sid, defaultLoadPageSize)
+	require.NoError(t, err)
+	require.NoError(t, handle.close(ctx))
+	require.NotEmpty(t, result.state.Messages)
+	assert.Equal(t, "b", result.state.Messages[0].Extra["trace"])
+}
+
+func TestSameSystemMessageComparesExtraExceptMessageID(t *testing.T) {
 	oldMsg := schema.SystemMessage("same")
 	oldMsg.Extra = map[string]any{"_eino_msg_id": "old", "trace": "a"}
 	newMsg := schema.SystemMessage("same")
-	newMsg.Extra = map[string]any{"_eino_msg_id": "new", "trace": "b"}
+	newMsg.Extra = map[string]any{"_eino_msg_id": "new", "trace": "a"}
+	setMessageIDFromTarget[*schema.Message](newMsg, GetMessageID(oldMsg))
 	assert.True(t, sameSystemMessage[*schema.Message](oldMsg, newMsg))
+	newMsg.Extra["trace"] = "b"
+	assert.False(t, sameSystemMessage[*schema.Message](oldMsg, newMsg))
 
 	oldAgentic := schema.SystemAgenticMessage("same")
 	oldAgentic.Extra = map[string]any{"_eino_msg_id": "old", "trace": "a"}
 	newAgentic := schema.SystemAgenticMessage("same")
-	newAgentic.Extra = map[string]any{"_eino_msg_id": "new", "trace": "b"}
+	newAgentic.Extra = map[string]any{"_eino_msg_id": "new", "trace": "a"}
+	setMessageIDFromTarget[*schema.AgenticMessage](newAgentic, GetMessageID(oldAgentic))
 	assert.True(t, sameSystemMessage[*schema.AgenticMessage](oldAgentic, newAgentic))
+	newAgentic.Extra["trace"] = "b"
+	assert.False(t, sameSystemMessage[*schema.AgenticMessage](oldAgentic, newAgentic))
+
+	setMessageIDFromTarget[*schema.Message](newMsg, "")
+	assert.Equal(t, "old", GetMessageID(newMsg))
+	setMessageIDFromTarget[*schema.Message](nil, "ignored")
 }
 
 func TestRunnerPersists_LeadingSystemMessageAgenticInsertAndUpdate(t *testing.T) {


### PR DESCRIPTION
## Problem

Generated leading system messages are visible to the model, but they were not always reconstructable from `SessionEventStore`. The runner persists caller input before `BeforeAgent` and `genModelInput` finish, so the effective system message could be missing from the durable event log.

A related branch fix also preserves model timeout stream behavior after the timeout middleware extraction, so stream timeout semantics stay stable on top of `alpha/10`.

## Solution

After `genModelInput` succeeds, `ChatModelAgent` now syncs the generated leading system message into the session event stream before model execution:

```text
no previous messages         -> message(system)
previous non-system head     -> message_inserted(system, before first message)
previous system head same    -> no update, preserve message ID
previous system head changed -> message_updated(existing system ID)
```

This keeps `genModelInput` as the authority for the actual model input while making the effective system message auditable through normal session replay.

## Key Insight

The durable session state and the model input have different timing boundaries. Caller input is persisted by the runner before the agent builds model input, but the leading system message is produced inside the agent after `BeforeAgent`. The correct place to bridge that gap is immediately after `genModelInput`, before any model output event can be emitted.

## Summary

| Problem | Solution |
|---------|----------|
| Effective leading system message was not always in `SessionEventStore` | Emit `message`, `message_inserted`, or `message_updated` from the generated model input |
| Replaying a newly inserted system message after existing user input would put it in the wrong order | Insert it before the first durable message |
| Stable system prompts could create noisy updates | Compare semantic system-message fields and ignore transient `Extra` data |
| Agentic messages need the same audit behavior | Apply the same sync logic to `*schema.AgenticMessage` |

---

## 问题

模型实际看到的 leading system message 不一定能从 `SessionEventStore` 重建。Runner 会先持久化调用方输入，而 `BeforeAgent` 和 `genModelInput` 在 agent 内部稍后才生成最终 system message，因此有效 system prompt 可能缺失在持久化事件日志中。

这个分支还包含一个既有修复：在 timeout middleware 提取之后，继续保持 model timeout 的 stream 语义稳定。

## 解决方案

`genModelInput` 成功返回后，`ChatModelAgent` 会在模型执行前把生成出的 leading system message 同步到 session event stream：

```text
没有历史消息              -> message(system)
历史首条不是 system       -> message_inserted(system, before first message)
历史 system 内容相同      -> 不发 update，但复用旧 message ID
历史 system 内容变化      -> message_updated(existing system ID)
```

这样 `genModelInput` 仍然是模型输入的权威来源，同时有效 system message 可以通过正常 session replay 审计和重建。

## 关键洞察

durable session state 和 model input 的生成边界不同。调用方输入由 runner 提前持久化，但 leading system message 是 `BeforeAgent` 之后在 agent 内部生成的。正确的补齐点是 `genModelInput` 之后、任何 model output event 之前。

## 总结

| 问题 | 解决方案 |
|------|----------|
| 有效 leading system message 不一定存在于 `SessionEventStore` | 根据生成出的模型输入发出 `message`、`message_inserted` 或 `message_updated` |
| 已有 user input 后追加 system message 会导致 replay 顺序错误 | 使用 `message_inserted` 插入到第一条 durable message 之前 |
| 稳定 system prompt 可能产生冗余 update | 只比较语义字段，忽略瞬态 `Extra` 数据 |
| Agentic message 也需要同样的审计能力 | 对 `*schema.AgenticMessage` 复用同一套同步逻辑 |
