### PR TITLE
fix(adk): deduplicate deep agent system prompts

### DIFF
--- a/adk/prebuilt/deep/deep.go
+++ b/adk/prebuilt/deep/deep.go
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 CloudWeGo Authors
+ * Copyright 2026 CloudWeGo Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -183,11 +183,17 @@ func typedGenModelInput[M adk.MessageType](_ context.Context, instruction string
 	switch any(zero).(type) {
 	case *schema.Message:
 		msgs := make([]*schema.Message, 0, len(input.Messages)+1)
+		inputMessages := input.Messages
 		if instruction != "" {
+			if len(inputMessages) > 0 {
+				if msg, ok := any(inputMessages[0]).(*schema.Message); ok && msg.Role == schema.System {
+					inputMessages = inputMessages[1:]
+				}
+			}
 			msgs = append(msgs, schema.SystemMessage(instruction))
 		}
 		// Type assertion is safe here because M = *schema.Message.
-		for _, m := range input.Messages {
+		for _, m := range inputMessages {
 			msgs = append(msgs, any(m).(*schema.Message))
 		}
 		result := make([]M, len(msgs))
@@ -197,10 +203,16 @@ func typedGenModelInput[M adk.MessageType](_ context.Context, instruction string
 		return result, nil
 	case *schema.AgenticMessage:
 		msgs := make([]*schema.AgenticMessage, 0, len(input.Messages)+1)
+		inputMessages := input.Messages
 		if instruction != "" {
+			if len(inputMessages) > 0 {
+				if msg, ok := any(inputMessages[0]).(*schema.AgenticMessage); ok && msg.Role == schema.AgenticRoleTypeSystem {
+					inputMessages = inputMessages[1:]
+				}
+			}
 			msgs = append(msgs, schema.SystemAgenticMessage(instruction))
 		}
-		for _, m := range input.Messages {
+		for _, m := range inputMessages {
 			msgs = append(msgs, any(m).(*schema.AgenticMessage))
 		}
 		result := make([]M, len(msgs))

--- a/adk/prebuilt/deep/deep_test.go
+++ b/adk/prebuilt/deep/deep_test.go
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 CloudWeGo Authors
+ * Copyright 2026 CloudWeGo Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -20,6 +20,7 @@ import (
 	"context"
 	"fmt"
 	"io"
+	"sync"
 	"sync/atomic"
 	"testing"
 
@@ -30,6 +31,7 @@ import (
 	"github.com/cloudwego/eino/adk/filesystem"
 	filesystem2 "github.com/cloudwego/eino/adk/middlewares/filesystem"
 	"github.com/cloudwego/eino/adk/prebuilt/planexecute"
+	adksession "github.com/cloudwego/eino/adk/session"
 	"github.com/cloudwego/eino/components/model"
 	"github.com/cloudwego/eino/components/tool"
 	"github.com/cloudwego/eino/compose"
@@ -91,6 +93,56 @@ func readAgenticText(msg *schema.AgenticMessage) string {
 	return ""
 }
 
+func readAgenticInputText(msg *schema.AgenticMessage) string {
+	if msg == nil {
+		return ""
+	}
+	for _, block := range msg.ContentBlocks {
+		if block == nil {
+			continue
+		}
+		if block.UserInputText != nil {
+			return block.UserInputText.Text
+		}
+	}
+	return ""
+}
+
+type recordingDeepModel struct {
+	mu       sync.Mutex
+	inputs   [][]*schema.Message
+	response *schema.Message
+}
+
+func (m *recordingDeepModel) Generate(_ context.Context, input []*schema.Message, _ ...model.Option) (*schema.Message, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	copied := append([]*schema.Message{}, input...)
+	m.inputs = append(m.inputs, copied)
+	if m.response != nil {
+		return m.response, nil
+	}
+	return schema.AssistantMessage("ok", nil), nil
+}
+
+func (m *recordingDeepModel) Stream(ctx context.Context, input []*schema.Message, opts ...model.Option) (*schema.StreamReader[*schema.Message], error) {
+	msg, err := m.Generate(ctx, input, opts...)
+	if err != nil {
+		return nil, err
+	}
+	return schema.StreamReaderFromArray([]*schema.Message{msg}), nil
+}
+
+func (m *recordingDeepModel) snapshotInputs() [][]*schema.Message {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	out := make([][]*schema.Message, len(m.inputs))
+	for i, input := range m.inputs {
+		out[i] = append([]*schema.Message{}, input...)
+	}
+	return out
+}
+
 type mockSearchTool struct{}
 
 func (m *mockSearchTool) Info(context.Context) (*schema.ToolInfo, error) {
@@ -129,6 +181,56 @@ func TestGenModelInput(t *testing.T) {
 		assert.Equal(t, "hello", msgs[1].Content)
 	})
 
+	t.Run("WithInstructionStripsLeadingSystemMessage", func(t *testing.T) {
+		input := &adk.AgentInput{
+			Messages: []*schema.Message{
+				schema.SystemMessage("old"),
+				schema.UserMessage("hello"),
+			},
+		}
+
+		msgs, err := typedGenModelInput(ctx, "new", input)
+		assert.NoError(t, err)
+		assert.Len(t, msgs, 2)
+		assert.Equal(t, schema.System, msgs[0].Role)
+		assert.Equal(t, "new", msgs[0].Content)
+		assert.Equal(t, schema.User, msgs[1].Role)
+		assert.Equal(t, "hello", msgs[1].Content)
+
+		systemCount := 0
+		for _, msg := range msgs {
+			if msg.Role == schema.System {
+				systemCount++
+			}
+		}
+		assert.Equal(t, 1, systemCount)
+	})
+
+	t.Run("WithInstructionStripsLeadingAgenticSystemMessage", func(t *testing.T) {
+		input := &adk.TypedAgentInput[*schema.AgenticMessage]{
+			Messages: []*schema.AgenticMessage{
+				schema.SystemAgenticMessage("old"),
+				schema.UserAgenticMessage("hello"),
+			},
+		}
+
+		msgs, err := typedGenModelInput(ctx, "new", input)
+		assert.NoError(t, err)
+		assert.Len(t, msgs, 2)
+		assert.Equal(t, schema.AgenticRoleTypeSystem, msgs[0].Role)
+		assert.Equal(t, "new", readAgenticInputText(msgs[0]))
+		assert.Equal(t, schema.AgenticRoleTypeUser, msgs[1].Role)
+		assert.Equal(t, "hello", readAgenticInputText(msgs[1]))
+
+		systemCount := 0
+		for _, msg := range msgs {
+			if msg.Role == schema.AgenticRoleTypeSystem {
+				systemCount++
+			}
+		}
+		assert.Equal(t, 1, systemCount)
+	})
+
 	t.Run("WithoutInstruction", func(t *testing.T) {
 		input := &adk.AgentInput{
 			Messages: []*schema.Message{
@@ -142,6 +244,83 @@ func TestGenModelInput(t *testing.T) {
 		assert.Equal(t, schema.User, msgs[0].Role)
 		assert.Equal(t, "hello", msgs[0].Content)
 	})
+
+	t.Run("WithoutInstructionPreservesLeadingSystemMessage", func(t *testing.T) {
+		input := &adk.AgentInput{
+			Messages: []*schema.Message{
+				schema.SystemMessage("old"),
+				schema.UserMessage("hello"),
+			},
+		}
+
+		msgs, err := typedGenModelInput(ctx, "", input)
+		assert.NoError(t, err)
+		assert.Len(t, msgs, 2)
+		assert.Equal(t, schema.System, msgs[0].Role)
+		assert.Equal(t, "old", msgs[0].Content)
+		assert.Equal(t, schema.User, msgs[1].Role)
+		assert.Equal(t, "hello", msgs[1].Content)
+	})
+}
+
+func TestDeepAgentTurn2DeduplicatesPersistedLeadingSystemMessage(t *testing.T) {
+	ctx := context.Background()
+	store := adksession.NewInMemoryStore[*schema.Message](nil)
+	model := &recordingDeepModel{}
+	agent, err := New(ctx, &Config{
+		Name:                   "deep",
+		Description:            "deep agent",
+		ChatModel:              model,
+		Instruction:            "you are deep agent",
+		MaxIteration:           2,
+		WithoutWriteTodos:      true,
+		WithoutGeneralSubAgent: true,
+	})
+	assert.NoError(t, err)
+	if err != nil {
+		return
+	}
+
+	runner := adk.NewRunner(ctx, adk.RunnerConfig{
+		Agent:        agent,
+		SessionID:    "deep-leading-system-dedup",
+		SessionStore: store,
+	})
+	for _, input := range [][]adk.Message{
+		{schema.UserMessage("turn one")},
+		{schema.UserMessage("turn two")},
+	} {
+		iter := runner.Run(ctx, input)
+		for {
+			if _, ok := iter.Next(); !ok {
+				break
+			}
+		}
+	}
+
+	inputs := model.snapshotInputs()
+	assert.Len(t, inputs, 2)
+	if len(inputs) < 2 {
+		return
+	}
+	secondTurnInput := inputs[1]
+	assert.NotEmpty(t, secondTurnInput)
+	if len(secondTurnInput) == 0 {
+		return
+	}
+	assert.Equal(t, schema.System, secondTurnInput[0].Role)
+	assert.Equal(t, "you are deep agent", secondTurnInput[0].Content)
+
+	systemCount := 0
+	for _, msg := range secondTurnInput {
+		if msg.Role == schema.System {
+			systemCount++
+		}
+	}
+	assert.Equal(t, 1, systemCount)
+	if len(secondTurnInput) > 1 {
+		assert.NotEqual(t, schema.System, secondTurnInput[1].Role, "reconstructed system message must not remain after fresh system message")
+	}
 }
 
 func TestWriteTodos(t *testing.T) {


### PR DESCRIPTION
# Deduplicate Deep Agent System Prompts

## Problem
Deep agent rebuilds model input with its configured `Instruction` on every turn. After leading system messages became persisted session events, a later turn can replay the previous persisted system message and then prepend a fresh system message again.

Expected: one leading system message with the current deep agent instruction.
Actual: the replayed system message can remain behind the fresh one, so the model input contains duplicate system prompts.

## Solution
When `typedGenModelInput` is about to prepend a non-empty instruction, it first removes an existing leading system message from the replayed input. This keeps the instruction authoritative for the current turn while preserving existing behavior when no instruction is configured.

The same rule is applied to both `*schema.Message` and `*schema.AgenticMessage` paths.

## Key Insight
Persisted leading system messages are replay state, not a second source of truth for prebuilt deep agent instructions. On each turn, the deep agent instruction should regenerate the leading system message, and any replayed leading system message should be treated as the previous materialization of that same slot.

## Summary
| Problem | Solution |
|---------|----------|
| Deep agent second-turn input can contain two system prompts after replay | Strip the replayed leading system message before prepending the current instruction |
| Empty-instruction deep agents may intentionally preserve replayed messages | Only strip when a fresh instruction is being prepended |

---

# 去重 Deep Agent 系统提示词

## Problem
Deep agent 每一轮都会用配置的 `Instruction` 重建模型输入。在首置系统消息开始作为 session event 持久化后，后续轮次可能先重放上一轮持久化的系统消息，再追加本轮新生成的系统消息。

期望行为：模型输入中只有一条首置系统消息，并且内容来自当前 deep agent instruction。
实际行为：重放出的系统消息可能保留在新系统消息之后，导致模型输入出现重复 system prompt。

## Solution
当 `typedGenModelInput` 准备追加非空 instruction 时，先移除重放输入中的首置系统消息。这样当前轮次的 instruction 仍然是权威来源，同时不改变未配置 instruction 时保留历史消息的行为。

同一规则同时覆盖 `*schema.Message` 和 `*schema.AgenticMessage` 两条路径。

## Key Insight
持久化的首置系统消息是 replay state，不应该成为 prebuilt deep agent instruction 的第二个权威来源。每一轮都应由 deep agent instruction 重新生成首置系统消息，而重放出来的首置系统消息应被视为同一个位置的上一轮物化结果。

## Summary
| Problem | Solution |
|---------|----------|
| Deep agent 第二轮输入在 replay 后可能包含两条 system prompt | 在追加当前 instruction 前剥离重放出的首置系统消息 |
| 空 instruction 的 deep agent 可能需要保留历史消息 | 仅在本轮确实要追加 instruction 时执行剥离 |
