### PR TITLE
refactor(adk): remove turn end session event

### DIFF
--- a/adk/call_option.go
+++ b/adk/call_option.go
@@ -28,7 +28,6 @@ type options struct {
 	enableInternalTimelineEvents bool
 	handlers                     []callbacks.Handler
 	cancelCtx                    *cancelContext
-	refreshToolInfos             bool
 }
 
 // AgentRunOption is the call option for adk Agent.
@@ -104,19 +103,6 @@ func withSharedParentSession() AgentRunOption {
 func WithCallbacks(handlers ...callbacks.Handler) AgentRunOption {
 	return WrapImplSpecificOptFn(func(o *options) {
 		o.handlers = append(o.handlers, handlers...)
-	})
-}
-
-// WithRefreshToolInfos forces the agent to re-derive its tool list from the current
-// BaseTool set instead of using the persisted TurnEndState.ToolInfos from the previous turn.
-//
-// By default, when a SessionEventStore is configured, the Runner reuses the exact tool list
-// from the previous turn's end to preserve the model's prompt cache. Use this option when
-// you have added, removed, or updated tools between turns and need the model to see the
-// changes immediately (accepting a cache miss).
-func WithRefreshToolInfos() AgentRunOption {
-	return WrapImplSpecificOptFn(func(o *options) {
-		o.refreshToolInfos = true
 	})
 }
 

--- a/adk/chatmodel.go
+++ b/adk/chatmodel.go
@@ -59,6 +59,8 @@ type typedChatModelAgentExecCtx[M MessageType] struct {
 	sessionEvents          bool
 	timelineEvents         bool
 	internalTimelineEvents bool
+	lastModelContext       *ModelContextEvent
+	sawModelContext        bool
 }
 
 func (e *typedChatModelAgentExecCtx[M]) send(ctx context.Context, event *TypedAgentEvent[M]) {
@@ -106,6 +108,38 @@ func (e *typedChatModelAgentExecCtx[M]) send(ctx context.Context, event *TypedAg
 		}
 	}
 	e.generator.trySend(event)
+}
+
+func copyModelContextEvent(event *ModelContextEvent) *ModelContextEvent {
+	if event == nil {
+		return nil
+	}
+	return &ModelContextEvent{
+		ToolInfos:         append([]*schema.ToolInfo{}, event.ToolInfos...),
+		DeferredToolInfos: append([]*schema.ToolInfo{}, event.DeferredToolInfos...),
+	}
+}
+
+func syncModelContextSessionEvent[M MessageType](ctx context.Context, state *TypedChatModelAgentState[M]) {
+	execCtx := getTypedChatModelAgentExecCtx[M](ctx)
+	if execCtx == nil || !execCtx.sessionEvents || state == nil {
+		return
+	}
+	current := &ModelContextEvent{
+		ToolInfos:         append([]*schema.ToolInfo{}, state.ToolInfos...),
+		DeferredToolInfos: append([]*schema.ToolInfo{}, state.DeferredToolInfos...),
+	}
+	changed := !execCtx.sawModelContext || !reflect.DeepEqual(execCtx.lastModelContext, current)
+	if changed {
+		execCtx.send(ctx, &TypedAgentEvent[M]{
+			SessionEvent: &SessionEvent[M]{
+				Kind:         SessionEventModelContext,
+				ModelContext: copyModelContextEvent(current),
+			},
+		})
+	}
+	execCtx.lastModelContext = copyModelContextEvent(current)
+	execCtx.sawModelContext = true
 }
 
 type chatModelAgentExecCtx = typedChatModelAgentExecCtx[*schema.Message]
@@ -167,16 +201,18 @@ type chatModelAgentRunOptions struct {
 
 	historyModifier func(context.Context, []Message) []Message
 
-	afterToolCallsHook func(ctx context.Context) error
-
-	previousTurnToolInfos         []*schema.ToolInfo
-	previousTurnDeferredToolInfos []*schema.ToolInfo
+	afterToolCallsHook     func(ctx context.Context) error
+	initialModelContext    *ModelContextEvent
+	sawInitialModelContext bool
 }
 
-func withPreviousTurnToolInfos(toolInfos, deferredToolInfos []*schema.ToolInfo) AgentRunOption {
+func withInitialModelContext(event *ModelContextEvent, saw bool) AgentRunOption {
 	return WrapImplSpecificOptFn(func(t *chatModelAgentRunOptions) {
-		t.previousTurnToolInfos = toolInfos
-		t.previousTurnDeferredToolInfos = deferredToolInfos
+		if !saw {
+			return
+		}
+		t.initialModelContext = copyModelContextEvent(event)
+		t.sawInitialModelContext = true
 	})
 }
 
@@ -691,8 +727,6 @@ type typedRunParams[M MessageType] struct {
 	internalTimelineEvents bool
 
 	afterToolCallsHook func(ctx context.Context) error
-
-	toolInfosPreSeeded bool
 }
 
 type typedRunFunc[M MessageType] func(ctx context.Context, p *typedRunParams[M])
@@ -1083,43 +1117,6 @@ func (a *TypedChatModelAgent[M]) applyAfterAgent(ctx context.Context) (context.C
 	return ctx, nil
 }
 
-func (a *TypedChatModelAgent[M]) snapshotTurnEndState(ctx context.Context) *TurnEndState[M] {
-	var state *TurnEndState[M]
-	_ = compose.ProcessState(ctx, func(_ context.Context, st *typedState[M]) error {
-		state = &TurnEndState[M]{
-			Messages:          append([]M{}, st.Messages...),
-			ToolInfos:         append([]*schema.ToolInfo{}, st.ToolInfos...),
-			DeferredToolInfos: append([]*schema.ToolInfo{}, st.DeferredToolInfos...),
-			SessionValues:     GetSessionValues(ctx),
-		}
-		return nil
-	})
-	return state
-}
-
-func (a *TypedChatModelAgent[M]) emitTurnEndState(ctx context.Context, state *TurnEndState[M]) {
-	execCtx := getTypedChatModelAgentExecCtx[M](ctx)
-	if execCtx == nil {
-		return
-	}
-	if state == nil {
-		state = &TurnEndState[M]{SessionValues: GetSessionValues(ctx)}
-	} else {
-		state.SessionValues = GetSessionValues(ctx)
-	}
-	execCtx.send(ctx, &TypedAgentEvent[M]{
-		AgentName: a.name,
-		SessionEvent: &SessionEvent[M]{
-			Kind: SessionEventTurnEnd,
-			TurnEnd: &TurnEndState[M]{
-				ToolInfos:         state.ToolInfos,
-				DeferredToolInfos: state.DeferredToolInfos,
-				SessionValues:     state.SessionValues,
-			},
-		},
-	})
-}
-
 func (a *TypedChatModelAgent[M]) prepareExecContext(ctx context.Context) (*execContext, error) {
 	instruction := a.instruction
 	toolsNodeConf := a.toolsConfig.ToolsNodeConfig
@@ -1289,14 +1286,12 @@ func (a *TypedChatModelAgent[M]) buildNoToolsRunFunc(_ context.Context) (typedRu
 
 		appendModelToChain(chain, wrappedModel)
 
-		var turnEndState *TurnEndState[M]
 		chain.AppendLambda(compose.InvokableLambda(func(ctx context.Context, msg M) (M, error) {
 			if len(a.handlers) > 0 {
 				if _, err := a.applyAfterAgent(ctx); err != nil {
 					return msg, err
 				}
 			}
-			turnEndState = a.snapshotTurnEndState(ctx)
 			return msg, nil
 		}))
 
@@ -1354,9 +1349,6 @@ func (a *TypedChatModelAgent[M]) buildNoToolsRunFunc(_ context.Context) (typedRu
 			} else if msgStream != nil {
 				msgStream.Close()
 			}
-			if p.sessionEvents {
-				a.emitTurnEndState(ctx, turnEndState)
-			}
 			return
 		}
 
@@ -1411,7 +1403,6 @@ func (a *TypedChatModelAgent[M]) buildMessageReActRunFunc(_ context.Context, bc 
 		}
 		ctx = withCancelContext(ctx, cancelCtx)
 
-		var turnEndState *TurnEndState[*schema.Message]
 		msgAgent := any(a).(*TypedChatModelAgent[*schema.Message])
 		msgConf.afterAgentFunc = func(ctx context.Context, msg *schema.Message) (*schema.Message, error) {
 			if len(a.handlers) > 0 {
@@ -1420,7 +1411,6 @@ func (a *TypedChatModelAgent[M]) buildMessageReActRunFunc(_ context.Context, bc 
 					return msg, err
 				}
 			}
-			turnEndState = msgAgent.snapshotTurnEndState(ctx)
 			return msg, nil
 		}
 
@@ -1433,9 +1423,6 @@ func (a *TypedChatModelAgent[M]) buildMessageReActRunFunc(_ context.Context, bc 
 		chain := compose.NewChain[reactRunInput, Message]().
 			AppendLambda(
 				compose.InvokableLambda(func(ctx context.Context, in reactRunInput) (*reactInput, error) {
-					if mp.toolInfosPreSeeded {
-						_ = SetRunLocalValue(ctx, ToolInfosPreSeededKey, true)
-					}
 					messages, genErr := genModelInputFn(ctx, in.instruction, in.input)
 					if genErr != nil {
 						return nil, genErr
@@ -1522,9 +1509,6 @@ func (a *TypedChatModelAgent[M]) buildMessageReActRunFunc(_ context.Context, bc 
 				msgStream.Close()
 			}
 
-			if p.sessionEvents {
-				any(a).(*TypedChatModelAgent[*schema.Message]).emitTurnEndState(ctx, turnEndState)
-			}
 			return
 		}
 
@@ -1565,7 +1549,6 @@ func (a *TypedChatModelAgent[M]) buildAgenticReActRunFunc(_ context.Context, bc 
 		}
 		ctx = withCancelContext(ctx, cancelCtx)
 
-		var turnEndState *TurnEndState[*schema.AgenticMessage]
 		agenticAgent := any(a).(*TypedChatModelAgent[*schema.AgenticMessage])
 		agenticConf.afterAgentFunc = func(ctx context.Context, msg *schema.AgenticMessage) (*schema.AgenticMessage, error) {
 			if len(a.handlers) > 0 {
@@ -1574,7 +1557,6 @@ func (a *TypedChatModelAgent[M]) buildAgenticReActRunFunc(_ context.Context, bc 
 					return msg, err
 				}
 			}
-			turnEndState = agenticAgent.snapshotTurnEndState(ctx)
 			return msg, nil
 		}
 
@@ -1587,9 +1569,6 @@ func (a *TypedChatModelAgent[M]) buildAgenticReActRunFunc(_ context.Context, bc 
 		chain := compose.NewChain[agenticReactRunInput, *schema.AgenticMessage]().
 			AppendLambda(
 				compose.InvokableLambda(func(ctx context.Context, in agenticReactRunInput) (*agenticReactInput, error) {
-					if ap.toolInfosPreSeeded {
-						_ = SetRunLocalValue(ctx, ToolInfosPreSeededKey, true)
-					}
 					messages, genErr := genModelInputFn(ctx, in.instruction, in.input)
 					if genErr != nil {
 						return nil, genErr
@@ -1673,9 +1652,6 @@ func (a *TypedChatModelAgent[M]) buildAgenticReActRunFunc(_ context.Context, bc 
 				msgStream.Close()
 			}
 
-			if p.sessionEvents {
-				any(a).(*TypedChatModelAgent[*schema.AgenticMessage]).emitTurnEndState(ctx, turnEndState)
-			}
 			return
 		}
 
@@ -1784,25 +1760,12 @@ func (a *TypedChatModelAgent[M]) Run(ctx context.Context, input *TypedAgentInput
 	co := getComposeOptions(opts)
 	co = append(co, compose.WithCheckPointID(bridgeCheckpointID))
 	runOps := GetImplSpecificOptions[chatModelAgentRunOptions](nil, opts...)
+	if execCtx := getTypedChatModelAgentExecCtx[M](ctx); execCtx != nil {
+		execCtx.lastModelContext = copyModelContextEvent(runOps.initialModelContext)
+		execCtx.sawModelContext = runOps.sawInitialModelContext
+	}
 
-	var toolInfosPreSeeded bool
-	if len(runOps.previousTurnToolInfos) > 0 {
-		// Use the exact tool list persisted at the previous turn's end for prompt cache preservation.
-		co = append(co, compose.WithChatModelOption(model.WithTools(runOps.previousTurnToolInfos)))
-		if len(runOps.previousTurnDeferredToolInfos) > 0 {
-			co = append(co, compose.WithChatModelOption(model.WithDeferredTools(runOps.previousTurnDeferredToolInfos)))
-		}
-		toolInfosPreSeeded = true
-		// Still apply tool execution configuration from bc.
-		if bc != nil {
-			if bc.toolSearchTool != nil {
-				co = append(co, compose.WithChatModelOption(model.WithToolSearchTool(bc.toolSearchTool)))
-			}
-			if bc.toolUpdated {
-				co = append(co, compose.WithToolsNodeOption(compose.WithToolList(bc.toolsNodeConf.Tools...)))
-			}
-		}
-	} else if bc != nil {
+	if bc != nil {
 		if len(bc.toolInfos) > 0 {
 			co = append(co, compose.WithChatModelOption(model.WithTools(bc.toolInfos)))
 		}
@@ -1848,7 +1811,6 @@ func (a *TypedChatModelAgent[M]) Run(ctx context.Context, input *TypedAgentInput
 			timelineEvents:         o.enableTimelineEvents,
 			internalTimelineEvents: o.enableInternalTimelineEvents,
 			afterToolCallsHook:     runOps.afterToolCallsHook,
-			toolInfosPreSeeded:     toolInfosPreSeeded,
 		})
 	}()
 
@@ -1881,6 +1843,10 @@ func (a *TypedChatModelAgent[M]) Resume(ctx context.Context, info *ResumeInfo, o
 	co := getComposeOptions(opts)
 	co = append(co, compose.WithCheckPointID(bridgeCheckpointID))
 	resumeRunOps := GetImplSpecificOptions[chatModelAgentRunOptions](nil, opts...)
+	if execCtx := getTypedChatModelAgentExecCtx[M](ctx); execCtx != nil {
+		execCtx.lastModelContext = copyModelContextEvent(resumeRunOps.initialModelContext)
+		execCtx.sawModelContext = resumeRunOps.sawInitialModelContext
+	}
 
 	if bc != nil {
 		if len(bc.toolInfos) > 0 {

--- a/adk/chatmodel_test.go
+++ b/adk/chatmodel_test.go
@@ -86,7 +86,7 @@ func TestChatModelAgentRun(t *testing.T) {
 		assert.False(t, ok)
 	})
 
-	t.Run("SessionEvents_NoTools_EmitsTurnEnd", func(t *testing.T) {
+	t.Run("SessionEvents_NoTools_EmitsModelContext", func(t *testing.T) {
 		ctx := context.Background()
 
 		ctrl := gomock.NewController(t)
@@ -122,15 +122,14 @@ func TestChatModelAgentRun(t *testing.T) {
 		require.NotNil(t, events[0].SessionEvent)
 		assert.Equal(t, SessionEventMessageInserted, events[0].SessionEvent.Kind)
 		assert.Equal(t, schema.System, events[0].SessionEvent.MessageInserted.Message.Role)
-		require.NotNil(t, events[1].Output)
-		assert.Equal(t, "session answer", events[1].Output.MessageOutput.Message.Content)
 
-		require.NotNil(t, events[2].SessionEvent)
-		assert.Equal(t, SessionEventTurnEnd, events[2].SessionEvent.Kind)
-		turnEnd := events[2].SessionEvent.TurnEnd
-		require.NotNil(t, turnEnd)
-		assert.Nil(t, turnEnd.Messages)
-		assert.Equal(t, "session answer", turnEnd.SessionValues["answer"])
+		require.NotNil(t, events[1].SessionEvent)
+		assert.Equal(t, SessionEventModelContext, events[1].SessionEvent.Kind)
+		require.NotNil(t, events[1].SessionEvent.ModelContext)
+		assert.Empty(t, events[1].SessionEvent.ModelContext.ToolInfos)
+
+		require.NotNil(t, events[2].Output)
+		assert.Equal(t, "session answer", events[2].Output.MessageOutput.Message.Content)
 	})
 
 	t.Run("BasicChatModelWithAgentMiddleware", func(t *testing.T) {
@@ -251,7 +250,7 @@ func TestChatModelAgentRun(t *testing.T) {
 		assert.Len(t, capturedMessages, 3)
 	})
 
-	t.Run("SessionEvents_ReAct_EmitsToolAwareTurnEnd", func(t *testing.T) {
+	t.Run("SessionEvents_ReAct_EmitsToolAwareModelContext", func(t *testing.T) {
 		ctx := context.Background()
 
 		ctrl := gomock.NewController(t)
@@ -302,15 +301,11 @@ func TestChatModelAgentRun(t *testing.T) {
 		assert.Equal(t, 2, generateCount)
 		require.NotNil(t, events[0].SessionEvent)
 		assert.Equal(t, SessionEventMessageInserted, events[0].SessionEvent.Kind)
-		require.NotNil(t, events[4].SessionEvent)
-		assert.Equal(t, SessionEventTurnEnd, events[4].SessionEvent.Kind)
-
-		turnEnd := events[4].SessionEvent.TurnEnd
-		require.NotNil(t, turnEnd)
-		assert.Nil(t, turnEnd.Messages)
-		require.Len(t, turnEnd.ToolInfos, 1)
-		assert.Equal(t, "test_tool", turnEnd.ToolInfos[0].Name)
-		assert.Equal(t, "final with tool", turnEnd.SessionValues["answer"])
+		require.NotNil(t, events[1].SessionEvent)
+		assert.Equal(t, SessionEventModelContext, events[1].SessionEvent.Kind)
+		require.NotNil(t, events[1].SessionEvent.ModelContext)
+		require.Len(t, events[1].SessionEvent.ModelContext.ToolInfos, 1)
+		assert.Equal(t, "test_tool", events[1].SessionEvent.ModelContext.ToolInfos[0].Name)
 	})
 
 	t.Run("AfterChatModel_ReAct_ModifyAffectsFlow", func(t *testing.T) {

--- a/adk/coverage_contract_test.go
+++ b/adk/coverage_contract_test.go
@@ -105,7 +105,6 @@ func TestCommonOptionsAndFilteringContracts(t *testing.T) {
 		WithSkipTransferMessages(),
 		withSharedParentSession(),
 		WithCallbacks(nil),
-		WithRefreshToolInfos(),
 	)
 	require.NotNil(t, base)
 	assert.Equal(t, values, base.sessionValues)
@@ -114,7 +113,6 @@ func TestCommonOptionsAndFilteringContracts(t *testing.T) {
 	assert.True(t, base.enableInternalTimelineEvents)
 	assert.True(t, base.skipTransferMessages)
 	assert.True(t, base.sharedParentSession)
-	assert.True(t, base.refreshToolInfos)
 	assert.Len(t, base.handlers, 1)
 
 	custom := GetImplSpecificOptions(&struct{ Seen bool }{}, WrapImplSpecificOptFn(func(o *struct{ Seen bool }) {
@@ -125,7 +123,7 @@ func TestCommonOptionsAndFilteringContracts(t *testing.T) {
 	undesignatedCallback := WithCallbacks(nil)
 	currentCallback := WithCallbacks(nil).DesignateAgent("parent")
 	otherCallback := WithCallbacks(nil).DesignateAgent("child")
-	nonCallback := WithRefreshToolInfos()
+	nonCallback := WithSessionValues(map[string]any{"x": "y"})
 	filtered := filterCallbackHandlersForNestedAgents("parent", []AgentRunOption{
 		undesignatedCallback,
 		currentCallback,

--- a/adk/handler.go
+++ b/adk/handler.go
@@ -328,12 +328,6 @@ func processTypedState(ctx context.Context, fn func(extra map[string]any) map[st
 	})
 }
 
-// ToolInfosPreSeededKey is the RunLocalValue key set to true when the Runner injects
-// persisted TurnEndState.ToolInfos into the compose-level options for prompt cache preservation.
-// Middlewares (e.g., ToolSearch) should check this key to skip their initialization logic
-// that would otherwise re-derive or strip the tool list.
-const ToolInfosPreSeededKey = "__tool_infos_pre_seeded__"
-
 // SetRunLocalValue sets a key-value pair that persists for the duration of the current agent Run() invocation.
 // The value is scoped to this specific execution and is not shared across different Run() calls or agent instances.
 //

--- a/adk/middlewares/automemory/automemory.go
+++ b/adk/middlewares/automemory/automemory.go
@@ -807,9 +807,13 @@ func (m *middleware[M]) AfterAgent(ctx context.Context, state *adk.TypedChatMode
 		return ctx, nil
 
 	case WriteModeAsync:
-		if sessionID == "" {
-			sessionID = getOrInitWriteSessionID(ctx)
-			coordKey = m.coordinatorKey(sessionID)
+		if coordKey == "" {
+			if err := m.runMemoryExtractionAgent(ctx, state.Messages, cursor, state.ToolInfos); err != nil {
+				m.onErr(ctx, OnErrorStageMemoryWriteSync, err)
+				return ctx, nil
+			}
+			state = markWriteCursor(state, len(state.Messages))
+			return ctx, nil
 		}
 		snap, err := buildPendingSnapshot(state.Messages, cursor, state.ToolInfos)
 		if err != nil {

--- a/adk/middlewares/automemory/automemory_test.go
+++ b/adk/middlewares/automemory/automemory_test.go
@@ -966,9 +966,7 @@ func TestMiddleware_AfterAgent_AsyncExtractionKeepsLatestPendingSnapshot(t *test
 		firstRunStarted: startedCh,
 	}
 	coord := &CoordinationConfig[*schema.Message]{
-		SessionIDFunc: func(ctx context.Context, state *adk.ChatModelAgentState) (string, error) {
-			return "session-1", nil
-		},
+		SessionID:   "session-1",
 		Coordinator: NewLocalCoordinator(),
 		LockTTL:     time.Minute,
 	}
@@ -1175,9 +1173,7 @@ func TestMiddleware_BeforeAgent_DistributedCursorSyncIntoMessageExtra(t *testing
 	ctx := context.Background()
 	b := NewInMemoryBackend()
 	coord := &CoordinationConfig[*schema.Message]{
-		SessionIDFunc: func(ctx context.Context, state *adk.ChatModelAgentState) (string, error) {
-			return "sess-cursor", nil
-		},
+		SessionID:   "sess-cursor",
 		Coordinator: NewLocalCoordinator(),
 		LockTTL:     time.Minute,
 	}
@@ -1210,9 +1206,7 @@ func TestMiddleware_BeforeAgent_WriteCursorDoesNotBlockInstructionInjection(t *t
 	b.put("/mem/MEMORY.md", "remembered\n", now)
 
 	coord := &CoordinationConfig[*schema.Message]{
-		SessionIDFunc: func(ctx context.Context, state *adk.ChatModelAgentState) (string, error) {
-			return "sess-cursor", nil
-		},
+		SessionID:   "sess-cursor",
 		Coordinator: NewLocalCoordinator(),
 		LockTTL:     time.Minute,
 	}
@@ -1536,9 +1530,7 @@ func TestMiddleware_AfterAgent_AsyncSetsPendingSnapshotWhenLockHeld(t *testing.T
 
 	extModel := &extractionModel{}
 	coord := &CoordinationConfig[*schema.Message]{
-		SessionIDFunc: func(ctx context.Context, state *adk.ChatModelAgentState) (string, error) {
-			return "sess-pending", nil
-		},
+		SessionID:   "sess-pending",
 		Coordinator: NewLocalCoordinator(),
 		LockTTL:     time.Minute,
 	}

--- a/adk/middlewares/automemory/coordinator.go
+++ b/adk/middlewares/automemory/coordinator.go
@@ -28,8 +28,6 @@ import (
 	"github.com/cloudwego/eino/adk"
 )
 
-type SessionIDFunc[M adk.MessageType] func(ctx context.Context, state *adk.TypedChatModelAgentState[M]) (string, error)
-
 // Coordinator abstracts distributed coordination for async memory extraction.
 // A Redis-backed implementation can map AcquireLock to SETNX + TTL, Set to SET,
 // Get to GET, and GetAndDelete to GETDEL.
@@ -56,9 +54,9 @@ type PendingSnapshot struct {
 }
 
 type CoordinationConfig[M adk.MessageType] struct {
-	// SessionIDFunc returns the logical session ID used to build the coordinator key.
-	// Optional. Defaults to an internal context-scoped session ID for write extraction.
-	SessionIDFunc SessionIDFunc[M]
+	// SessionID is the logical session ID used to build the coordinator key.
+	// Optional. When empty, cross-turn coordination is disabled.
+	SessionID string
 
 	// Coordinator stores cursor/pending state and coordinates async extraction locks.
 	// Optional. Defaults to NewLocalCoordinator().

--- a/adk/middlewares/automemory/dream/config.go
+++ b/adk/middlewares/automemory/dream/config.go
@@ -29,7 +29,6 @@ import (
 )
 
 const (
-	defaultSessionKey        = "__eino_automemory_dream_session_id__"
 	defaultMinInterval       = 24 * time.Hour
 	defaultMinTouchedSession = 5
 	defaultScanInterval      = 10 * time.Minute
@@ -58,9 +57,9 @@ type Config[M adk.MessageType] struct {
 	// Required.
 	Model model.BaseModel[M]
 
-	// SessionIDFunc resolves the current session ID.
-	// Optional. Default: a generated session-scoped ID.
-	SessionIDFunc automemory.SessionIDFunc[M]
+	// SessionID is the current logical session ID.
+	// Optional. When empty, dream runs without cross-turn session grouping.
+	SessionID string
 
 	// OnError handles non-fatal runtime errors.
 	// Optional. Default: nil.
@@ -121,9 +120,6 @@ func applyCoreDefaults[M adk.MessageType](cfg *Config[M]) error {
 	if cfg.MemoryDirectory == "" || cfg.MemoryBackend == nil || cfg.Model == nil {
 		return fmt.Errorf("auto dream config: invalid")
 	}
-	if cfg.SessionIDFunc == nil {
-		cfg.SessionIDFunc = defaultSessionIDFunc[M]
-	}
 	return nil
 }
 
@@ -163,15 +159,4 @@ func applyScheduleDefaults[M adk.MessageType](cfg *Config[M]) error {
 		cfg.Schedule.Store = NewLocalStore()
 	}
 	return nil
-}
-
-func defaultSessionIDFunc[M adk.MessageType](ctx context.Context, _ *adk.TypedChatModelAgentState[M]) (string, error) {
-	if v, ok := adk.GetSessionValue(ctx, defaultSessionKey); ok {
-		if s, ok := v.(string); ok && s != "" {
-			return s, nil
-		}
-	}
-	s := fmt.Sprintf("dream-%d", time.Now().UnixNano())
-	adk.AddSessionValue(ctx, defaultSessionKey, s)
-	return s, nil
 }

--- a/adk/middlewares/automemory/dream/dream.go
+++ b/adk/middlewares/automemory/dream/dream.go
@@ -70,18 +70,14 @@ func Run[M adk.MessageType](ctx context.Context, cfg *Config[M], req *RunRequest
 	}
 	sessionID := strings.TrimSpace(req.SessionID)
 	if sessionID == "" {
-		sessionID, err = cfg.SessionIDFunc(ctx, nil)
-		if err != nil {
-			m.onErr(ctx, stageResolveSessionID, err)
-			return err
-		}
+		sessionID = strings.TrimSpace(cfg.SessionID)
 	}
 	return m.runDream(ctx, sessionID, nil)
 }
 
 type RunRequest struct {
 	// SessionID identifies the current session.
-	// Optional. When empty, `SessionIDFunc` is used.
+	// Optional. When empty, Config.SessionID is used.
 	SessionID string
 }
 
@@ -125,11 +121,7 @@ func (m *middleware[M]) AfterAgent(ctx context.Context, state *adk.TypedChatMode
 	if m == nil || m.cfg == nil || m.cfg.Schedule == nil {
 		return ctx, nil
 	}
-	sessionID, err := m.cfg.SessionIDFunc(ctx, state)
-	if err != nil {
-		m.onErr(ctx, stageResolveSessionID, err)
-		return ctx, nil
-	}
+	sessionID := strings.TrimSpace(m.cfg.SessionID)
 	now := m.now()
 	if err := m.cfg.Schedule.Store.RecordSessionTouch(ctx, m.resolvedMemoryDir, sessionID, now); err != nil {
 		m.onErr(ctx, stageRecordTouch, err)

--- a/adk/middlewares/automemory/dream/dream_test.go
+++ b/adk/middlewares/automemory/dream/dream_test.go
@@ -18,7 +18,6 @@ package dream
 
 import (
 	"context"
-	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
@@ -181,7 +180,7 @@ func TestNew_DoesNotMutateConfig(t *testing.T) {
 
 	_, err := New(ctx, cfg)
 	require.NoError(t, err)
-	require.Nil(t, cfg.SessionIDFunc)
+	require.Empty(t, cfg.SessionID)
 	require.Zero(t, cfg.Schedule.MinInterval)
 	require.Zero(t, cfg.Schedule.MinTouchedSession)
 	require.Zero(t, cfg.Schedule.ScanInterval)
@@ -373,46 +372,19 @@ func TestIntegration_UserPerspective_AgentMiddlewareAutoDream(t *testing.T) {
 	require.Contains(t, string(index), "dream.md")
 }
 
-func TestIntegration_UserPerspective_RunReturnsCallbackErrors(t *testing.T) {
-	ctx := context.Background()
-	tmp := t.TempDir()
-	require.NoError(t, os.WriteFile(filepath.Join(tmp, "MEMORY.md"), []byte(""), 0o644))
-
-	expected := fmt.Errorf("resolve session failed")
-	var onErrStages []string
-	err := Run(ctx, &Config[*schema.Message]{
-		MemoryDirectory: tmp,
-		MemoryBackend:   automemory.NewLocalBackend(),
-		Model:           &dreamModel{},
-		SessionIDFunc: func(context.Context, *adk.TypedChatModelAgentState[*schema.Message]) (string, error) {
-			return "", expected
-		},
-		OnError: func(_ context.Context, stage string, err error) {
-			onErrStages = append(onErrStages, stage+":"+err.Error())
-		},
-	}, nil)
-	require.ErrorIs(t, err, expected)
-	require.Equal(t, []string{stageResolveSessionID + ":" + expected.Error()}, onErrStages)
-}
-
-func TestIntegration_UserPerspective_RunFallsBackToSessionIDFuncWithoutState(t *testing.T) {
+func TestIntegration_UserPerspective_RunFallsBackToConfigSessionIDWithoutRequest(t *testing.T) {
 	ctx := context.Background()
 	tmp := t.TempDir()
 	require.NoError(t, os.WriteFile(filepath.Join(tmp, "MEMORY.md"), []byte(""), 0o644))
 
 	model := &dreamModel{}
-	var resolvedState *adk.TypedChatModelAgentState[*schema.Message]
 	err := Run(ctx, &Config[*schema.Message]{
 		MemoryDirectory: tmp,
 		MemoryBackend:   automemory.NewLocalBackend(),
 		Model:           model,
-		SessionIDFunc: func(_ context.Context, state *adk.TypedChatModelAgentState[*schema.Message]) (string, error) {
-			resolvedState = state
-			return "fallback-session", nil
-		},
+		SessionID:       "fallback-session",
 	}, nil)
 	require.NoError(t, err)
-	require.Nil(t, resolvedState)
 
 	raw, err := os.ReadFile(filepath.Join(tmp, "dream.md"))
 	require.NoError(t, err)

--- a/adk/middlewares/automemory/utils.go
+++ b/adk/middlewares/automemory/utils.go
@@ -779,18 +779,6 @@ func countModelVisibleMessages[M adk.MessageType](msgs []M) int {
 	return n
 }
 
-func getOrInitWriteSessionID(ctx context.Context) string {
-	const key = "__automemory_write_session_id__"
-	if v, ok := adk.GetSessionValue(ctx, key); ok {
-		if s, ok := v.(string); ok && s != "" {
-			return s
-		}
-	}
-	s := fmt.Sprintf("%d", time.Now().UnixNano())
-	adk.AddSessionValue(ctx, key, s)
-	return s
-}
-
 func buildPendingSnapshot[M adk.MessageType](messages []M, cursor int, toolInfos []*schema.ToolInfo) (*PendingSnapshot, error) {
 	raw, err := json.Marshal(messages)
 	if err != nil {
@@ -956,10 +944,10 @@ func (m *middleware[M]) topicSelectionTopK() int {
 }
 
 func (m *middleware[M]) resolveSessionID(ctx context.Context, state *adk.TypedChatModelAgentState[M]) (string, error) {
-	if m.coordination != nil && m.coordination.SessionIDFunc != nil {
-		return m.coordination.SessionIDFunc(ctx, state)
+	if m.coordination != nil {
+		return strings.TrimSpace(m.coordination.SessionID), nil
 	}
-	return getOrInitWriteSessionID(ctx), nil
+	return "", nil
 }
 
 func (m *middleware[M]) sendTopicMemoryEvent(ctx context.Context, msgs []M, memMsg M) {

--- a/adk/middlewares/dynamictool/toolsearch/toolsearch.go
+++ b/adk/middlewares/dynamictool/toolsearch/toolsearch.go
@@ -160,13 +160,6 @@ func (m *typedMiddleware[M]) isInitialized(ctx context.Context) bool {
 			return true
 		}
 	}
-	// Tool infos pre-seeded from previous turn's TurnEndState — skip initialization strip logic.
-	val, ok, err = adk.GetRunLocalValue(ctx, adk.ToolInfosPreSeededKey)
-	if err == nil && ok {
-		if b, _ := val.(bool); b {
-			return true
-		}
-	}
 	return false
 }
 

--- a/adk/retry_chatmodel.go
+++ b/adk/retry_chatmodel.go
@@ -329,12 +329,12 @@ func emitRetryingTimeline[M MessageType](ctx context.Context, err error, rejectR
 	sendSessionTimelineEvent(ctx, &SessionEvent[M]{
 		Timestamp: newEventTimestamp(),
 		Kind:      SessionEventSessionStatusRescheduled,
-		Lifecycle: &LifecycleEvent{Scope: LifecycleScopeSession, State: SessionRunStateRescheduled},
+		Lifecycle: &LifecycleEvent{State: SessionRunStateRescheduled},
 	})
 	sendSessionTimelineEvent(ctx, &SessionEvent[M]{
 		Timestamp: newEventTimestamp(),
 		Kind:      SessionEventSessionStatusRunning,
-		Lifecycle: &LifecycleEvent{Scope: LifecycleScopeSession, State: SessionRunStateRunning},
+		Lifecycle: &LifecycleEvent{State: SessionRunStateRunning},
 	})
 }
 

--- a/adk/runner.go
+++ b/adk/runner.go
@@ -173,7 +173,7 @@ type runnerSessionRunState[M MessageType] struct {
 	enabled         bool
 	sessionID       string
 	checkPointID    *string
-	latestState     *TurnEndState[M]
+	latestState     *reconstructedSessionState[M]
 	sessionConfig   SessionConfig[M]
 	sessionStore    SessionEventStore[M]
 	sessionHandle   sessionHandle[M]
@@ -183,20 +183,6 @@ type runnerSessionRunState[M MessageType] struct {
 	// inputMessages are the caller-provided messages for this turn (before history prepend).
 	// Captured so the Runner can persist them as session events at turn start.
 	inputMessages []M
-}
-
-func mergeSessionValues(restored, overrides map[string]any) map[string]any {
-	if len(restored) == 0 && len(overrides) == 0 {
-		return nil
-	}
-	merged := make(map[string]any, len(restored)+len(overrides))
-	for k, v := range restored {
-		merged[k] = v
-	}
-	for k, v := range overrides {
-		merged[k] = v
-	}
-	return merged
 }
 
 func valueOrEmpty(v *string) string {
@@ -288,7 +274,7 @@ func prepareRunnerSessionRun[M MessageType]( //nolint:revive // argument-limit
 	state.sessionStore = sessionStore
 	state.checkPointStore = checkPointStore
 	state.sessionConfig = normalizeSessionConfig(sessionConfig)
-	state.latestState = &TurnEndState[M]{}
+	state.latestState = &reconstructedSessionState[M]{}
 	openResult, err := openRunnerSession[M](ctx, sessionStore, sessionID, state.sessionConfig)
 	if err != nil {
 		return nil, err
@@ -300,8 +286,8 @@ func prepareRunnerSessionRun[M MessageType]( //nolint:revive // argument-limit
 		_ = state.sessionHandle.close(ctx)
 		return nil, fmt.Errorf("failed to reconstruct session[%s]: %w", sessionID, err)
 	}
-	// In Run, only the reconstructed state matters; inFlightTurnID is
-	// deliberately unused because fresh turns always get new TurnIDs.
+	// Fresh Run uses only reconstructed durable state. Resume gets its
+	// TurnID from the loaded runner checkpoint.
 	if reconstructResult != nil && reconstructResult.state != nil {
 		state.latestState = reconstructResult.state
 	}
@@ -309,7 +295,7 @@ func prepareRunnerSessionRun[M MessageType]( //nolint:revive // argument-limit
 		Timestamp: newEventTimestamp(),
 		Kind:      SessionEventSessionStatusRunning,
 		TurnID:    state.turnID,
-		Lifecycle: &LifecycleEvent{Scope: LifecycleScopeSession, State: SessionRunStateRunning},
+		Lifecycle: &LifecycleEvent{State: SessionRunStateRunning},
 	}
 	err = assignSessionEventID(ctx, runningEvent, state.sessionConfig.EventIDGenerator)
 	if err != nil {
@@ -373,7 +359,7 @@ func prepareRunnerSessionResume[M MessageType]( //nolint:revive // argument-limi
 	state.sessionStore = sessionStore
 	state.checkPointStore = checkPointStore
 	state.sessionConfig = normalizeSessionConfig(sessionConfig)
-	state.latestState = &TurnEndState[M]{}
+	state.latestState = &reconstructedSessionState[M]{}
 	openResult, err := openRunnerSession[M](ctx, sessionStore, sessionID, state.sessionConfig)
 	if err != nil {
 		return nil, "", err
@@ -385,13 +371,8 @@ func prepareRunnerSessionResume[M MessageType]( //nolint:revive // argument-limi
 		_ = state.sessionHandle.close(ctx)
 		return nil, "", fmt.Errorf("failed to reconstruct session[%s]: %w", sessionID, err)
 	}
-	if reconstructResult != nil {
-		if reconstructResult.state != nil {
-			state.latestState = reconstructResult.state
-		}
-		if reconstructResult.inFlightTurnID != "" {
-			state.turnID = reconstructResult.inFlightTurnID
-		}
+	if reconstructResult != nil && reconstructResult.state != nil {
+		state.latestState = reconstructResult.state
 	}
 	// Pick the checkpoint ID: caller-provided takes precedence over the implicit
 	// session-scoped one. The session-scoped key still drives existence checks
@@ -406,7 +387,7 @@ func prepareRunnerSessionResume[M MessageType]( //nolint:revive // argument-limi
 	// passing an explicit checkpoint ID has asserted the checkpoint should exist
 	// and any error will surface from the subsequent load. For implicit resume,
 	// the absence of a pending checkpoint is fatal and reported here.
-	_, existed, err := loadRunnerSessionCheckpoint(ctx, checkPointStore, effectiveCheckPointID)
+	cp, existed, err := loadRunnerSessionCheckpoint(ctx, checkPointStore, effectiveCheckPointID)
 	if err != nil {
 		_ = state.sessionHandle.close(ctx)
 		return nil, "", err
@@ -417,6 +398,9 @@ func prepareRunnerSessionResume[M MessageType]( //nolint:revive // argument-limi
 			return nil, "", fmt.Errorf("no pending session checkpoint for session %q", sessionID)
 		}
 		return nil, "", fmt.Errorf("checkpoint[%s] not exist", effectiveCheckPointID)
+	}
+	if cp != nil && cp.TurnID != "" {
+		state.turnID = cp.TurnID
 	}
 	resumeEvent := &SessionEvent[M]{
 		Timestamp: newEventTimestamp(),
@@ -603,15 +587,12 @@ func typedRunnerRunImpl[M MessageType](a TypedAgent[M], enableStreaming bool, st
 			return errorIterator[M](err)
 		}
 		sessionState.inputMessages = nil
-		o.sessionValues = mergeSessionValues(sessionState.latestState.SessionValues, o.sessionValues)
 		opts = append(opts, withEnableSessionEvents())
 		opts = append(opts, withEnableInternalTimelineEvents())
-		if !o.refreshToolInfos && len(sessionState.latestState.ToolInfos) > 0 {
-			opts = append(opts, withPreviousTurnToolInfos(
-				sessionState.latestState.ToolInfos,
-				sessionState.latestState.DeferredToolInfos,
-			))
-		}
+		opts = append(opts, withInitialModelContext(&ModelContextEvent{
+			ToolInfos:         sessionState.latestState.ToolInfos,
+			DeferredToolInfos: sessionState.latestState.DeferredToolInfos,
+		}, sessionState.latestState.sawModelContext))
 	}
 
 	input := &TypedAgentInput[M]{
@@ -694,6 +675,10 @@ func typedRunnerResumeInternalImpl[M MessageType](a TypedAgent[M], store CheckPo
 	if sessionState.enabled {
 		opts = append(opts, withEnableSessionEvents())
 		opts = append(opts, withEnableInternalTimelineEvents())
+		opts = append(opts, withInitialModelContext(&ModelContextEvent{
+			ToolInfos:         sessionState.latestState.ToolInfos,
+			DeferredToolInfos: sessionState.latestState.DeferredToolInfos,
+		}, sessionState.latestState.sawModelContext))
 	}
 
 	ctx, runCtx, resumeInfo, err := runnerLoadCheckPointForSession(store, ctx, checkPointID, sessionState.enabled)
@@ -787,7 +772,6 @@ func typedRunnerHandleIterImpl[M MessageType](enableStreaming bool, store CheckP
 		cancelled         bool
 		retryExhausted    bool
 		terminalErr       error
-		sawTurnEnd        bool
 		persister         *sessionEventPersister[M]
 		persistErr        error
 
@@ -1022,11 +1006,6 @@ func typedRunnerHandleIterImpl[M MessageType](enableStreaming bool, store CheckP
 
 		liveDelivered := false
 		if persister != nil {
-			// Track TurnEnd presence for commit validation.
-			if isTurnEndAgentEvent(event) {
-				sawTurnEnd = true
-			}
-
 			// Skip persistence (but not live delivery) for events owned by a
 			// different session (inner agent events forwarded via AgentTool).
 			fromOtherSession := event.SessionEvent != nil &&
@@ -1140,8 +1119,6 @@ func typedRunnerHandleIterImpl[M MessageType](enableStreaming bool, store CheckP
 			stopReason = "failed"
 		case terminalErr != nil:
 			stopReason = "failed"
-		case !sawTurnEnd:
-			stopReason = "failed"
 		}
 		if stopReason == "failed" {
 			errMsg := ""
@@ -1173,7 +1150,7 @@ func typedRunnerHandleIterImpl[M MessageType](enableStreaming bool, store CheckP
 		sendTimelineEvent(&SessionEvent[M]{
 			Timestamp: newEventTimestamp(),
 			Kind:      SessionEventSessionStatusIdle,
-			Lifecycle: &LifecycleEvent{Scope: LifecycleScopeSession, State: SessionRunStateIdle, StopReason: &StopReason{Type: stopReason}},
+			Lifecycle: &LifecycleEvent{State: SessionRunStateIdle, StopReason: &StopReason{Type: stopReason}},
 		})
 		res := &sessionTurnResult[M]{
 			persister:         persister,
@@ -1181,7 +1158,6 @@ func typedRunnerHandleIterImpl[M MessageType](enableStreaming bool, store CheckP
 			interrupted:       interrupted,
 			cancelled:         cancelled,
 			terminalErr:       terminalErr,
-			sawTurnEnd:        sawTurnEnd,
 			sessionState:      sessionState,
 			store:             store,
 			checkPointID:      checkPointID,
@@ -1247,7 +1223,6 @@ type sessionTurnResult[M MessageType] struct {
 	interrupted       bool
 	cancelled         bool
 	terminalErr       error
-	sawTurnEnd        bool
 	sessionState      *runnerSessionRunState[M]
 	store             CheckPointStore
 	checkPointID      *string
@@ -1286,9 +1261,6 @@ func (r *sessionTurnResult[M]) finalize(ctx context.Context) error {
 		return nil
 	}
 	if r.checkPointID != nil && !isNilCheckPointStore(r.store) {
-		if !r.sawTurnEnd {
-			return fmt.Errorf("failed to commit session[%s]: missing SessionEventTurnEnd", r.sessionState.sessionID)
-		}
 		if err := deleteCheckPointIfSupported(ctx, r.store, *r.checkPointID); err != nil {
 			return fmt.Errorf("failed to delete session checkpoint: %w", err)
 		}

--- a/adk/session.go
+++ b/adk/session.go
@@ -59,7 +59,7 @@ var ErrEventIDOutOfRange = errors.New("adk: session event id out of range")
 var ErrRollbackTargetNotFound = errors.New("adk: rollback target turn not found")
 var ErrInvalidRollbackTarget = errors.New("adk: invalid rollback target")
 var ErrRollbackTargetInactive = errors.New("adk: rollback target is not active")
-var ErrSessionHeadChanged = errors.New("adk: session committed turn_end head changed")
+var ErrSessionHeadChanged = errors.New("adk: session committed idle head changed")
 var ErrSessionBusy = errors.New("adk: session already has an active handle")
 var ErrDuplicateEventID = errors.New("adk: duplicate session event_id")
 
@@ -129,10 +129,6 @@ type AppendSessionEventsRequest[M MessageType] struct {
 // SessionEvent is the JSON-serializable persistence format for session events.
 // Exactly one semantic content field is active per event. The MessagesReplaced field
 // uses pointer-to-slice semantics (nil = absent, non-nil = active replacement).
-//
-// TurnEndState is persisted as a SessionEvent with the TurnEnd field set. The Messages
-// field within TurnEnd is intentionally left nil — messages are reconstructed from the
-// event log on read.
 type SessionEvent[M MessageType] struct {
 	// SessionID identifies the session timeline this event belongs to. Runner-owned
 	// root events use the runner SessionID; nested AgentTool events use their
@@ -169,7 +165,7 @@ type SessionEvent[M MessageType] struct {
 	MessageUpdated   *MessageUpdatedEvent[M]  `json:"message_updated,omitempty"`
 	MessageInserted  *MessageInsertedEvent[M] `json:"message_inserted,omitempty"`
 	MessagesDeleted  *MessagesDeletedEvent    `json:"messages_deleted,omitempty"`
-	TurnEnd          *TurnEndState[M]         `json:"turn_end,omitempty"`
+	ModelContext     *ModelContextEvent       `json:"model_context,omitempty"`
 	Rollback         *SessionRollbackEvent    `json:"rollback,omitempty"`
 
 	Lifecycle *LifecycleEvent    `json:"lifecycle,omitempty"`
@@ -189,7 +185,7 @@ const (
 	SessionEventMessageUpdated   SessionEventKind = "message_updated"
 	SessionEventMessageInserted  SessionEventKind = "message_inserted"
 	SessionEventMessagesDeleted  SessionEventKind = "messages_deleted"
-	SessionEventTurnEnd          SessionEventKind = "turn_end"
+	SessionEventModelContext     SessionEventKind = "model_context"
 	SessionEventRollback         SessionEventKind = "rollback"
 
 	SessionEventSessionStatusRunning     SessionEventKind = "session.status_running"
@@ -209,23 +205,16 @@ const (
 )
 
 type LifecycleEvent struct {
-	Scope      LifecycleScope  `json:"scope,omitempty"`
 	State      SessionRunState `json:"state,omitempty"`
 	StopReason *StopReason     `json:"stop_reason,omitempty"`
 }
 
 type SessionRollbackEvent struct {
-	ToEventID             string `json:"to_event_id"`
-	ToTurnID              string `json:"to_turn_id,omitempty"`
-	PreviousHeadTurnEndID string `json:"previous_head_turn_end_id,omitempty"`
-	PreviousHeadTurnID    string `json:"previous_head_turn_id,omitempty"`
+	ToEventID                 string `json:"to_event_id"`
+	ToTurnID                  string `json:"to_turn_id,omitempty"`
+	PreviousHeadCommitEventID string `json:"previous_head_commit_event_id,omitempty"`
+	PreviousHeadTurnID        string `json:"previous_head_turn_id,omitempty"`
 }
-
-type LifecycleScope string
-
-const (
-	LifecycleScopeSession LifecycleScope = "session"
-)
 
 type SessionRunState string
 
@@ -237,6 +226,11 @@ const (
 
 type StopReason struct {
 	Type string `json:"type,omitempty"`
+}
+
+type ModelContextEvent struct {
+	ToolInfos         []*schema.ToolInfo `json:"tool_infos,omitempty"`
+	DeferredToolInfos []*schema.ToolInfo `json:"deferred_tool_infos,omitempty"`
 }
 
 type SessionErrorEvent struct {
@@ -476,12 +470,11 @@ type SessionConfig[M MessageType] struct {
 	SessionAcquireTimeout time.Duration
 }
 
-// TurnEndState is the agent-visible state materialized at a successful turn boundary.
-type TurnEndState[M MessageType] struct {
+type reconstructedSessionState[M MessageType] struct {
 	Messages          []M
 	ToolInfos         []*schema.ToolInfo
 	DeferredToolInfos []*schema.ToolInfo
-	SessionValues     map[string]any
+	sawModelContext   bool
 }
 
 type runnerSessionCheckpoint struct {
@@ -492,9 +485,6 @@ type runnerSessionCheckpoint struct {
 }
 
 func init() {
-	schema.RegisterName[*TurnEndState[*schema.Message]]("_eino_adk_turn_end_state")
-	schema.RegisterName[*TurnEndState[*schema.AgenticMessage]]("_eino_adk_agentic_turn_end_state")
-
 	// Register SessionEvent and helper types for HumanReadableSerializer.
 	schema.RegisterName[*SessionEvent[*schema.Message]]("_eino_adk_session_event")
 	schema.RegisterName[*SessionEvent[*schema.AgenticMessage]]("_eino_adk_agentic_session_event")
@@ -503,6 +493,7 @@ func init() {
 	schema.RegisterName[*MessageInsertedEvent[*schema.Message]]("_eino_adk_message_inserted_event")
 	schema.RegisterName[*MessageInsertedEvent[*schema.AgenticMessage]]("_eino_adk_agentic_message_inserted_event")
 	schema.RegisterName[*MessagesDeletedEvent]("_eino_adk_messages_deleted_event")
+	schema.RegisterName[*ModelContextEvent]("_eino_adk_model_context_event")
 	schema.RegisterName[*LifecycleEvent]("_eino_adk_lifecycle_event")
 	schema.RegisterName[*SessionErrorEvent]("_eino_adk_session_error_event")
 	schema.RegisterName[*RetryStatus]("_eino_adk_retry_status")
@@ -687,11 +678,6 @@ func normalizeAgentSessionEventWithAssigner[M MessageType](
 		event.Timestamp = ts
 		se.Timestamp = ts
 	}
-	if se.TurnEnd != nil {
-		turnEnd := *se.TurnEnd
-		turnEnd.Messages = nil
-		se.TurnEnd = &turnEnd
-	}
 	event.EventID = se.EventID
 	event.Timestamp = se.Timestamp
 	event.SessionEvent = &se
@@ -736,8 +722,11 @@ func ClassifySessionEvent[M MessageType](event *SessionEvent[M]) (SessionEventKi
 		}
 		add(SessionEventMessagesDeleted)
 	}
-	if event.TurnEnd != nil {
-		add(SessionEventTurnEnd)
+	if event.ModelContext != nil {
+		if err := validateModelContextEvent(event.ModelContext); err != nil {
+			return "", err
+		}
+		add(SessionEventModelContext)
 	}
 	if event.Rollback != nil {
 		if event.EventID == "" {
@@ -764,37 +753,11 @@ func ClassifySessionEvent[M MessageType](event *SessionEvent[M]) (SessionEventKi
 		add(SessionEventSessionError)
 	}
 	if event.Span != nil {
-		if (event.Span.Model != nil) == (event.Span.Tool != nil) {
-			return "", errors.New("span event must populate exactly one of Model or Tool")
+		kind, err := classifySpanSessionEvent(event.Span)
+		if err != nil {
+			return "", err
 		}
-		switch event.Span.Kind {
-		case SpanKindModel:
-			if event.Span.Model == nil {
-				return "", errors.New("model span requires Span.Model meta")
-			}
-			switch {
-			case !event.Span.StartedAt.IsZero() && event.Span.EndedAt.IsZero():
-				add(SessionEventSpanModelRequestStart)
-			case !event.Span.EndedAt.IsZero():
-				add(SessionEventSpanModelRequestEnd)
-			default:
-				return "", errors.New("model span must have start or end timestamp")
-			}
-		case SpanKindTool:
-			if event.Span.Tool == nil {
-				return "", errors.New("tool span requires Span.Tool meta")
-			}
-			switch {
-			case !event.Span.StartedAt.IsZero() && event.Span.EndedAt.IsZero():
-				add(SessionEventSpanToolCallStart)
-			case !event.Span.EndedAt.IsZero():
-				add(SessionEventSpanToolCallEnd)
-			default:
-				return "", errors.New("tool span must have start or end timestamp")
-			}
-		default:
-			return "", fmt.Errorf("unknown span kind %q", event.Span.Kind)
-		}
+		add(kind)
 	}
 	if event.UserObservation != nil {
 		if event.UserObservation.Interrupt == nil {
@@ -820,9 +783,46 @@ func ClassifySessionEvent[M MessageType](event *SessionEvent[M]) (SessionEventKi
 	return kinds[0], nil
 }
 
+func classifySpanSessionEvent(span *SpanEvent) (SessionEventKind, error) {
+	if (span.Model != nil) == (span.Tool != nil) {
+		return "", errors.New("span event must populate exactly one of Model or Tool")
+	}
+	switch span.Kind {
+	case SpanKindModel:
+		if span.Model == nil {
+			return "", errors.New("model span requires Span.Model meta")
+		}
+		switch {
+		case !span.StartedAt.IsZero() && span.EndedAt.IsZero():
+			return SessionEventSpanModelRequestStart, nil
+		case !span.EndedAt.IsZero():
+			return SessionEventSpanModelRequestEnd, nil
+		default:
+			return "", errors.New("model span must have start or end timestamp")
+		}
+	case SpanKindTool:
+		if span.Tool == nil {
+			return "", errors.New("tool span requires Span.Tool meta")
+		}
+		switch {
+		case !span.StartedAt.IsZero() && span.EndedAt.IsZero():
+			return SessionEventSpanToolCallStart, nil
+		case !span.EndedAt.IsZero():
+			return SessionEventSpanToolCallEnd, nil
+		default:
+			return "", errors.New("tool span must have start or end timestamp")
+		}
+	default:
+		return "", fmt.Errorf("unknown span kind %q", span.Kind)
+	}
+}
+
 // NormalizeSessionEventKind fills an empty Kind from the active payload and
 // rejects mismatches between Kind and payload shape.
 func NormalizeSessionEventKind[M MessageType](event *SessionEvent[M]) error {
+	if event != nil && event.Kind == "turn_end" {
+		return nil
+	}
 	kind, err := ClassifySessionEvent(event)
 	if err != nil {
 		return err
@@ -848,7 +848,7 @@ func ValidateEmittedSessionEventKind[M MessageType](event *SessionEvent[M]) erro
 
 func isSessionDurableBoundaryKind(kind SessionEventKind) bool {
 	switch kind {
-	case SessionEventMessage, SessionEventTurnEnd, SessionEventAgentInterrupt:
+	case SessionEventMessage, SessionEventSessionStatusIdle, SessionEventAgentInterrupt:
 		return true
 	default:
 		return false
@@ -1073,7 +1073,7 @@ func stripSessionEventFields[M MessageType](event *TypedAgentEvent[M]) *TypedAge
 }
 
 // applySessionEvent applies a single SessionEvent to the message array, mutating in place.
-// TurnEnd events are metadata-only and do not mutate messages.
+// Non-message events are ignored.
 func applySessionEvent[M MessageType](messages *[]M, event *SessionEvent[M]) error {
 	if !isContextSessionEvent(event) {
 		return nil
@@ -1087,15 +1087,6 @@ func isContextSessionEvent[M MessageType](event *SessionEvent[M]) bool {
 	}
 	return !isNilMessage(event.Message) || event.MessagesReplaced != nil ||
 		event.MessageUpdated != nil || event.MessageInserted != nil || event.MessagesDeleted != nil
-}
-
-func isTurnEndSessionEvent[M MessageType](event *SessionEvent[M]) bool {
-	return event != nil && event.TurnEnd != nil
-}
-
-func isTurnEndAgentEvent[M MessageType](event *TypedAgentEvent[M]) bool {
-	return event != nil && event.SessionEvent != nil &&
-		event.SessionEvent.Kind == SessionEventTurnEnd && event.SessionEvent.TurnEnd != nil
 }
 
 func applyContextSessionEvent[M MessageType](messages []M, event *SessionEvent[M]) ([]M, error) {
@@ -1150,19 +1141,6 @@ func applyContextSessionEventInPlace[M MessageType](event *SessionEvent[M], out 
 		}
 	}
 	return nil
-}
-
-func applyTurnEndSessionEvent[M MessageType](state *TurnEndState[M], event *SessionEvent[M]) *TurnEndState[M] {
-	if state == nil {
-		state = &TurnEndState[M]{}
-	}
-	if event == nil || event.TurnEnd == nil {
-		return state
-	}
-	state.ToolInfos = event.TurnEnd.ToolInfos
-	state.DeferredToolInfos = event.TurnEnd.DeferredToolInfos
-	state.SessionValues = event.TurnEnd.SessionValues
-	return state
 }
 
 // replaceMessageByID finds the message with the given ID and replaces it.
@@ -1225,21 +1203,49 @@ func validateMessageIDs(field string, ids []string) error {
 	return nil
 }
 
-type sessionReconstructResult[M MessageType] struct {
-	state          *TurnEndState[M]
-	inFlightTurnID string // TurnID from events after the last committed TurnEnd (the interrupted turn)
+func validateModelContextEvent(event *ModelContextEvent) error {
+	if event == nil {
+		return nil
+	}
+	if err := validateToolInfoNames("ModelContext.ToolInfos", event.ToolInfos); err != nil {
+		return err
+	}
+	return validateToolInfoNames("ModelContext.DeferredToolInfos", event.DeferredToolInfos)
 }
 
-// modelContextSessionEventKinds is the set of event kinds required to reconstruct
-// model-facing session state (messages + turn metadata). Timeline-only events
-// (lifecycle, span, error, interrupt) are excluded.
-var modelContextSessionEventKinds = []SessionEventKind{
+func validateToolInfoNames(field string, infos []*schema.ToolInfo) error {
+	seen := make(map[string]struct{}, len(infos))
+	for _, info := range infos {
+		if info == nil {
+			continue
+		}
+		if info.Name == "" {
+			return fmt.Errorf("%s must not contain empty tool name", field)
+		}
+		if _, ok := seen[info.Name]; ok {
+			return fmt.Errorf("%s contains duplicate tool name %q", field, info.Name)
+		}
+		seen[info.Name] = struct{}{}
+	}
+	return nil
+}
+
+type sessionReconstructResult[M MessageType] struct {
+	state *reconstructedSessionState[M]
+}
+
+// sessionReplayEventKinds is the set of event kinds required to project the active
+// session log and reconstruct model-facing state.
+var sessionReplayEventKinds = []SessionEventKind{
 	SessionEventMessage,
 	SessionEventMessagesReplaced,
 	SessionEventMessageUpdated,
 	SessionEventMessageInserted,
 	SessionEventMessagesDeleted,
-	SessionEventTurnEnd,
+	SessionEventModelContext,
+	SessionEventSessionStatusIdle,
+	SessionEventAgentInterrupt,
+	SessionEventCancel,
 	SessionEventRollback,
 }
 
@@ -1335,10 +1341,10 @@ func RollbackSession[M MessageType](
 		Timestamp: newEventTimestamp(),
 		Kind:      SessionEventRollback,
 		Rollback: &SessionRollbackEvent{
-			ToEventID:             target.EventID,
-			ToTurnID:              target.TurnID,
-			PreviousHeadTurnEndID: head.EventID,
-			PreviousHeadTurnID:    head.TurnID,
+			ToEventID:                 target.EventID,
+			ToTurnID:                  target.TurnID,
+			PreviousHeadCommitEventID: head.EventID,
+			PreviousHeadTurnID:        head.TurnID,
 		},
 	}
 	if err := assignSessionEventID(ctx, rb, cfg.EventIDGenerator); err != nil {
@@ -1360,12 +1366,9 @@ func RollbackSession[M MessageType](
 	return nil
 }
 
-// reconstructSessionState rebuilds session state from the append log.
-// Durable context events are replayed through the log tail, including messages
-// after the latest TurnEnd. The latest TurnEnd remains the metadata boundary for
-// tool infos, deferred tool infos, and session values. This preserves framework
-// context fidelity; provider-specific sanitization for dangling tool-call
-// structures remains a caller or middleware concern.
+// reconstructSessionState rebuilds session state by replaying the active log.
+// Committed idle lifecycle events are loaded for rollback projection but are not
+// applied as reconstructed state.
 func reconstructSessionState[M MessageType](
 	ctx context.Context,
 	handle sessionHandle[M],
@@ -1380,32 +1383,11 @@ func reconstructSessionState[M MessageType](
 		return nil, nil
 	}
 
-	committedEndIdx := latestCommittedTurnEnd(allEvents)
-	contextTailIdx := len(allEvents) - 1
-	inFlightStartIdx := committedEndIdx + 1
-	if committedEndIdx < 0 {
-		// Compatibility for historical/session-fixture logs written before
-		// TurnEnd became the explicit commit boundary.
-		inFlightStartIdx = 0
-		committedEndIdx = contextTailIdx
-	}
-
-	// After the last committed TurnEnd, any events belong to an interrupted
-	// turn. The first TurnID found identifies that turn — all events within a
-	// single turn share the same TurnID, so only the first match is needed.
-	var inFlightTurnID string
-	for i := inFlightStartIdx; i <= contextTailIdx; i++ {
-		if allEvents[i] != nil && allEvents[i].TurnID != "" {
-			inFlightTurnID = allEvents[i].TurnID
-			break
-		}
-	}
-
-	state, err := replayDurableContextEvents(allEvents, committedEndIdx, contextTailIdx)
+	state, err := replayDurableContextEvents(allEvents)
 	if err != nil {
 		return nil, err
 	}
-	return &sessionReconstructResult[M]{state: state, inFlightTurnID: inFlightTurnID}, nil
+	return &sessionReconstructResult[M]{state: state}, nil
 }
 
 func loadActiveSessionEventsReverse[M MessageType](
@@ -1425,7 +1407,7 @@ func loadActiveSessionEventsReverse[M MessageType](
 			After:     after,
 			Limit:     pageSize,
 			Reverse:   true,
-			Kinds:     modelContextSessionEventKinds,
+			Kinds:     sessionReplayEventKinds,
 		})
 		if err != nil {
 			return nil, err
@@ -1460,13 +1442,11 @@ func projectActiveEventsFromReverse[M MessageType](
 				return nil, ErrRollbackTargetInactive
 			}
 			target := active[pos]
-			if target.Kind != SessionEventTurnEnd {
+			if !isCommittedIdleEvent(target) {
 				return nil, ErrInvalidRollbackTarget
 			}
-			if rb.ToTurnID != "" {
-				if target.TurnEnd == nil || target.TurnID != rb.ToTurnID {
-					return nil, ErrInvalidRollbackTarget
-				}
+			if rb.ToTurnID != "" && target.TurnID != rb.ToTurnID {
+				return nil, ErrInvalidRollbackTarget
 			}
 			activeLen = pos + 1
 			continue
@@ -1512,7 +1492,7 @@ func findPhysicalRollbackTargetEvidence[M MessageType](
 			After:     after,
 			Limit:     pageSize,
 			Reverse:   false,
-			Kinds:     modelContextSessionEventKinds,
+			Kinds:     sessionReplayEventKinds,
 		})
 		if err != nil {
 			return rollbackTargetEvidenceNone, err
@@ -1527,7 +1507,7 @@ func findPhysicalRollbackTargetEvidence[M MessageType](
 			if event.TurnID != targetTurnID {
 				continue
 			}
-			if event.Kind == SessionEventTurnEnd && event.TurnEnd != nil {
+			if isCommittedIdleEvent(event) {
 				return rollbackTargetEvidenceCommitted, nil
 			}
 			evidence = rollbackTargetEvidenceUncommitted
@@ -1556,16 +1536,13 @@ func resolveRollbackTarget[M MessageType](
 ) (target *SessionEvent[M], head *SessionEvent[M], err error) {
 	var sawTargetTurnEvidence bool
 	for _, event := range activeEvents {
-		if event.Kind != SessionEventTurnEnd {
+		if !isCommittedIdleEvent(event) {
 			if !sawTargetTurnEvidence {
 				if event.TurnID == targetTurnID {
 					sawTargetTurnEvidence = true
 				}
 			}
 			continue
-		}
-		if event.Kind != SessionEventTurnEnd || event.TurnEnd == nil || event.TurnID == "" {
-			return nil, nil, ErrInvalidRollbackTarget
 		}
 		head = event
 		if event.TurnID == targetTurnID {
@@ -1582,24 +1559,14 @@ func resolveRollbackTarget[M MessageType](
 	return nil, nil, ErrRollbackTargetNotFound
 }
 
-func replayDurableContextEvents[M MessageType](events []*SessionEvent[M], metadataTurnEndPos int, contextTailPos int) (*TurnEndState[M], error) {
-	if len(events) == 0 || metadataTurnEndPos < 0 || contextTailPos < 0 {
+func replayDurableContextEvents[M MessageType](events []*SessionEvent[M]) (*reconstructedSessionState[M], error) {
+	if len(events) == 0 {
 		return nil, nil
 	}
-	if metadataTurnEndPos >= len(events) {
-		metadataTurnEndPos = len(events) - 1
-	}
-	if contextTailPos >= len(events) {
-		contextTailPos = len(events) - 1
-	}
-	if contextTailPos < metadataTurnEndPos {
-		contextTailPos = metadataTurnEndPos
-	}
-
 	var messages []M
 	startIdx := 0
 	boundaryIdx := -1
-	for i := 0; i <= contextTailPos; i++ {
+	for i := 0; i < len(events); i++ {
 		if events[i].MessagesReplaced != nil {
 			boundaryIdx = i
 		}
@@ -1610,28 +1577,36 @@ func replayDurableContextEvents[M MessageType](events []*SessionEvent[M], metada
 		startIdx = boundaryIdx + 1
 	}
 
-	for i := startIdx; i <= contextTailPos; i++ {
+	// Model-context reconstruction is intentionally scoped to events at or after
+	// the latest MessagesReplaced boundary, the same window used for messages.
+	// A model_context emitted before that boundary is not recovered: doing so
+	// would require scanning the full session log, which defeats the point of
+	// shortcutting reconstruction at MessagesReplaced. The only consequence is
+	// that the next turn's first model call re-emits a model_context snapshot
+	// (sawModelContext starts false) even when the tool set is unchanged — an
+	// extra audit event, not a correctness issue, since reconstructed ToolInfos
+	// feed only the change-detection baseline and never the model itself.
+	state := &reconstructedSessionState[M]{Messages: messages}
+	for i := startIdx; i < len(events); i++ {
 		if err := applySessionEvent(&messages, events[i]); err != nil {
 			return nil, fmt.Errorf("reconstruct: %w", err)
 		}
+		if events[i] != nil && events[i].ModelContext != nil {
+			state.ToolInfos = append([]*schema.ToolInfo{}, events[i].ModelContext.ToolInfos...)
+			state.DeferredToolInfos = append([]*schema.ToolInfo{}, events[i].ModelContext.DeferredToolInfos...)
+			state.sawModelContext = true
+		}
 	}
-
-	state := &TurnEndState[M]{Messages: messages}
-	state = applyTurnEndSessionEvent(state, events[metadataTurnEndPos])
+	state.Messages = messages
 	return state, nil
 }
 
-func latestCommittedTurnEnd[M MessageType](events []*SessionEvent[M]) int {
-	for i := len(events) - 1; i >= 0; i-- {
-		if events[i] != nil && events[i].Kind == SessionEventTurnEnd && events[i].TurnID != "" && events[i].TurnEnd != nil {
-			return i
-		}
-	}
-	// Fallback for legacy logs that lack Kind/TurnID on TurnEnd events.
-	for i := len(events) - 1; i >= 0; i-- {
-		if events[i] != nil && events[i].TurnEnd != nil {
-			return i
-		}
-	}
-	return -1
+func isCommittedIdleEvent[M MessageType](event *SessionEvent[M]) bool {
+	return event != nil &&
+		event.Kind == SessionEventSessionStatusIdle &&
+		event.Lifecycle != nil &&
+		event.Lifecycle.State == SessionRunStateIdle &&
+		event.Lifecycle.StopReason != nil &&
+		event.Lifecycle.StopReason.Type == "end_turn" &&
+		event.TurnID != ""
 }

--- a/adk/session/conformance.go
+++ b/adk/session/conformance.go
@@ -426,9 +426,12 @@ func messageEvent[M adk.MessageType](id string, msg M) *adk.SessionEvent[M] {
 func turnEndEvent[M adk.MessageType](id, turnID string) *adk.SessionEvent[M] {
 	return &adk.SessionEvent[M]{
 		EventID: id,
-		Kind:    adk.SessionEventTurnEnd,
+		Kind:    adk.SessionEventSessionStatusIdle,
 		TurnID:  turnID,
-		TurnEnd: &adk.TurnEndState[M]{},
+		Lifecycle: &adk.LifecycleEvent{
+			State:      adk.SessionRunStateIdle,
+			StopReason: &adk.StopReason{Type: "end_turn"},
+		},
 	}
 }
 

--- a/adk/session/file_store_test.go
+++ b/adk/session/file_store_test.go
@@ -57,7 +57,7 @@ func TestFileStorePersistsAcrossInstances(t *testing.T) {
 	require.NoError(t, err)
 
 	first := testMessageEvent("persist-1", "first")
-	second := testTurnEndEvent("persist-2", "turn-1")
+	second := testCommittedIdleEvent("persist-2", "turn-1")
 	err = store.AppendEvents(ctx, &adk.AppendSessionEventsRequest[*schema.Message]{SessionID: "s", Events: []*adk.SessionEvent[*schema.Message]{first, second}})
 	require.NoError(t, err)
 
@@ -77,7 +77,7 @@ func TestFileStoreWritesHumanReadableEvlogLines(t *testing.T) {
 	require.NoError(t, err)
 
 	first := testMessageEvent("line-1", "first")
-	second := testTurnEndEvent("line-2", "turn-1")
+	second := testCommittedIdleEvent("line-2", "turn-1")
 	err = store.AppendEvents(ctx, &adk.AppendSessionEventsRequest[*schema.Message]{SessionID: "s", Events: []*adk.SessionEvent[*schema.Message]{first, second}})
 	require.NoError(t, err)
 
@@ -95,7 +95,7 @@ func TestFileStoreWritesHumanReadableEvlogLines(t *testing.T) {
 	parts1 := strings.SplitN(lines[1], "\t", 3)
 	require.Len(t, parts1, 3)
 	assert.Equal(t, "line-2", parts1[0])
-	assert.Equal(t, "turn_end", parts1[1])
+	assert.Equal(t, "session.status_idle", parts1[1])
 }
 
 func TestFileStoreRollbackPreservesPhysicalAuditLog(t *testing.T) {
@@ -107,9 +107,9 @@ func TestFileStoreRollbackPreservesPhysicalAuditLog(t *testing.T) {
 
 	err = store.AppendEvents(ctx, &adk.AppendSessionEventsRequest[*schema.Message]{SessionID: sessionID, Events: []*adk.SessionEvent[*schema.Message]{
 		withTurn(testMessageEvent("msg-1", "Q1"), "turn-1"),
-		testTurnEndEvent("end-1", "turn-1"),
+		testCommittedIdleEvent("end-1", "turn-1"),
 		withTurn(testMessageEvent("msg-2", "Q2"), "turn-2"),
-		testTurnEndEvent("end-2", "turn-2"),
+		testCommittedIdleEvent("end-2", "turn-2"),
 	}})
 	require.NoError(t, err)
 
@@ -204,7 +204,7 @@ func TestFileStoreValidationReplayAndReversePagination(t *testing.T) {
 	events := []*adk.SessionEvent[*schema.Message]{
 		testMessageEvent("e1", "one"),
 		testSpanEvent("e2"),
-		testTurnEndEvent("e3", "turn-1"),
+		testCommittedIdleEvent("e3", "turn-1"),
 	}
 	err = store.AppendEvents(ctx, &adk.AppendSessionEventsRequest[*schema.Message]{
 		SessionID: "s",
@@ -241,7 +241,7 @@ func TestFileStoreValidationReplayAndReversePagination(t *testing.T) {
 	forward, err := store.LoadEvents(ctx, &adk.LoadSessionEventsRequest{
 		SessionID: "s",
 		After:     "e1",
-		Kinds:     []adk.SessionEventKind{adk.SessionEventTurnEnd, adk.SessionEventMessage},
+		Kinds:     []adk.SessionEventKind{adk.SessionEventSessionStatusIdle, adk.SessionEventMessage},
 		Limit:     1,
 	})
 	require.NoError(t, err)

--- a/adk/session/in_memory_store_test.go
+++ b/adk/session/in_memory_store_test.go
@@ -74,7 +74,7 @@ func TestInMemoryStoreKindFilterAndPagination(t *testing.T) {
 	events := []*adk.SessionEvent[*schema.Message]{
 		testMessageEvent("e1", "one"),
 		testSpanEvent("e2"),
-		testTurnEndEvent("e3", "turn-1"),
+		testCommittedIdleEvent("e3", "turn-1"),
 		testMessageEvent("e4", "four"),
 	}
 	err := store.AppendEvents(ctx, &adk.AppendSessionEventsRequest[*schema.Message]{SessionID: "s", Events: events})
@@ -83,7 +83,7 @@ func TestInMemoryStoreKindFilterAndPagination(t *testing.T) {
 	res, err := store.LoadEvents(ctx, &adk.LoadSessionEventsRequest{
 		SessionID: "s",
 		After:     "e2",
-		Kinds:     []adk.SessionEventKind{adk.SessionEventMessage, adk.SessionEventTurnEnd},
+		Kinds:     []adk.SessionEventKind{adk.SessionEventMessage, adk.SessionEventSessionStatusIdle},
 		Limit:     1,
 	})
 	require.NoError(t, err)
@@ -118,7 +118,7 @@ func TestInMemoryStoreValidationReplayAndReversePagination(t *testing.T) {
 	events := []*adk.SessionEvent[*schema.Message]{
 		testMessageEvent("e1", "one"),
 		testSpanEvent("e2"),
-		testTurnEndEvent("e3", "turn-1"),
+		testCommittedIdleEvent("e3", "turn-1"),
 	}
 	err := store.AppendEvents(ctx, &adk.AppendSessionEventsRequest[*schema.Message]{
 		SessionID: "s",
@@ -188,12 +188,15 @@ func testMessageEvent(id, content string) *adk.SessionEvent[*schema.Message] {
 	}
 }
 
-func testTurnEndEvent(id, turnID string) *adk.SessionEvent[*schema.Message] {
+func testCommittedIdleEvent(id, turnID string) *adk.SessionEvent[*schema.Message] {
 	return &adk.SessionEvent[*schema.Message]{
 		EventID: id,
-		Kind:    adk.SessionEventTurnEnd,
+		Kind:    adk.SessionEventSessionStatusIdle,
 		TurnID:  turnID,
-		TurnEnd: &adk.TurnEndState[*schema.Message]{},
+		Lifecycle: &adk.LifecycleEvent{
+			State:      adk.SessionRunStateIdle,
+			StopReason: &adk.StopReason{Type: "end_turn"},
+		},
 	}
 }
 

--- a/adk/session_test.go
+++ b/adk/session_test.go
@@ -147,6 +147,17 @@ func withTestEventID[M MessageType](se *SessionEvent[M]) *SessionEvent[M] {
 	return se
 }
 
+func withTestCommittedIdle[M MessageType](turnID string) *SessionEvent[M] {
+	return withTestEventID(&SessionEvent[M]{
+		Kind:   SessionEventSessionStatusIdle,
+		TurnID: turnID,
+		Lifecycle: &LifecycleEvent{
+			State:      SessionRunStateIdle,
+			StopReason: &StopReason{Type: "end_turn"},
+		},
+	})
+}
+
 func testSequentialEventIDGenerator(prefix string) SessionEventIDGenerator[*schema.Message] {
 	var n int64
 	return func(_ context.Context, _ *SessionEvent[*schema.Message]) (string, error) {
@@ -220,9 +231,12 @@ func appendCommittedTestTurn(t *testing.T, ctx context.Context, store testSessio
 		})
 	}
 	return appendTestSessionEvent(t, ctx, store, sid, &SessionEvent[*schema.Message]{
-		Kind:    SessionEventTurnEnd,
-		TurnID:  turnID,
-		TurnEnd: &TurnEndState[*schema.Message]{SessionValues: map[string]any{"turn": turnID}},
+		Kind:   SessionEventSessionStatusIdle,
+		TurnID: turnID,
+		Lifecycle: &LifecycleEvent{
+			State:      SessionRunStateIdle,
+			StopReason: &StopReason{Type: "end_turn"},
+		},
 	})
 }
 
@@ -230,7 +244,14 @@ type runnerSessionAgent struct {
 	name    string
 	inputs  [][]*schema.Message
 	values  []map[string]any
-	turnEnd *TurnEndState[*schema.Message]
+	turnEnd *testTurnState[*schema.Message]
+}
+
+type testTurnState[M MessageType] struct {
+	Messages          []M
+	ToolInfos         []*schema.ToolInfo
+	DeferredToolInfos []*schema.ToolInfo
+	SessionValues     map[string]any
 }
 
 func (a *runnerSessionAgent) Name(_ context.Context) string        { return a.name }
@@ -239,23 +260,12 @@ func (a *runnerSessionAgent) Run(ctx context.Context, input *AgentInput, _ ...Ag
 	iter, gen := NewAsyncIteratorPair[*AgentEvent]()
 	a.inputs = append(a.inputs, append([]*schema.Message{}, input.Messages...))
 	a.values = append(a.values, GetSessionValues(ctx))
-	turnEnd := a.turnEnd
-	if turnEnd == nil {
-		turnEnd = &TurnEndState[*schema.Message]{Messages: append([]*schema.Message{}, input.Messages...)}
-	}
 	go func() {
 		defer gen.Close()
 		gen.Send(&AgentEvent{
 			AgentName: a.name,
 			Output: &AgentOutput{
 				MessageOutput: &MessageVariant{Message: schema.AssistantMessage("ok", nil), Role: schema.Assistant},
-			},
-		})
-		gen.Send(&AgentEvent{
-			AgentName: a.name,
-			SessionEvent: &SessionEvent[*schema.Message]{
-				Kind:    SessionEventTurnEnd,
-				TurnEnd: turnEnd,
 			},
 		})
 	}()
@@ -286,15 +296,6 @@ func (a *streamingSessionAgent) Run(_ context.Context, _ *AgentInput, _ ...Agent
 		})
 		<-a.release
 		sw.Close()
-		gen.Send(&AgentEvent{
-			AgentName: a.Name(context.Background()),
-			SessionEvent: &SessionEvent[*schema.Message]{
-				Kind: SessionEventTurnEnd,
-				TurnEnd: &TurnEndState[*schema.Message]{
-					Messages: []*schema.Message{schema.AssistantMessage("partial", nil)},
-				},
-			},
-		})
 	}()
 	return iter
 }
@@ -612,7 +613,7 @@ func TestRunnerSessionModePrependsCommittedMessagesOnce(t *testing.T) {
 	sessionID := "runner-session"
 	firstAgent := &runnerSessionAgent{
 		name: "runner-session-agent",
-		turnEnd: &TurnEndState[*schema.Message]{
+		turnEnd: &testTurnState[*schema.Message]{
 			Messages:      []*schema.Message{schema.UserMessage("first"), schema.AssistantMessage("answer1", nil)},
 			SessionValues: map[string]any{"k": "restored"},
 		},
@@ -626,7 +627,7 @@ func TestRunnerSessionModePrependsCommittedMessagesOnce(t *testing.T) {
 
 	secondAgent := &runnerSessionAgent{
 		name: "runner-session-agent",
-		turnEnd: &TurnEndState[*schema.Message]{
+		turnEnd: &testTurnState[*schema.Message]{
 			Messages:      []*schema.Message{schema.UserMessage("first"), schema.AssistantMessage("answer1", nil), schema.UserMessage("second"), schema.AssistantMessage("answer2", nil)},
 			SessionValues: map[string]any{"k": "next"},
 		},
@@ -644,7 +645,7 @@ func TestRunnerSessionModePrependsCommittedMessagesOnce(t *testing.T) {
 	assert.Equal(t, "ok", secondAgent.inputs[0][1].Content)
 	assert.Equal(t, "second", secondAgent.inputs[0][2].Content)
 	require.Len(t, secondAgent.values, 1)
-	assert.Equal(t, "restored", secondAgent.values[0]["k"])
+	assert.Nil(t, secondAgent.values[0]["k"])
 	assert.Equal(t, "value", secondAgent.values[0]["override"])
 }
 
@@ -993,8 +994,7 @@ func TestRunnerSessionModeDeleteCheckpointFailureIsReported(t *testing.T) {
 	store.deleteErr = errors.New("delete failed")
 
 	res := &sessionTurnResult[*schema.Message]{
-		persister:  persister,
-		sawTurnEnd: true,
+		persister: persister,
 		sessionState: &runnerSessionRunState[*schema.Message]{
 			enabled:      true,
 			sessionID:    "delete-fail-session",
@@ -1007,12 +1007,10 @@ func TestRunnerSessionModeDeleteCheckpointFailureIsReported(t *testing.T) {
 	err := res.finalize(ctx)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "failed to delete session checkpoint")
-	assert.True(t, res.sawTurnEnd, "turn must have been seen before stale checkpoint cleanup")
 }
 
-func TestTurnEndStateSessionValues_JSONLikeRoundTrip(t *testing.T) {
-	state := &TurnEndState[*schema.Message]{
-		Messages: []*schema.Message{schema.UserMessage("hello")},
+func TestModelContextEvent_JSONLikeRoundTrip(t *testing.T) {
+	modelCtx := &ModelContextEvent{
 		ToolInfos: []*schema.ToolInfo{
 			{
 				Name:        "lookup",
@@ -1020,23 +1018,16 @@ func TestTurnEndStateSessionValues_JSONLikeRoundTrip(t *testing.T) {
 				ParamsOneOf: schema.NewParamsOneOfByParams(map[string]*schema.ParameterInfo{"q": {Type: schema.String}}),
 			},
 		},
-		SessionValues: map[string]any{
-			"nested": map[string]any{"count": int64(9007199254740993)},
-			"list":   []any{"a", int64(7), true},
-		},
 	}
 
-	se := &SessionEvent[*schema.Message]{TurnEnd: state}
+	se := &SessionEvent[*schema.Message]{Kind: SessionEventModelContext, ModelContext: modelCtx}
 	data, err := encodeSessionEvent(withTestEventID(se))
 	require.NoError(t, err)
 	decoded, err := decodeSessionEvent[*schema.Message](data)
 	require.NoError(t, err)
-	require.NotNil(t, decoded.TurnEnd)
-	require.Len(t, decoded.TurnEnd.Messages, 1)
-	assert.Equal(t, "hello", decoded.TurnEnd.Messages[0].Content)
-	require.Len(t, decoded.TurnEnd.ToolInfos, 1)
-	assert.Equal(t, "lookup", decoded.TurnEnd.ToolInfos[0].Name)
-	assert.Equal(t, state.SessionValues, decoded.TurnEnd.SessionValues)
+	require.NotNil(t, decoded.ModelContext)
+	require.Len(t, decoded.ModelContext.ToolInfos, 1)
+	assert.Equal(t, "lookup", decoded.ModelContext.ToolInfos[0].Name)
 }
 
 func TestRunnerSessionStreamingDoesNotBlockLiveEvent(t *testing.T) {
@@ -1203,15 +1194,6 @@ func (a *runnerInterruptAgent) Resume(ctx context.Context, info *ResumeInfo, _ .
 				},
 			},
 		})
-		gen.Send(&AgentEvent{
-			AgentName: "InterruptAgent",
-			SessionEvent: &SessionEvent[*schema.Message]{
-				Kind: SessionEventTurnEnd,
-				TurnEnd: &TurnEndState[*schema.Message]{
-					Messages: []*schema.Message{schema.AssistantMessage("resumed ok", nil)},
-				},
-			},
-		})
 	}()
 	return iter
 }
@@ -1237,7 +1219,6 @@ func (a *runnerCheckpointSanitizeAgent) Run(ctx context.Context, _ *AgentInput, 
 				EventID: "checkpoint-session-only",
 				Kind:    SessionEventSessionStatusRunning,
 				Lifecycle: &LifecycleEvent{
-					Scope: LifecycleScopeSession,
 					State: SessionRunStateRunning,
 				},
 			},
@@ -1313,7 +1294,7 @@ func TestRunnerSessionModeFlushFailurePreventsCommit(t *testing.T) {
 
 	agent := &runnerSessionAgent{
 		name: "flush-fail-agent",
-		turnEnd: &TurnEndState[*schema.Message]{
+		turnEnd: &testTurnState[*schema.Message]{
 			Messages: []*schema.Message{schema.AssistantMessage("done", nil)},
 		},
 	}
@@ -1345,7 +1326,7 @@ func TestRunnerSessionSyncModeBlocksDeliveryUntilAppendCompletes(t *testing.T) {
 	store := newBlockingAppendStore()
 	agent := &runnerSessionAgent{
 		name: "sync-block-agent",
-		turnEnd: &TurnEndState[*schema.Message]{
+		turnEnd: &testTurnState[*schema.Message]{
 			Messages: []*schema.Message{schema.AssistantMessage("ok", nil)},
 		},
 	}
@@ -1413,7 +1394,7 @@ func TestRunnerSessionSyncModeAppendFailureSuppressesOutput(t *testing.T) {
 	store.appendErr = errors.New("sync append failed")
 	agent := &runnerSessionAgent{
 		name: "sync-fail-agent",
-		turnEnd: &TurnEndState[*schema.Message]{
+		turnEnd: &testTurnState[*schema.Message]{
 			Messages: []*schema.Message{schema.AssistantMessage("ok", nil)},
 		},
 	}
@@ -1562,7 +1543,6 @@ func TestRunnerSessionDurableBoundaryBatchShape(t *testing.T) {
 		{SessionEventSessionStatusRunning},
 		{SessionEventMessage},
 		{SessionEventMessage},
-		{SessionEventTurnEnd},
 		{SessionEventSessionStatusIdle},
 	}, store.appendBatches)
 }
@@ -1627,19 +1607,16 @@ func TestSessionPersister_DirectAppendNoRetryAndLatch(t *testing.T) {
 	})
 }
 
-// TestTurnEndState_GobRoundtripNilFields verifies gob roundtrip preserves nil semantics.
-func TestTurnEndState_GobRoundtripNilFields(t *testing.T) {
-	original := &TurnEndState[*schema.Message]{}
-	se := &SessionEvent[*schema.Message]{TurnEnd: original}
+// TestModelContextEvent_GobRoundtripNilFields verifies gob roundtrip preserves nil semantics.
+func TestModelContextEvent_GobRoundtripNilFields(t *testing.T) {
+	se := &SessionEvent[*schema.Message]{Kind: SessionEventModelContext, ModelContext: &ModelContextEvent{}}
 	encoded, err := encodeSessionEvent(withTestEventID(se))
 	require.NoError(t, err)
 	decoded, err := decodeSessionEvent[*schema.Message](encoded)
 	require.NoError(t, err)
-	require.NotNil(t, decoded.TurnEnd)
-	assert.Nil(t, decoded.TurnEnd.Messages)
-	assert.Nil(t, decoded.TurnEnd.ToolInfos)
-	assert.Nil(t, decoded.TurnEnd.DeferredToolInfos)
-	assert.Nil(t, decoded.TurnEnd.SessionValues)
+	require.NotNil(t, decoded.ModelContext)
+	assert.Nil(t, decoded.ModelContext.ToolInfos)
+	assert.Nil(t, decoded.ModelContext.DeferredToolInfos)
 }
 
 func TestNormalizeSessionConfig_Variations(t *testing.T) {
@@ -1964,8 +1941,8 @@ func TestStripSessionEventFields(t *testing.T) {
 	t.Run("SessionEvent-only event drops to nil", func(t *testing.T) {
 		ev := &AgentEvent{
 			SessionEvent: &SessionEvent[*schema.Message]{
-				Kind:    SessionEventTurnEnd,
-				TurnEnd: &TurnEndState[*schema.Message]{},
+				Kind:         SessionEventModelContext,
+				ModelContext: &ModelContextEvent{},
 			},
 		}
 		stripped := stripSessionEventFields(ev)
@@ -1990,9 +1967,9 @@ func TestStripSessionEventFields(t *testing.T) {
 			Timestamp: ts,
 			Err:       errors.New("visible"),
 			SessionEvent: &SessionEvent[*schema.Message]{
-				SessionID: "child-1",
-				Kind:      SessionEventTurnEnd,
-				TurnEnd:   &TurnEndState[*schema.Message]{},
+				SessionID:    "child-1",
+				Kind:         SessionEventModelContext,
+				ModelContext: &ModelContextEvent{},
 			},
 		}
 		stripped := stripSessionEventFields(ev)
@@ -2156,10 +2133,10 @@ func TestSessionRollbackEventRoundTrip(t *testing.T) {
 		EventID: uuid.NewString(),
 		Kind:    SessionEventRollback,
 		Rollback: &SessionRollbackEvent{
-			ToEventID:             "turn-end-1",
-			ToTurnID:              "turn-1",
-			PreviousHeadTurnEndID: "turn-end-2",
-			PreviousHeadTurnID:    "turn-2",
+			ToEventID:                 "turn-end-1",
+			ToTurnID:                  "turn-1",
+			PreviousHeadCommitEventID: "turn-end-2",
+			PreviousHeadTurnID:        "turn-2",
 		},
 	}
 	data, err := encodeSessionEvent(se)
@@ -2171,7 +2148,7 @@ func TestSessionRollbackEventRoundTrip(t *testing.T) {
 	assert.Equal(t, SessionEventRollback, decoded.Kind)
 	assert.Equal(t, "turn-end-1", decoded.Rollback.ToEventID)
 	assert.Equal(t, "turn-1", decoded.Rollback.ToTurnID)
-	assert.Equal(t, "turn-end-2", decoded.Rollback.PreviousHeadTurnEndID)
+	assert.Equal(t, "turn-end-2", decoded.Rollback.PreviousHeadCommitEventID)
 	assert.Equal(t, "turn-2", decoded.Rollback.PreviousHeadTurnID)
 }
 
@@ -2223,7 +2200,6 @@ func TestRollbackSessionReconstructionHidesDeadBranchAndKeepsNewSuffix(t *testin
 	assert.Equal(t, "A1", result.state.Messages[1].Content)
 	assert.Equal(t, "Q3", result.state.Messages[2].Content)
 	assert.Equal(t, "A3", result.state.Messages[3].Content)
-	assert.Equal(t, "turn-3", result.state.SessionValues["turn"])
 
 	rollbackEvents := filterStoredSessionEvents(t, store.events, func(se *SessionEvent[*schema.Message]) bool {
 		return se.Kind == SessionEventRollback
@@ -2232,7 +2208,7 @@ func TestRollbackSessionReconstructionHidesDeadBranchAndKeepsNewSuffix(t *testin
 	require.NotNil(t, rollbackEvents[0].Rollback)
 	assert.Equal(t, t1.EventID, rollbackEvents[0].Rollback.ToEventID)
 	assert.Equal(t, "turn-1", rollbackEvents[0].Rollback.ToTurnID)
-	assert.Equal(t, t2.EventID, rollbackEvents[0].Rollback.PreviousHeadTurnEndID)
+	assert.Equal(t, t2.EventID, rollbackEvents[0].Rollback.PreviousHeadCommitEventID)
 	assert.Equal(t, "turn-2", rollbackEvents[0].Rollback.PreviousHeadTurnID)
 	assert.NotContains(t, store.checkpoints, sessionRunnerCheckpointID(sid))
 }
@@ -2255,7 +2231,6 @@ func TestRollbackSessionMultipleRollbacksProjectActiveBranch(t *testing.T) {
 	require.Len(t, result.state.Messages, 2)
 	assert.Equal(t, "Q1", result.state.Messages[0].Content)
 	assert.Equal(t, "A1", result.state.Messages[1].Content)
-	assert.Equal(t, "turn-1", result.state.SessionValues["turn"])
 
 	rollbackEvents := filterStoredSessionEvents(t, store.events, func(se *SessionEvent[*schema.Message]) bool {
 		return se.Kind == SessionEventRollback
@@ -2270,7 +2245,7 @@ func TestRunnerQueryAfterRollbackUsesActiveProjection(t *testing.T) {
 
 	firstAgent := &runnerSessionAgent{
 		name: "runner-session-agent",
-		turnEnd: &TurnEndState[*schema.Message]{
+		turnEnd: &testTurnState[*schema.Message]{
 			Messages: []*schema.Message{schema.UserMessage("first"), schema.AssistantMessage("answer1", nil)},
 		},
 	}
@@ -2280,15 +2255,15 @@ func TestRunnerQueryAfterRollbackUsesActiveProjection(t *testing.T) {
 		SessionStore: store,
 	})
 	drainSessionEvents(t, firstRunner.Query(ctx, "first"))
-	firstTurnEndEvents := filterStoredSessionEvents(t, store.events, func(se *SessionEvent[*schema.Message]) bool {
-		return se.Kind == SessionEventTurnEnd
+	firstCommittedIdleEvents := filterStoredSessionEvents(t, store.events, func(se *SessionEvent[*schema.Message]) bool {
+		return isCommittedIdleEvent(se)
 	})
-	require.Len(t, firstTurnEndEvents, 1)
-	firstTurnID := firstTurnEndEvents[0].TurnID
+	require.Len(t, firstCommittedIdleEvents, 1)
+	firstTurnID := firstCommittedIdleEvents[0].TurnID
 
 	secondAgent := &runnerSessionAgent{
 		name: "runner-session-agent",
-		turnEnd: &TurnEndState[*schema.Message]{
+		turnEnd: &testTurnState[*schema.Message]{
 			Messages: []*schema.Message{schema.UserMessage("first"), schema.AssistantMessage("answer1", nil), schema.UserMessage("second"), schema.AssistantMessage("answer2", nil)},
 		},
 	}
@@ -2303,7 +2278,7 @@ func TestRunnerQueryAfterRollbackUsesActiveProjection(t *testing.T) {
 
 	thirdAgent := &runnerSessionAgent{
 		name: "runner-session-agent",
-		turnEnd: &TurnEndState[*schema.Message]{
+		turnEnd: &testTurnState[*schema.Message]{
 			Messages: []*schema.Message{schema.UserMessage("first"), schema.AssistantMessage("answer1", nil), schema.UserMessage("third"), schema.AssistantMessage("answer3", nil)},
 		},
 	}
@@ -2431,7 +2406,7 @@ func TestReconstructRollbackMalformedRecordsFailClosed(t *testing.T) {
 	require.ErrorIs(t, err, ErrRollbackTargetInactive)
 }
 
-// TestRunnerSessionReconstructsFromEventLog: Delete TurnEndState from store,
+// TestRunnerSessionReconstructsFromEventLog: Delete testTurnState from store,
 // next turn should reconstruct from events.
 func TestRunnerSessionReconstructsFromEventLog(t *testing.T) {
 	ctx := context.Background()
@@ -2440,7 +2415,7 @@ func TestRunnerSessionReconstructsFromEventLog(t *testing.T) {
 
 	firstAgent := &runnerSessionAgent{
 		name: "ra",
-		turnEnd: &TurnEndState[*schema.Message]{
+		turnEnd: &testTurnState[*schema.Message]{
 			Messages: []*schema.Message{schema.UserMessage("first"), schema.AssistantMessage("answer1", nil)},
 		},
 	}
@@ -2453,14 +2428,14 @@ func TestRunnerSessionReconstructsFromEventLog(t *testing.T) {
 
 	// Verify context-commit events were captured: caller input + assistant output + turn-end.
 	commitEvents := filterStoredSessionEvents(t, store.events, func(se *SessionEvent[*schema.Message]) bool {
-		return se.Kind == SessionEventMessage || se.Kind == SessionEventTurnEnd
+		return se.Kind == SessionEventMessage || isCommittedIdleEvent(se)
 	})
 	require.Len(t, commitEvents, 3, "input event + assistant event + turn-end event should be in event log")
 
 	// Capture the prepared session state before agent runs.
 	capturedAgent := &runnerSessionAgent{
 		name: "ra",
-		turnEnd: &TurnEndState[*schema.Message]{
+		turnEnd: &testTurnState[*schema.Message]{
 			Messages: []*schema.Message{},
 		},
 	}
@@ -2490,7 +2465,7 @@ func TestRunnerSessionInputEventsPersisted(t *testing.T) {
 
 	agent := &runnerSessionAgent{
 		name: "input-agent",
-		turnEnd: &TurnEndState[*schema.Message]{
+		turnEnd: &testTurnState[*schema.Message]{
 			Messages: []*schema.Message{schema.AssistantMessage("answer", nil)},
 		},
 	}
@@ -2501,10 +2476,10 @@ func TestRunnerSessionInputEventsPersisted(t *testing.T) {
 	})
 	drainSessionEvents(t, runner.Query(ctx, "user-question"))
 
-	// Single-turn run: 1 user input event + 1 assistant output event + 1 TurnEnd event,
+	// Single-turn run: 1 user input event + 1 assistant output event + 1 idle commit event,
 	// plus non-context lifecycle timeline records.
 	commitEvents := filterStoredSessionEvents(t, store.events, func(se *SessionEvent[*schema.Message]) bool {
-		return se.Kind == SessionEventMessage || se.Kind == SessionEventTurnEnd
+		return se.Kind == SessionEventMessage || isCommittedIdleEvent(se)
 	})
 	require.Len(t, commitEvents, 3)
 	// The first message event should be the user input.
@@ -2946,12 +2921,11 @@ func TestSessionPersister_FlushContextCancellation(t *testing.T) {
 	assert.Equal(t, 1, store.getAppendCalls())
 }
 
-// --- Attack tests for TurnID / inFlightTurnID recovery ---
+// --- Attack tests for TurnID recovery ---
 
-// TestAttack_InFlightTurnIDRecoveryOnResume verifies that reconstructSessionState
-// correctly identifies an in-flight (interrupted) turn's TurnID from events
-// after the last committed TurnEnd.
-func TestAttack_InFlightTurnIDRecoveryOnResume(t *testing.T) {
+// TestAttack_ReconstructionIncludesInterruptedTailOnResume verifies that
+// reconstructSessionState keeps interrupted-tail messages during replay.
+func TestAttack_ReconstructionIncludesInterruptedTailOnResume(t *testing.T) {
 	ctx := context.Background()
 	store := newSessionHelperStore()
 	sid := "inflight-recovery"
@@ -2959,14 +2933,14 @@ func TestAttack_InFlightTurnIDRecoveryOnResume(t *testing.T) {
 	committedMsg := schema.UserMessage("committed-msg")
 	EnsureMessageID(committedMsg)
 
-	// A committed turn: TurnStart (lifecycle running) + Message + TurnEnd, all with TurnID "turn-committed"
+	// A committed turn: TurnStart (lifecycle running) + Message + committed idle, all with TurnID "turn-committed"
 	events := []*SessionEvent[*schema.Message]{
-		{EventID: uuid.NewString(), Kind: SessionEventSessionStatusRunning, TurnID: "turn-committed", Lifecycle: &LifecycleEvent{Scope: LifecycleScopeSession, State: SessionRunStateRunning}},
+		{EventID: uuid.NewString(), Kind: SessionEventSessionStatusRunning, TurnID: "turn-committed", Lifecycle: &LifecycleEvent{State: SessionRunStateRunning}},
 		{EventID: uuid.NewString(), Kind: SessionEventMessage, TurnID: "turn-committed", Message: committedMsg},
-		{EventID: uuid.NewString(), Kind: SessionEventTurnEnd, TurnID: "turn-committed", TurnEnd: &TurnEndState[*schema.Message]{SessionValues: map[string]any{"k": "v"}}},
+		{EventID: uuid.NewString(), Kind: SessionEventSessionStatusIdle, TurnID: "turn-committed", Lifecycle: &LifecycleEvent{State: SessionRunStateIdle, StopReason: &StopReason{Type: "end_turn"}}},
 	}
 
-	// An interrupted turn: a Message event with TurnID "turn-interrupted" and NO TurnEnd
+	// An interrupted turn: a Message event with TurnID "turn-interrupted" and no committed idle.
 	interruptedMsg := schema.AssistantMessage("interrupted-msg", nil)
 	EnsureMessageID(interruptedMsg)
 	events = append(events, &SessionEvent[*schema.Message]{
@@ -2980,7 +2954,6 @@ func TestAttack_InFlightTurnIDRecoveryOnResume(t *testing.T) {
 	result, err := reconstructSessionState[*schema.Message](ctx, store, sid, defaultLoadPageSize)
 	require.NoError(t, err)
 	require.NotNil(t, result)
-	assert.Equal(t, "turn-interrupted", result.inFlightTurnID)
 	require.NotNil(t, result.state)
 	// State should have messages from committed turn (1) + interrupted turn (1).
 	require.Len(t, result.state.Messages, 2)
@@ -2988,7 +2961,7 @@ func TestAttack_InFlightTurnIDRecoveryOnResume(t *testing.T) {
 	assert.Equal(t, "interrupted-msg", result.state.Messages[1].Content)
 }
 
-func TestAttack_InFlightTurnIDRecoveryWithoutCommittedTurnEnd(t *testing.T) {
+func TestAttack_ReconstructionWithoutCommittedIdle(t *testing.T) {
 	ctx := context.Background()
 	store := newSessionHelperStore()
 	sid := "inflight-no-committed-turn"
@@ -3013,68 +2986,9 @@ func TestAttack_InFlightTurnIDRecoveryWithoutCommittedTurnEnd(t *testing.T) {
 	result, err := reconstructSessionState[*schema.Message](ctx, store, sid, defaultLoadPageSize)
 	require.NoError(t, err)
 	require.NotNil(t, result)
-	assert.Equal(t, "turn-interrupted", result.inFlightTurnID)
 	require.NotNil(t, result.state)
 	require.Len(t, result.state.Messages, 1)
 	assert.Equal(t, "first-turn", result.state.Messages[0].Content)
-}
-
-// TestAttack_InFlightTurnIDEmptyWhenNoPostTurnEndEvents verifies that when
-// the last event is a TurnEnd (complete turn), inFlightTurnID is empty.
-func TestAttack_InFlightTurnIDEmptyWhenNoPostTurnEndEvents(t *testing.T) {
-	ctx := context.Background()
-	store := newSessionHelperStore()
-	sid := "no-inflight"
-
-	msg := schema.UserMessage("hello")
-	EnsureMessageID(msg)
-
-	events := []*SessionEvent[*schema.Message]{
-		{EventID: uuid.NewString(), Kind: SessionEventMessage, TurnID: "turn-1", Message: msg},
-		{EventID: uuid.NewString(), Kind: SessionEventTurnEnd, TurnID: "turn-1", TurnEnd: &TurnEndState[*schema.Message]{SessionValues: map[string]any{"done": true}}},
-	}
-
-	for _, se := range events {
-		require.NoError(t, store.AppendEventsForSession(ctx, sid, []*SessionEvent[*schema.Message]{se}))
-	}
-
-	result, err := reconstructSessionState[*schema.Message](ctx, store, sid, defaultLoadPageSize)
-	require.NoError(t, err)
-	require.NotNil(t, result)
-	assert.Equal(t, "", result.inFlightTurnID)
-}
-
-// TestAttack_InFlightTurnIDMultipleTurnIDsInTail verifies that when multiple
-// post-TurnEnd events have different TurnIDs, only the first one is used.
-func TestAttack_InFlightTurnIDMultipleTurnIDsInTail(t *testing.T) {
-	ctx := context.Background()
-	store := newSessionHelperStore()
-	sid := "multi-turnid-tail"
-
-	committedMsg := schema.UserMessage("committed")
-	EnsureMessageID(committedMsg)
-
-	msgA := schema.UserMessage("msg-A")
-	EnsureMessageID(msgA)
-	msgB := schema.AssistantMessage("msg-B", nil)
-	EnsureMessageID(msgB)
-
-	events := []*SessionEvent[*schema.Message]{
-		{EventID: uuid.NewString(), Kind: SessionEventMessage, TurnID: "turn-committed", Message: committedMsg},
-		{EventID: uuid.NewString(), Kind: SessionEventTurnEnd, TurnID: "turn-committed", TurnEnd: &TurnEndState[*schema.Message]{}},
-		// Post-TurnEnd events with different TurnIDs
-		{EventID: uuid.NewString(), Kind: SessionEventMessage, TurnID: "turn-A", Message: msgA},
-		{EventID: uuid.NewString(), Kind: SessionEventMessage, TurnID: "turn-B", Message: msgB},
-	}
-
-	for _, se := range events {
-		require.NoError(t, store.AppendEventsForSession(ctx, sid, []*SessionEvent[*schema.Message]{se}))
-	}
-
-	result, err := reconstructSessionState[*schema.Message](ctx, store, sid, defaultLoadPageSize)
-	require.NoError(t, err)
-	require.NotNil(t, result)
-	assert.Equal(t, "turn-A", result.inFlightTurnID, "should take the first TurnID found after committed TurnEnd")
 }
 
 // TestAttack_OldRunIDFieldIgnoredOnDeserialization verifies that a JSON payload
@@ -3106,10 +3020,10 @@ func TestAttack_ResumePreservesTurnIDFromInterruptedRun(t *testing.T) {
 	store := newSessionHelperStore()
 	sessionID := "resume-turnid-preserve"
 
-	// First, run a normal turn that completes (provides a committed TurnEnd baseline).
+	// First, run a normal turn that completes (provides a committed idle baseline).
 	normalAgent := &runnerSessionAgent{
 		name: "normal-agent",
-		turnEnd: &TurnEndState[*schema.Message]{
+		turnEnd: &testTurnState[*schema.Message]{
 			Messages: []*schema.Message{schema.AssistantMessage("first answer", nil)},
 		},
 	}
@@ -3151,17 +3065,17 @@ func TestAttack_ResumePreservesTurnIDFromInterruptedRun(t *testing.T) {
 	require.GreaterOrEqual(t, len(turnIDSet), 2, "must have at least 2 distinct TurnIDs (committed + interrupted)")
 
 	// The interrupted TurnID is the one on reconstructable model-context events
-	// after the last TurnEnd. Timeline status events are not replay anchors.
-	var lastTurnEndIdx int
+	// after the last committed idle. Timeline status events are not replay anchors.
+	var lastCommittedIdleIdx int
 	for i, ep := range store.events {
 		se, err := decodeSessionEvent[*schema.Message](ep.Data)
 		require.NoError(t, err)
-		if se.Kind == SessionEventTurnEnd && se.TurnID != "" {
-			lastTurnEndIdx = i
+		if isCommittedIdleEvent(se) {
+			lastCommittedIdleIdx = i
 		}
 	}
 	var interruptedTurnID string
-	for i := lastTurnEndIdx + 1; i < len(store.events); i++ {
+	for i := lastCommittedIdleIdx + 1; i < len(store.events); i++ {
 		se, err := decodeSessionEvent[*schema.Message](store.events[i].Data)
 		require.NoError(t, err)
 		if se.Kind == SessionEventMessage && se.TurnID != "" {
@@ -3169,7 +3083,7 @@ func TestAttack_ResumePreservesTurnIDFromInterruptedRun(t *testing.T) {
 			break
 		}
 	}
-	require.NotEmpty(t, interruptedTurnID, "interrupted run must have events with a TurnID after the last TurnEnd")
+	require.NotEmpty(t, interruptedTurnID, "interrupted run must have events with a TurnID after the last committed idle")
 
 	// Record event count before resume.
 	eventsBeforeResume := len(store.events)
@@ -3206,10 +3120,10 @@ func TestAttack_FreshRunIgnoresInFlightTurnID(t *testing.T) {
 	store := newSessionHelperStore()
 	sessionID := "fresh-run-ignores-inflight"
 
-	// First, run a normal turn that completes (provides a committed TurnEnd baseline).
+	// First, run a normal turn that completes (provides a committed idle baseline).
 	normalAgent := &runnerSessionAgent{
 		name: "normal-agent",
-		turnEnd: &TurnEndState[*schema.Message]{
+		turnEnd: &testTurnState[*schema.Message]{
 			Messages: []*schema.Message{schema.AssistantMessage("baseline", nil)},
 		},
 	}
@@ -3238,17 +3152,17 @@ func TestAttack_FreshRunIgnoresInFlightTurnID(t *testing.T) {
 		}
 	}
 
-	// Identify the interrupted TurnID (events after the last committed TurnEnd).
-	var lastTurnEndIdx int
+	// Identify the interrupted TurnID (events after the last committed idle).
+	var lastCommittedIdleIdx int
 	for i, ep := range store.events {
 		se, err := decodeSessionEvent[*schema.Message](ep.Data)
 		require.NoError(t, err)
-		if se.Kind == SessionEventTurnEnd && se.TurnID != "" {
-			lastTurnEndIdx = i
+		if isCommittedIdleEvent(se) {
+			lastCommittedIdleIdx = i
 		}
 	}
 	var interruptedTurnID string
-	for i := lastTurnEndIdx + 1; i < len(store.events); i++ {
+	for i := lastCommittedIdleIdx + 1; i < len(store.events); i++ {
 		se, err := decodeSessionEvent[*schema.Message](store.events[i].Data)
 		require.NoError(t, err)
 		if se.TurnID != "" {
@@ -3262,7 +3176,7 @@ func TestAttack_FreshRunIgnoresInFlightTurnID(t *testing.T) {
 	eventsBeforeFresh := len(store.events)
 	freshAgent := &runnerSessionAgent{
 		name: "fresh-agent",
-		turnEnd: &TurnEndState[*schema.Message]{
+		turnEnd: &testTurnState[*schema.Message]{
 			Messages: []*schema.Message{schema.AssistantMessage("fresh answer", nil)},
 		},
 	}
@@ -3289,11 +3203,11 @@ func TestAttack_FreshRunIgnoresInFlightTurnID(t *testing.T) {
 	}
 }
 
-// sessionStreamingAgent emits a single streaming assistant output followed by a
-// SessionEventTurnEnd. Used to verify the runner's stream-copy/persist path.
+// sessionStreamingAgent emits a single streaming assistant output. Used to
+// verify the runner's stream-copy/persist path.
 type sessionStreamingAgent struct {
 	chunks   []*schema.Message
-	turnEnd  *TurnEndState[*schema.Message]
+	turnEnd  *testTurnState[*schema.Message]
 	role     schema.RoleType
 	tool     string
 	preEvent *SessionEvent[*schema.Message]
@@ -3315,20 +3229,13 @@ func (a *sessionStreamingAgent) Run(_ context.Context, _ *AgentInput, _ ...Agent
 		}
 		mv := &MessageVariant{IsStreaming: true, MessageStream: stream, Role: role, ToolName: a.tool}
 		gen.Send(&AgentEvent{AgentName: "session-stream-agent", Output: &AgentOutput{MessageOutput: mv}})
-		gen.Send(&AgentEvent{
-			AgentName: "session-stream-agent",
-			SessionEvent: &SessionEvent[*schema.Message]{
-				Kind:    SessionEventTurnEnd,
-				TurnEnd: a.turnEnd,
-			},
-		})
 	}()
 	return iter
 }
 
 type agenticSessionStreamingAgent struct {
 	chunks  []*schema.AgenticMessage
-	turnEnd *TurnEndState[*schema.AgenticMessage]
+	turnEnd *testTurnState[*schema.AgenticMessage]
 }
 
 func (a *agenticSessionStreamingAgent) Name(_ context.Context) string {
@@ -3357,13 +3264,6 @@ func (a *agenticSessionStreamingAgent) Run(
 				},
 			},
 		})
-		gen.Send(&TypedAgentEvent[*schema.AgenticMessage]{
-			AgentName: "agentic-session-stream-agent",
-			SessionEvent: &SessionEvent[*schema.AgenticMessage]{
-				Kind:    SessionEventTurnEnd,
-				TurnEnd: a.turnEnd,
-			},
-		})
 	}()
 	return iter
 }
@@ -3383,7 +3283,7 @@ func TestStreamPersistence_CopyAndConcat(t *testing.T) {
 	}
 	agent := &sessionStreamingAgent{
 		chunks: chunks,
-		turnEnd: &TurnEndState[*schema.Message]{
+		turnEnd: &testTurnState[*schema.Message]{
 			Messages: []*schema.Message{schema.UserMessage("q"), schema.AssistantMessage("hello world", nil)},
 		},
 	}
@@ -3437,7 +3337,7 @@ func TestStreamPersistence_StreamingLiveBeforeMaterializedBoundary(t *testing.T)
 			schema.AssistantMessage("hello ", nil),
 			schema.AssistantMessage("sync", nil),
 		},
-		turnEnd: &TurnEndState[*schema.Message]{
+		turnEnd: &testTurnState[*schema.Message]{
 			Messages: []*schema.Message{schema.UserMessage("q"), schema.AssistantMessage("hello sync", nil)},
 		},
 	}
@@ -3495,7 +3395,7 @@ func TestStreamPersistence_PendingAnnotationFlushesBeforeMaterializedBoundary(t 
 			schema.AssistantMessage("hello ", nil),
 			schema.AssistantMessage("stream", nil),
 		},
-		turnEnd: &TurnEndState[*schema.Message]{
+		turnEnd: &testTurnState[*schema.Message]{
 			Messages: []*schema.Message{schema.UserMessage("q"), schema.AssistantMessage("hello stream", nil)},
 		},
 	}
@@ -3513,7 +3413,6 @@ func TestStreamPersistence_PendingAnnotationFlushesBeforeMaterializedBoundary(t 
 		{SessionEventMessage},
 		{annotationKind},
 		{SessionEventMessage},
-		{SessionEventTurnEnd},
 		{SessionEventSessionStatusIdle},
 	}, store.appendBatches)
 }
@@ -3528,7 +3427,7 @@ func TestStreamPersistence_ToolResultStreamingLiveBeforeMaterializedBoundary(t *
 			schema.ToolMessage("tool ", "tc-1", schema.WithToolName("t1")),
 			schema.ToolMessage("result", "tc-1", schema.WithToolName("t1")),
 		},
-		turnEnd: &TurnEndState[*schema.Message]{
+		turnEnd: &testTurnState[*schema.Message]{
 			Messages: []*schema.Message{schema.ToolMessage("tool result", "tc-1", schema.WithToolName("t1"))},
 		},
 		role: schema.Tool,
@@ -3586,7 +3485,7 @@ func TestStreamPersistence_AgenticToolResultChunksConcat(t *testing.T) {
 			agenticToolResultMessage("call_1", "execute", "first\n"),
 			agenticToolResultMessage("call_1", "execute", "second\n"),
 		},
-		turnEnd: &TurnEndState[*schema.AgenticMessage]{
+		turnEnd: &testTurnState[*schema.AgenticMessage]{
 			Messages: []*schema.AgenticMessage{
 				schema.UserAgenticMessage("q"),
 				agenticToolResultMessage("call_1", "execute", "first\nsecond\n"),
@@ -3656,7 +3555,7 @@ func TestStreamPersistence_AgenticToolResultChunksWithStreamingMeta(t *testing.T
 
 	agent := &agenticSessionStreamingAgent{
 		chunks: []*schema.AgenticMessage{first, second},
-		turnEnd: &TurnEndState[*schema.AgenticMessage]{
+		turnEnd: &testTurnState[*schema.AgenticMessage]{
 			Messages: []*schema.AgenticMessage{
 				schema.UserAgenticMessage("q"),
 				agenticToolResultMessage("call_1", "execute", "first\nsecond\n"),
@@ -3750,7 +3649,7 @@ func TestStreamPersistence_GetMessageError_NotEnqueued(t *testing.T) {
 
 	agent := &streamingAgentRaw{
 		stream: streamReader,
-		turnEnd: &TurnEndState[*schema.Message]{
+		turnEnd: &testTurnState[*schema.Message]{
 			Messages: []*schema.Message{schema.AssistantMessage("ok", nil)},
 		},
 	}
@@ -3803,7 +3702,7 @@ func TestStreamPersistence_GetMessageErrorSurfacesAfterLiveStreaming(t *testing.
 
 	agent := &streamingAgentRaw{
 		stream: streamReader,
-		turnEnd: &TurnEndState[*schema.Message]{
+		turnEnd: &testTurnState[*schema.Message]{
 			Messages: []*schema.Message{schema.AssistantMessage("ok", nil)},
 		},
 	}
@@ -3847,7 +3746,7 @@ func TestStreamPersistence_GetMessageErrorSurfacesAfterLiveStreaming(t *testing.
 // one that emits errors).
 type streamingAgentRaw struct {
 	stream  *schema.StreamReader[*schema.Message]
-	turnEnd *TurnEndState[*schema.Message]
+	turnEnd *testTurnState[*schema.Message]
 }
 
 func (a *streamingAgentRaw) Name(_ context.Context) string        { return "streaming-raw" }
@@ -3858,13 +3757,6 @@ func (a *streamingAgentRaw) Run(_ context.Context, _ *AgentInput, _ ...AgentRunO
 		defer gen.Close()
 		mv := &MessageVariant{IsStreaming: true, MessageStream: a.stream, Role: schema.Assistant}
 		gen.Send(&AgentEvent{AgentName: "streaming-raw", Output: &AgentOutput{MessageOutput: mv}})
-		gen.Send(&AgentEvent{
-			AgentName: "streaming-raw",
-			SessionEvent: &SessionEvent[*schema.Message]{
-				Kind:    SessionEventTurnEnd,
-				TurnEnd: a.turnEnd,
-			},
-		})
 	}()
 	return iter
 }
@@ -3905,7 +3797,7 @@ func TestRunnerInputEvents_MixedRoles(t *testing.T) {
 
 	agent := &runnerSessionAgent{
 		name: "mr-agent",
-		turnEnd: &TurnEndState[*schema.Message]{
+		turnEnd: &testTurnState[*schema.Message]{
 			Messages: []*schema.Message{schema.AssistantMessage("ok", nil)},
 		},
 	}
@@ -3936,20 +3828,12 @@ func TestRunnerInputEvents_MixedRoles(t *testing.T) {
 	assert.Equal(t, "hello", second.Message.Content)
 }
 
-// TestTurnEndOnly_PersistedAsSessionEvent verifies that an event carrying only
-// SessionEventTurnEnd (no message output, no mutations) persists the TurnEnd as
-// a SessionEvent variant in the log.
-func TestTurnEndOnly_PersistedAsSessionEvent(t *testing.T) {
+func TestCustomAgentNormalCloseCommitsIdle(t *testing.T) {
 	ctx := context.Background()
 	store := newSessionHelperStore()
 	sid := "turn-end-only"
 
-	// Custom agent that emits ONLY a TurnEnd event (no output, no mutations).
-	agent := &turnEndOnlyAgent{
-		turnEnd: &TurnEndState[*schema.Message]{
-			Messages: []*schema.Message{schema.UserMessage("x")},
-		},
-	}
+	agent := &turnEndOnlyAgent{}
 
 	runner := NewRunner(ctx, RunnerConfig{
 		Agent:        agent,
@@ -3958,21 +3842,18 @@ func TestTurnEndOnly_PersistedAsSessionEvent(t *testing.T) {
 	})
 	drainSessionEvents(t, runner.Query(ctx, "input"))
 
-	// The log should contain: the input event + a TurnEnd event.
-	var sawTurnEnd bool
+	var sawCommit bool
 	for _, ep := range store.events {
 		se, err := decodeSessionEvent[*schema.Message](ep.Data)
 		require.NoError(t, err)
-		if se.TurnEnd != nil {
-			sawTurnEnd = true
+		if isCommittedIdleEvent(se) {
+			sawCommit = true
 		}
 	}
-	assert.True(t, sawTurnEnd, "TurnEnd must be persisted as a SessionEvent")
+	assert.True(t, sawCommit)
 }
 
-type turnEndOnlyAgent struct {
-	turnEnd *TurnEndState[*schema.Message]
-}
+type turnEndOnlyAgent struct{}
 
 func (a *turnEndOnlyAgent) Name(_ context.Context) string        { return "turn-end-only" }
 func (a *turnEndOnlyAgent) Description(_ context.Context) string { return "" }
@@ -3980,25 +3861,18 @@ func (a *turnEndOnlyAgent) Run(_ context.Context, _ *AgentInput, _ ...AgentRunOp
 	iter, gen := NewAsyncIteratorPair[*AgentEvent]()
 	go func() {
 		defer gen.Close()
-		gen.Send(&AgentEvent{
-			AgentName: "turn-end-only",
-			SessionEvent: &SessionEvent[*schema.Message]{
-				Kind:    SessionEventTurnEnd,
-				TurnEnd: a.turnEnd,
-			},
-		})
 	}()
 	return iter
 }
 
-// TestTailReplay_PartialTurnWithoutTurnEnd verifies that events appended after
-// the last TurnEnd event are replayed on reconstruction (partial/interrupted turn).
-func TestTailReplay_PartialTurnWithoutTurnEnd(t *testing.T) {
+// TestTailReplay_PartialTurnWithoutCommittedIdle verifies that events appended
+// after the last committed idle are replayed on reconstruction.
+func TestTailReplay_PartialTurnWithoutCommittedIdle(t *testing.T) {
 	ctx := context.Background()
 	store := newSessionHelperStore()
 	sid := "tail-replay"
 
-	// Phase 1: a normal completed turn (messages + TurnEnd event).
+	// Phase 1: a normal completed turn (messages + committed idle event).
 	a1 := schema.UserMessage("Q1")
 	EnsureMessageID(a1)
 	r1 := schema.AssistantMessage("A1", nil)
@@ -4007,14 +3881,11 @@ func TestTailReplay_PartialTurnWithoutTurnEnd(t *testing.T) {
 		se := withTestEventID(&SessionEvent[*schema.Message]{Message: m})
 		require.NoError(t, store.AppendEventsForSession(ctx, sid, []*SessionEvent[*schema.Message]{se}))
 	}
-	// Persist TurnEnd as a SessionEvent.
-	turnEndSE := withTestEventID(&SessionEvent[*schema.Message]{TurnEnd: &TurnEndState[*schema.Message]{
-		Messages: []*schema.Message{a1, r1},
-	}})
-	require.NoError(t, store.AppendEventsForSession(ctx, sid, []*SessionEvent[*schema.Message]{turnEndSE}))
+	committedIdleSE := withTestCommittedIdle[*schema.Message]("turn-1")
+	require.NoError(t, store.AppendEventsForSession(ctx, sid, []*SessionEvent[*schema.Message]{committedIdleSE}))
 
 	// Phase 2: simulate a partial second turn where events were appended but
-	// no TurnEnd was persisted (interrupted).
+	// no committed idle was persisted (interrupted).
 	a2 := schema.UserMessage("Q2")
 	EnsureMessageID(a2)
 	r2 := schema.AssistantMessage("A2", nil)
@@ -4024,8 +3895,7 @@ func TestTailReplay_PartialTurnWithoutTurnEnd(t *testing.T) {
 		require.NoError(t, store.AppendEventsForSession(ctx, sid, []*SessionEvent[*schema.Message]{se}))
 	}
 
-	// Boot: prepareRunnerSessionRun reconstructs durable context through the log
-	// tail. The latest TurnEnd remains the metadata boundary.
+	// Boot: prepareRunnerSessionRun reconstructs durable context through the log tail.
 	state, err := prepareRunnerSessionRun[*schema.Message](ctx, nil, nil, sid, store, nil)
 	require.NoError(t, err)
 	require.True(t, state.enabled)
@@ -4048,10 +3918,7 @@ func TestTailReplay_NoTailEvents(t *testing.T) {
 	se := withTestEventID(&SessionEvent[*schema.Message]{Message: q})
 	require.NoError(t, store.AppendEventsForSession(ctx, sid, []*SessionEvent[*schema.Message]{se}))
 
-	// Persist TurnEnd as a SessionEvent.
-	turnEndSE := withTestEventID(&SessionEvent[*schema.Message]{TurnEnd: &TurnEndState[*schema.Message]{
-		Messages: []*schema.Message{q},
-	}})
+	turnEndSE := withTestCommittedIdle[*schema.Message]("turn-1")
 	require.NoError(t, store.AppendEventsForSession(ctx, sid, []*SessionEvent[*schema.Message]{turnEndSE}))
 
 	state, err := prepareRunnerSessionRun[*schema.Message](ctx, nil, nil, sid, store, nil)
@@ -4213,7 +4080,7 @@ func (h *agenticTestSessionHandle) appendEvents(ctx context.Context, req *Append
 func (h *agenticTestSessionHandle) close(context.Context) error { return nil }
 
 // TestPartialInterrupted_ThenNewRun verifies that when a turn is interrupted
-// after some events have been appended (but before SaveTurnEnd commits), a new
+// after some events have been appended (but before the committed idle marker), a new
 // Run with NO CheckPointStore (i.e. session-only mode) recovers the in-flight
 // events via tail replay rather than treating the session as fresh.
 //
@@ -4233,13 +4100,10 @@ func TestPartialInterrupted_ThenNewRun(t *testing.T) {
 		se := withTestEventID(&SessionEvent[*schema.Message]{Message: m})
 		require.NoError(t, store.AppendEventsForSession(ctx, sid, []*SessionEvent[*schema.Message]{se}))
 	}
-	// Persist TurnEnd as a SessionEvent (marks end of completed turn).
-	turnEndSE := withTestEventID(&SessionEvent[*schema.Message]{TurnEnd: &TurnEndState[*schema.Message]{
-		Messages: []*schema.Message{q1, r1},
-	}})
-	require.NoError(t, store.AppendEventsForSession(ctx, sid, []*SessionEvent[*schema.Message]{turnEndSE}))
+	committedIdleSE := withTestCommittedIdle[*schema.Message]("turn-1")
+	require.NoError(t, store.AppendEventsForSession(ctx, sid, []*SessionEvent[*schema.Message]{committedIdleSE}))
 
-	// Phase 2: simulate an interrupted turn — events appended, no new SaveTurnEnd.
+	// Phase 2: simulate an interrupted turn with events appended but no committed idle.
 	q2 := schema.UserMessage("partial")
 	EnsureMessageID(q2)
 	for _, m := range []*schema.Message{q2} {
@@ -4250,7 +4114,7 @@ func TestPartialInterrupted_ThenNewRun(t *testing.T) {
 	// Phase 3: new Run (no CheckPointStore; Runner skips pending checkpoints on fresh Run).
 	captured := &runnerSessionAgent{
 		name: "ra",
-		turnEnd: &TurnEndState[*schema.Message]{
+		turnEnd: &testTurnState[*schema.Message]{
 			Messages: []*schema.Message{},
 		},
 	}
@@ -4304,24 +4168,24 @@ func TestSessionEvent_StreamCopyConcat_ByteIdentical(t *testing.T) {
 
 // TestExplicitCheckpointResume_WithSessionMode verifies that when a caller passes
 // an explicit checkpoint ID alongside a configured SessionID/SessionStore[*schema.Message], the
-// resume path still loads the latest TurnEndState (and runs tail replay).
+// resume path still loads reconstructed session state.
 func TestExplicitCheckpointResume_WithSessionMode(t *testing.T) {
 	ctx := context.Background()
 	store := newSessionHelperStore()
 	sid := "explicit-cp-session"
 
-	// Seed the session store with events and a TurnEnd.
-	prior := &TurnEndState[*schema.Message]{
+	// Seed the session store with events and a committed idle marker.
+	prior := &testTurnState[*schema.Message]{
 		Messages: []*schema.Message{schema.UserMessage("seed"), schema.AssistantMessage("seed-ans", nil)},
 	}
-	// Seed session events (messages + TurnEnd).
+	// Seed session events (messages + committed idle).
 	for _, m := range prior.Messages {
 		EnsureMessageID(m)
 		se := withTestEventID(&SessionEvent[*schema.Message]{Message: m})
 		require.NoError(t, store.AppendEventsForSession(ctx, sid, []*SessionEvent[*schema.Message]{se}))
 	}
-	turnEndSE := withTestEventID(&SessionEvent[*schema.Message]{TurnEnd: prior})
-	require.NoError(t, store.AppendEventsForSession(ctx, sid, []*SessionEvent[*schema.Message]{turnEndSE}))
+	committedIdleSE := withTestCommittedIdle[*schema.Message]("turn-1")
+	require.NoError(t, store.AppendEventsForSession(ctx, sid, []*SessionEvent[*schema.Message]{committedIdleSE}))
 
 	// Seed an arbitrary checkpoint ID with a runner-session-checkpoint wrapper
 	// so runnerLoadCheckPointForSession can decode it.
@@ -4357,10 +4221,7 @@ func TestResumePath_TailReplay(t *testing.T) {
 		se := withTestEventID(&SessionEvent[*schema.Message]{Message: m})
 		require.NoError(t, store.AppendEventsForSession(ctx, sid, []*SessionEvent[*schema.Message]{se}))
 	}
-	// Persist TurnEnd as a SessionEvent.
-	turnEndSE := withTestEventID(&SessionEvent[*schema.Message]{TurnEnd: &TurnEndState[*schema.Message]{
-		Messages: []*schema.Message{q1, r1},
-	}})
+	turnEndSE := withTestCommittedIdle[*schema.Message]("turn-1")
 	require.NoError(t, store.AppendEventsForSession(ctx, sid, []*SessionEvent[*schema.Message]{turnEndSE}))
 
 	// Append a tail event after the snapshot.
@@ -4388,12 +4249,12 @@ func TestResumePath_TailReplay(t *testing.T) {
 
 // Ensure the io package import is used (for compile when chunks are empty).
 
-// mutationAgent emits a sequence of caller-provided TypedAgentEvents and a
-// final SessionEventTurnEnd. Used to verify the runner persists each session-mutation
+// mutationAgent emits a sequence of caller-provided TypedAgentEvents. Used to
+// verify the runner persists each session-mutation
 // event variant (MessagesReplaced, MessageUpdated, MessageInserted) faithfully.
 type mutationAgent struct {
 	events  []*AgentEvent
-	turnEnd *TurnEndState[*schema.Message]
+	turnEnd *testTurnState[*schema.Message]
 }
 
 func (a *mutationAgent) Name(_ context.Context) string        { return "mutation-agent" }
@@ -4405,13 +4266,6 @@ func (a *mutationAgent) Run(_ context.Context, _ *AgentInput, _ ...AgentRunOptio
 		for _, ev := range a.events {
 			gen.Send(ev)
 		}
-		gen.Send(&AgentEvent{
-			AgentName: "mutation-agent",
-			SessionEvent: &SessionEvent[*schema.Message]{
-				Kind:    SessionEventTurnEnd,
-				TurnEnd: a.turnEnd,
-			},
-		})
 	}()
 	return iter
 }
@@ -4437,7 +4291,7 @@ func TestRunnerPersists_MessagesReplaced(t *testing.T) {
 				},
 			},
 		},
-		turnEnd: &TurnEndState[*schema.Message]{Messages: []*schema.Message{summary}},
+		turnEnd: &testTurnState[*schema.Message]{Messages: []*schema.Message{summary}},
 	}
 	runner := NewRunner(ctx, RunnerConfig{
 		Agent:        agent,
@@ -4519,7 +4373,7 @@ func TestRunnerPersists_MessageUpdated_BothMessages(t *testing.T) {
 				},
 			},
 		},
-		turnEnd: &TurnEndState[*schema.Message]{
+		turnEnd: &testTurnState[*schema.Message]{
 			Messages: []*schema.Message{updatedAssistant, updatedTool},
 		},
 	}
@@ -4609,7 +4463,7 @@ func TestRunnerPersists_MessageInserted_AnchorAndAppend(t *testing.T) {
 				},
 			},
 		},
-		turnEnd: &TurnEndState[*schema.Message]{Messages: finalMessages},
+		turnEnd: &testTurnState[*schema.Message]{Messages: finalMessages},
 	}
 
 	runner := NewRunner(ctx, RunnerConfig{
@@ -5065,7 +4919,7 @@ func TestRunnerPersists_MessagesDeleted_Reconstructs(t *testing.T) {
 				},
 			},
 		},
-		turnEnd: &TurnEndState[*schema.Message]{Messages: []*schema.Message{a, c}},
+		turnEnd: &testTurnState[*schema.Message]{Messages: []*schema.Message{a, c}},
 	}
 	runner := NewRunner(ctx, RunnerConfig{
 		Agent:        agent,
@@ -5109,12 +4963,7 @@ func TestReconstructSessionState_MessagesDeletedMissingTargetFails(t *testing.T)
 	})
 	require.NoError(t, store.AppendEventsForSession(ctx, sid, []*SessionEvent[*schema.Message]{deleteEvent}))
 
-	turnEndEvent := withTestEventID(&SessionEvent[*schema.Message]{
-		TurnID: "turn-1",
-		TurnEnd: &TurnEndState[*schema.Message]{
-			Messages: []*schema.Message{a},
-		},
-	})
+	turnEndEvent := withTestCommittedIdle[*schema.Message]("turn-1")
 	require.NoError(t, store.AppendEventsForSession(ctx, sid, []*SessionEvent[*schema.Message]{turnEndEvent}))
 
 	_, err := reconstructSessionState[*schema.Message](ctx, mustOpenTestSession[*schema.Message](t, ctx, store, sid), sid, defaultLoadPageSize)
@@ -5159,7 +5008,7 @@ func TestAgentTool_ChildSessionID_FiltersFromParentLog(t *testing.T) {
 				},
 			},
 		},
-		turnEnd: &TurnEndState[*schema.Message]{
+		turnEnd: &testTurnState[*schema.Message]{
 			Messages: []*schema.Message{parentMsg},
 		},
 	}

--- a/adk/session_timeline_test.go
+++ b/adk/session_timeline_test.go
@@ -66,7 +66,7 @@ func TestSessionTimeline_ClassifyAndSerializeVariants(t *testing.T) {
 	}{
 		{
 			name: "lifecycle",
-			se:   &SessionEvent[*schema.Message]{Lifecycle: &LifecycleEvent{Scope: LifecycleScopeSession, State: SessionRunStateRunning}},
+			se:   &SessionEvent[*schema.Message]{Lifecycle: &LifecycleEvent{State: SessionRunStateRunning}},
 			kind: SessionEventSessionStatusRunning,
 		},
 		{
@@ -223,7 +223,7 @@ func TestSessionTimeline_ReconstructionIgnoresNonContextVariants(t *testing.T) {
 	msg := schema.UserMessage("hello")
 	EnsureMessageID(msg)
 	events := []*SessionEvent[*schema.Message]{
-		{EventID: uuid.NewString(), Kind: SessionEventSessionStatusRunning, Lifecycle: &LifecycleEvent{Scope: LifecycleScopeSession, State: SessionRunStateRunning}},
+		{EventID: uuid.NewString(), Kind: SessionEventSessionStatusRunning, Lifecycle: &LifecycleEvent{State: SessionRunStateRunning}},
 		{EventID: uuid.NewString(), Kind: SessionEventMessage, Message: msg},
 		{EventID: uuid.NewString(), Kind: SessionEventSpanModelRequestStart, Span: &SpanEvent{SpanID: uuid.NewString(), Kind: SpanKindModel, StartedAt: time.Now().UTC(), Model: &ModelSpanMeta{}}},
 		{EventID: uuid.NewString(), Kind: SessionEventKind("x.outcome.started"), Extension: &SessionExtensionEvent{Data: &sessionTimelineExtensionPayload{Attempt: 1}}},
@@ -236,7 +236,7 @@ func TestSessionTimeline_ReconstructionIgnoresNonContextVariants(t *testing.T) {
 			},
 		}},
 		{EventID: uuid.NewString(), Kind: SessionEventSessionError, Error: &SessionErrorEvent{Type: "transient", RetryStatus: &RetryStatus{Type: "retrying"}}},
-		{EventID: uuid.NewString(), Kind: SessionEventTurnEnd, TurnEnd: &TurnEndState[*schema.Message]{SessionValues: map[string]any{"k": "v"}}},
+		{EventID: uuid.NewString(), Kind: SessionEventModelContext, ModelContext: &ModelContextEvent{}},
 	}
 	for _, se := range events {
 		require.NoError(t, store.AppendEventsForSession(ctx, sid, []*SessionEvent[*schema.Message]{se}))
@@ -248,7 +248,7 @@ func TestSessionTimeline_ReconstructionIgnoresNonContextVariants(t *testing.T) {
 	require.NotNil(t, result.state)
 	require.Len(t, result.state.Messages, 1)
 	assert.Equal(t, "hello", result.state.Messages[0].Content)
-	assert.Equal(t, map[string]any{"k": "v"}, result.state.SessionValues)
+	assert.True(t, result.state.sawModelContext)
 }
 
 func TestSessionTimeline_AgentInterruptRoundTripPreservesContexts(t *testing.T) {
@@ -359,13 +359,13 @@ func TestRunner_PersistsAgentInterruptSessionEvent(t *testing.T) {
 	assert.Equal(t, liveInterruptContexts[0].Info, ctx0.Info)
 	requireStoredIdleStopReason(t, store.events, "interrupted")
 
-	turnEnds := filterStoredSessionEvents(t, store.events, func(se *SessionEvent[*schema.Message]) bool {
-		return se.Kind == SessionEventTurnEnd
+	committedIdleEvents := filterStoredSessionEvents(t, store.events, func(se *SessionEvent[*schema.Message]) bool {
+		return isCommittedIdleEvent(se)
 	})
-	assert.Empty(t, turnEnds, "business interrupt should remain an in-flight turn without TurnEnd")
+	assert.Empty(t, committedIdleEvents, "business interrupt should not commit")
 }
 
-func TestSessionTimeline_ReconstructionIncludesPartialContextAfterLatestTurnEnd(t *testing.T) {
+func TestSessionTimeline_ReconstructionIncludesPartialContextAfterLatestCommittedIdle(t *testing.T) {
 	ctx := context.Background()
 	store := newSessionHelperStore()
 	sid := "timeline-partial"
@@ -381,8 +381,8 @@ func TestSessionTimeline_ReconstructionIncludesPartialContextAfterLatestTurnEnd(
 	events := []*SessionEvent[*schema.Message]{
 		{EventID: uuid.NewString(), Kind: SessionEventMessage, Message: committedUser},
 		{EventID: uuid.NewString(), Kind: SessionEventMessage, Message: committedAssistant},
-		{EventID: uuid.NewString(), Kind: SessionEventTurnEnd, TurnID: "turn-1", TurnEnd: &TurnEndState[*schema.Message]{SessionValues: map[string]any{"turn": "committed"}}},
-		{EventID: uuid.NewString(), Kind: SessionEventSessionStatusRunning, Lifecycle: &LifecycleEvent{Scope: LifecycleScopeSession, State: SessionRunStateRunning}},
+		{EventID: uuid.NewString(), Kind: SessionEventSessionStatusIdle, TurnID: "turn-1", Lifecycle: &LifecycleEvent{State: SessionRunStateIdle, StopReason: &StopReason{Type: "end_turn"}}},
+		{EventID: uuid.NewString(), Kind: SessionEventSessionStatusRunning, Lifecycle: &LifecycleEvent{State: SessionRunStateRunning}},
 		{EventID: uuid.NewString(), Kind: SessionEventMessage, Message: partialUser},
 		{EventID: uuid.NewString(), Kind: SessionEventMessage, Message: partialAssistant},
 		{EventID: uuid.NewString(), Kind: SessionEventSessionError, Error: &SessionErrorEvent{Type: SessionErrorTypeModelRetry, RetryStatus: &RetryStatus{Type: "retrying"}}},
@@ -400,7 +400,6 @@ func TestSessionTimeline_ReconstructionIncludesPartialContextAfterLatestTurnEnd(
 	assert.Equal(t, "committed assistant", result.state.Messages[1].Content)
 	assert.Equal(t, "partial user", result.state.Messages[2].Content)
 	assert.Equal(t, "partial assistant", result.state.Messages[3].Content)
-	assert.Equal(t, map[string]any{"turn": "committed"}, result.state.SessionValues)
 }
 
 func TestSessionTimeline_ReconstructionPartialContextMissingAnchorFails(t *testing.T) {
@@ -415,7 +414,7 @@ func TestSessionTimeline_ReconstructionPartialContextMissingAnchorFails(t *testi
 
 	events := []*SessionEvent[*schema.Message]{
 		{EventID: uuid.NewString(), Kind: SessionEventMessage, Message: committedUser},
-		{EventID: uuid.NewString(), Kind: SessionEventTurnEnd, TurnID: "turn-1", TurnEnd: &TurnEndState[*schema.Message]{}},
+		{EventID: uuid.NewString(), Kind: SessionEventSessionStatusIdle, TurnID: "turn-1", Lifecycle: &LifecycleEvent{State: SessionRunStateIdle, StopReason: &StopReason{Type: "end_turn"}}},
 		{EventID: uuid.NewString(), Kind: SessionEventMessageInserted, MessageInserted: &MessageInsertedEvent[*schema.Message]{
 			Message:         inserted,
 			BeforeMessageID: "missing-anchor",
@@ -430,7 +429,7 @@ func TestSessionTimeline_ReconstructionPartialContextMissingAnchorFails(t *testi
 	assert.Contains(t, err.Error(), "missing-anchor")
 }
 
-func TestSessionTimeline_LatestCommittedTurnEndPrefersTurnIDBoundary(t *testing.T) {
+func TestSessionTimeline_CommittedIdleIsReplayBoundaryOnly(t *testing.T) {
 	committedUser := schema.UserMessage("committed user")
 	partialUser := schema.UserMessage("partial user")
 	for _, msg := range []*schema.Message{committedUser, partialUser} {
@@ -439,26 +438,22 @@ func TestSessionTimeline_LatestCommittedTurnEndPrefersTurnIDBoundary(t *testing.
 
 	events := []*SessionEvent[*schema.Message]{
 		{EventID: uuid.NewString(), Kind: SessionEventMessage, Message: committedUser},
-		{EventID: uuid.NewString(), Kind: SessionEventTurnEnd, TurnID: "turn-1", TurnEnd: &TurnEndState[*schema.Message]{SessionValues: map[string]any{"turn": "committed"}}},
+		{EventID: uuid.NewString(), Kind: SessionEventSessionStatusIdle, TurnID: "turn-1", Lifecycle: &LifecycleEvent{State: SessionRunStateIdle, StopReason: &StopReason{Type: "end_turn"}}},
 		{EventID: uuid.NewString(), Kind: SessionEventMessage, Message: partialUser},
-		{EventID: uuid.NewString(), Kind: SessionEventTurnEnd, TurnEnd: &TurnEndState[*schema.Message]{SessionValues: map[string]any{"turn": "legacy-tail"}}},
+		{EventID: uuid.NewString(), Kind: "turn_end"},
 	}
 
-	idx := latestCommittedTurnEnd(events)
-	require.Equal(t, 1, idx)
-
-	state, err := replayDurableContextEvents(events, idx, idx)
+	state, err := replayDurableContextEvents(events)
 	require.NoError(t, err)
-	require.Len(t, state.Messages, 1)
+	require.Len(t, state.Messages, 2)
 	assert.Equal(t, "committed user", state.Messages[0].Content)
-	assert.Equal(t, map[string]any{"turn": "committed"}, state.SessionValues)
+	assert.Equal(t, "partial user", state.Messages[1].Content)
 }
 
 func TestWithTimelineEvents_LiveExposure(t *testing.T) {
 	ctx := context.Background()
 	agent := &runnerSessionAgent{
-		name:    "timeline-agent",
-		turnEnd: &TurnEndState[*schema.Message]{Messages: []*schema.Message{schema.AssistantMessage("ok", nil)}},
+		name: "timeline-agent",
 	}
 
 	t.Run("stripped by default", func(t *testing.T) {
@@ -767,7 +762,6 @@ func TestSessionTimeline_EmittedKindMustBeExplicit(t *testing.T) {
 		EventID:   uuid.NewString(),
 		Timestamp: newEventTimestamp(),
 		Lifecycle: &LifecycleEvent{
-			Scope: LifecycleScopeSession,
 			State: SessionRunStateRunning,
 		},
 	})
@@ -1030,25 +1024,13 @@ func TestSessionTimeline_NormalizeAgentSessionEventMaterializesEnvelope(t *testi
 		assert.Equal(t, ts, out.Timestamp)
 	})
 
-	t.Run("turn end messages stripped without mutating producer event", func(t *testing.T) {
-		msg := schema.AssistantMessage("kept only by producer", nil)
-		original := &SessionEvent[*schema.Message]{
-			Kind: SessionEventTurnEnd,
-			TurnEnd: &TurnEndState[*schema.Message]{
-				Messages:      []*schema.Message{msg},
-				SessionValues: map[string]any{"answer": "ok"},
-			},
-		}
+	t.Run("model context event normalizes without mutation", func(t *testing.T) {
+		original := &SessionEvent[*schema.Message]{Kind: SessionEventModelContext, ModelContext: &ModelContextEvent{}}
 		event := &AgentEvent{SessionEvent: original}
 		se, err := normalizeAgentSessionEvent(event)
 		require.NoError(t, err)
-		require.NotNil(t, se.TurnEnd)
-		assert.Nil(t, se.TurnEnd.Messages)
-		require.NotNil(t, event.SessionEvent.TurnEnd)
-		assert.Nil(t, event.SessionEvent.TurnEnd.Messages)
-		require.NotNil(t, original.TurnEnd)
-		require.Len(t, original.TurnEnd.Messages, 1)
-		assert.Equal(t, "ok", se.TurnEnd.SessionValues["answer"])
+		require.NotNil(t, se.ModelContext)
+		require.NotNil(t, event.SessionEvent.ModelContext)
 	})
 }
 
@@ -1199,9 +1181,9 @@ func TestRunnerTimelineRetryExhaustedStopReason(t *testing.T) {
 	requireStoredIdleStopReason(t, store.events, "retries_exhausted")
 
 	turnEnds := filterStoredSessionEvents(t, store.events, func(se *SessionEvent[*schema.Message]) bool {
-		return se.Kind == SessionEventTurnEnd
+		return isCommittedIdleEvent(se)
 	})
-	assert.Empty(t, turnEnds, "retry exhaustion should not commit a TurnEnd")
+	assert.Empty(t, turnEnds, "retry exhaustion should not commit")
 }
 
 func TestRunnerTimelineFailedStopReason(t *testing.T) {
@@ -1227,7 +1209,7 @@ func TestRunnerTimelineFailedStopReason(t *testing.T) {
 	require.NotEmpty(t, gotErrs)
 	assert.EqualError(t, gotErrs[0], "boom")
 	for _, err := range gotErrs {
-		assert.NotContains(t, err.Error(), "missing SessionEventTurnEnd")
+		assert.NotContains(t, err.Error(), "missing committed idle")
 	}
 
 	sessionErrors := filterStoredSessionEvents(t, store.events, func(se *SessionEvent[*schema.Message]) bool {
@@ -1239,13 +1221,13 @@ func TestRunnerTimelineFailedStopReason(t *testing.T) {
 	assert.Equal(t, "boom", sessionErrors[len(sessionErrors)-1].Error.Message)
 	requireStoredIdleStopReason(t, store.events, "failed")
 
-	turnEnds := filterStoredSessionEvents(t, store.events, func(se *SessionEvent[*schema.Message]) bool {
-		return se.Kind == SessionEventTurnEnd
+	committedIdleEvents := filterStoredSessionEvents(t, store.events, func(se *SessionEvent[*schema.Message]) bool {
+		return isCommittedIdleEvent(se)
 	})
-	assert.Empty(t, turnEnds, "failed turn should not commit a TurnEnd")
+	assert.Empty(t, committedIdleEvents, "failed turn should not commit")
 }
 
-func TestRunnerTimelineModelCallFatalDoesNotRequireTurnEnd(t *testing.T) {
+func TestRunnerTimelineModelCallFatalDoesNotRequireCommitMarker(t *testing.T) {
 	ctx := context.Background()
 	modelErr := errors.New("model exploded")
 	agent, err := NewChatModelAgent(ctx, &ChatModelAgentConfig{
@@ -1278,7 +1260,7 @@ func TestRunnerTimelineModelCallFatalDoesNotRequireTurnEnd(t *testing.T) {
 	require.NotEmpty(t, gotErrs)
 	assert.ErrorIs(t, gotErrs[0], modelErr)
 	for _, err := range gotErrs {
-		assert.NotContains(t, err.Error(), "missing SessionEventTurnEnd")
+		assert.NotContains(t, err.Error(), "missing committed idle")
 	}
 
 	sessionErrors := filterStoredSessionEvents(t, store.events, func(se *SessionEvent[*schema.Message]) bool {
@@ -1291,9 +1273,9 @@ func TestRunnerTimelineModelCallFatalDoesNotRequireTurnEnd(t *testing.T) {
 	requireStoredIdleStopReason(t, store.events, "failed")
 
 	turnEnds := filterStoredSessionEvents(t, store.events, func(se *SessionEvent[*schema.Message]) bool {
-		return se.Kind == SessionEventTurnEnd
+		return isCommittedIdleEvent(se)
 	})
-	assert.Empty(t, turnEnds, "fatal model call should abort without committing a TurnEnd")
+	assert.Empty(t, turnEnds, "fatal model call should not commit")
 }
 
 func TestRunnerTimelineCancelStopReasonAndUserInterruptPersisted(t *testing.T) {
@@ -1358,9 +1340,9 @@ func TestRunnerTimelineCancelStopReasonAndUserInterruptPersisted(t *testing.T) {
 	requireStoredIdleStopReason(t, store.events, "cancelled")
 
 	turnEnds := filterStoredSessionEvents(t, store.events, func(se *SessionEvent[*schema.Message]) bool {
-		return se.Kind == SessionEventTurnEnd
+		return isCommittedIdleEvent(se)
 	})
-	assert.Empty(t, turnEnds, "cancelled turn should not commit a TurnEnd")
+	assert.Empty(t, turnEnds, "cancelled turn should not commit")
 }
 
 func TestToolSpan_PersistedAroundToolCallAndLinksToMessages(t *testing.T) {
@@ -1559,7 +1541,7 @@ func TestSessionTimeline_ReconstructionUsesKindFilter(t *testing.T) {
 		{EventID: uuid.NewString(), Kind: SessionEventMessage, Message: msg1},
 		{EventID: uuid.NewString(), Kind: SessionEventMessage, Message: msg2},
 		{EventID: uuid.NewString(), Kind: SessionEventSpanModelRequestStart, Span: &SpanEvent{SpanID: uuid.NewString(), Kind: SpanKindModel, StartedAt: time.Now().UTC(), Model: &ModelSpanMeta{}}},
-		{EventID: uuid.NewString(), Kind: SessionEventTurnEnd, TurnEnd: &TurnEndState[*schema.Message]{SessionValues: map[string]any{"done": true}}},
+		{EventID: uuid.NewString(), Kind: SessionEventModelContext, ModelContext: &ModelContextEvent{}},
 	}
 	for _, se := range events {
 		require.NoError(t, inner.AppendEventsForSession(ctx, sid, []*SessionEvent[*schema.Message]{se}))
@@ -1568,10 +1550,10 @@ func TestSessionTimeline_ReconstructionUsesKindFilter(t *testing.T) {
 	result, err := reconstructSessionState[*schema.Message](ctx, wrapper, sid, defaultLoadPageSize)
 	require.NoError(t, err)
 
-	// All recorded Kinds slices should equal modelContextSessionEventKinds.
+	// All recorded Kinds slices should equal sessionReplayEventKinds.
 	require.NotEmpty(t, wrapper.recordedKinds)
 	for _, kinds := range wrapper.recordedKinds {
-		assert.Equal(t, modelContextSessionEventKinds, kinds)
+		assert.Equal(t, sessionReplayEventKinds, kinds)
 	}
 
 	// Verify reconstruction result.
@@ -1580,7 +1562,7 @@ func TestSessionTimeline_ReconstructionUsesKindFilter(t *testing.T) {
 	require.Len(t, result.state.Messages, 2)
 	assert.Equal(t, "hello", result.state.Messages[0].Content)
 	assert.Equal(t, "world", result.state.Messages[1].Content)
-	assert.Equal(t, map[string]any{"done": true}, result.state.SessionValues)
+	assert.True(t, result.state.sawModelContext)
 }
 
 func TestToolSpan_StreamableToolEmitsEndAfterEOF(t *testing.T) {

--- a/adk/turn_loop_test.go
+++ b/adk/turn_loop_test.go
@@ -55,16 +55,6 @@ func (a *turnLoopMockAgent) Run(ctx context.Context, input *AgentInput, _ ...Age
 				return
 			}
 			gen.Send(&AgentEvent{Output: output})
-			if output != nil && output.MessageOutput != nil && output.MessageOutput.Message != nil {
-				gen.Send(&AgentEvent{
-					SessionEvent: &SessionEvent[*schema.Message]{
-						Kind: SessionEventTurnEnd,
-						TurnEnd: &TurnEndState[*schema.Message]{
-							Messages: []*schema.Message{output.MessageOutput.Message},
-						},
-					},
-				})
-			}
 		}()
 		return iter
 	}
@@ -2667,12 +2657,7 @@ func TestTurnLoop_ManagedInterrupt_StartNewTurnUsesConfiguredSessionStore(t *tes
 	for _, se := range []*SessionEvent[*schema.Message]{
 		withTestEventID(&SessionEvent[*schema.Message]{Kind: SessionEventMessage, Message: committedUser}),
 		withTestEventID(&SessionEvent[*schema.Message]{Kind: SessionEventMessage, Message: committedAssistant}),
-		withTestEventID(&SessionEvent[*schema.Message]{
-			Kind: SessionEventTurnEnd,
-			TurnEnd: &TurnEndState[*schema.Message]{
-				Messages: []*schema.Message{committedUser, committedAssistant},
-			},
-		}),
+		withTestCommittedIdle[*schema.Message]("turn-committed"),
 		withTestEventID(&SessionEvent[*schema.Message]{Kind: SessionEventMessage, Message: partialUser}),
 	} {
 		require.NoError(t, sessionStore.AppendEventsForSession(ctx, sessionID, []*SessionEvent[*schema.Message]{se}))
@@ -2821,7 +2806,7 @@ func TestTurnLoop_ManagedInterrupt_DecisionResumeUsesCapturedCheckpointIDAndPara
 	assert.Equal(t, interruptTargetID, interruptEvents[0].AgentInterrupt.Contexts[0].InterruptID)
 
 	turnEndEvents := filterStoredSessionEvents(t, sessionStore.events, func(se *SessionEvent[*schema.Message]) bool {
-		return se.Kind == SessionEventTurnEnd
+		return isCommittedIdleEvent(se)
 	})
 	require.Len(t, turnEndEvents, 1)
 	assert.Equal(t, interruptEvents[0].TurnID, turnEndEvents[0].TurnID)
@@ -3000,13 +2985,6 @@ func (a *turnLoopManagedResumeAgent) Resume(ctx context.Context, info *ResumeInf
 					Message: schema.AssistantMessage("resumed", nil),
 					Role:    schema.Assistant,
 				},
-			},
-		})
-		gen.Send(&AgentEvent{
-			AgentName: a.Name(ctx),
-			SessionEvent: &SessionEvent[*schema.Message]{
-				Kind:    SessionEventTurnEnd,
-				TurnEnd: &TurnEndState[*schema.Message]{Messages: []*schema.Message{schema.AssistantMessage("resumed", nil)}},
 			},
 		})
 	}()

--- a/adk/wrappers.go
+++ b/adk/wrappers.go
@@ -953,13 +953,6 @@ func ensureSessionEventMessageIDs[M MessageType](event *SessionEvent[M]) {
 	if event.MessageInserted != nil && !isNilMessage(event.MessageInserted.Message) {
 		EnsureMessageID(event.MessageInserted.Message)
 	}
-	if event.TurnEnd != nil {
-		for _, msg := range event.TurnEnd.Messages {
-			if !isNilMessage(msg) {
-				EnsureMessageID(msg)
-			}
-		}
-	}
 }
 
 func typedPopToolGenAction[M MessageType](ctx context.Context, toolName string) *AgentAction {
@@ -1978,6 +1971,7 @@ func (w *typedStateModelWrapper[M]) Generate(ctx context.Context, _ []M, opts ..
 		st.DeferredToolInfos = state.DeferredToolInfos
 		return nil
 	})
+	syncModelContextSessionEvent(ctx, state)
 
 	// Derive model options from state. Append after caller opts so state takes precedence
 	// (model.GetCommonOptions applies left-to-right, last wins).
@@ -2105,6 +2099,7 @@ func (w *typedStateModelWrapper[M]) Stream(ctx context.Context, _ []M, opts ...m
 		st.DeferredToolInfos = state.DeferredToolInfos
 		return nil
 	})
+	syncModelContextSessionEvent(ctx, state)
 
 	// Derive model options from state. Append after caller opts so state takes precedence
 	// (model.GetCommonOptions applies left-to-right, last wins).


### PR DESCRIPTION
# Remove TurnEnd Session Events

## Problem

`TurnEnd` was doing two different jobs: marking a successful turn boundary and carrying state snapshots for tool context and session values. That made session replay harder to audit because durable message history, lifecycle state, prompt-cache policy, and arbitrary run-local values were all coupled through one end-of-turn side channel.

The runner already emits `session.status_idle` with `StopReason.Type == "end_turn"` when a turn completes successfully, so a separate `turn_end` marker was redundant.

## Solution

Use committed idle lifecycle events as the successful-turn marker:

```go
Kind == SessionEventSessionStatusIdle
Lifecycle.State == SessionRunStateIdle
Lifecycle.StopReason.Type == "end_turn"
```

Model-call tool context is now represented by explicit `model_context` snapshot events before model calls. Session reconstruction replays message and model-context events through the active log tail, while rollback and commit validation use committed idle events for head classification.

Old `turn_end` records are treated as dead events rather than state snapshots.

## Decisions

`SessionValues` are no longer restored from session events. They are run-local state, and persisting arbitrary key/value data through a commit marker made replay semantics less explicit.

AutoMemory and Dream now require explicit `SessionID` configuration for cross-turn grouping. Empty `SessionID` means no hidden generated durable grouping.

## Key Insight

Session replay has two separate concerns:

1. Reconstruct model-facing context from durable message and `model_context` events.
2. Classify successful committed heads from lifecycle idle events with `end_turn`.

Keeping those concerns separate removes the need for a stateful end-of-turn payload.

## Summary

| Problem | Solution |
|---------|----------|
| `TurnEnd` mixed commit marking and state snapshots | Use committed `session.status_idle(end_turn)` as the marker |
| Tool context was restored through turn-end payloads | Persist explicit `model_context` snapshots before model calls |
| Generic `SessionValues` were hidden in session replay | Stop restoring arbitrary run-local values from session events |
| AutoMemory/Dream generated hidden session IDs | Require explicit `SessionID` for cross-turn grouping |

---

# 移除 TurnEnd Session Event

## Problem

`TurnEnd` 同时承担两个职责：标记成功 turn 边界，以及携带 tool context 和 session values 的状态快照。这会让 session replay 难以审计，因为 durable message history、lifecycle state、prompt-cache policy 和任意 run-local values 都耦合在同一个 turn-end side channel 上。

Runner 在成功完成 turn 时已经会发出 `session.status_idle`，并带有 `StopReason.Type == "end_turn"`，因此额外的 `turn_end` marker 是冗余的。

## Solution

使用 committed idle lifecycle event 作为成功 turn marker：

```go
Kind == SessionEventSessionStatusIdle
Lifecycle.State == SessionRunStateIdle
Lifecycle.StopReason.Type == "end_turn"
```

Model-call tool context 现在通过 model call 前的 `model_context` snapshot event 显式记录。Session reconstruction 会 replay active log tail 中的 message 和 `model_context` events，而 rollback 和 commit validation 使用 committed idle events 做 head classification。

旧的 `turn_end` records 会被当作 dead events 处理，不再作为 state snapshot。

## Decisions

`SessionValues` 不再从 session events 中恢复。它们属于 run-local state，通过 commit marker 持久化任意 key/value 数据会让 replay 语义变得不够明确。

AutoMemory 和 Dream 现在需要显式配置 `SessionID` 才启用 cross-turn grouping。空 `SessionID` 表示不会生成隐藏的 durable grouping。

## Key Insight

Session replay 有两个独立关注点：

1. 从 durable message 和 `model_context` events 重建 model-facing context。
2. 通过带有 `end_turn` 的 lifecycle idle events 识别成功 committed heads。

拆开这两个关注点后，就不再需要 stateful end-of-turn payload。

## Summary

| Problem | Solution |
|---------|----------|
| `TurnEnd` 混合了 commit marker 和 state snapshot | 使用 committed `session.status_idle(end_turn)` 作为 marker |
| Tool context 通过 turn-end payload 恢复 | 在 model call 前显式持久化 `model_context` snapshots |
| Generic `SessionValues` 隐式参与 session replay | 停止从 session events 恢复任意 run-local values |
| AutoMemory/Dream 生成隐藏 session IDs | 使用显式 `SessionID` 启用 cross-turn grouping |
