### PR TITLE
fix(adk): snapshot leading system sync state

### DIFF
--- a/adk/chatmodel.go
+++ b/adk/chatmodel.go
@@ -379,6 +379,45 @@ func leadingSystemMessage[M MessageType](messages []M) (M, bool) {
 	return zero, false
 }
 
+type leadingSystemSyncInput[M MessageType] struct {
+	previous     []M
+	generated    []M
+	oldSystem    M
+	hasOldSystem bool
+}
+
+func snapshotLeadingSystemForSync[M MessageType](messages []M) (M, bool) {
+	oldSys, ok := leadingSystemMessage(messages)
+	if !ok {
+		var zero M
+		return zero, false
+	}
+	EnsureMessageID(oldSys)
+	snapshot := copyMessage(oldSys)
+	cloneMessageExtra(snapshot)
+	return snapshot, true
+}
+
+func cloneMessageExtra[M MessageType](msg M) {
+	switch v := any(msg).(type) {
+	case *schema.Message:
+		v.Extra = cloneExtraMap(v.Extra)
+	case *schema.AgenticMessage:
+		v.Extra = cloneExtraMap(v.Extra)
+	}
+}
+
+func cloneExtraMap(extra map[string]any) map[string]any {
+	if extra == nil {
+		return nil
+	}
+	cloned := make(map[string]any, len(extra))
+	for k, v := range extra {
+		cloned[k] = v
+	}
+	return cloned
+}
+
 func sameSystemMessage[M MessageType](oldSys, newSys M) bool {
 	if isNilMessage(oldSys) || isNilMessage(newSys) {
 		return isNilMessage(oldSys) && isNilMessage(newSys)
@@ -404,25 +443,23 @@ func setMessageIDFromTarget[M MessageType](msg M, targetID string) {
 
 func syncLeadingSystemMessageSessionEvent[M MessageType](
 	ctx context.Context,
-	previous []M,
-	generated []M,
+	input leadingSystemSyncInput[M],
 ) error {
 	execCtx := getTypedChatModelAgentExecCtx[M](ctx)
 	if execCtx == nil || !execCtx.sessionEvents {
 		return nil
 	}
 
-	newSys, ok := leadingSystemMessage(generated)
+	newSys, ok := leadingSystemMessage(input.generated)
 	if !ok {
 		return nil
 	}
 
 	var event *TypedAgentEvent[M]
-	if oldSys, hasOldSys := leadingSystemMessage(previous); hasOldSys {
-		EnsureMessageID(oldSys)
-		oldID := GetMessageID(oldSys)
+	if input.hasOldSystem {
+		oldID := GetMessageID(input.oldSystem)
 		setMessageIDFromTarget(newSys, oldID)
-		if sameSystemMessage(oldSys, newSys) {
+		if sameSystemMessage(input.oldSystem, newSys) {
 			return nil
 		}
 		event = &TypedAgentEvent[M]{
@@ -434,7 +471,7 @@ func syncLeadingSystemMessageSessionEvent[M MessageType](
 				},
 			},
 		}
-	} else if len(previous) == 0 {
+	} else if len(input.previous) == 0 {
 		EnsureMessageID(newSys)
 		event = &TypedAgentEvent[M]{
 			SessionEvent: &SessionEvent[M]{
@@ -443,17 +480,17 @@ func syncLeadingSystemMessageSessionEvent[M MessageType](
 			},
 		}
 	} else {
-		if isNilMessage(previous[0]) {
+		if isNilMessage(input.previous[0]) {
 			return errors.New("sync leading system message: previous first message is nil")
 		}
-		EnsureMessageID(previous[0])
+		EnsureMessageID(input.previous[0])
 		EnsureMessageID(newSys)
 		event = &TypedAgentEvent[M]{
 			SessionEvent: &SessionEvent[M]{
 				Kind: SessionEventMessageInserted,
 				MessageInserted: &MessageInsertedEvent[M]{
 					Message:         newSys,
-					BeforeMessageID: GetMessageID(previous[0]),
+					BeforeMessageID: GetMessageID(input.previous[0]),
 				},
 			},
 		}
@@ -1265,12 +1302,24 @@ func (a *TypedChatModelAgent[M]) buildNoToolsRunFunc(_ context.Context) (typedRu
 			}))
 
 		chain.AppendLambda(compose.InvokableLambda(func(ctx context.Context, in typedNoToolsInput[M]) ([]M, error) {
+			var syncInput leadingSystemSyncInput[M]
+			if p.sessionEvents {
+				oldSys, hasOldSys := snapshotLeadingSystemForSync(in.input.Messages)
+				syncInput = leadingSystemSyncInput[M]{
+					previous:     in.input.Messages,
+					oldSystem:    oldSys,
+					hasOldSystem: hasOldSys,
+				}
+			}
 			messages, err := a.genModelInput(ctx, in.instruction, in.input)
 			if err != nil {
 				return nil, err
 			}
-			if err := syncLeadingSystemMessageSessionEvent(ctx, in.input.Messages, messages); err != nil {
-				return nil, err
+			if p.sessionEvents {
+				syncInput.generated = messages
+				if err := syncLeadingSystemMessageSessionEvent(ctx, syncInput); err != nil {
+					return nil, err
+				}
 			}
 			if p.sessionEvents {
 				ensureGeneratedMessageIDs(messages)
@@ -1423,12 +1472,24 @@ func (a *TypedChatModelAgent[M]) buildMessageReActRunFunc(_ context.Context, bc 
 		chain := compose.NewChain[reactRunInput, Message]().
 			AppendLambda(
 				compose.InvokableLambda(func(ctx context.Context, in reactRunInput) (*reactInput, error) {
+					var syncInput leadingSystemSyncInput[*schema.Message]
+					if mp.sessionEvents {
+						oldSys, hasOldSys := snapshotLeadingSystemForSync(in.input.Messages)
+						syncInput = leadingSystemSyncInput[*schema.Message]{
+							previous:     in.input.Messages,
+							oldSystem:    oldSys,
+							hasOldSystem: hasOldSys,
+						}
+					}
 					messages, genErr := genModelInputFn(ctx, in.instruction, in.input)
 					if genErr != nil {
 						return nil, genErr
 					}
-					if genErr = syncLeadingSystemMessageSessionEvent(ctx, in.input.Messages, messages); genErr != nil {
-						return nil, genErr
+					if mp.sessionEvents {
+						syncInput.generated = messages
+						if genErr = syncLeadingSystemMessageSessionEvent(ctx, syncInput); genErr != nil {
+							return nil, genErr
+						}
 					}
 					if mp.sessionEvents {
 						ensureGeneratedMessageIDs(messages)
@@ -1569,12 +1630,24 @@ func (a *TypedChatModelAgent[M]) buildAgenticReActRunFunc(_ context.Context, bc 
 		chain := compose.NewChain[agenticReactRunInput, *schema.AgenticMessage]().
 			AppendLambda(
 				compose.InvokableLambda(func(ctx context.Context, in agenticReactRunInput) (*agenticReactInput, error) {
+					var syncInput leadingSystemSyncInput[*schema.AgenticMessage]
+					if ap.sessionEvents {
+						oldSys, hasOldSys := snapshotLeadingSystemForSync(in.input.Messages)
+						syncInput = leadingSystemSyncInput[*schema.AgenticMessage]{
+							previous:     in.input.Messages,
+							oldSystem:    oldSys,
+							hasOldSystem: hasOldSys,
+						}
+					}
 					messages, genErr := genModelInputFn(ctx, in.instruction, in.input)
 					if genErr != nil {
 						return nil, genErr
 					}
-					if genErr = syncLeadingSystemMessageSessionEvent(ctx, in.input.Messages, messages); genErr != nil {
-						return nil, genErr
+					if ap.sessionEvents {
+						syncInput.generated = messages
+						if genErr = syncLeadingSystemMessageSessionEvent(ctx, syncInput); genErr != nil {
+							return nil, genErr
+						}
 					}
 					if ap.sessionEvents {
 						ensureGeneratedMessageIDs(messages)

--- a/adk/session_test.go
+++ b/adk/session_test.go
@@ -4808,6 +4808,154 @@ func TestAttack_LeadingSystemMessageExtraChangesArePersisted(t *testing.T) {
 	assert.Equal(t, "b", result.state.Messages[0].Extra["trace"])
 }
 
+func TestAttack_LeadingSystemMessageMutationInGenModelInputStillPersistsUpdate(t *testing.T) {
+	ctx := context.Background()
+	store := newSessionHelperStore()
+	sid := "leading-system-content-mutation"
+	seedModel := &leadingSystemTestModel[*schema.Message]{response: schema.AssistantMessage("seed answer", nil)}
+	seedAgent, err := NewChatModelAgent(ctx, &ChatModelAgentConfig{
+		Name:        "system-content-seed-agent",
+		Description: "test",
+		Instruction: "system v1",
+		Model:       seedModel,
+	})
+	require.NoError(t, err)
+	drainSessionEvents(t, NewRunner(ctx, RunnerConfig{Agent: seedAgent, SessionID: sid, SessionStore: store}).
+		Run(ctx, []*schema.Message{schema.UserMessage("seed")}))
+
+	updateModel := &leadingSystemTestModel[*schema.Message]{response: schema.AssistantMessage("updated answer", nil)}
+	updateAgent, err := NewChatModelAgent(ctx, &ChatModelAgentConfig{
+		Name:        "system-content-update-agent",
+		Description: "test",
+		Model:       updateModel,
+		GenModelInput: func(_ context.Context, _ string, input *AgentInput) ([]*schema.Message, error) {
+			require.NotEmpty(t, input.Messages)
+			input.Messages[0].Content = "mutated old system"
+			return append([]*schema.Message{schema.SystemMessage("system v2")}, input.Messages[1:]...), nil
+		},
+	})
+	require.NoError(t, err)
+	drainSessionEvents(t, NewRunner(ctx, RunnerConfig{Agent: updateAgent, SessionID: sid, SessionStore: store}).
+		Run(ctx, []*schema.Message{schema.UserMessage("update")}))
+
+	var update *MessageUpdatedEvent[*schema.Message]
+	for _, event := range loadMessageSessionEvents(t, ctx, store, sid) {
+		if event.MessageUpdated != nil && event.MessageUpdated.Message.Role == schema.System {
+			update = event.MessageUpdated
+		}
+	}
+	require.NotNil(t, update)
+	assert.Equal(t, "system v2", update.Message.Content)
+
+	handle := mustOpenTestSession[*schema.Message](t, ctx, store, sid)
+	result, err := reconstructSessionState[*schema.Message](ctx, handle, sid, defaultLoadPageSize)
+	require.NoError(t, err)
+	require.NoError(t, handle.close(ctx))
+	require.NotEmpty(t, result.state.Messages)
+	assert.Equal(t, "system v2", result.state.Messages[0].Content)
+}
+
+func TestAttack_LeadingSystemMessageExtraMutationInGenModelInputStillPersistsUpdate(t *testing.T) {
+	ctx := context.Background()
+	store := newSessionHelperStore()
+	sid := "leading-system-extra-mutation"
+
+	runTurn := func(trace string, mutateOld bool) {
+		model := &leadingSystemTestModel[*schema.Message]{response: schema.AssistantMessage("answer "+trace, nil)}
+		agent, err := NewChatModelAgent(ctx, &ChatModelAgentConfig{
+			Name:        "system-extra-mutation-agent",
+			Description: "test",
+			Model:       model,
+			GenModelInput: func(_ context.Context, _ string, input *AgentInput) ([]*schema.Message, error) {
+				tail := input.Messages
+				if mutateOld {
+					require.NotEmpty(t, input.Messages)
+					require.NotNil(t, input.Messages[0].Extra)
+					input.Messages[0].Extra["trace"] = trace
+					tail = input.Messages[1:]
+				}
+				system := schema.SystemMessage("same")
+				system.Extra = map[string]any{"trace": trace}
+				return append([]*schema.Message{system}, tail...), nil
+			},
+		})
+		require.NoError(t, err)
+		drainSessionEvents(t, NewRunner(ctx, RunnerConfig{Agent: agent, SessionID: sid, SessionStore: store}).
+			Run(ctx, []*schema.Message{schema.UserMessage(trace)}))
+	}
+
+	runTurn("old", false)
+	runTurn("new", true)
+
+	var update *MessageUpdatedEvent[*schema.Message]
+	for _, event := range loadMessageSessionEvents(t, ctx, store, sid) {
+		if event.MessageUpdated != nil && event.MessageUpdated.Message.Role == schema.System {
+			update = event.MessageUpdated
+		}
+	}
+	require.NotNil(t, update, "system Extra mutation must not hide the generated update")
+	assert.Equal(t, "new", update.Message.Extra["trace"])
+
+	handle := mustOpenTestSession[*schema.Message](t, ctx, store, sid)
+	result, err := reconstructSessionState[*schema.Message](ctx, handle, sid, defaultLoadPageSize)
+	require.NoError(t, err)
+	require.NoError(t, handle.close(ctx))
+	require.NotEmpty(t, result.state.Messages)
+	assert.Equal(t, "new", result.state.Messages[0].Extra["trace"])
+}
+
+func TestAttack_LeadingSystemSnapshotAssignsIDToSource(t *testing.T) {
+	ctx := context.Background()
+	sourceSystem := schema.SystemMessage("system v1")
+	input := &AgentInput{Messages: []*schema.Message{sourceSystem, schema.UserMessage("hello")}}
+	model := &leadingSystemTestModel[*schema.Message]{response: schema.AssistantMessage("answer", nil)}
+	agent, err := NewChatModelAgent(ctx, &ChatModelAgentConfig{
+		Name:        "system-source-id-agent",
+		Description: "test",
+		Model:       model,
+		GenModelInput: func(_ context.Context, _ string, input *AgentInput) ([]*schema.Message, error) {
+			return append([]*schema.Message{schema.SystemMessage("system v2")}, input.Messages[1:]...), nil
+		},
+	})
+	require.NoError(t, err)
+
+	var update *MessageUpdatedEvent[*schema.Message]
+	for iter := agent.Run(ctx, input, withEnableSessionEvents()); ; {
+		event, ok := iter.Next()
+		if !ok {
+			break
+		}
+		require.NoError(t, event.Err)
+		if event.SessionEvent != nil && event.SessionEvent.MessageUpdated != nil {
+			update = event.SessionEvent.MessageUpdated
+		}
+	}
+
+	sourceID := GetMessageID(sourceSystem)
+	require.NotEmpty(t, sourceID)
+	require.NotNil(t, update)
+	assert.Equal(t, sourceID, update.MessageID)
+}
+
+func TestAttack_LeadingSystemSnapshotDoesNotAssignIDWhenSessionEventsDisabled(t *testing.T) {
+	ctx := context.Background()
+	sourceSystem := schema.SystemMessage("system v1")
+	input := &AgentInput{Messages: []*schema.Message{sourceSystem, schema.UserMessage("hello")}}
+	model := &leadingSystemTestModel[*schema.Message]{response: schema.AssistantMessage("answer", nil)}
+	agent, err := NewChatModelAgent(ctx, &ChatModelAgentConfig{
+		Name:        "system-disabled-source-id-agent",
+		Description: "test",
+		Model:       model,
+		GenModelInput: func(_ context.Context, _ string, input *AgentInput) ([]*schema.Message, error) {
+			return append([]*schema.Message{schema.SystemMessage("system v2")}, input.Messages[1:]...), nil
+		},
+	})
+	require.NoError(t, err)
+
+	drainSessionEvents(t, agent.Run(ctx, input))
+	assert.Empty(t, GetMessageID(sourceSystem))
+}
+
 func TestSameSystemMessageComparesExtraExceptMessageID(t *testing.T) {
 	oldMsg := schema.SystemMessage("same")
 	oldMsg.Extra = map[string]any{"_eino_msg_id": "old", "trace": "a"}


### PR DESCRIPTION
# Leading system sync snapshot hardening

## Problem

Session-event persistence compares the previous leading system message with the generated current system message after `GenModelInput` returns.

That works for the built-in generators, but a third-party `GenModelInput` can mutate `input.Messages[0]` in place before returning. In that case, persistence can observe the already-mutated "old" system message and incorrectly skip `SessionEventMessageUpdated`.

Example:

```go
input.Messages[0].Content = "mutated old system"
return append([]*schema.Message{schema.SystemMessage("system v2")}, input.Messages[1:]...), nil
```

Expected: persist a system `MessageUpdated` event for `system v2`.
Actual before this PR: the old state could be overwritten before comparison.

## Solution

Snapshot the previous leading system message before calling `GenModelInput`, but only when session events are enabled.

The snapshot path intentionally assigns any missing message ID to the source old system first, then copies it and clones `Extra`. This keeps `MessageUpdated.MessageID` consistent with the source history while preventing custom generators from hiding content or metadata changes through in-place mutation.

## Key Insight

Leading system-message persistence must compare against the state that existed before model-input generation. `GenModelInput` is an extension point, so persistence cannot assume it leaves `input.Messages` unchanged.

## Summary

| Problem | Solution |
|---------|----------|
| Custom `GenModelInput` can mutate the old leading system before sync compares it | Snapshot the old leading system before generation |
| Missing old-system IDs could exist only on a discarded copy | Assign the ID on the source before snapshotting |
| Shared `Extra` maps could let metadata mutation change both source and snapshot | Clone `Extra` on the snapshot |
| Session-events-disabled runs must remain side-effect free | Snapshot only when session events are enabled |

---

# Leading system sync 快照加固

## Problem

Session-event 持久化会在 `GenModelInput` 返回后，对比上一条 leading system message 和当前生成的 system message。

内置生成器没有问题，但第三方 `GenModelInput` 可能在返回前原地修改 `input.Messages[0]`。这种情况下，持久化逻辑可能看到已经被修改过的“旧”system message，从而错误跳过 `SessionEventMessageUpdated`。

示例：

```go
input.Messages[0].Content = "mutated old system"
return append([]*schema.Message{schema.SystemMessage("system v2")}, input.Messages[1:]...), nil
```

预期：持久化 `system v2` 对应的 system `MessageUpdated` 事件。
修复前：旧状态可能在比较前已经被覆盖。

## Solution

在调用 `GenModelInput` 前快照上一条 leading system message，但只在启用 session events 时执行。

快照路径会先把缺失的 message ID 写回源 old system，再复制消息并克隆 `Extra`。这样既保证 `MessageUpdated.MessageID` 与源历史一致，也能防止自定义生成器通过原地修改 content 或 metadata 隐藏变更。

## Key Insight

Leading system-message 持久化必须和 model-input 生成之前的状态比较。`GenModelInput` 是扩展点，因此持久化逻辑不能假设它不会修改 `input.Messages`。

## Summary

| Problem | Solution |
|---------|----------|
| 自定义 `GenModelInput` 可能在 sync 比较前修改旧 leading system | 在生成前快照旧 leading system |
| 缺失的 old-system ID 可能只存在于被丢弃的 copy 上 | 快照前先把 ID 写回源消息 |
| 共享 `Extra` map 会让 metadata 修改同时影响源消息和快照 | 对快照克隆 `Extra` |
| 未启用 session events 的运行必须保持无副作用 | 仅在启用 session events 时执行快照 |
