### PR TITLE
fix(adk): delete consumed resume checkpoint

### DIFF
--- a/adk/turn_loop.go
+++ b/adk/turn_loop.go
@@ -1096,6 +1096,18 @@ func (l *TurnLoop[T, M]) deleteTurnLoopCheckpoint(ctx context.Context, checkPoin
 	return nil
 }
 
+func (l *TurnLoop[T, M]) deleteLoadedCheckpointAfterSuccessfulResume(ctx context.Context, runErr error, isResume bool, hasInterrupt bool) error {
+	if runErr != nil || !isResume || hasInterrupt || l.loadCheckpointID == "" {
+		return runErr
+	}
+	checkpointID := l.loadCheckpointID
+	if err := l.deleteTurnLoopCheckpoint(ctx, checkpointID); err != nil {
+		return fmt.Errorf("failed to delete consumed checkpoint[%s] after resume: %w", checkpointID, err)
+	}
+	l.loadCheckpointID = ""
+	return nil
+}
+
 func (l *TurnLoop[T, M]) tryLoadCheckpoint(ctx context.Context) error {
 	// Adopt any Resume() items submitted before the checkpoint finished loading.
 	// Registered as a defer so it runs on ALL exit paths, including the early
@@ -2146,6 +2158,7 @@ func (l *TurnLoop[T, M]) run(ctx context.Context) {
 		l.buffer.PushFront(plan.remaining)
 
 		runErr := l.runAgentAndHandleEvents(plan.turnCtx, agent, plan.spec)
+		runErr = l.deleteLoadedCheckpointAfterSuccessfulResume(ctx, runErr, plan.spec.isResume, l.interruptContexts != nil)
 
 		if runErr != nil {
 			// Set interruptedItems when a cancel or interrupt was captured from the

--- a/adk/turn_loop_test.go
+++ b/adk/turn_loop_test.go
@@ -7785,6 +7785,102 @@ func TestTurnLoop_ManagedRestore_WaitsForExplicitResume(t *testing.T) {
 	assert.Equal(t, int32(1), atomic.LoadInt32(&genResumeRan))
 }
 
+func TestTurnLoop_ManagedRestore_DeletesConsumedCheckpointAfterSuccessfulResume(t *testing.T) {
+	ctx := context.Background()
+	cpID := "managed-restore-delete-after-resume"
+	store := &deletableCheckpointStore{
+		turnLoopCheckpointStore: turnLoopCheckpointStore{m: make(map[string][]byte)},
+	}
+
+	interruptObserved := make(chan struct{})
+	var interruptOnce sync.Once
+	firstAgent := &turnLoopManagedResumeAgent{interruptInfo: "approval_needed"}
+	loop1 := newAndRunTurnLoop(ctx, TurnLoopConfig[string, *schema.Message]{
+		InterruptMode: TurnLoopInterruptWaitsForExplicitResume,
+		Store:         store,
+		CheckpointID:  cpID,
+		GenInput:      genInputConsumeAllWithMsg,
+		PrepareAgent:  prepareAgent(firstAgent),
+		OnAgentEvents: func(_ context.Context, _ *TurnContext[string, *schema.Message], events *AsyncIterator[*AgentEvent]) error {
+			for {
+				event, ok := events.Next()
+				if !ok {
+					break
+				}
+				if event.Action != nil && event.Action.Interrupted != nil {
+					interruptOnce.Do(func() { close(interruptObserved) })
+				}
+			}
+			return nil
+		},
+	})
+	loop1.Push("trigger-interrupt")
+	waitOrFail(t, interruptObserved, "interrupt was not observed")
+	loop1.Stop()
+	exit1 := loop1.Wait()
+	require.NoError(t, exit1.ExitReason)
+	require.True(t, exit1.CheckpointAttempted)
+	require.NoError(t, exit1.CheckpointErr)
+
+	store.mu.Lock()
+	_, exists := store.m[cpID]
+	store.deleteCalled = false
+	store.deletedKey = ""
+	store.mu.Unlock()
+	require.True(t, exists, "setup checkpoint should exist")
+
+	resumeObserved := make(chan struct{})
+	resumedRunDone := make(chan struct{})
+	var resumeOnce, resumedRunOnce sync.Once
+	secondAgent := &turnLoopManagedResumeAgent{
+		onResume: func(*ResumeInfo) {
+			resumeOnce.Do(func() { close(resumeObserved) })
+		},
+	}
+	loop2 := NewTurnLoop(TurnLoopConfig[string, *schema.Message]{
+		InterruptMode: TurnLoopInterruptWaitsForExplicitResume,
+		Store:         store,
+		CheckpointID:  cpID,
+		GenInput:      genInputConsumeAllWithMsg,
+		GenResume: func(_ context.Context, _ *TurnLoop[string, *schema.Message], interruptedItems, _, resumeItems []string) (*GenResumeResult[string, *schema.Message], error) {
+			return &GenResumeResult[string, *schema.Message]{
+				Decision: TurnLoopResumeDecisionResume,
+				Consumed: append(append([]string{}, interruptedItems...), resumeItems...),
+			}, nil
+		},
+		PrepareAgent: prepareAgent(secondAgent),
+		OnAgentEvents: func(_ context.Context, _ *TurnContext[string, *schema.Message], events *AsyncIterator[*AgentEvent]) error {
+			for {
+				if _, ok := events.Next(); !ok {
+					break
+				}
+			}
+			resumedRunOnce.Do(func() { close(resumedRunDone) })
+			return nil
+		},
+	})
+	loop2.Run(ctx)
+	require.Eventually(t, func() bool {
+		loop2.resumeMu.Lock()
+		defer loop2.resumeMu.Unlock()
+		return loop2.checkpointLoaded
+	}, time.Second, 5*time.Millisecond)
+	require.Eventually(t, func() bool { return loop2.Resume("approve") == nil }, time.Second, 5*time.Millisecond)
+	waitOrFail(t, resumeObserved, "agent resume was not observed")
+	waitOrFail(t, resumedRunDone, "resumed run did not finish")
+
+	require.Eventually(t, func() bool {
+		store.mu.Lock()
+		defer store.mu.Unlock()
+		_, exists := store.m[cpID]
+		return store.deleteCalled && store.deletedKey == cpID && !exists
+	}, time.Second, 5*time.Millisecond, "consumed checkpoint should be deleted while loop stays alive")
+
+	loop2.Stop()
+	exit2 := loop2.Wait()
+	require.NoError(t, exit2.ExitReason)
+}
+
 // Test #9
 func TestTurnLoop_ManagedRestore_PreRunResumeSubmitsImmediately(t *testing.T) {
 	ctx := context.Background()


### PR DESCRIPTION
# Delete Consumed TurnLoop Resume Checkpoint

## Problem
A restored TurnLoop checkpoint stayed in the checkpoint store after a real resume succeeded. While the resumed run was in flight, keeping that checkpoint was useful for crash recovery. After the resumed turn completed normally, the checkpoint was already consumed, but it could remain authoritative until TurnLoop cleanup.

That left a crash window: if the process died after the permission resume visibly succeeded but before cleanup, the next process could load the stale checkpoint and treat normal input as being behind an old managed resume.

## Solution
Delete the loaded outer checkpoint immediately after a restored resume turn finishes successfully and does not produce another interrupt. The delete happens only after `runAgentAndHandleEvents` returns cleanly, so the checkpoint is still available while the resume is in flight.

If the resumed run interrupts again, TurnLoop keeps the normal checkpoint persistence path so the new interrupted state remains resumable.

## Key Insight
For TurnLoop resume, checkpoint ownership changes when the resumed runner turn is accepted and completes without producing a replacement interrupt. Before that point, the restored checkpoint is recovery state. After that point, it is stale state and must not survive as the source of truth.

## Summary

| Problem | Solution |
|---------|----------|
| A consumed restored checkpoint could remain in storage while TurnLoop stayed alive | Delete the loaded checkpoint immediately after successful restored resume completion |
| A later crash could reload stale managed-resume state | Clear `loadCheckpointID` once the delete succeeds so cleanup does not treat it as still loaded |

---

# 删除已消费的 TurnLoop Resume Checkpoint

## 问题
恢复出来的 TurnLoop checkpoint 在真实 resume 成功后仍可能留在 checkpoint store 中。resume 执行过程中保留它是有价值的，因为它还能用于崩溃恢复；但 resumed turn 正常完成后，这个 checkpoint 已经被消费，不应该继续等到 TurnLoop cleanup 才清理。

这会留下一个崩溃窗口：如果权限 resume 已经成功可见，但进程在 cleanup 前崩溃，下一次启动可能重新加载这个陈旧 checkpoint，并把普通用户输入错误地放到旧的 managed resume 后面。

## 方案
当恢复出来的 resume turn 成功完成，并且没有产生新的 interrupt 时，立即删除已加载的外层 checkpoint。删除发生在 `runAgentAndHandleEvents` 正常返回之后，因此 resume 仍在执行时 checkpoint 依然可用于崩溃恢复。

如果 resumed run 再次 interrupt，TurnLoop 会继续走原有 checkpoint 持久化路径，让新的 interrupted state 保持可恢复。

## 关键点
对 TurnLoop resume 来说，checkpoint 的权威性在 resumed runner turn 被接受并且无替代 interrupt 地完成时发生变化。在此之前，恢复出来的 checkpoint 是恢复状态；在此之后，它就是陈旧状态，不能继续作为 source of truth。

## 总结

| 问题 | 方案 |
|------|------|
| 已消费的 restored checkpoint 可能在 TurnLoop 继续运行时留在存储中 | restored resume 成功完成后立即删除已加载 checkpoint |
| 后续崩溃可能重新加载陈旧 managed-resume state | 删除成功后清空 `loadCheckpointID`，避免 cleanup 继续把它视为已加载 checkpoint |