### PR TITLE
refactor(adk): introduce SessionEventVariant and simplify session event model

### DIFF
--- a/adk/agent_tool.go
+++ b/adk/agent_tool.go
@@ -456,35 +456,33 @@ func stampAgentToolSessionEvent[M MessageType](event *TypedAgentEvent[M], childS
 	if event == nil || childSessionID == "" {
 		return
 	}
-	if event.EventID == "" {
-		event.EventID = uuid.NewString()
-	}
-	if event.Timestamp.IsZero() {
-		event.Timestamp = newEventTimestamp()
-	}
-	if event.SessionEvent == nil {
-		event.SessionEvent = &SessionEvent[M]{
-			SessionID: childSessionID,
-			EventID:   event.EventID,
-			Timestamp: event.Timestamp,
+	if event.SessionEventVariant == nil && event.Output != nil && event.Output.MessageOutput != nil {
+		ts := newEventTimestamp()
+		if event.Output.MessageOutput.IsStreaming {
+			event.SessionEventVariant = &SessionEventVariant[M]{
+				MessageStreamRef: &MessageStreamRef{
+					Timestamp: ts,
+					Kind:      SessionEventMessage,
+				},
+			}
+		} else if !isNilMessage(event.Output.MessageOutput.Message) {
+			event.SessionEventVariant = &SessionEventVariant[M]{
+				Event: &SessionEvent[M]{
+					Timestamp: ts,
+					Kind:      SessionEventMessage,
+					Message:   event.Output.MessageOutput.Message,
+				},
+			}
 		}
-		if event.Output != nil && event.Output.MessageOutput != nil {
-			event.SessionEvent.Kind = SessionEventMessage
-		}
-		return
 	}
-	event.SessionEvent.SessionID = childSessionID
-	if event.SessionEvent.EventID == "" {
-		event.SessionEvent.EventID = event.EventID
-	}
-	if event.SessionEvent.Timestamp.IsZero() {
-		event.SessionEvent.Timestamp = event.Timestamp
+	if event.SessionEventVariant != nil {
+		event.SessionEventVariant.SessionID = childSessionID
 	}
 }
 
 // newTypedInvokableAgentToolRunner creates a runner for the inner agent without
 // SessionEventStore. The child's events are forwarded to the parent's live stream
-// (tagged with childSessionID on SessionEvent) and filtered out of the parent's persistence.
+// (tagged with childSessionID on SessionEventVariant) and filtered out of the parent's persistence.
 // The child's durability relies solely on the bridge checkpoint stored inside
 // agentToolInterruptState — there is no independent child session log.
 // This may change in the future if AgentTool needs cross-turn context

--- a/adk/agent_tool_test.go
+++ b/adk/agent_tool_test.go
@@ -947,11 +947,32 @@ func TestStampAgentToolSessionEvent(t *testing.T) {
 
 	stampAgentToolSessionEvent(event, "agent_tool:child")
 
-	require.NotNil(t, event.SessionEvent)
-	assert.Equal(t, "agent_tool:child", event.SessionEvent.SessionID)
-	assert.Equal(t, event.EventID, event.SessionEvent.EventID)
-	assert.Equal(t, event.Timestamp, event.SessionEvent.Timestamp)
-	assert.Equal(t, SessionEventMessage, event.SessionEvent.Kind)
+	require.NotNil(t, event.SessionEventVariant.GetEvent())
+	assert.Equal(t, "agent_tool:child", event.SessionEventVariant.SessionID)
+	assert.Empty(t, event.SessionEventVariant.GetEvent().EventID)
+	assert.False(t, event.SessionEventVariant.GetEvent().Timestamp.IsZero())
+	assert.Equal(t, SessionEventMessage, event.SessionEventVariant.GetEvent().Kind)
+}
+
+func TestStampAgentToolSessionEvent_Streaming(t *testing.T) {
+	event := &AgentEvent{
+		Output: &AgentOutput{
+			MessageOutput: &MessageVariant{
+				IsStreaming:   true,
+				MessageStream: schema.StreamReaderFromArray([]Message{schema.AssistantMessage("child", nil)}),
+				Role:          schema.Assistant,
+			},
+		},
+	}
+
+	stampAgentToolSessionEvent(event, "agent_tool:child")
+
+	ref := event.SessionEventVariant.GetMessageStreamRef()
+	require.NotNil(t, ref)
+	assert.Equal(t, "agent_tool:child", event.SessionEventVariant.SessionID)
+	assert.Empty(t, ref.EventID)
+	assert.False(t, ref.Timestamp.IsZero())
+	assert.Equal(t, SessionEventMessage, ref.Kind)
 }
 
 func TestSequentialWorkflow_WithChatModelAgentTool_NestedRunPathAndSessions(t *testing.T) {

--- a/adk/agent_tool_test.go
+++ b/adk/agent_tool_test.go
@@ -947,11 +947,11 @@ func TestStampAgentToolSessionEvent(t *testing.T) {
 
 	stampAgentToolSessionEvent(event, "agent_tool:child")
 
-	require.NotNil(t, event.SessionEventVariant.GetEvent())
+	require.NotNil(t, event.SessionEventVariant.Event)
 	assert.Equal(t, "agent_tool:child", event.SessionEventVariant.SessionID)
-	assert.Empty(t, event.SessionEventVariant.GetEvent().EventID)
-	assert.False(t, event.SessionEventVariant.GetEvent().Timestamp.IsZero())
-	assert.Equal(t, SessionEventMessage, event.SessionEventVariant.GetEvent().Kind)
+	assert.Empty(t, event.SessionEventVariant.Event.EventID)
+	assert.False(t, event.SessionEventVariant.Event.Timestamp.IsZero())
+	assert.Equal(t, SessionEventMessage, event.SessionEventVariant.Event.Kind)
 }
 
 func TestStampAgentToolSessionEvent_Streaming(t *testing.T) {
@@ -967,7 +967,7 @@ func TestStampAgentToolSessionEvent_Streaming(t *testing.T) {
 
 	stampAgentToolSessionEvent(event, "agent_tool:child")
 
-	ref := event.SessionEventVariant.GetMessageStreamRef()
+	ref := event.SessionEventVariant.MessageStreamRef
 	require.NotNil(t, ref)
 	assert.Equal(t, "agent_tool:child", event.SessionEventVariant.SessionID)
 	assert.Empty(t, ref.EventID)

--- a/adk/chatmodel.go
+++ b/adk/chatmodel.go
@@ -375,6 +375,31 @@ func sameSystemMessage[M MessageType](oldSys, newSys M) bool {
 	}
 }
 
+func deepCopyMessage[M MessageType](msg M) M {
+	switch v := any(msg).(type) {
+	case *schema.Message:
+		cp := *v
+		if v.Extra != nil {
+			cp.Extra = make(map[string]any, len(v.Extra))
+			for k, val := range v.Extra {
+				cp.Extra[k] = val
+			}
+		}
+		return any(&cp).(M)
+	case *schema.AgenticMessage:
+		cp := *v
+		if v.Extra != nil {
+			cp.Extra = make(map[string]any, len(v.Extra))
+			for k, val := range v.Extra {
+				cp.Extra[k] = val
+			}
+		}
+		return any(&cp).(M)
+	default:
+		return msg
+	}
+}
+
 func setMessageIDFromTarget[M MessageType](msg M, targetID string) {
 	if targetID == "" || isNilMessage(msg) {
 		return
@@ -385,6 +410,8 @@ func setMessageIDFromTarget[M MessageType](msg M, targetID string) {
 func syncLeadingSystemMessageSessionEvent[M MessageType](
 	ctx context.Context,
 	previous []M,
+	oldSys M,
+	hasOldSys bool,
 	generated []M,
 ) error {
 	execCtx := getTypedChatModelAgentExecCtx[M](ctx)
@@ -398,7 +425,7 @@ func syncLeadingSystemMessageSessionEvent[M MessageType](
 	}
 
 	var event *TypedAgentEvent[M]
-	if oldSys, hasOldSys := leadingSystemMessage(previous); hasOldSys {
+	if hasOldSys {
 		EnsureMessageID(oldSys)
 		oldID := GetMessageID(oldSys)
 		setMessageIDFromTarget(newSys, oldID)
@@ -1251,11 +1278,15 @@ func (a *TypedChatModelAgent[M]) buildNoToolsRunFunc(_ context.Context) (typedRu
 			}))
 
 		chain.AppendLambda(compose.InvokableLambda(func(ctx context.Context, in typedNoToolsInput[M]) ([]M, error) {
+			oldSys, hasOldSys := leadingSystemMessage(in.input.Messages)
+			if hasOldSys {
+				oldSys = deepCopyMessage(oldSys)
+			}
 			messages, err := a.genModelInput(ctx, in.instruction, in.input)
 			if err != nil {
 				return nil, err
 			}
-			if err := syncLeadingSystemMessageSessionEvent(ctx, in.input.Messages, messages); err != nil {
+			if err := syncLeadingSystemMessageSessionEvent(ctx, in.input.Messages, oldSys, hasOldSys, messages); err != nil {
 				return nil, err
 			}
 			if p.sessionEvents {
@@ -1409,11 +1440,15 @@ func (a *TypedChatModelAgent[M]) buildMessageReActRunFunc(_ context.Context, bc 
 		chain := compose.NewChain[reactRunInput, Message]().
 			AppendLambda(
 				compose.InvokableLambda(func(ctx context.Context, in reactRunInput) (*reactInput, error) {
+					oldSys, hasOldSys := leadingSystemMessage(in.input.Messages)
+					if hasOldSys {
+						oldSys = deepCopyMessage(oldSys)
+					}
 					messages, genErr := genModelInputFn(ctx, in.instruction, in.input)
 					if genErr != nil {
 						return nil, genErr
 					}
-					if genErr = syncLeadingSystemMessageSessionEvent(ctx, in.input.Messages, messages); genErr != nil {
+					if genErr = syncLeadingSystemMessageSessionEvent(ctx, in.input.Messages, oldSys, hasOldSys, messages); genErr != nil {
 						return nil, genErr
 					}
 					if mp.sessionEvents {
@@ -1555,11 +1590,15 @@ func (a *TypedChatModelAgent[M]) buildAgenticReActRunFunc(_ context.Context, bc 
 		chain := compose.NewChain[agenticReactRunInput, *schema.AgenticMessage]().
 			AppendLambda(
 				compose.InvokableLambda(func(ctx context.Context, in agenticReactRunInput) (*agenticReactInput, error) {
+					oldSys, hasOldSys := leadingSystemMessage(in.input.Messages)
+					if hasOldSys {
+						oldSys = deepCopyMessage(oldSys)
+					}
 					messages, genErr := genModelInputFn(ctx, in.instruction, in.input)
 					if genErr != nil {
 						return nil, genErr
 					}
-					if genErr = syncLeadingSystemMessageSessionEvent(ctx, in.input.Messages, messages); genErr != nil {
+					if genErr = syncLeadingSystemMessageSessionEvent(ctx, in.input.Messages, oldSys, hasOldSys, messages); genErr != nil {
 						return nil, genErr
 					}
 					if ap.sessionEvents {

--- a/adk/chatmodel.go
+++ b/adk/chatmodel.go
@@ -70,41 +70,19 @@ func (e *typedChatModelAgentExecCtx[M]) send(ctx context.Context, event *TypedAg
 	if e.cancelCtx != nil && e.cancelCtx.isImmediateCancelled() {
 		return
 	}
-	// Allocate EventID at the first emission boundary so live (user-land) and
-	// persisted (SessionEventStore) copies of the same logical event share identity.
-	// User-supplied non-empty IDs (e.g. replay scenarios) are preserved.
-	//
-	// SessionEvent[M] drafts route ID allocation through the runner-installed
-	// SessionEventIDGenerator[M] via normalizeAgentSessionEventWithAssigner so
-	// producer-owned identity applies. Live-only TypedAgentEvent (no
-	// SessionEvent payload) calls the generator with a nil draft as the
-	// documented exception (see runner.go:944): no draft exists for the
-	// transport-level event, so the generator falls through to UUID by
-	// default while still respecting any application override.
 	if event == nil {
 		return
 	}
 	ensureTypedAgentEventMessageIDs(event)
-	if event.EventID == "" || event.SessionEvent != nil {
+	if event.SessionEventVariant != nil && event.SessionEventVariant.Event != nil {
 		gen := sessionEventIDGeneratorFromContext[M](ctx)
 		if gen == nil {
 			gen = DefaultSessionEventIDGenerator[M]
 		}
-		if event.SessionEvent != nil {
-			if _, err := normalizeAgentSessionEventWithAssigner(event, func(se *SessionEvent[M]) (string, error) {
-				return gen(ctx, se)
-			}); err != nil {
-				event.Err = err
-			}
-		} else if event.EventID == "" {
-			id, err := gen(ctx, nil)
-			if err != nil {
-				event.Err = err
-			} else if id == "" {
-				event.Err = ErrSessionEventIDGeneratorEmpty
-			} else {
-				event.EventID = id
-			}
+		if _, err := normalizeAgentSessionEventWithAssigner(event, func(se *SessionEvent[M]) (string, error) {
+			return gen(ctx, se)
+		}); err != nil {
+			event.Err = err
 		}
 	}
 	e.generator.trySend(event)
@@ -132,9 +110,11 @@ func syncModelContextSessionEvent[M MessageType](ctx context.Context, state *Typ
 	changed := !execCtx.sawModelContext || !reflect.DeepEqual(execCtx.lastModelContext, current)
 	if changed {
 		execCtx.send(ctx, &TypedAgentEvent[M]{
-			SessionEvent: &SessionEvent[M]{
-				Kind:         SessionEventModelContext,
-				ModelContext: copyModelContextEvent(current),
+			SessionEventVariant: &SessionEventVariant[M]{
+				Event: &SessionEvent[M]{
+					Kind:         SessionEventModelContext,
+					ModelContext: copyModelContextEvent(current),
+				},
 			},
 		})
 	}
@@ -379,45 +359,6 @@ func leadingSystemMessage[M MessageType](messages []M) (M, bool) {
 	return zero, false
 }
 
-type leadingSystemSyncInput[M MessageType] struct {
-	previous     []M
-	generated    []M
-	oldSystem    M
-	hasOldSystem bool
-}
-
-func snapshotLeadingSystemForSync[M MessageType](messages []M) (M, bool) {
-	oldSys, ok := leadingSystemMessage(messages)
-	if !ok {
-		var zero M
-		return zero, false
-	}
-	EnsureMessageID(oldSys)
-	snapshot := copyMessage(oldSys)
-	cloneMessageExtra(snapshot)
-	return snapshot, true
-}
-
-func cloneMessageExtra[M MessageType](msg M) {
-	switch v := any(msg).(type) {
-	case *schema.Message:
-		v.Extra = cloneExtraMap(v.Extra)
-	case *schema.AgenticMessage:
-		v.Extra = cloneExtraMap(v.Extra)
-	}
-}
-
-func cloneExtraMap(extra map[string]any) map[string]any {
-	if extra == nil {
-		return nil
-	}
-	cloned := make(map[string]any, len(extra))
-	for k, v := range extra {
-		cloned[k] = v
-	}
-	return cloned
-}
-
 func sameSystemMessage[M MessageType](oldSys, newSys M) bool {
 	if isNilMessage(oldSys) || isNilMessage(newSys) {
 		return isNilMessage(oldSys) && isNilMessage(newSys)
@@ -443,54 +384,62 @@ func setMessageIDFromTarget[M MessageType](msg M, targetID string) {
 
 func syncLeadingSystemMessageSessionEvent[M MessageType](
 	ctx context.Context,
-	input leadingSystemSyncInput[M],
+	previous []M,
+	generated []M,
 ) error {
 	execCtx := getTypedChatModelAgentExecCtx[M](ctx)
 	if execCtx == nil || !execCtx.sessionEvents {
 		return nil
 	}
 
-	newSys, ok := leadingSystemMessage(input.generated)
+	newSys, ok := leadingSystemMessage(generated)
 	if !ok {
 		return nil
 	}
 
 	var event *TypedAgentEvent[M]
-	if input.hasOldSystem {
-		oldID := GetMessageID(input.oldSystem)
+	if oldSys, hasOldSys := leadingSystemMessage(previous); hasOldSys {
+		EnsureMessageID(oldSys)
+		oldID := GetMessageID(oldSys)
 		setMessageIDFromTarget(newSys, oldID)
-		if sameSystemMessage(input.oldSystem, newSys) {
+		if sameSystemMessage(oldSys, newSys) {
 			return nil
 		}
 		event = &TypedAgentEvent[M]{
-			SessionEvent: &SessionEvent[M]{
-				Kind: SessionEventMessageUpdated,
-				MessageUpdated: &MessageUpdatedEvent[M]{
-					MessageID: oldID,
-					Message:   newSys,
+			SessionEventVariant: &SessionEventVariant[M]{
+				Event: &SessionEvent[M]{
+					Kind: SessionEventMessageUpdated,
+					MessageUpdated: &MessageUpdatedEvent[M]{
+						MessageID: oldID,
+						Message:   newSys,
+					},
 				},
 			},
 		}
-	} else if len(input.previous) == 0 {
+	} else if len(previous) == 0 {
 		EnsureMessageID(newSys)
 		event = &TypedAgentEvent[M]{
-			SessionEvent: &SessionEvent[M]{
-				Kind:    SessionEventMessage,
-				Message: newSys,
+			SessionEventVariant: &SessionEventVariant[M]{
+				Event: &SessionEvent[M]{
+					Kind:    SessionEventMessage,
+					Message: newSys,
+				},
 			},
 		}
 	} else {
-		if isNilMessage(input.previous[0]) {
+		if isNilMessage(previous[0]) {
 			return errors.New("sync leading system message: previous first message is nil")
 		}
-		EnsureMessageID(input.previous[0])
+		EnsureMessageID(previous[0])
 		EnsureMessageID(newSys)
 		event = &TypedAgentEvent[M]{
-			SessionEvent: &SessionEvent[M]{
-				Kind: SessionEventMessageInserted,
-				MessageInserted: &MessageInsertedEvent[M]{
-					Message:         newSys,
-					BeforeMessageID: GetMessageID(input.previous[0]),
+			SessionEventVariant: &SessionEventVariant[M]{
+				Event: &SessionEvent[M]{
+					Kind: SessionEventMessageInserted,
+					MessageInserted: &MessageInsertedEvent[M]{
+						Message:         newSys,
+						BeforeMessageID: GetMessageID(previous[0]),
+					},
 				},
 			},
 		}
@@ -1302,24 +1251,12 @@ func (a *TypedChatModelAgent[M]) buildNoToolsRunFunc(_ context.Context) (typedRu
 			}))
 
 		chain.AppendLambda(compose.InvokableLambda(func(ctx context.Context, in typedNoToolsInput[M]) ([]M, error) {
-			var syncInput leadingSystemSyncInput[M]
-			if p.sessionEvents {
-				oldSys, hasOldSys := snapshotLeadingSystemForSync(in.input.Messages)
-				syncInput = leadingSystemSyncInput[M]{
-					previous:     in.input.Messages,
-					oldSystem:    oldSys,
-					hasOldSystem: hasOldSys,
-				}
-			}
 			messages, err := a.genModelInput(ctx, in.instruction, in.input)
 			if err != nil {
 				return nil, err
 			}
-			if p.sessionEvents {
-				syncInput.generated = messages
-				if err := syncLeadingSystemMessageSessionEvent(ctx, syncInput); err != nil {
-					return nil, err
-				}
+			if err := syncLeadingSystemMessageSessionEvent(ctx, in.input.Messages, messages); err != nil {
+				return nil, err
 			}
 			if p.sessionEvents {
 				ensureGeneratedMessageIDs(messages)
@@ -1472,24 +1409,12 @@ func (a *TypedChatModelAgent[M]) buildMessageReActRunFunc(_ context.Context, bc 
 		chain := compose.NewChain[reactRunInput, Message]().
 			AppendLambda(
 				compose.InvokableLambda(func(ctx context.Context, in reactRunInput) (*reactInput, error) {
-					var syncInput leadingSystemSyncInput[*schema.Message]
-					if mp.sessionEvents {
-						oldSys, hasOldSys := snapshotLeadingSystemForSync(in.input.Messages)
-						syncInput = leadingSystemSyncInput[*schema.Message]{
-							previous:     in.input.Messages,
-							oldSystem:    oldSys,
-							hasOldSystem: hasOldSys,
-						}
-					}
 					messages, genErr := genModelInputFn(ctx, in.instruction, in.input)
 					if genErr != nil {
 						return nil, genErr
 					}
-					if mp.sessionEvents {
-						syncInput.generated = messages
-						if genErr = syncLeadingSystemMessageSessionEvent(ctx, syncInput); genErr != nil {
-							return nil, genErr
-						}
+					if genErr = syncLeadingSystemMessageSessionEvent(ctx, in.input.Messages, messages); genErr != nil {
+						return nil, genErr
 					}
 					if mp.sessionEvents {
 						ensureGeneratedMessageIDs(messages)
@@ -1630,24 +1555,12 @@ func (a *TypedChatModelAgent[M]) buildAgenticReActRunFunc(_ context.Context, bc 
 		chain := compose.NewChain[agenticReactRunInput, *schema.AgenticMessage]().
 			AppendLambda(
 				compose.InvokableLambda(func(ctx context.Context, in agenticReactRunInput) (*agenticReactInput, error) {
-					var syncInput leadingSystemSyncInput[*schema.AgenticMessage]
-					if ap.sessionEvents {
-						oldSys, hasOldSys := snapshotLeadingSystemForSync(in.input.Messages)
-						syncInput = leadingSystemSyncInput[*schema.AgenticMessage]{
-							previous:     in.input.Messages,
-							oldSystem:    oldSys,
-							hasOldSystem: hasOldSys,
-						}
-					}
 					messages, genErr := genModelInputFn(ctx, in.instruction, in.input)
 					if genErr != nil {
 						return nil, genErr
 					}
-					if ap.sessionEvents {
-						syncInput.generated = messages
-						if genErr = syncLeadingSystemMessageSessionEvent(ctx, syncInput); genErr != nil {
-							return nil, genErr
-						}
+					if genErr = syncLeadingSystemMessageSessionEvent(ctx, in.input.Messages, messages); genErr != nil {
+						return nil, genErr
 					}
 					if ap.sessionEvents {
 						ensureGeneratedMessageIDs(messages)

--- a/adk/chatmodel_test.go
+++ b/adk/chatmodel_test.go
@@ -119,14 +119,14 @@ func TestChatModelAgentRun(t *testing.T) {
 		}
 
 		require.Len(t, events, 3)
-		require.NotNil(t, events[0].SessionEvent)
-		assert.Equal(t, SessionEventMessageInserted, events[0].SessionEvent.Kind)
-		assert.Equal(t, schema.System, events[0].SessionEvent.MessageInserted.Message.Role)
+		require.NotNil(t, events[0].SessionEventVariant.GetEvent())
+		assert.Equal(t, SessionEventMessageInserted, events[0].SessionEventVariant.GetEvent().Kind)
+		assert.Equal(t, schema.System, events[0].SessionEventVariant.GetEvent().MessageInserted.Message.Role)
 
-		require.NotNil(t, events[1].SessionEvent)
-		assert.Equal(t, SessionEventModelContext, events[1].SessionEvent.Kind)
-		require.NotNil(t, events[1].SessionEvent.ModelContext)
-		assert.Empty(t, events[1].SessionEvent.ModelContext.ToolInfos)
+		require.NotNil(t, events[1].SessionEventVariant.GetEvent())
+		assert.Equal(t, SessionEventModelContext, events[1].SessionEventVariant.GetEvent().Kind)
+		require.NotNil(t, events[1].SessionEventVariant.GetEvent().ModelContext)
+		assert.Empty(t, events[1].SessionEventVariant.GetEvent().ModelContext.ToolInfos)
 
 		require.NotNil(t, events[2].Output)
 		assert.Equal(t, "session answer", events[2].Output.MessageOutput.Message.Content)
@@ -299,13 +299,13 @@ func TestChatModelAgentRun(t *testing.T) {
 
 		require.Len(t, events, 5)
 		assert.Equal(t, 2, generateCount)
-		require.NotNil(t, events[0].SessionEvent)
-		assert.Equal(t, SessionEventMessageInserted, events[0].SessionEvent.Kind)
-		require.NotNil(t, events[1].SessionEvent)
-		assert.Equal(t, SessionEventModelContext, events[1].SessionEvent.Kind)
-		require.NotNil(t, events[1].SessionEvent.ModelContext)
-		require.Len(t, events[1].SessionEvent.ModelContext.ToolInfos, 1)
-		assert.Equal(t, "test_tool", events[1].SessionEvent.ModelContext.ToolInfos[0].Name)
+		require.NotNil(t, events[0].SessionEventVariant.GetEvent())
+		assert.Equal(t, SessionEventMessageInserted, events[0].SessionEventVariant.GetEvent().Kind)
+		require.NotNil(t, events[1].SessionEventVariant.GetEvent())
+		assert.Equal(t, SessionEventModelContext, events[1].SessionEventVariant.GetEvent().Kind)
+		require.NotNil(t, events[1].SessionEventVariant.GetEvent().ModelContext)
+		require.Len(t, events[1].SessionEventVariant.GetEvent().ModelContext.ToolInfos, 1)
+		assert.Equal(t, "test_tool", events[1].SessionEventVariant.GetEvent().ModelContext.ToolInfos[0].Name)
 	})
 
 	t.Run("AfterChatModel_ReAct_ModifyAffectsFlow", func(t *testing.T) {

--- a/adk/chatmodel_test.go
+++ b/adk/chatmodel_test.go
@@ -119,14 +119,14 @@ func TestChatModelAgentRun(t *testing.T) {
 		}
 
 		require.Len(t, events, 3)
-		require.NotNil(t, events[0].SessionEventVariant.GetEvent())
-		assert.Equal(t, SessionEventMessageInserted, events[0].SessionEventVariant.GetEvent().Kind)
-		assert.Equal(t, schema.System, events[0].SessionEventVariant.GetEvent().MessageInserted.Message.Role)
+		require.NotNil(t, events[0].SessionEventVariant.Event)
+		assert.Equal(t, SessionEventMessageInserted, events[0].SessionEventVariant.Event.Kind)
+		assert.Equal(t, schema.System, events[0].SessionEventVariant.Event.MessageInserted.Message.Role)
 
-		require.NotNil(t, events[1].SessionEventVariant.GetEvent())
-		assert.Equal(t, SessionEventModelContext, events[1].SessionEventVariant.GetEvent().Kind)
-		require.NotNil(t, events[1].SessionEventVariant.GetEvent().ModelContext)
-		assert.Empty(t, events[1].SessionEventVariant.GetEvent().ModelContext.ToolInfos)
+		require.NotNil(t, events[1].SessionEventVariant.Event)
+		assert.Equal(t, SessionEventModelContext, events[1].SessionEventVariant.Event.Kind)
+		require.NotNil(t, events[1].SessionEventVariant.Event.ModelContext)
+		assert.Empty(t, events[1].SessionEventVariant.Event.ModelContext.ToolInfos)
 
 		require.NotNil(t, events[2].Output)
 		assert.Equal(t, "session answer", events[2].Output.MessageOutput.Message.Content)
@@ -299,13 +299,13 @@ func TestChatModelAgentRun(t *testing.T) {
 
 		require.Len(t, events, 5)
 		assert.Equal(t, 2, generateCount)
-		require.NotNil(t, events[0].SessionEventVariant.GetEvent())
-		assert.Equal(t, SessionEventMessageInserted, events[0].SessionEventVariant.GetEvent().Kind)
-		require.NotNil(t, events[1].SessionEventVariant.GetEvent())
-		assert.Equal(t, SessionEventModelContext, events[1].SessionEventVariant.GetEvent().Kind)
-		require.NotNil(t, events[1].SessionEventVariant.GetEvent().ModelContext)
-		require.Len(t, events[1].SessionEventVariant.GetEvent().ModelContext.ToolInfos, 1)
-		assert.Equal(t, "test_tool", events[1].SessionEventVariant.GetEvent().ModelContext.ToolInfos[0].Name)
+		require.NotNil(t, events[0].SessionEventVariant.Event)
+		assert.Equal(t, SessionEventMessageInserted, events[0].SessionEventVariant.Event.Kind)
+		require.NotNil(t, events[1].SessionEventVariant.Event)
+		assert.Equal(t, SessionEventModelContext, events[1].SessionEventVariant.Event.Kind)
+		require.NotNil(t, events[1].SessionEventVariant.Event.ModelContext)
+		require.Len(t, events[1].SessionEventVariant.Event.ModelContext.ToolInfos, 1)
+		assert.Equal(t, "test_tool", events[1].SessionEventVariant.Event.ModelContext.ToolInfos[0].Name)
 	})
 
 	t.Run("AfterChatModel_ReAct_ModifyAffectsFlow", func(t *testing.T) {

--- a/adk/coverage_contract_test.go
+++ b/adk/coverage_contract_test.go
@@ -30,13 +30,16 @@ import (
 )
 
 type serviceContractStore struct {
-	loadReqs   []*LoadSessionEventsRequest
-	appendReqs []*AppendSessionEventsRequest[*schema.Message]
-	loadErr    error
-	appendErr  error
+	loadSessionIDs   []string
+	loadReqs         []*LoadSessionEventsRequest
+	appendSessionIDs []string
+	appendEvents     [][]*SessionEvent[*schema.Message]
+	loadErr          error
+	appendErr        error
 }
 
-func (s *serviceContractStore) LoadEvents(_ context.Context, req *LoadSessionEventsRequest) (*LoadSessionEventsResult[*schema.Message], error) {
+func (s *serviceContractStore) LoadEvents(_ context.Context, sessionID string, req *LoadSessionEventsRequest) (*LoadSessionEventsResult[*schema.Message], error) {
+	s.loadSessionIDs = append(s.loadSessionIDs, sessionID)
 	s.loadReqs = append(s.loadReqs, req)
 	if s.loadErr != nil {
 		return nil, s.loadErr
@@ -44,8 +47,9 @@ func (s *serviceContractStore) LoadEvents(_ context.Context, req *LoadSessionEve
 	return &LoadSessionEventsResult[*schema.Message]{}, nil
 }
 
-func (s *serviceContractStore) AppendEvents(_ context.Context, req *AppendSessionEventsRequest[*schema.Message]) error {
-	s.appendReqs = append(s.appendReqs, req)
+func (s *serviceContractStore) AppendEvents(_ context.Context, sessionID string, events []*SessionEvent[*schema.Message]) error {
+	s.appendSessionIDs = append(s.appendSessionIDs, sessionID)
+	s.appendEvents = append(s.appendEvents, events)
 	if s.appendErr != nil {
 		return s.appendErr
 	}
@@ -175,20 +179,18 @@ func TestLocalSessionStoreHandleContracts(t *testing.T) {
 	require.NoError(t, err)
 	require.NotNil(t, res)
 	require.Len(t, store.loadReqs, 1)
-	assert.Equal(t, "sid", store.loadReqs[0].SessionID)
+	assert.Equal(t, "sid", store.loadSessionIDs[0])
 
 	event := validTestPayload()
-	err = opened.handle.appendEvents(ctx, &AppendSessionEventsRequest[*schema.Message]{
-		Events: []*SessionEvent[*schema.Message]{event},
-	})
+	err = opened.handle.appendEvents(ctx, []*SessionEvent[*schema.Message]{event})
 	require.NoError(t, err)
-	require.Len(t, store.appendReqs, 1)
-	assert.Equal(t, "sid", store.appendReqs[0].SessionID)
+	require.Len(t, store.appendEvents, 1)
+	assert.Equal(t, "sid", store.appendSessionIDs[0])
 
 	err = opened.handle.appendEvents(ctx, nil)
 	require.NoError(t, err)
-	require.Len(t, store.appendReqs, 2)
-	assert.Equal(t, "sid", store.appendReqs[1].SessionID)
+	require.Len(t, store.appendEvents, 2)
+	assert.Equal(t, "sid", store.appendSessionIDs[1])
 
 	require.NoError(t, opened.handle.close(ctx))
 	require.NoError(t, opened.handle.close(ctx))
@@ -210,9 +212,7 @@ func TestLocalSessionStoreHandleContracts(t *testing.T) {
 	store.appendErr = errors.New("append failed")
 	opened, err = openLocalSession[*schema.Message](ctx, store, &openSessionRequest{sessionID: "sid-append-err"})
 	require.NoError(t, err)
-	err = opened.handle.appendEvents(ctx, &AppendSessionEventsRequest[*schema.Message]{
-		Events: []*SessionEvent[*schema.Message]{validTestPayload()},
-	})
+	err = opened.handle.appendEvents(ctx, []*SessionEvent[*schema.Message]{validTestPayload()})
 	require.ErrorContains(t, err, "append failed")
 	require.NoError(t, opened.handle.close(ctx))
 }

--- a/adk/handler.go
+++ b/adk/handler.go
@@ -401,7 +401,7 @@ func DeleteRunLocalValue(ctx context.Context, key string) error {
 // This allows TypedChatModelAgentMiddleware implementations to emit custom events that will be
 // received by the caller iterating over the agent's event stream.
 // To emit custom session timeline events during a Runner run, wrap a SessionEvent
-// with Extension set and an x.* Kind in TypedAgentEvent.SessionEvent. This is the
+// with Extension set and an x.* Kind in TypedAgentEvent.SessionEventVariant.GetEvent(). This is the
 // canonical in-run path because Runner materializes identity, emits the live
 // event, and persists it through the ordered session event pipeline.
 //
@@ -425,7 +425,7 @@ func TypedSendEvent[M MessageType](ctx context.Context, event *TypedAgentEvent[M
 // SendEvent sends a custom AgentEvent to the event stream during agent execution.
 // This allows ChatModelAgentMiddleware implementations to emit custom events that will be
 // received by the caller iterating over the agent's event stream.
-// For custom session timeline events during a Runner run, set AgentEvent.SessionEvent
+// For custom session timeline events during a Runner run, set AgentEvent.SessionEventVariant.GetEvent()
 // to an extension SessionEvent with an x.* Kind and send it through this function.
 //
 // When called outside of an agent execution context, or from a path without an

--- a/adk/handler.go
+++ b/adk/handler.go
@@ -401,7 +401,7 @@ func DeleteRunLocalValue(ctx context.Context, key string) error {
 // This allows TypedChatModelAgentMiddleware implementations to emit custom events that will be
 // received by the caller iterating over the agent's event stream.
 // To emit custom session timeline events during a Runner run, wrap a SessionEvent
-// with Extension set and an x.* Kind in TypedAgentEvent.SessionEventVariant.GetEvent(). This is the
+// with Extension set and an x.* Kind in TypedAgentEvent.SessionEventVariant.Event. This is the
 // canonical in-run path because Runner materializes identity, emits the live
 // event, and persists it through the ordered session event pipeline.
 //
@@ -425,7 +425,7 @@ func TypedSendEvent[M MessageType](ctx context.Context, event *TypedAgentEvent[M
 // SendEvent sends a custom AgentEvent to the event stream during agent execution.
 // This allows ChatModelAgentMiddleware implementations to emit custom events that will be
 // received by the caller iterating over the agent's event stream.
-// For custom session timeline events during a Runner run, set AgentEvent.SessionEventVariant.GetEvent()
+// For custom session timeline events during a Runner run, set AgentEvent.SessionEventVariant.Event
 // to an extension SessionEvent with an x.* Kind and send it through this function.
 //
 // When called outside of an agent execution context, or from a path without an

--- a/adk/integration_middleware_test.go
+++ b/adk/integration_middleware_test.go
@@ -109,7 +109,7 @@ func TestAgentsMDIntegration_PersistsMessageInserted(t *testing.T) {
 	}
 
 	// Read the persisted event log.
-	res, err := store.LoadEvents(ctx, &adk.LoadSessionEventsRequest{SessionID: "agentsmd-test"})
+	res, err := store.LoadEvents(ctx, "agentsmd-test", &adk.LoadSessionEventsRequest{})
 	require.NoError(t, err)
 
 	var sawInsertedAgentsmd bool
@@ -175,7 +175,7 @@ func TestAgentsMDIntegration_NextTurnSkipsReinsertion(t *testing.T) {
 
 	// Count agentsmd MessageInserted events after turn 1.
 	countAgentsmdInserts := func() int {
-		res, err := store.LoadEvents(ctx, &adk.LoadSessionEventsRequest{SessionID: sid})
+		res, err := store.LoadEvents(ctx, sid, &adk.LoadSessionEventsRequest{})
 		require.NoError(t, err)
 		count := 0
 		for _, se := range res.Events {
@@ -273,7 +273,7 @@ func TestToolSearchIntegration_PersistsMessageInserted(t *testing.T) {
 		require.NoError(t, ev.Err)
 	}
 
-	res, err := store.LoadEvents(ctx, &adk.LoadSessionEventsRequest{SessionID: sid})
+	res, err := store.LoadEvents(ctx, sid, &adk.LoadSessionEventsRequest{})
 	require.NoError(t, err)
 
 	var sawInsertedReminder bool
@@ -327,10 +327,7 @@ func TestPatchToolCallsIntegration_PersistsMessageInserted(t *testing.T) {
 
 	for _, m := range []*schema.Message{user, dangling} {
 		se := &adk.SessionEvent[*schema.Message]{EventID: uuid.NewString(), Kind: adk.SessionEventMessage, Message: m}
-		err := store.AppendEvents(ctx, &adk.AppendSessionEventsRequest[*schema.Message]{
-			SessionID: sid,
-			Events:    []*adk.SessionEvent[*schema.Message]{se},
-		})
+		err := store.AppendEvents(ctx, sid, []*adk.SessionEvent[*schema.Message]{se})
 		require.NoError(t, err)
 	}
 
@@ -365,7 +362,7 @@ func TestPatchToolCallsIntegration_PersistsMessageInserted(t *testing.T) {
 
 	// Read events back; among the events appended on this turn there should be
 	// a MessageInserted carrying a Tool-role synthetic message.
-	res, err := store.LoadEvents(ctx, &adk.LoadSessionEventsRequest{SessionID: sid})
+	res, err := store.LoadEvents(ctx, sid, &adk.LoadSessionEventsRequest{})
 	require.NoError(t, err)
 	var sawInsertedToolResult bool
 	for _, se := range res.Events {
@@ -430,10 +427,7 @@ func TestReductionIntegration_PersistsBothMessageUpdated(t *testing.T) {
 	}
 	for _, m := range []*schema.Message{user, assistantA, toolResultA, assistantB, toolResultB} {
 		se := &adk.SessionEvent[*schema.Message]{EventID: uuid.NewString(), Kind: adk.SessionEventMessage, Message: m}
-		err := store.AppendEvents(ctx, &adk.AppendSessionEventsRequest[*schema.Message]{
-			SessionID: sid,
-			Events:    []*adk.SessionEvent[*schema.Message]{se},
-		})
+		err := store.AppendEvents(ctx, sid, []*adk.SessionEvent[*schema.Message]{se})
 		require.NoError(t, err)
 	}
 
@@ -488,7 +482,7 @@ func TestReductionIntegration_PersistsBothMessageUpdated(t *testing.T) {
 		require.NoError(t, ev.Err)
 	}
 
-	res, err := store.LoadEvents(ctx, &adk.LoadSessionEventsRequest{SessionID: sid})
+	res, err := store.LoadEvents(ctx, sid, &adk.LoadSessionEventsRequest{})
 	require.NoError(t, err)
 
 	var sawAssistantUpdated, sawToolUpdated bool

--- a/adk/interface.go
+++ b/adk/interface.go
@@ -253,7 +253,6 @@ func gobDecodeAgenticMessageVariant(mv *TypedMessageVariant[*schema.AgenticMessa
 func typedEventFromMessage[M MessageType](msg M, msgStream *schema.StreamReader[M],
 	role schema.RoleType, toolName string) *TypedAgentEvent[M] {
 	return &TypedAgentEvent[M]{
-		Timestamp: newEventTimestamp(),
 		Output: &TypedAgentOutput[M]{
 			MessageOutput: &TypedMessageVariant[M]{
 				IsStreaming:   msgStream != nil,
@@ -304,7 +303,6 @@ func EventFromMessage(msg Message, msgStream *schema.StreamReader[Message],
 // In streaming mode, the role is available on the event before consuming the stream.
 func EventFromAgenticMessage(msg AgenticMessage, msgStream AgenticMessageStream, agenticRole schema.AgenticRoleType) *TypedAgentEvent[AgenticMessage] {
 	return &TypedAgentEvent[AgenticMessage]{
-		Timestamp: newEventTimestamp(),
 		Output: &TypedAgentOutput[AgenticMessage]{
 			MessageOutput: &TypedMessageVariant[AgenticMessage]{
 				IsStreaming:   msgStream != nil,
@@ -425,19 +423,6 @@ type runStepSerialization struct {
 // TypedAgentEvent represents a single event emitted during agent execution.
 // CheckpointSchema: persisted via serialization.RunCtx (gob).
 type TypedAgentEvent[M MessageType] struct {
-	// EventID is the run-unique identity of this event, allocated once at the
-	// first emission boundary by execCtx.send. Live (user-land) and persisted
-	// (SessionEventStore) copies of the same logical event share this ID, allowing
-	// SSE adapters to use it as `id:` and resume from the session event log.
-	// Format: UUIDv4 string when allocated by the runtime. Leave empty to let
-	// the runtime allocate; an explicitly set non-empty value is preserved.
-	EventID string
-
-	// Timestamp is the wall-clock time when this event occurred at the ADK-visible
-	// emission boundary. The runtime fills it when unset; built-in wrappers set it
-	// at their semantic source boundary before sending the event.
-	Timestamp time.Time
-
 	AgentName string
 
 	// RunPath represents the execution path from root agent to the current event source.
@@ -454,12 +439,11 @@ type TypedAgentEvent[M MessageType] struct {
 
 	Err error
 
-	// SessionEvent is the first-class live timeline envelope. All session-semantic
-	// payloads, including lifecycle, error, span, observation, message mutation,
-	// and turn-end records, must be carried here. For durable managed-session
-	// events, EventID and SessionEvent.EventID must be identical after runtime
-	// materialization.
-	SessionEvent *SessionEvent[M]
+	// SessionEventVariant is the first-class live session envelope. Event carries
+	// a materialized durable SessionEvent. MessageStreamRef carries only the
+	// reserved durable metadata for a streaming message whose content remains in
+	// Output.MessageOutput.MessageStream.
+	SessionEventVariant *SessionEventVariant[M]
 }
 
 // AgentEvent is the default event type using *schema.Message.

--- a/adk/interrupt_test.go
+++ b/adk/interrupt_test.go
@@ -586,10 +586,6 @@ func TestWorkflowInterrupt(t *testing.T) {
 		}
 
 		assert.Equal(t, 2, len(events))
-		for i := range messageEvents {
-			assert.False(t, events[i].Timestamp.IsZero())
-			messageEvents[i].Timestamp = events[i].Timestamp
-		}
 		assert.Equal(t, messageEvents, events)
 	})
 
@@ -935,10 +931,6 @@ func TestWorkflowInterrupt(t *testing.T) {
 			},
 		}
 		assert.Equal(t, 2, len(events))
-		for i := range loopFinalMessageEvents {
-			assert.False(t, events[i].Timestamp.IsZero())
-			loopFinalMessageEvents[i].Timestamp = events[i].Timestamp
-		}
 		assert.Equal(t, loopFinalMessageEvents, events)
 	})
 
@@ -1007,7 +999,6 @@ func TestWorkflowInterrupt(t *testing.T) {
 					event.Output != nil && event.Output.MessageOutput != nil &&
 					event.Output.MessageOutput.Message != nil &&
 					event.Output.MessageOutput.Message.Content == want.Output.MessageOutput.Message.Content {
-					assert.False(t, event.Timestamp.IsZero())
 					return
 				}
 			}

--- a/adk/middlewares/agentsmd/agentsmd.go
+++ b/adk/middlewares/agentsmd/agentsmd.go
@@ -124,11 +124,13 @@ func (m *typedMiddleware[M]) BeforeModelRewriteState(ctx context.Context, state 
 		beforeID = adk.GetMessageID(anchorMsg)
 	}
 	_ = adk.TypedSendEvent(ctx, &adk.TypedAgentEvent[M]{
-		SessionEvent: &adk.SessionEvent[M]{
-			Kind: adk.SessionEventMessageInserted,
-			MessageInserted: &adk.MessageInsertedEvent[M]{
-				Message:         insertedMsg,
-				BeforeMessageID: beforeID,
+		SessionEventVariant: &adk.SessionEventVariant[M]{
+			Event: &adk.SessionEvent[M]{
+				Kind: adk.SessionEventMessageInserted,
+				MessageInserted: &adk.MessageInsertedEvent[M]{
+					Message:         insertedMsg,
+					BeforeMessageID: beforeID,
+				},
 			},
 		},
 	})

--- a/adk/middlewares/automemory/dream/dream_test.go
+++ b/adk/middlewares/automemory/dream/dream_test.go
@@ -137,9 +137,9 @@ type countingSessionStore struct {
 	loadCalls int32
 }
 
-func (s *countingSessionStore) LoadEvents(ctx context.Context, req *adk.LoadSessionEventsRequest) (*adk.LoadSessionEventsResult[*schema.Message], error) {
+func (s *countingSessionStore) LoadEvents(ctx context.Context, sessionID string, req *adk.LoadSessionEventsRequest) (*adk.LoadSessionEventsResult[*schema.Message], error) {
 	atomic.AddInt32(&s.loadCalls, 1)
-	return s.SessionEventStore.LoadEvents(ctx, req)
+	return s.SessionEventStore.LoadEvents(ctx, sessionID, req)
 }
 
 type nilStateStore struct {
@@ -195,14 +195,11 @@ func TestMiddleware_AfterAgent_RunInlineWithSessionStore(t *testing.T) {
 	store := NewLocalStore()
 	model := &dreamModel{}
 	eventStore := &countingSessionStore{SessionEventStore: adksession.NewInMemoryStore[*schema.Message](nil)}
-	err := eventStore.AppendEvents(ctx, &adk.AppendSessionEventsRequest[*schema.Message]{
-		SessionID: "session-a",
-		Events: []*adk.SessionEvent[*schema.Message]{{
-			EventID: "e1",
-			Kind:    adk.SessionEventMessage,
-			Message: schema.AssistantMessage("build failure: missing dependency", nil),
-		}},
-	})
+	err := eventStore.AppendEvents(ctx, "session-a", []*adk.SessionEvent[*schema.Message]{{
+		EventID: "e1",
+		Kind:    adk.SessionEventMessage,
+		Message: schema.AssistantMessage("build failure: missing dependency", nil),
+	}})
 	require.NoError(t, err)
 	mw, err := New(ctx, &Config[*schema.Message]{
 		MemoryDirectory: tmp,

--- a/adk/middlewares/automemory/dream/session.go
+++ b/adk/middlewares/automemory/dream/session.go
@@ -93,12 +93,11 @@ func newSessionHistoryGrepTool[M adk.MessageType](store adk.SessionEventStore[M]
 		for _, sessionID := range sessionIDs {
 			after = ""
 			for len(found) < limit {
-				result, err := store.LoadEvents(ctx, &adk.LoadSessionEventsRequest{
-					SessionID: sessionID,
-					After:     after,
-					Limit:     pageSize,
-					Reverse:   true,
-					Kinds:     []adk.SessionEventKind{adk.SessionEventMessage},
+				result, err := store.LoadEvents(ctx, sessionID, &adk.LoadSessionEventsRequest{
+					After:   after,
+					Limit:   pageSize,
+					Reverse: true,
+					Kinds:   []adk.SessionEventKind{adk.SessionEventMessage},
 				})
 				if err != nil {
 					return "", err

--- a/adk/middlewares/automemory/dream/session_test.go
+++ b/adk/middlewares/automemory/dream/session_test.go
@@ -34,14 +34,11 @@ func TestNewSessionHistoryGrepTool(t *testing.T) {
 	sessionID := "session-1"
 
 	appendEvent := func(eventID string, msg *schema.Message) {
-		err := store.AppendEvents(ctx, &adk.AppendSessionEventsRequest[*schema.Message]{
-			SessionID: sessionID,
-			Events: []*adk.SessionEvent[*schema.Message]{{
-				EventID: eventID,
-				Kind:    adk.SessionEventMessage,
-				Message: msg,
-			}},
-		})
+		err := store.AppendEvents(ctx, sessionID, []*adk.SessionEvent[*schema.Message]{{
+			EventID: eventID,
+			Kind:    adk.SessionEventMessage,
+			Message: msg,
+		}})
 		require.NoError(t, err)
 	}
 
@@ -65,14 +62,11 @@ func TestNewSessionHistoryGrepTool_SearchesRunScopedSessions(t *testing.T) {
 	store := adksession.NewInMemoryStore[*schema.Message](nil)
 
 	appendEvent := func(sessionID, eventID string, msg *schema.Message) {
-		err := store.AppendEvents(ctx, &adk.AppendSessionEventsRequest[*schema.Message]{
-			SessionID: sessionID,
-			Events: []*adk.SessionEvent[*schema.Message]{{
-				EventID: eventID,
-				Kind:    adk.SessionEventMessage,
-				Message: msg,
-			}},
-		})
+		err := store.AppendEvents(ctx, sessionID, []*adk.SessionEvent[*schema.Message]{{
+			EventID: eventID,
+			Kind:    adk.SessionEventMessage,
+			Message: msg,
+		}})
 		require.NoError(t, err)
 	}
 

--- a/adk/middlewares/automemory/utils.go
+++ b/adk/middlewares/automemory/utils.go
@@ -955,13 +955,17 @@ func (m *middleware[M]) sendTopicMemoryEvent(ctx context.Context, msgs []M, memM
 	if len(msgs) > 0 && !isNilMessage(msgs[len(msgs)-1]) {
 		beforeID = adk.GetMessageID(msgs[len(msgs)-1])
 	}
-	if sendEventErr := adk.TypedSendEvent(ctx, &adk.TypedAgentEvent[M]{SessionEvent: &adk.SessionEvent[M]{
-		Kind: adk.SessionEventMessageInserted,
-		MessageInserted: &adk.MessageInsertedEvent[M]{
-			Message:         memMsg,
-			BeforeMessageID: beforeID,
+	if sendEventErr := adk.TypedSendEvent(ctx, &adk.TypedAgentEvent[M]{
+		SessionEventVariant: &adk.SessionEventVariant[M]{
+			Event: &adk.SessionEvent[M]{
+				Kind: adk.SessionEventMessageInserted,
+				MessageInserted: &adk.MessageInsertedEvent[M]{
+					Message:         memMsg,
+					BeforeMessageID: beforeID,
+				},
+			},
 		},
-	}}); sendEventErr != nil {
+	}); sendEventErr != nil {
 		m.onErr(ctx, OnErrorStageSendSessionEvent, sendEventErr)
 	}
 }

--- a/adk/middlewares/dynamictool/toolsearch/toolsearch.go
+++ b/adk/middlewares/dynamictool/toolsearch/toolsearch.go
@@ -292,11 +292,13 @@ func (m *typedMiddleware[M]) BeforeModelRewriteState(ctx context.Context, state 
 			beforeID = adk.GetMessageID(anchorMsg)
 		}
 		_ = adk.TypedSendEvent(ctx, &adk.TypedAgentEvent[M]{
-			SessionEvent: &adk.SessionEvent[M]{
-				Kind: adk.SessionEventMessageInserted,
-				MessageInserted: &adk.MessageInsertedEvent[M]{
-					Message:         insertedMsg,
-					BeforeMessageID: beforeID,
+			SessionEventVariant: &adk.SessionEventVariant[M]{
+				Event: &adk.SessionEvent[M]{
+					Kind: adk.SessionEventMessageInserted,
+					MessageInserted: &adk.MessageInsertedEvent[M]{
+						Message:         insertedMsg,
+						BeforeMessageID: beforeID,
+					},
 				},
 			},
 		})

--- a/adk/middlewares/modeltimeout/timeout_test.go
+++ b/adk/middlewares/modeltimeout/timeout_test.go
@@ -455,8 +455,8 @@ func TestModelTimeoutTimelineEventContainsTimeoutMeta(t *testing.T) {
 		if !ok {
 			break
 		}
-		if event.SessionEventVariant.GetEvent() != nil && event.SessionEventVariant.GetEvent().Kind == SessionEventSpanModelRequestEnd {
-			endEvent = event.SessionEventVariant.GetEvent()
+		if event.SessionEventVariant != nil && event.SessionEventVariant.Event != nil && event.SessionEventVariant.Event.Kind == SessionEventSpanModelRequestEnd {
+			endEvent = event.SessionEventVariant.Event
 		}
 	}
 	require.NotNil(t, endEvent)
@@ -494,8 +494,8 @@ func TestAttack_ModelTimeoutRetryExhaustionKeepsTimelineTimeoutMeta(t *testing.T
 		if !ok {
 			break
 		}
-		if event.SessionEventVariant.GetEvent() != nil && event.SessionEventVariant.GetEvent().Kind == SessionEventSpanModelRequestEnd {
-			endEvent = event.SessionEventVariant.GetEvent()
+		if event.SessionEventVariant != nil && event.SessionEventVariant.Event != nil && event.SessionEventVariant.Event.Kind == SessionEventSpanModelRequestEnd {
+			endEvent = event.SessionEventVariant.Event
 		}
 	}
 	require.NotNil(t, endEvent)

--- a/adk/middlewares/modeltimeout/timeout_test.go
+++ b/adk/middlewares/modeltimeout/timeout_test.go
@@ -455,8 +455,8 @@ func TestModelTimeoutTimelineEventContainsTimeoutMeta(t *testing.T) {
 		if !ok {
 			break
 		}
-		if event.SessionEvent != nil && event.SessionEvent.Kind == SessionEventSpanModelRequestEnd {
-			endEvent = event.SessionEvent
+		if event.SessionEventVariant.GetEvent() != nil && event.SessionEventVariant.GetEvent().Kind == SessionEventSpanModelRequestEnd {
+			endEvent = event.SessionEventVariant.GetEvent()
 		}
 	}
 	require.NotNil(t, endEvent)
@@ -494,8 +494,8 @@ func TestAttack_ModelTimeoutRetryExhaustionKeepsTimelineTimeoutMeta(t *testing.T
 		if !ok {
 			break
 		}
-		if event.SessionEvent != nil && event.SessionEvent.Kind == SessionEventSpanModelRequestEnd {
-			endEvent = event.SessionEvent
+		if event.SessionEventVariant.GetEvent() != nil && event.SessionEventVariant.GetEvent().Kind == SessionEventSpanModelRequestEnd {
+			endEvent = event.SessionEventVariant.GetEvent()
 		}
 	}
 	require.NotNil(t, endEvent)

--- a/adk/middlewares/patchtoolcalls/patchtoolcalls.go
+++ b/adk/middlewares/patchtoolcalls/patchtoolcalls.go
@@ -564,7 +564,9 @@ func deletedAgenticMessageIDs(messages []*schema.AgenticMessage, rewrites []agen
 
 func sendNormalizationEvents[M adk.MessageType](ctx context.Context, events []*adk.SessionEvent[M]) error {
 	for _, event := range events {
-		err := adk.TypedSendEvent(ctx, &adk.TypedAgentEvent[M]{SessionEvent: event})
+		err := adk.TypedSendEvent(ctx, &adk.TypedAgentEvent[M]{
+			SessionEventVariant: &adk.SessionEventVariant[M]{Event: event},
+		})
 		if isOutOfRunContextError(err) {
 			continue
 		}

--- a/adk/middlewares/permission/permission.go
+++ b/adk/middlewares/permission/permission.go
@@ -361,9 +361,11 @@ func emitDecisionEvent[M adk.MessageType](ctx context.Context, tCtx *adk.ToolCon
 		HasUpdatedInput: decision.HasUpdatedInput,
 	}
 	return adk.TypedSendEvent[M](ctx, &adk.TypedAgentEvent[M]{
-		SessionEvent: &adk.SessionEvent[M]{
-			Kind:      SessionEventPermissionDecision,
-			Extension: &adk.SessionExtensionEvent{Data: payload},
+		SessionEventVariant: &adk.SessionEventVariant[M]{
+			Event: &adk.SessionEvent[M]{
+				Kind:      SessionEventPermissionDecision,
+				Extension: &adk.SessionExtensionEvent{Data: payload},
+			},
 		},
 	})
 }

--- a/adk/middlewares/permission/permission_test.go
+++ b/adk/middlewares/permission/permission_test.go
@@ -757,10 +757,10 @@ func TestPermissionDecisionAppearsInToolUseTimeline(t *testing.T) {
 			break
 		}
 		require.NoError(t, event.Err)
-		if event.SessionEvent == nil || event.SessionEvent.Span == nil || event.SessionEvent.Span.Tool == nil {
+		if event.SessionEventVariant.GetEvent() == nil || event.SessionEventVariant.GetEvent().Span == nil || event.SessionEventVariant.GetEvent().Span.Tool == nil {
 			continue
 		}
-		if event.SessionEvent.Kind == adk.SessionEventSpanToolCallEnd && event.SessionEvent.Span.Status == "ok" {
+		if event.SessionEventVariant.GetEvent().Kind == adk.SessionEventSpanToolCallEnd && event.SessionEventVariant.GetEvent().Span.Status == "ok" {
 			sawToolCallEndOK = true
 		}
 	}
@@ -879,12 +879,12 @@ func TestPermissionDecisionEventResumeLiveAndPersisted(t *testing.T) {
 					break
 				}
 				require.NoError(t, event.Err)
-				if event.SessionEvent == nil || event.SessionEvent.Kind != adk.SessionEventAgentInterrupt {
+				if event.SessionEventVariant.GetEvent() == nil || event.SessionEventVariant.GetEvent().Kind != adk.SessionEventInterrupt {
 					continue
 				}
-				require.NotNil(t, event.SessionEvent.AgentInterrupt)
-				require.Len(t, event.SessionEvent.AgentInterrupt.Contexts, 1)
-				interruptID = event.SessionEvent.AgentInterrupt.Contexts[0].InterruptID
+				require.NotNil(t, event.SessionEventVariant.GetEvent().Interrupt)
+				require.Len(t, event.SessionEventVariant.GetEvent().Interrupt.Contexts, 1)
+				interruptID = event.SessionEventVariant.GetEvent().Interrupt.Contexts[0].InterruptID
 			}
 			require.NotEmpty(t, interruptID)
 
@@ -900,8 +900,8 @@ func TestPermissionDecisionEventResumeLiveAndPersisted(t *testing.T) {
 					break
 				}
 				require.NoError(t, event.Err)
-				if event.SessionEvent != nil && event.SessionEvent.Kind == SessionEventPermissionDecision {
-					liveDecision = event.SessionEvent
+				if event.SessionEventVariant.GetEvent() != nil && event.SessionEventVariant.GetEvent().Kind == SessionEventPermissionDecision {
+					liveDecision = event.SessionEventVariant.GetEvent()
 				}
 			}
 			requireDecisionEvent(t, liveDecision, tt.wantAction, tt.wantDecisionText, tt.wantUpdatedInput, tt.wantHasUpdated)
@@ -992,10 +992,10 @@ func TestAttack_InvalidRespondDoesNotPersistDecisionEvent(t *testing.T) {
 			break
 		}
 		require.NoError(t, event.Err)
-		if event.SessionEvent != nil && event.SessionEvent.Kind == adk.SessionEventAgentInterrupt {
-			require.NotNil(t, event.SessionEvent.AgentInterrupt)
-			require.Len(t, event.SessionEvent.AgentInterrupt.Contexts, 1)
-			interruptID = event.SessionEvent.AgentInterrupt.Contexts[0].InterruptID
+		if event.SessionEventVariant.GetEvent() != nil && event.SessionEventVariant.GetEvent().Kind == adk.SessionEventInterrupt {
+			require.NotNil(t, event.SessionEventVariant.GetEvent().Interrupt)
+			require.Len(t, event.SessionEventVariant.GetEvent().Interrupt.Contexts, 1)
+			interruptID = event.SessionEventVariant.GetEvent().Interrupt.Contexts[0].InterruptID
 		}
 	}
 	require.NotEmpty(t, interruptID)
@@ -1015,8 +1015,8 @@ func TestAttack_InvalidRespondDoesNotPersistDecisionEvent(t *testing.T) {
 			resumeErr = event.Err
 			continue
 		}
-		if event.SessionEvent != nil {
-			assert.NotEqual(t, SessionEventPermissionDecision, event.SessionEvent.Kind)
+		if event.SessionEventVariant.GetEvent() != nil {
+			assert.NotEqual(t, SessionEventPermissionDecision, event.SessionEventVariant.GetEvent().Kind)
 		}
 	}
 	require.Error(t, resumeErr)
@@ -1091,17 +1091,17 @@ func TestToolSpan_PermissionDenyEmitsBothSpansOnSameRun(t *testing.T) {
 			break
 		}
 		require.NoError(t, event.Err)
-		if event.SessionEvent == nil || event.SessionEvent.Span == nil || event.SessionEvent.Span.Tool == nil {
+		if event.SessionEventVariant.GetEvent() == nil || event.SessionEventVariant.GetEvent().Span == nil || event.SessionEventVariant.GetEvent().Span.Tool == nil {
 			continue
 		}
-		switch event.SessionEvent.Kind {
+		switch event.SessionEventVariant.GetEvent().Kind {
 		case adk.SessionEventSpanToolCallStart:
 			startCount++
-			startSpanID = event.SessionEvent.Span.SpanID
-			startEventID = event.SessionEvent.EventID
+			startSpanID = event.SessionEventVariant.GetEvent().Span.SpanID
+			startEventID = event.SessionEventVariant.GetEvent().EventID
 		case adk.SessionEventSpanToolCallEnd:
 			endCount++
-			endSpan = event.SessionEvent
+			endSpan = event.SessionEventVariant.GetEvent()
 		}
 	}
 
@@ -1186,17 +1186,17 @@ func TestPermissionGate_PersistedAgentInterruptOmitsPrivateInfo(t *testing.T) {
 
 			var interrupt *adk.SessionEvent[*schema.Message]
 			for _, event := range store.events {
-				if event.Kind != adk.SessionEventAgentInterrupt {
+				if event.Kind != adk.SessionEventInterrupt {
 					continue
 				}
 				interrupt = event
 				break
 			}
 			require.NotNil(t, interrupt)
-			require.NotNil(t, interrupt.AgentInterrupt)
-			require.Len(t, interrupt.AgentInterrupt.Contexts, 1)
+			require.NotNil(t, interrupt.Interrupt)
+			require.Len(t, interrupt.Interrupt.Contexts, 1)
 
-			ctx0 := interrupt.AgentInterrupt.Contexts[0]
+			ctx0 := interrupt.Interrupt.Contexts[0]
 			assert.Equal(t, "permission_call", ctx0.ToolUseID)
 
 			infoJSON, err := json.Marshal(ctx0.Info)
@@ -1245,14 +1245,12 @@ type permissionSessionStore struct {
 	events []*adk.SessionEvent[*schema.Message]
 }
 
-func (s *permissionSessionStore) AppendEvents(_ context.Context, req *adk.AppendSessionEventsRequest[*schema.Message]) error {
-	if req != nil {
-		s.events = append(s.events, req.Events...)
-	}
+func (s *permissionSessionStore) AppendEvents(_ context.Context, _ string, events []*adk.SessionEvent[*schema.Message]) error {
+	s.events = append(s.events, events...)
 	return nil
 }
 
-func (s *permissionSessionStore) LoadEvents(_ context.Context, req *adk.LoadSessionEventsRequest) (*adk.LoadSessionEventsResult[*schema.Message], error) {
+func (s *permissionSessionStore) LoadEvents(_ context.Context, _ string, req *adk.LoadSessionEventsRequest) (*adk.LoadSessionEventsResult[*schema.Message], error) {
 	if req == nil {
 		req = &adk.LoadSessionEventsRequest{}
 	}

--- a/adk/middlewares/permission/permission_test.go
+++ b/adk/middlewares/permission/permission_test.go
@@ -757,10 +757,10 @@ func TestPermissionDecisionAppearsInToolUseTimeline(t *testing.T) {
 			break
 		}
 		require.NoError(t, event.Err)
-		if event.SessionEventVariant.GetEvent() == nil || event.SessionEventVariant.GetEvent().Span == nil || event.SessionEventVariant.GetEvent().Span.Tool == nil {
+		if event.SessionEventVariant == nil || event.SessionEventVariant.Event == nil || event.SessionEventVariant.Event.Span == nil || event.SessionEventVariant.Event.Span.Tool == nil {
 			continue
 		}
-		if event.SessionEventVariant.GetEvent().Kind == adk.SessionEventSpanToolCallEnd && event.SessionEventVariant.GetEvent().Span.Status == "ok" {
+		if event.SessionEventVariant.Event.Kind == adk.SessionEventSpanToolCallEnd && event.SessionEventVariant.Event.Span.Status == "ok" {
 			sawToolCallEndOK = true
 		}
 	}
@@ -879,12 +879,12 @@ func TestPermissionDecisionEventResumeLiveAndPersisted(t *testing.T) {
 					break
 				}
 				require.NoError(t, event.Err)
-				if event.SessionEventVariant.GetEvent() == nil || event.SessionEventVariant.GetEvent().Kind != adk.SessionEventInterrupt {
+				if event.SessionEventVariant == nil || event.SessionEventVariant.Event == nil || event.SessionEventVariant.Event.Kind != adk.SessionEventInterrupt {
 					continue
 				}
-				require.NotNil(t, event.SessionEventVariant.GetEvent().Interrupt)
-				require.Len(t, event.SessionEventVariant.GetEvent().Interrupt.Contexts, 1)
-				interruptID = event.SessionEventVariant.GetEvent().Interrupt.Contexts[0].InterruptID
+				require.NotNil(t, event.SessionEventVariant.Event.Interrupt)
+				require.Len(t, event.SessionEventVariant.Event.Interrupt.Contexts, 1)
+				interruptID = event.SessionEventVariant.Event.Interrupt.Contexts[0].InterruptID
 			}
 			require.NotEmpty(t, interruptID)
 
@@ -900,8 +900,8 @@ func TestPermissionDecisionEventResumeLiveAndPersisted(t *testing.T) {
 					break
 				}
 				require.NoError(t, event.Err)
-				if event.SessionEventVariant.GetEvent() != nil && event.SessionEventVariant.GetEvent().Kind == SessionEventPermissionDecision {
-					liveDecision = event.SessionEventVariant.GetEvent()
+				if event.SessionEventVariant != nil && event.SessionEventVariant.Event != nil && event.SessionEventVariant.Event.Kind == SessionEventPermissionDecision {
+					liveDecision = event.SessionEventVariant.Event
 				}
 			}
 			requireDecisionEvent(t, liveDecision, tt.wantAction, tt.wantDecisionText, tt.wantUpdatedInput, tt.wantHasUpdated)
@@ -992,10 +992,10 @@ func TestAttack_InvalidRespondDoesNotPersistDecisionEvent(t *testing.T) {
 			break
 		}
 		require.NoError(t, event.Err)
-		if event.SessionEventVariant.GetEvent() != nil && event.SessionEventVariant.GetEvent().Kind == adk.SessionEventInterrupt {
-			require.NotNil(t, event.SessionEventVariant.GetEvent().Interrupt)
-			require.Len(t, event.SessionEventVariant.GetEvent().Interrupt.Contexts, 1)
-			interruptID = event.SessionEventVariant.GetEvent().Interrupt.Contexts[0].InterruptID
+		if event.SessionEventVariant != nil && event.SessionEventVariant.Event != nil && event.SessionEventVariant.Event.Kind == adk.SessionEventInterrupt {
+			require.NotNil(t, event.SessionEventVariant.Event.Interrupt)
+			require.Len(t, event.SessionEventVariant.Event.Interrupt.Contexts, 1)
+			interruptID = event.SessionEventVariant.Event.Interrupt.Contexts[0].InterruptID
 		}
 	}
 	require.NotEmpty(t, interruptID)
@@ -1015,8 +1015,8 @@ func TestAttack_InvalidRespondDoesNotPersistDecisionEvent(t *testing.T) {
 			resumeErr = event.Err
 			continue
 		}
-		if event.SessionEventVariant.GetEvent() != nil {
-			assert.NotEqual(t, SessionEventPermissionDecision, event.SessionEventVariant.GetEvent().Kind)
+		if event.SessionEventVariant != nil && event.SessionEventVariant.Event != nil {
+			assert.NotEqual(t, SessionEventPermissionDecision, event.SessionEventVariant.Event.Kind)
 		}
 	}
 	require.Error(t, resumeErr)
@@ -1091,17 +1091,17 @@ func TestToolSpan_PermissionDenyEmitsBothSpansOnSameRun(t *testing.T) {
 			break
 		}
 		require.NoError(t, event.Err)
-		if event.SessionEventVariant.GetEvent() == nil || event.SessionEventVariant.GetEvent().Span == nil || event.SessionEventVariant.GetEvent().Span.Tool == nil {
+		if event.SessionEventVariant == nil || event.SessionEventVariant.Event == nil || event.SessionEventVariant.Event.Span == nil || event.SessionEventVariant.Event.Span.Tool == nil {
 			continue
 		}
-		switch event.SessionEventVariant.GetEvent().Kind {
+		switch event.SessionEventVariant.Event.Kind {
 		case adk.SessionEventSpanToolCallStart:
 			startCount++
-			startSpanID = event.SessionEventVariant.GetEvent().Span.SpanID
-			startEventID = event.SessionEventVariant.GetEvent().EventID
+			startSpanID = event.SessionEventVariant.Event.Span.SpanID
+			startEventID = event.SessionEventVariant.Event.EventID
 		case adk.SessionEventSpanToolCallEnd:
 			endCount++
-			endSpan = event.SessionEventVariant.GetEvent()
+			endSpan = event.SessionEventVariant.Event
 		}
 	}
 

--- a/adk/middlewares/reduction/reduction.go
+++ b/adk/middlewares/reduction/reduction.go
@@ -897,7 +897,9 @@ func (t *typedToolReductionMiddleware[M]) applyClearRewriteGeneric(ctx context.C
 }
 
 func sendClearRewriteSessionEvent[M adk.MessageType](ctx context.Context, event *adk.SessionEvent[M]) error {
-	err := adk.TypedSendEvent(ctx, &adk.TypedAgentEvent[M]{SessionEvent: event})
+	err := adk.TypedSendEvent(ctx, &adk.TypedAgentEvent[M]{
+		SessionEventVariant: &adk.SessionEventVariant[M]{Event: event},
+	})
 	if err != nil && strings.Contains(err.Error(), "must be called within a ChatModelAgent Run() or Resume() execution context") {
 		return nil
 	}

--- a/adk/middlewares/reduction/reduction_test.go
+++ b/adk/middlewares/reduction/reduction_test.go
@@ -3047,7 +3047,7 @@ func drainReductionEvents(t *testing.T, iter *adk.AsyncIterator[*adk.AgentEvent]
 
 func loadReductionSessionEvents(t *testing.T, ctx context.Context, store adk.SessionEventStore[*schema.Message], sessionID string) []*adk.SessionEvent[*schema.Message] {
 	t.Helper()
-	res, err := store.LoadEvents(ctx, &adk.LoadSessionEventsRequest{SessionID: sessionID})
+	res, err := store.LoadEvents(ctx, sessionID, &adk.LoadSessionEventsRequest{})
 	assert.NoError(t, err)
 	return res.Events
 }

--- a/adk/middlewares/summarization/summarization.go
+++ b/adk/middlewares/summarization/summarization.go
@@ -360,9 +360,11 @@ func (m *TypedMiddleware[M]) BeforeModelRewriteState(ctx context.Context, state 
 	// event simply has no consumer.
 	msgs := afterState.Messages
 	_ = adk.TypedSendEvent(ctx, &adk.TypedAgentEvent[M]{
-		SessionEvent: &adk.SessionEvent[M]{
-			Kind:             adk.SessionEventMessagesReplaced,
-			MessagesReplaced: &msgs,
+		SessionEventVariant: &adk.SessionEventVariant[M]{
+			Event: &adk.SessionEvent[M]{
+				Kind:             adk.SessionEventMessagesReplaced,
+				MessagesReplaced: &msgs,
+			},
 		},
 	})
 

--- a/adk/retry_chatmodel.go
+++ b/adk/retry_chatmodel.go
@@ -328,11 +328,6 @@ func emitRetryingTimeline[M MessageType](ctx context.Context, err error, rejectR
 	})
 	sendSessionTimelineEvent(ctx, &SessionEvent[M]{
 		Timestamp: newEventTimestamp(),
-		Kind:      SessionEventSessionStatusRescheduled,
-		Lifecycle: &LifecycleEvent{State: SessionRunStateRescheduled},
-	})
-	sendSessionTimelineEvent(ctx, &SessionEvent[M]{
-		Timestamp: newEventTimestamp(),
 		Kind:      SessionEventSessionStatusRunning,
 		Lifecycle: &LifecycleEvent{State: SessionRunStateRunning},
 	})

--- a/adk/retry_chatmodel.go
+++ b/adk/retry_chatmodel.go
@@ -326,11 +326,6 @@ func emitRetryingTimeline[M MessageType](ctx context.Context, err error, rejectR
 			RetryStatus: &RetryStatus{Type: "retrying"},
 		},
 	})
-	sendSessionTimelineEvent(ctx, &SessionEvent[M]{
-		Timestamp: newEventTimestamp(),
-		Kind:      SessionEventSessionStatusRunning,
-		Lifecycle: &LifecycleEvent{State: SessionRunStateRunning},
-	})
 }
 
 func emitRetryExhaustedTimeline[M MessageType](ctx context.Context, err error) {

--- a/adk/runctx.go
+++ b/adk/runctx.go
@@ -242,9 +242,6 @@ func GetSessionValue(ctx context.Context, key string) (any, bool) {
 
 func (rs *runSession) addEvent(event *AgentEvent) {
 	now := time.Now()
-	if event.Timestamp.IsZero() {
-		event.Timestamp = now.UTC()
-	}
 	wrapper := &agentEventWrapper{AgentEvent: event, TS: now.UnixNano()}
 	// If LaneEvents is not nil, we are in a parallel lane.
 	// Append to the lane's local event slice (lock-free).
@@ -303,9 +300,6 @@ func addTypedEvent[M MessageType](session *runSession, event *TypedAgentEvent[M]
 		return
 	}
 	now := time.Now()
-	if event.Timestamp.IsZero() {
-		event.Timestamp = now.UTC()
-	}
 	session.mtx.Lock()
 	defer session.mtx.Unlock()
 	wrapper := &typedAgentEventWrapper[M]{event: event, TS: now.UnixNano()}
@@ -467,7 +461,7 @@ func sanitizeAgentEventWrapperForSessionCheckpoint(w *agentEventWrapper) *agentE
 
 	event := *w.AgentEvent
 	event.RunPath = append([]RunStep(nil), w.AgentEvent.RunPath...)
-	event.SessionEvent = nil
+	event.SessionEventVariant = nil
 	if event.Output == nil && event.Action == nil && event.Err == nil {
 		return nil
 	}
@@ -489,7 +483,7 @@ func sanitizeTypedAgentEventWrapperForSessionCheckpoint[M MessageType](
 
 	event := *w.event
 	event.RunPath = append([]RunStep(nil), w.event.RunPath...)
-	event.SessionEvent = nil
+	event.SessionEventVariant = nil
 	if event.Output == nil && event.Action == nil && event.Err == nil {
 		return nil
 	}

--- a/adk/runctx_test.go
+++ b/adk/runctx_test.go
@@ -695,15 +695,15 @@ func TestSanitizeRunContextForSessionCheckpointStripsSessionEvents(t *testing.T)
 	require.NotSame(t, rc, sanitized)
 	require.NotSame(t, session, sanitized.Session)
 	require.Len(t, sanitized.Session.Events, 2)
-	assert.Nil(t, sanitized.Session.Events[0].SessionEventVariant.GetEvent())
+	assert.Nil(t, sanitized.Session.Events[0].SessionEventVariant)
 	assert.Same(t, output, sanitized.Session.Events[0].Output)
 	assert.NotNil(t, sanitized.Session.Events[1].Action.Interrupted)
-	assert.Nil(t, sanitized.Session.Events[1].SessionEventVariant.GetEvent())
+	assert.Nil(t, sanitized.Session.Events[1].SessionEventVariant)
 	assert.Equal(t, map[string]any{"k": "v"}, sanitized.Session.Values)
 
-	assert.NotNil(t, kept.SessionEventVariant.GetEvent(), "sanitizer must not mutate the original output event")
-	assert.NotNil(t, dropped.SessionEventVariant.GetEvent(), "sanitizer must not mutate the original timeline event")
-	assert.NotNil(t, interrupt.SessionEventVariant.GetEvent(), "sanitizer must not mutate the original interrupt event")
+	assert.NotNil(t, kept.SessionEventVariant.Event, "sanitizer must not mutate the original output event")
+	assert.NotNil(t, dropped.SessionEventVariant.Event, "sanitizer must not mutate the original timeline event")
+	assert.NotNil(t, interrupt.SessionEventVariant.Event, "sanitizer must not mutate the original interrupt event")
 }
 
 func TestSanitizeRunContextForSessionCheckpointTypedEvents(t *testing.T) {
@@ -748,10 +748,10 @@ func TestSanitizeRunContextForSessionCheckpointTypedEvents(t *testing.T) {
 	store, ok := sanitized.Session.TypedEvents.(*[]*typedAgentEventWrapper[*schema.AgenticMessage])
 	require.True(t, ok)
 	require.Len(t, *store, 1)
-	assert.Nil(t, (*store)[0].event.SessionEventVariant.GetEvent())
+	assert.Nil(t, (*store)[0].event.SessionEventVariant)
 	assert.Same(t, output, (*store)[0].event.Output)
-	assert.NotNil(t, events[0].event.SessionEventVariant.GetEvent(), "sanitizer must not mutate the original typed event")
-	assert.NotNil(t, events[1].event.SessionEventVariant.GetEvent(), "sanitizer must not mutate the original typed timeline event")
+	assert.NotNil(t, events[0].event.SessionEventVariant.Event, "sanitizer must not mutate the original typed event")
+	assert.NotNil(t, events[1].event.SessionEventVariant.Event, "sanitizer must not mutate the original typed timeline event")
 }
 
 func TestSanitizeRunContextForSessionCheckpointReducesEncodedPayload(t *testing.T) {
@@ -794,7 +794,7 @@ func TestSanitizeRunContextForSessionCheckpointReducesEncodedPayload(t *testing.
 	_, decoded, _, err := runnerLoadCheckPointBytes(context.Background(), sanitized)
 	require.NoError(t, err)
 	require.Len(t, decoded.Session.Events, 1)
-	assert.Nil(t, decoded.Session.Events[0].SessionEventVariant.GetEvent())
+	assert.Nil(t, decoded.Session.Events[0].SessionEventVariant)
 	assert.NotNil(t, decoded.Session.Events[0].Output)
 }
 
@@ -841,8 +841,8 @@ func TestSanitizeRunContextForSessionCheckpointPreservesLaneChain(t *testing.T) 
 	require.NotNil(t, sanitized.Session.LaneEvents.Parent)
 	require.Len(t, sanitized.Session.LaneEvents.Events, 1)
 	require.Len(t, sanitized.Session.LaneEvents.Parent.Events, 1)
-	assert.Nil(t, sanitized.Session.LaneEvents.Events[0].SessionEventVariant.GetEvent())
-	assert.Nil(t, sanitized.Session.LaneEvents.Parent.Events[0].SessionEventVariant.GetEvent())
-	assert.NotNil(t, childTimelineOnly.SessionEventVariant.GetEvent(), "sanitizer must not mutate original child lane")
-	assert.NotNil(t, parentTimelineOnly.SessionEventVariant.GetEvent(), "sanitizer must not mutate original parent lane")
+	assert.Nil(t, sanitized.Session.LaneEvents.Events[0].SessionEventVariant)
+	assert.Nil(t, sanitized.Session.LaneEvents.Parent.Events[0].SessionEventVariant)
+	assert.NotNil(t, childTimelineOnly.SessionEventVariant.Event, "sanitizer must not mutate original child lane")
+	assert.NotNil(t, parentTimelineOnly.SessionEventVariant.Event, "sanitizer must not mutate original parent lane")
 }

--- a/adk/runctx_test.go
+++ b/adk/runctx_test.go
@@ -636,7 +636,6 @@ func TestGobEncodeStreamErrors(t *testing.T) {
 }
 
 func TestSanitizeRunContextForSessionCheckpointStripsSessionEvents(t *testing.T) {
-	now := time.Now().UTC()
 	output := &AgentOutput{
 		MessageOutput: &MessageVariant{
 			Message: schema.AssistantMessage("kept", nil),
@@ -645,36 +644,38 @@ func TestSanitizeRunContextForSessionCheckpointStripsSessionEvents(t *testing.T)
 	}
 	kept := &agentEventWrapper{
 		AgentEvent: &AgentEvent{
-			EventID:   "event-output",
-			Timestamp: now,
 			AgentName: "agent",
 			RunPath:   []RunStep{{agentName: "root"}},
 			Output:    output,
-			SessionEvent: &SessionEvent[*schema.Message]{
-				EventID: "event-output",
-				Kind:    SessionEventMessage,
-				Message: schema.AssistantMessage("kept", nil),
+			SessionEventVariant: &SessionEventVariant[*schema.Message]{
+				Event: &SessionEvent[*schema.Message]{
+					EventID: "event-output",
+					Kind:    SessionEventMessage,
+					Message: schema.AssistantMessage("kept", nil),
+				},
 			},
 		},
 		TS: 10,
 	}
 	dropped := &agentEventWrapper{
 		AgentEvent: &AgentEvent{
-			EventID: "event-session-only",
-			SessionEvent: &SessionEvent[*schema.Message]{
-				EventID: "event-session-only",
-				Kind:    SessionEventSessionStatusRunning,
+			SessionEventVariant: &SessionEventVariant[*schema.Message]{
+				Event: &SessionEvent[*schema.Message]{
+					EventID: "event-session-only",
+					Kind:    SessionEventSessionStatusRunning,
+				},
 			},
 		},
 		TS: 11,
 	}
 	interrupt := &agentEventWrapper{
 		AgentEvent: &AgentEvent{
-			EventID: "event-interrupt",
-			Action:  &AgentAction{Interrupted: &InterruptInfo{Data: "pause"}},
-			SessionEvent: &SessionEvent[*schema.Message]{
-				EventID: "event-interrupt",
-				Kind:    SessionEventAgentInterrupt,
+			Action: &AgentAction{Interrupted: &InterruptInfo{Data: "pause"}},
+			SessionEventVariant: &SessionEventVariant[*schema.Message]{
+				Event: &SessionEvent[*schema.Message]{
+					EventID: "event-interrupt",
+					Kind:    SessionEventInterrupt,
+				},
 			},
 		},
 		TS: 12,
@@ -694,17 +695,15 @@ func TestSanitizeRunContextForSessionCheckpointStripsSessionEvents(t *testing.T)
 	require.NotSame(t, rc, sanitized)
 	require.NotSame(t, session, sanitized.Session)
 	require.Len(t, sanitized.Session.Events, 2)
-	assert.Equal(t, "event-output", sanitized.Session.Events[0].EventID)
-	assert.Nil(t, sanitized.Session.Events[0].SessionEvent)
+	assert.Nil(t, sanitized.Session.Events[0].SessionEventVariant.GetEvent())
 	assert.Same(t, output, sanitized.Session.Events[0].Output)
-	assert.Equal(t, "event-interrupt", sanitized.Session.Events[1].EventID)
 	assert.NotNil(t, sanitized.Session.Events[1].Action.Interrupted)
-	assert.Nil(t, sanitized.Session.Events[1].SessionEvent)
+	assert.Nil(t, sanitized.Session.Events[1].SessionEventVariant.GetEvent())
 	assert.Equal(t, map[string]any{"k": "v"}, sanitized.Session.Values)
 
-	assert.NotNil(t, kept.SessionEvent, "sanitizer must not mutate the original output event")
-	assert.NotNil(t, dropped.SessionEvent, "sanitizer must not mutate the original timeline event")
-	assert.NotNil(t, interrupt.SessionEvent, "sanitizer must not mutate the original interrupt event")
+	assert.NotNil(t, kept.SessionEventVariant.GetEvent(), "sanitizer must not mutate the original output event")
+	assert.NotNil(t, dropped.SessionEventVariant.GetEvent(), "sanitizer must not mutate the original timeline event")
+	assert.NotNil(t, interrupt.SessionEventVariant.GetEvent(), "sanitizer must not mutate the original interrupt event")
 }
 
 func TestSanitizeRunContextForSessionCheckpointTypedEvents(t *testing.T) {
@@ -717,22 +716,24 @@ func TestSanitizeRunContextForSessionCheckpointTypedEvents(t *testing.T) {
 	events := []*typedAgentEventWrapper[*schema.AgenticMessage]{
 		{
 			event: &TypedAgentEvent[*schema.AgenticMessage]{
-				EventID: "typed-output",
-				Output:  output,
-				SessionEvent: &SessionEvent[*schema.AgenticMessage]{
-					EventID: "typed-output",
-					Kind:    SessionEventMessage,
-					Message: schema.UserAgenticMessage("kept"),
+				Output: output,
+				SessionEventVariant: &SessionEventVariant[*schema.AgenticMessage]{
+					Event: &SessionEvent[*schema.AgenticMessage]{
+						EventID: "typed-output",
+						Kind:    SessionEventMessage,
+						Message: schema.UserAgenticMessage("kept"),
+					},
 				},
 			},
 			TS: 20,
 		},
 		{
 			event: &TypedAgentEvent[*schema.AgenticMessage]{
-				EventID: "typed-session-only",
-				SessionEvent: &SessionEvent[*schema.AgenticMessage]{
-					EventID: "typed-session-only",
-					Kind:    SessionEventSessionStatusRunning,
+				SessionEventVariant: &SessionEventVariant[*schema.AgenticMessage]{
+					Event: &SessionEvent[*schema.AgenticMessage]{
+						EventID: "typed-session-only",
+						Kind:    SessionEventSessionStatusRunning,
+					},
 				},
 			},
 			TS: 21,
@@ -747,11 +748,10 @@ func TestSanitizeRunContextForSessionCheckpointTypedEvents(t *testing.T) {
 	store, ok := sanitized.Session.TypedEvents.(*[]*typedAgentEventWrapper[*schema.AgenticMessage])
 	require.True(t, ok)
 	require.Len(t, *store, 1)
-	assert.Equal(t, "typed-output", (*store)[0].event.EventID)
-	assert.Nil(t, (*store)[0].event.SessionEvent)
+	assert.Nil(t, (*store)[0].event.SessionEventVariant.GetEvent())
 	assert.Same(t, output, (*store)[0].event.Output)
-	assert.NotNil(t, events[0].event.SessionEvent, "sanitizer must not mutate the original typed event")
-	assert.NotNil(t, events[1].event.SessionEvent, "sanitizer must not mutate the original typed timeline event")
+	assert.NotNil(t, events[0].event.SessionEventVariant.GetEvent(), "sanitizer must not mutate the original typed event")
+	assert.NotNil(t, events[1].event.SessionEventVariant.GetEvent(), "sanitizer must not mutate the original typed timeline event")
 }
 
 func TestSanitizeRunContextForSessionCheckpointReducesEncodedPayload(t *testing.T) {
@@ -764,20 +764,18 @@ func TestSanitizeRunContextForSessionCheckpointReducesEncodedPayload(t *testing.
 	rc.Session.Events = []*agentEventWrapper{
 		{
 			AgentEvent: &AgentEvent{
-				EventID:      "large-session-event",
-				SessionEvent: sessionEvent,
+				SessionEventVariant: &SessionEventVariant[*schema.Message]{Event: sessionEvent},
 			},
 		},
 		{
 			AgentEvent: &AgentEvent{
-				EventID: "mixed-event",
 				Output: &AgentOutput{
 					MessageOutput: &MessageVariant{
 						Message: schema.AssistantMessage("kept output", nil),
 						Role:    schema.Assistant,
 					},
 				},
-				SessionEvent: sessionEvent,
+				SessionEventVariant: &SessionEventVariant[*schema.Message]{Event: sessionEvent},
 			},
 		},
 	}
@@ -796,40 +794,40 @@ func TestSanitizeRunContextForSessionCheckpointReducesEncodedPayload(t *testing.
 	_, decoded, _, err := runnerLoadCheckPointBytes(context.Background(), sanitized)
 	require.NoError(t, err)
 	require.Len(t, decoded.Session.Events, 1)
-	assert.Nil(t, decoded.Session.Events[0].SessionEvent)
+	assert.Nil(t, decoded.Session.Events[0].SessionEventVariant.GetEvent())
 	assert.NotNil(t, decoded.Session.Events[0].Output)
 }
 
 func TestSanitizeRunContextForSessionCheckpointPreservesLaneChain(t *testing.T) {
 	parentTimelineOnly := &agentEventWrapper{
 		AgentEvent: &AgentEvent{
-			EventID:      "parent-session-only",
-			SessionEvent: &SessionEvent[*schema.Message]{Kind: SessionEventSessionStatusRunning},
+			SessionEventVariant: &SessionEventVariant[*schema.Message]{Event: &SessionEvent[*schema.Message]{Kind: SessionEventSessionStatusRunning}},
 		},
 	}
 	parentOutput := &agentEventWrapper{
 		AgentEvent: &AgentEvent{
-			EventID: "parent-output",
-			Output:  &AgentOutput{MessageOutput: &MessageVariant{Message: schema.AssistantMessage("parent", nil)}},
-			SessionEvent: &SessionEvent[*schema.Message]{
-				EventID: "parent-output",
-				Kind:    SessionEventMessage,
+			Output: &AgentOutput{MessageOutput: &MessageVariant{Message: schema.AssistantMessage("parent", nil)}},
+			SessionEventVariant: &SessionEventVariant[*schema.Message]{
+				Event: &SessionEvent[*schema.Message]{
+					EventID: "parent-output",
+					Kind:    SessionEventMessage,
+				},
 			},
 		},
 	}
 	childTimelineOnly := &agentEventWrapper{
 		AgentEvent: &AgentEvent{
-			EventID:      "child-session-only",
-			SessionEvent: &SessionEvent[*schema.Message]{Kind: SessionEventSessionStatusIdle},
+			SessionEventVariant: &SessionEventVariant[*schema.Message]{Event: &SessionEvent[*schema.Message]{Kind: SessionEventSessionStatusIdle}},
 		},
 	}
 	childOutput := &agentEventWrapper{
 		AgentEvent: &AgentEvent{
-			EventID: "child-output",
-			Output:  &AgentOutput{MessageOutput: &MessageVariant{Message: schema.AssistantMessage("child", nil)}},
-			SessionEvent: &SessionEvent[*schema.Message]{
-				EventID: "child-output",
-				Kind:    SessionEventMessage,
+			Output: &AgentOutput{MessageOutput: &MessageVariant{Message: schema.AssistantMessage("child", nil)}},
+			SessionEventVariant: &SessionEventVariant[*schema.Message]{
+				Event: &SessionEvent[*schema.Message]{
+					EventID: "child-output",
+					Kind:    SessionEventMessage,
+				},
 			},
 		},
 	}
@@ -843,10 +841,8 @@ func TestSanitizeRunContextForSessionCheckpointPreservesLaneChain(t *testing.T) 
 	require.NotNil(t, sanitized.Session.LaneEvents.Parent)
 	require.Len(t, sanitized.Session.LaneEvents.Events, 1)
 	require.Len(t, sanitized.Session.LaneEvents.Parent.Events, 1)
-	assert.Equal(t, "child-output", sanitized.Session.LaneEvents.Events[0].EventID)
-	assert.Nil(t, sanitized.Session.LaneEvents.Events[0].SessionEvent)
-	assert.Equal(t, "parent-output", sanitized.Session.LaneEvents.Parent.Events[0].EventID)
-	assert.Nil(t, sanitized.Session.LaneEvents.Parent.Events[0].SessionEvent)
-	assert.NotNil(t, childTimelineOnly.SessionEvent, "sanitizer must not mutate original child lane")
-	assert.NotNil(t, parentTimelineOnly.SessionEvent, "sanitizer must not mutate original parent lane")
+	assert.Nil(t, sanitized.Session.LaneEvents.Events[0].SessionEventVariant.GetEvent())
+	assert.Nil(t, sanitized.Session.LaneEvents.Parent.Events[0].SessionEventVariant.GetEvent())
+	assert.NotNil(t, childTimelineOnly.SessionEventVariant.GetEvent(), "sanitizer must not mutate original child lane")
+	assert.NotNil(t, parentTimelineOnly.SessionEventVariant.GetEvent(), "sanitizer must not mutate original parent lane")
 }

--- a/adk/runner.go
+++ b/adk/runner.go
@@ -36,7 +36,7 @@ import (
 
 func errorIterator[M MessageType](err error) *AsyncIterator[*TypedAgentEvent[M]] {
 	iter, gen := NewAsyncIteratorPair[*TypedAgentEvent[M]]()
-	gen.Send(&TypedAgentEvent[M]{Timestamp: newEventTimestamp(), Err: err})
+	gen.Send(&TypedAgentEvent[M]{Err: err})
 	gen.Close()
 	return iter
 }
@@ -428,19 +428,13 @@ func appendRunnerSessionControlEvent[M MessageType](
 	if state == nil || !state.enabled || state.sessionHandle == nil || event == nil {
 		return nil
 	}
-	if event.SessionID == "" {
-		event.SessionID = state.sessionID
-	}
 	if event.TurnID == "" {
 		event.TurnID = state.turnID
 	}
 	if err := ValidateEmittedSessionEventKind(event); err != nil {
 		return err
 	}
-	err := state.sessionHandle.appendEvents(ctx, &AppendSessionEventsRequest[M]{
-		SessionID: state.sessionID,
-		Events:    []*SessionEvent[M]{event},
-	})
+	err := state.sessionHandle.appendEvents(ctx, []*SessionEvent[M]{event})
 	return err
 }
 
@@ -454,7 +448,6 @@ func appendRunnerSessionInputEvents[M MessageType](
 	}
 	for _, msg := range messages {
 		se := makeInputSessionEvent[M](msg)
-		se.SessionID = state.sessionID
 		se.TurnID = state.turnID
 		if err := assignSessionEventID(ctx, se, state.sessionConfig.EventIDGenerator); err != nil {
 			return err
@@ -462,10 +455,7 @@ func appendRunnerSessionInputEvents[M MessageType](
 		if err := ValidateEmittedSessionEventKind(se); err != nil {
 			return err
 		}
-		if err := state.sessionHandle.appendEvents(ctx, &AppendSessionEventsRequest[M]{
-			SessionID: state.sessionID,
-			Events:    []*SessionEvent[M]{se},
-		}); err != nil {
+		if err := state.sessionHandle.appendEvents(ctx, []*SessionEvent[M]{se}); err != nil {
 			return err
 		}
 		state.initialTimeline = append(state.initialTimeline, se)
@@ -759,7 +749,7 @@ func typedRunnerHandleIterImpl[M MessageType](enableStreaming bool, store CheckP
 		panicErr := recover()
 		if panicErr != nil {
 			e := safe.NewPanicErr(panicErr, debug.Stack())
-			gen.Send(&TypedAgentEvent[M]{Timestamp: newEventTimestamp(), Err: e})
+			gen.Send(&TypedAgentEvent[M]{Err: e})
 		}
 
 		gen.Close()
@@ -786,7 +776,7 @@ func typedRunnerHandleIterImpl[M MessageType](enableStreaming bool, store CheckP
 	if enableTimelineEvents && sessionState != nil && sessionState.enabled {
 		for _, se := range sessionState.initialTimeline {
 			if se != nil {
-				gen.Send(&TypedAgentEvent[M]{EventID: se.EventID, Timestamp: se.Timestamp, SessionEvent: se})
+				gen.Send(&TypedAgentEvent[M]{SessionEventVariant: &SessionEventVariant[M]{SessionID: sessionState.sessionID, Event: se}})
 			}
 		}
 	}
@@ -798,9 +788,6 @@ func typedRunnerHandleIterImpl[M MessageType](enableStreaming bool, store CheckP
 	annotateSessionEvent := func(se *SessionEvent[M]) *SessionEvent[M] {
 		if se == nil || sessionState == nil || !sessionState.enabled {
 			return se
-		}
-		if se.SessionID == "" {
-			se.SessionID = sessionState.sessionID
 		}
 		se.TurnID = sessionState.turnID
 		return se
@@ -856,38 +843,61 @@ func typedRunnerHandleIterImpl[M MessageType](enableStreaming bool, store CheckP
 		if err := persistSessionEvent(se); err != nil {
 			return false
 		}
-		event := &TypedAgentEvent[M]{EventID: se.EventID, Timestamp: se.Timestamp, SessionEvent: se}
+		event := &TypedAgentEvent[M]{SessionEventVariant: &SessionEventVariant[M]{SessionID: sessionState.sessionID, Event: se}}
 		if enableTimelineEvents {
 			gen.Send(event)
 		}
 		return true
 	}
-	assignStreamingShellEventID := func(event *TypedAgentEvent[M]) error {
-		if event == nil || event.EventID != "" {
-			return nil
+	reserveMessageStreamRef := func(event *TypedAgentEvent[M]) (*MessageStreamRef, error) {
+		if event != nil && event.SessionEventVariant != nil && event.SessionEventVariant.MessageStreamRef != nil {
+			ref := event.SessionEventVariant.MessageStreamRef
+			if ref.Timestamp.IsZero() {
+				ref.Timestamp = newEventTimestamp()
+			}
+			ref.Kind = SessionEventMessage
+			ref.TurnID = sessionState.turnID
+			if ref.EventID == "" {
+				draft := &SessionEvent[M]{
+					TurnID:    ref.TurnID,
+					Timestamp: ref.Timestamp,
+					Kind:      SessionEventMessage,
+				}
+				if err := assignSessionEventID(ctx, draft, sessionState.sessionConfig.EventIDGenerator); err != nil {
+					setPersistErr(err)
+					return nil, err
+				}
+				ref.EventID = draft.EventID
+				ref.Timestamp = draft.Timestamp
+				ref.TurnID = draft.TurnID
+			}
+			return ref, nil
 		}
-		shell := &SessionEvent[M]{
-			SessionID: sessionState.sessionID,
+		draft := &SessionEvent[M]{
 			TurnID:    sessionState.turnID,
-			Timestamp: event.Timestamp,
+			Timestamp: newEventTimestamp(),
 			Kind:      SessionEventMessage,
 		}
-		if err := assignSessionEventID(ctx, shell, sessionState.sessionConfig.EventIDGenerator); err != nil {
+		if err := assignSessionEventID(ctx, draft, sessionState.sessionConfig.EventIDGenerator); err != nil {
 			setPersistErr(err)
-			return err
+			return nil, err
 		}
-		event.EventID = shell.EventID
-		return nil
+		return &MessageStreamRef{
+			EventID:   draft.EventID,
+			Timestamp: draft.Timestamp,
+			Kind:      SessionEventMessage,
+			TurnID:    draft.TurnID,
+		}, nil
 	}
 	toSessionEventCheckedWithGenerator := func(event *TypedAgentEvent[M]) (*SessionEvent[M], error) {
 		se, err := toSessionEventChecked(event)
-		if err == nil || event == nil || event.EventID != "" || event.SessionEvent != nil ||
+		if err == nil || event == nil || event.SessionEventVariant != nil ||
 			event.Output == nil || event.Output.MessageOutput == nil ||
 			isNilMessage(event.Output.MessageOutput.Message) {
 			return se, err
 		}
 		draft := &SessionEvent[M]{
-			Timestamp: event.Timestamp,
+			Timestamp: newEventTimestamp(),
 			Kind:      SessionEventMessage,
 			Message:   event.Output.MessageOutput.Message,
 		}
@@ -895,7 +905,7 @@ func typedRunnerHandleIterImpl[M MessageType](enableStreaming bool, store CheckP
 		if idErr := assignSessionEventID(ctx, draft, sessionState.sessionConfig.EventIDGenerator); idErr != nil {
 			return nil, idErr
 		}
-		event.EventID = draft.EventID
+		event.SessionEventVariant = &SessionEventVariant[M]{SessionID: sessionState.sessionID, Event: draft}
 		return draft, NormalizeSessionEventKind(draft)
 	}
 	// saveCheckpointNow is the path used when no session persister is active —
@@ -915,7 +925,7 @@ func typedRunnerHandleIterImpl[M MessageType](enableStreaming bool, store CheckP
 			return
 		}
 		if err := saveRunnerCheckpoint(enableStreaming, store, ctx, *checkPointID, info, sig, sessionState); err != nil {
-			gen.Send(&TypedAgentEvent[M]{Timestamp: newEventTimestamp(), Err: fmt.Errorf("%s: %w", errLabel, err)})
+			gen.Send(&TypedAgentEvent[M]{Err: fmt.Errorf("%s: %w", errLabel, err)})
 		}
 	}
 
@@ -924,10 +934,11 @@ func typedRunnerHandleIterImpl[M MessageType](enableStreaming bool, store CheckP
 		if !ok {
 			break
 		}
-		if event.Timestamp.IsZero() {
-			event.Timestamp = newEventTimestamp()
-		}
-		if event.SessionEvent != nil {
+		fromOtherSession := event.SessionEventVariant != nil &&
+			sessionState != nil && sessionState.enabled &&
+			event.SessionEventVariant.SessionID != "" &&
+			event.SessionEventVariant.SessionID != sessionState.sessionID
+		if !fromOtherSession && event.SessionEventVariant != nil && event.SessionEventVariant.Event != nil {
 			gen := DefaultSessionEventIDGenerator[M]
 			if sessionState != nil && sessionState.enabled {
 				gen = sessionState.sessionConfig.EventIDGenerator
@@ -983,7 +994,6 @@ func typedRunnerHandleIterImpl[M MessageType](enableStreaming bool, store CheckP
 			interruptSignal = event.Action.internalInterrupted
 			interruptContexts = core.ToInterruptContexts(interruptSignal, allowedAddressSegmentTypes)
 			event = &TypedAgentEvent[M]{
-				Timestamp: event.Timestamp,
 				AgentName: event.AgentName,
 				RunPath:   event.RunPath,
 				Output:    event.Output,
@@ -1008,14 +1018,11 @@ func typedRunnerHandleIterImpl[M MessageType](enableStreaming bool, store CheckP
 		if persister != nil {
 			// Skip persistence (but not live delivery) for events owned by a
 			// different session (inner agent events forwarded via AgentTool).
-			fromOtherSession := event.SessionEvent != nil &&
-				event.SessionEvent.SessionID != "" &&
-				event.SessionEvent.SessionID != sessionState.sessionID
-
 			if !fromOtherSession {
 				if event.Output != nil && event.Output.MessageOutput != nil &&
 					event.Output.MessageOutput.IsStreaming && event.Output.MessageOutput.MessageStream != nil {
-					if err := assignStreamingShellEventID(event); err != nil {
+					ref, err := reserveMessageStreamRef(event)
+					if err != nil {
 						continue
 					}
 					// Streaming output is split into two stream copies: copies[1] is
@@ -1029,14 +1036,7 @@ func typedRunnerHandleIterImpl[M MessageType](enableStreaming bool, store CheckP
 
 					liveOutput.MessageOutput = &liveMV
 					event.Output = &liveOutput
-					// Attach a SessionEvent shell so downstream consumers know this
-					// streaming event's persisted identity before materialization.
-					event.SessionEvent = &SessionEvent[M]{
-						SessionID: sessionState.sessionID,
-						EventID:   event.EventID,
-						Timestamp: event.Timestamp,
-						Kind:      SessionEventMessage,
-					}
+					event.SessionEventVariant = &SessionEventVariant[M]{SessionID: sessionState.sessionID, MessageStreamRef: ref}
 					liveEvent := event
 					if !enableTimelineEvents {
 						liveEvent = stripSessionEventFields(liveEvent)
@@ -1055,8 +1055,9 @@ func typedRunnerHandleIterImpl[M MessageType](enableStreaming bool, store CheckP
 					if streamErr != nil {
 						if hasChunks {
 							_ = persistSessionEvent(&SessionEvent[M]{
-								EventID:   event.EventID,
-								Timestamp: event.Timestamp,
+								EventID:   ref.EventID,
+								Timestamp: ref.Timestamp,
+								TurnID:    ref.TurnID,
 								Kind:      SessionEventMessageStreamIncomplete,
 								MessageStreamIncomplete: &MessageStreamIncompleteEvent[M]{
 									Message: persistedMsg,
@@ -1076,18 +1077,14 @@ func typedRunnerHandleIterImpl[M MessageType](enableStreaming bool, store CheckP
 					persistMV.IsStreaming = false
 					persistOutput := *event.Output
 					persistOutput.MessageOutput = &persistMV
-					persistEvent := *event
-					persistEvent.Output = &persistOutput
-					persistEvent.SessionEvent = nil
-
-					se, err := toSessionEventChecked(&persistEvent)
-					if err != nil {
-						setPersistErr(err)
-						continue
-					}
-					if se != nil {
-						_ = persistSessionEvent(se)
-					}
+					_ = persistOutput
+					_ = persistSessionEvent(&SessionEvent[M]{
+						EventID:   ref.EventID,
+						Timestamp: ref.Timestamp,
+						TurnID:    ref.TurnID,
+						Kind:      SessionEventMessage,
+						Message:   persistedMsg,
+					})
 				} else {
 					// Non-streaming events go through toSessionEvent directly.
 					se, err := toSessionEventCheckedWithGenerator(event)
@@ -1099,11 +1096,11 @@ func typedRunnerHandleIterImpl[M MessageType](enableStreaming bool, store CheckP
 						if err := persistSessionEvent(se); err != nil {
 							continue
 						}
-						// Backfill SessionEvent onto the live event so downstream
+						// Backfill SessionEventVariant onto the live event so downstream
 						// consumers (TurnLoop/onAgentEvents) see message events
 						// with their persisted SessionEvent identity, consistent
 						// with how span events are already delivered.
-						event.SessionEvent = se
+						event.SessionEventVariant = &SessionEventVariant[M]{SessionID: sessionState.sessionID, Event: se}
 					}
 				}
 			}
@@ -1150,16 +1147,16 @@ func typedRunnerHandleIterImpl[M MessageType](enableStreaming bool, store CheckP
 		}
 		if interrupted {
 			sendTimelineEvent(&SessionEvent[M]{
-				Timestamp:      newEventTimestamp(),
-				Kind:           SessionEventAgentInterrupt,
-				AgentInterrupt: buildAgentInterruptEvent(interruptContexts),
+				Timestamp: newEventTimestamp(),
+				Kind:      SessionEventInterrupt,
+				Interrupt: buildInterruptEvent(interruptContexts),
 			})
 		}
 		if cancelled {
 			sendTimelineEvent(&SessionEvent[M]{
-				Timestamp:       newEventTimestamp(),
-				Kind:            SessionEventCancel,
-				UserObservation: &UserObservationEvent{Interrupt: &UserInterruptEvent{Reason: "cancelled"}},
+				Timestamp: newEventTimestamp(),
+				Kind:      SessionEventCancel,
+				Cancel:    &CancelEvent{Reason: "cancelled"},
 			})
 		}
 		sendTimelineEvent(&SessionEvent[M]{
@@ -1180,22 +1177,22 @@ func typedRunnerHandleIterImpl[M MessageType](enableStreaming bool, store CheckP
 			pendingCheckpoint: pendingCheckpoint,
 		}
 		if err := res.finalize(ctx); err != nil {
-			gen.Send(&TypedAgentEvent[M]{Timestamp: newEventTimestamp(), Err: err})
+			gen.Send(&TypedAgentEvent[M]{Err: err})
 		}
 	}
 }
 
-func buildAgentInterruptEvent(
+func buildInterruptEvent(
 	contexts []*InterruptCtx,
-) *AgentInterruptEvent {
-	event := &AgentInterruptEvent{
-		Contexts: make([]*AgentInterruptContext, 0, len(contexts)),
+) *InterruptEvent {
+	event := &InterruptEvent{
+		Contexts: make([]*InterruptContext, 0, len(contexts)),
 	}
 	for _, ctx := range contexts {
 		if ctx == nil {
 			continue
 		}
-		aic := &AgentInterruptContext{
+		aic := &InterruptContext{
 			InterruptID: ctx.ID,
 			Info:        ctx.Info,
 		}

--- a/adk/runner.go
+++ b/adk/runner.go
@@ -1071,13 +1071,6 @@ func typedRunnerHandleIterImpl[M MessageType](enableStreaming bool, store CheckP
 						continue
 					}
 
-					persistMV := *event.Output.MessageOutput
-					persistMV.Message = persistedMsg
-					persistMV.MessageStream = nil
-					persistMV.IsStreaming = false
-					persistOutput := *event.Output
-					persistOutput.MessageOutput = &persistMV
-					_ = persistOutput
 					_ = persistSessionEvent(&SessionEvent[M]{
 						EventID:   ref.EventID,
 						Timestamp: ref.Timestamp,

--- a/adk/session.go
+++ b/adk/session.go
@@ -220,6 +220,37 @@ const (
 	SessionEventExtensionPrefix = "x."
 )
 
+var knownSessionEventKinds = map[SessionEventKind]struct{}{
+	SessionEventMessage:                 {},
+	SessionEventMessageStreamIncomplete: {},
+	SessionEventMessagesReplaced:        {},
+	SessionEventMessageUpdated:          {},
+	SessionEventMessageInserted:         {},
+	SessionEventMessagesDeleted:         {},
+	SessionEventModelContext:            {},
+	SessionEventRollback:                {},
+	SessionEventSessionStatusRunning:    {},
+	SessionEventSessionStatusIdle:       {},
+	SessionEventSessionError:            {},
+	SessionEventSpanModelRequestStart:   {},
+	SessionEventSpanModelRequestEnd:     {},
+	SessionEventSpanToolCallStart:       {},
+	SessionEventSpanToolCallEnd:         {},
+	SessionEventCancel:                  {},
+	SessionEventInterrupt:               {},
+}
+
+func isKnownSessionEventKind(kind SessionEventKind) bool {
+	if kind == "" {
+		return false
+	}
+	if strings.HasPrefix(string(kind), SessionEventExtensionPrefix) {
+		return true
+	}
+	_, ok := knownSessionEventKinds[kind]
+	return ok
+}
+
 type LifecycleEvent struct {
 	State      SessionRunState `json:"state,omitempty"`
 	StopReason *StopReason     `json:"stop_reason,omitempty"`
@@ -778,6 +809,56 @@ func ClassifySessionEvent[M MessageType](event *SessionEvent[M]) (SessionEventKi
 	return kinds[0], nil
 }
 
+func countActiveSessionEventPayloads[M MessageType](event *SessionEvent[M]) int {
+	if event == nil {
+		return 0
+	}
+	count := 0
+	if !isNilMessage(event.Message) {
+		count++
+	}
+	if event.MessageStreamIncomplete != nil {
+		count++
+	}
+	if event.MessagesReplaced != nil {
+		count++
+	}
+	if event.MessageUpdated != nil {
+		count++
+	}
+	if event.MessageInserted != nil {
+		count++
+	}
+	if event.MessagesDeleted != nil {
+		count++
+	}
+	if event.ModelContext != nil {
+		count++
+	}
+	if event.Rollback != nil {
+		count++
+	}
+	if event.Lifecycle != nil {
+		count++
+	}
+	if event.Error != nil {
+		count++
+	}
+	if event.Span != nil {
+		count++
+	}
+	if event.Cancel != nil {
+		count++
+	}
+	if event.Interrupt != nil {
+		count++
+	}
+	if event.Extension != nil {
+		count++
+	}
+	return count
+}
+
 func classifySpanSessionEvent(span *SpanEvent) (SessionEventKind, error) {
 	if (span.Model != nil) == (span.Tool != nil) {
 		return "", errors.New("span event must populate exactly one of Model or Tool")
@@ -814,12 +895,14 @@ func classifySpanSessionEvent(span *SpanEvent) (SessionEventKind, error) {
 
 // NormalizeSessionEventKind fills an empty Kind from the active payload and
 // rejects mismatches between Kind and payload shape.
+//
+// Unknown kinds (kinds not in the known set and not prefixed with "x.") with
+// no recognized payload are tolerated as a forward/backward compatibility
+// mechanism: legacy data (e.g. pre-refactor "turn_end") and events written by
+// newer code with kinds we don't yet understand are accepted as-is rather than
+// failing replay.
 func NormalizeSessionEventKind[M MessageType](event *SessionEvent[M]) error {
-	// Legacy compatibility: "turn_end" is the pre-refactor lifecycle event kind.
-	// Sessions persisted before the SessionRunState refactor may carry this kind
-	// on replay. Bypassing classification avoids failing on legacy data that has
-	// no active payload field matching any current kind.
-	if event != nil && event.Kind == "turn_end" {
+	if event != nil && event.Kind != "" && !isKnownSessionEventKind(event.Kind) && countActiveSessionEventPayloads(event) == 0 {
 		return nil
 	}
 	kind, err := ClassifySessionEvent(event)

--- a/adk/session.go
+++ b/adk/session.go
@@ -78,8 +78,8 @@ const (
 // session event log. Runner coordinates process-local single-writer access for
 // a session before calling AppendEvents.
 type SessionEventStore[M MessageType] interface {
-	LoadEvents(ctx context.Context, req *LoadSessionEventsRequest) (*LoadSessionEventsResult[M], error)
-	AppendEvents(ctx context.Context, req *AppendSessionEventsRequest[M]) error
+	LoadEvents(ctx context.Context, sessionID string, req *LoadSessionEventsRequest) (*LoadSessionEventsResult[M], error)
+	AppendEvents(ctx context.Context, sessionID string, events []*SessionEvent[M]) error
 }
 
 type openSessionRequest struct {
@@ -92,14 +92,12 @@ type openSessionResult[M MessageType] struct {
 
 type sessionHandle[M MessageType] interface {
 	loadEvents(ctx context.Context, req *LoadSessionEventsRequest) (*LoadSessionEventsResult[M], error)
-	appendEvents(ctx context.Context, req *AppendSessionEventsRequest[M]) error
+	appendEvents(ctx context.Context, events []*SessionEvent[M]) error
 	close(ctx context.Context) error
 }
 
 // LoadSessionEventsRequest configures typed event loading pagination and direction.
 type LoadSessionEventsRequest struct {
-	// SessionID identifies the session log to load.
-	SessionID string
 	// After is the last-seen event_id used as an exclusive append-position cursor.
 	After string
 	// Limit is the maximum number of events to return. 0 means no limit.
@@ -118,23 +116,13 @@ type LoadSessionEventsResult[M MessageType] struct {
 	Next string
 }
 
-type AppendSessionEventsRequest[M MessageType] struct {
-	// SessionID identifies the session log to append to.
-	SessionID string
-	// Events are appended as one batch. Each EventID must be non-empty and
-	// unique within the session.
-	Events []*SessionEvent[M]
-}
-
 // SessionEvent is the JSON-serializable persistence format for session events.
+// SessionEvent is session-local; stores receive the owning session id as a
+// first-class argument. The pair (session_id, event_id) globally identifies a
+// persisted event.
 // Exactly one semantic content field is active per event. The MessagesReplaced field
 // uses pointer-to-slice semantics (nil = absent, non-nil = active replacement).
 type SessionEvent[M MessageType] struct {
-	// SessionID identifies the session timeline this event belongs to. Runner-owned
-	// root events use the runner SessionID; nested AgentTool events use their
-	// synthetic child SessionID so live consumers can distinguish event ownership.
-	SessionID string `json:"session_id,omitempty"`
-
 	// EventID is the canonical, session-unique identity of this event.
 	// Assigned exactly once by the Runner at event materialization
 	// (in makeInputSessionEvent / toSessionEvent). Persister-level retries
@@ -173,9 +161,48 @@ type SessionEvent[M MessageType] struct {
 	Error     *SessionErrorEvent `json:"error,omitempty"`
 	Span      *SpanEvent         `json:"span,omitempty"`
 
-	UserObservation *UserObservationEvent  `json:"user_observation,omitempty"`
-	AgentInterrupt  *AgentInterruptEvent   `json:"agent_interrupt,omitempty"`
-	Extension       *SessionExtensionEvent `json:"extension,omitempty"`
+	Cancel    *CancelEvent           `json:"cancel,omitempty"`
+	Interrupt *InterruptEvent        `json:"interrupt,omitempty"`
+	Extension *SessionExtensionEvent `json:"extension,omitempty"`
+}
+
+// SessionEventVariant is the live AgentEvent envelope for session-related
+// metadata. SessionID is live ownership metadata only; it is intentionally not
+// part of durable SessionEvent payloads.
+type SessionEventVariant[M MessageType] struct {
+	SessionID string
+
+	Event            *SessionEvent[M]
+	MessageStreamRef *MessageStreamRef
+}
+
+func (v *SessionEventVariant[M]) IsEvent() bool {
+	return v != nil && v.Event != nil
+}
+
+func (v *SessionEventVariant[M]) IsMessageStream() bool {
+	return v != nil && v.MessageStreamRef != nil
+}
+
+func (v *SessionEventVariant[M]) GetEvent() *SessionEvent[M] {
+	if v == nil {
+		return nil
+	}
+	return v.Event
+}
+
+func (v *SessionEventVariant[M]) GetMessageStreamRef() *MessageStreamRef {
+	if v == nil {
+		return nil
+	}
+	return v.MessageStreamRef
+}
+
+type MessageStreamRef struct {
+	EventID   string
+	Timestamp time.Time
+	Kind      SessionEventKind
+	TurnID    string
 }
 
 type SessionEventKind string
@@ -190,18 +217,17 @@ const (
 	SessionEventModelContext            SessionEventKind = "model_context"
 	SessionEventRollback                SessionEventKind = "rollback"
 
-	SessionEventSessionStatusRunning     SessionEventKind = "session.status_running"
-	SessionEventSessionStatusIdle        SessionEventKind = "session.status_idle"
-	SessionEventSessionStatusRescheduled SessionEventKind = "session.status_rescheduled"
-	SessionEventSessionError             SessionEventKind = "session.error"
+	SessionEventSessionStatusRunning SessionEventKind = "session.status_running"
+	SessionEventSessionStatusIdle    SessionEventKind = "session.status_idle"
+	SessionEventSessionError         SessionEventKind = "session.error"
 
 	SessionEventSpanModelRequestStart SessionEventKind = "span.model_request_start"
 	SessionEventSpanModelRequestEnd   SessionEventKind = "span.model_request_end"
 	SessionEventSpanToolCallStart     SessionEventKind = "span.tool_call_start"
 	SessionEventSpanToolCallEnd       SessionEventKind = "span.tool_call_end"
 
-	SessionEventCancel         SessionEventKind = "cancel"
-	SessionEventAgentInterrupt SessionEventKind = "agent.interrupt"
+	SessionEventCancel    SessionEventKind = "cancel"
+	SessionEventInterrupt SessionEventKind = "interrupt"
 
 	SessionEventExtensionPrefix = "x."
 )
@@ -221,9 +247,8 @@ type SessionRollbackEvent struct {
 type SessionRunState string
 
 const (
-	SessionRunStateRunning     SessionRunState = "running"
-	SessionRunStateIdle        SessionRunState = "idle"
-	SessionRunStateRescheduled SessionRunState = "rescheduled"
+	SessionRunStateRunning SessionRunState = "running"
+	SessionRunStateIdle    SessionRunState = "idle"
 )
 
 type StopReason struct {
@@ -355,23 +380,19 @@ type ToolSpanMeta struct {
 	ToolResultMessageEventID string `json:"tool_result_message_event_id,omitempty"`
 }
 
-type UserObservationEvent struct {
-	Interrupt *UserInterruptEvent `json:"interrupt,omitempty"`
-}
-
-type UserInterruptEvent struct {
+type CancelEvent struct {
 	Reason string `json:"reason,omitempty"`
 }
 
-// AgentInterruptEvent records a business interrupt in the durable session timeline.
-type AgentInterruptEvent struct {
+// InterruptEvent records a business interrupt in the durable session timeline.
+type InterruptEvent struct {
 	// Contexts is the set of interrupt contexts that caused the agent to pause.
 	// Each element represents a single root-cause interrupt point.
-	Contexts []*AgentInterruptContext `json:"contexts,omitempty"`
+	Contexts []*InterruptContext `json:"contexts,omitempty"`
 }
 
-// AgentInterruptContext describes a single interrupt point within a batch.
-type AgentInterruptContext struct {
+// InterruptContext describes a single interrupt point within a batch.
+type InterruptContext struct {
 	// InterruptID is the fully-qualified address of the interrupt point
 	// (e.g. "agent:A;tool:lookup:call_1"). Use this as the key in ResumeParams.Targets.
 	InterruptID string `json:"interrupt_id,omitempty"`
@@ -432,8 +453,8 @@ type MessagesDeletedEvent struct {
 
 // SessionEventIDGenerator returns the EventID for a draft SessionEvent[M].
 //
-// Generators see the fully-populated draft (Kind, Message, Span, Extension,
-// SessionID, TurnID, ...) and may return a business-side identifier such as
+// Generators see the fully-populated session-local draft (Kind, Message, Span,
+// Extension, TurnID, ...) and may return a business-side identifier such as
 // the matching application order/job/result ID. When a generator does not
 // recognize a draft event, it should fall through to
 // DefaultSessionEventIDGenerator[M] rather than allocating a UUID directly,
@@ -513,10 +534,12 @@ func init() {
 	schema.RegisterName[*ModelTimeoutMeta]("_eino_adk_model_timeout_meta")
 	schema.RegisterName[*ModelUsage]("_eino_adk_model_usage")
 	schema.RegisterName[*ToolSpanMeta]("_eino_adk_tool_span_meta")
-	schema.RegisterName[*UserObservationEvent]("_eino_adk_user_observation_event")
-	schema.RegisterName[*UserInterruptEvent]("_eino_adk_user_interrupt_event")
-	schema.RegisterName[*AgentInterruptEvent]("_eino_adk_agent_interrupt_event")
-	schema.RegisterName[*AgentInterruptContext]("_eino_adk_agent_interrupt_context")
+	schema.RegisterName[*SessionEventVariant[*schema.Message]]("_eino_adk_session_event_variant")
+	schema.RegisterName[*SessionEventVariant[*schema.AgenticMessage]]("_eino_adk_agentic_session_event_variant")
+	schema.RegisterName[*MessageStreamRef]("_eino_adk_message_stream_ref")
+	schema.RegisterName[*CancelEvent]("_eino_adk_cancel_event")
+	schema.RegisterName[*InterruptEvent]("_eino_adk_interrupt_event")
+	schema.RegisterName[*InterruptContext]("_eino_adk_interrupt_context")
 	schema.RegisterName[*SessionExtensionEvent]("_eino_adk_session_extension_event")
 	schema.RegisterName[*SessionRollbackEvent]("_eino_adk_session_rollback_event")
 }
@@ -598,8 +621,7 @@ func makeInputSessionEvent[M MessageType](msg M) *SessionEvent[M] {
 }
 
 // toSessionEvent converts an internal TypedAgentEvent into the persistence format.
-// Returns nil if the event has no persistable content. Reuses event.EventID
-// allocated upstream by execCtx.send so live and persisted views share identity.
+// Returns nil if the event has no persistable content.
 func toSessionEvent[M MessageType](event *TypedAgentEvent[M]) *SessionEvent[M] {
 	se, _ := toSessionEventChecked(event)
 	return se
@@ -609,7 +631,7 @@ func toSessionEventChecked[M MessageType](event *TypedAgentEvent[M]) (*SessionEv
 	if event == nil {
 		return nil, nil
 	}
-	if event.SessionEvent != nil {
+	if event.SessionEventVariant != nil && event.SessionEventVariant.Event != nil {
 		se, err := normalizeAgentSessionEvent(event)
 		if err != nil {
 			return nil, err
@@ -619,7 +641,7 @@ func toSessionEventChecked[M MessageType](event *TypedAgentEvent[M]) (*SessionEv
 		}
 		return &se, nil
 	}
-	se := &SessionEvent[M]{Timestamp: event.Timestamp}
+	se := &SessionEvent[M]{Timestamp: newEventTimestamp()}
 	switch {
 	case event.Output != nil && event.Output.MessageOutput != nil:
 		if !isNilMessage(event.Output.MessageOutput.Message) {
@@ -631,11 +653,7 @@ func toSessionEventChecked[M MessageType](event *TypedAgentEvent[M]) (*SessionEv
 	default:
 		return nil, nil
 	}
-	if event.EventID != "" {
-		se.EventID = event.EventID
-	} else {
-		return nil, errors.New("persistable AgentEvent has empty EventID")
-	}
+	return nil, errors.New("persistable AgentEvent has no SessionEventVariant.Event")
 	return se, NormalizeSessionEventKind(se)
 }
 
@@ -653,22 +671,14 @@ func normalizeAgentSessionEventWithAssigner[M MessageType](
 	event *TypedAgentEvent[M],
 	assign func(*SessionEvent[M]) (string, error),
 ) (SessionEvent[M], error) {
-	if event == nil || event.SessionEvent == nil {
+	if event == nil || event.SessionEventVariant == nil || event.SessionEventVariant.Event == nil {
 		return SessionEvent[M]{}, errors.New("missing session event")
 	}
 	if assign == nil {
 		assign = func(*SessionEvent[M]) (string, error) { return uuid.NewString(), nil }
 	}
-	se := *event.SessionEvent
-	if event.EventID != "" && se.EventID != "" && event.EventID != se.EventID {
-		return SessionEvent[M]{}, fmt.Errorf("session event identity mismatch: agent event %q session event %q", event.EventID, se.EventID)
-	}
-	switch {
-	case event.EventID != "":
-		se.EventID = event.EventID
-	case se.EventID != "":
-		event.EventID = se.EventID
-	default:
+	se := *event.SessionEventVariant.Event
+	if se.EventID == "" {
 		id, err := assign(&se)
 		if err != nil {
 			return SessionEvent[M]{}, err
@@ -676,31 +686,24 @@ func normalizeAgentSessionEventWithAssigner[M MessageType](
 		if id == "" {
 			return SessionEvent[M]{}, ErrSessionEventIDGeneratorEmpty
 		}
-		event.EventID = id
 		se.EventID = id
 	}
-	switch {
-	case !event.Timestamp.IsZero() && se.Timestamp.IsZero():
-		se.Timestamp = event.Timestamp
-	case event.Timestamp.IsZero() && !se.Timestamp.IsZero():
-		event.Timestamp = se.Timestamp
-	case event.Timestamp.IsZero() && se.Timestamp.IsZero():
-		ts := newEventTimestamp()
-		event.Timestamp = ts
-		se.Timestamp = ts
+	if se.Timestamp.IsZero() {
+		se.Timestamp = newEventTimestamp()
 	}
-	event.EventID = se.EventID
-	event.Timestamp = se.Timestamp
-	event.SessionEvent = &se
+	event.SessionEventVariant.Event = &se
 	return se, nil
 }
 
 func validateAgentSessionEventIdentity[M MessageType](event *TypedAgentEvent[M]) error {
-	if event == nil || event.SessionEvent == nil {
+	if event == nil || event.SessionEventVariant == nil {
 		return nil
 	}
-	if event.EventID == "" || event.SessionEvent.EventID == "" || event.EventID != event.SessionEvent.EventID {
-		return fmt.Errorf("session event identity mismatch: agent event %q session event %q", event.EventID, event.SessionEvent.EventID)
+	if (event.SessionEventVariant.Event == nil) == (event.SessionEventVariant.MessageStreamRef == nil) {
+		return errors.New("session event variant must set exactly one payload")
+	}
+	if ref := event.SessionEventVariant.MessageStreamRef; ref != nil && ref.Kind != SessionEventMessage {
+		return fmt.Errorf("message stream ref kind must be %q, got %q", SessionEventMessage, ref.Kind)
 	}
 	return nil
 }
@@ -760,8 +763,6 @@ func ClassifySessionEvent[M MessageType](event *SessionEvent[M]) (SessionEventKi
 			add(SessionEventSessionStatusRunning)
 		case SessionRunStateIdle:
 			add(SessionEventSessionStatusIdle)
-		case SessionRunStateRescheduled:
-			add(SessionEventSessionStatusRescheduled)
 		default:
 			return "", fmt.Errorf("unknown lifecycle state %q", event.Lifecycle.State)
 		}
@@ -776,14 +777,11 @@ func ClassifySessionEvent[M MessageType](event *SessionEvent[M]) (SessionEventKi
 		}
 		add(kind)
 	}
-	if event.UserObservation != nil {
-		if event.UserObservation.Interrupt == nil {
-			return "", errors.New("user observation has no active payload")
-		}
+	if event.Cancel != nil {
 		add(SessionEventCancel)
 	}
-	if event.AgentInterrupt != nil {
-		add(SessionEventAgentInterrupt)
+	if event.Interrupt != nil {
+		add(SessionEventInterrupt)
 	}
 	if event.Extension != nil {
 		if event.Kind == "" {
@@ -865,7 +863,7 @@ func ValidateEmittedSessionEventKind[M MessageType](event *SessionEvent[M]) erro
 
 func isSessionDurableBoundaryKind(kind SessionEventKind) bool {
 	switch kind {
-	case SessionEventMessage, SessionEventSessionStatusIdle, SessionEventAgentInterrupt:
+	case SessionEventMessage, SessionEventSessionStatusIdle, SessionEventInterrupt:
 		return true
 	default:
 		return false
@@ -897,7 +895,7 @@ func normalizeSessionConfig[M MessageType](cfg *SessionConfig[M]) SessionConfig[
 // persisting the event.
 //
 // Callers MUST construct the draft with EventID == "" and populate every
-// other relevant field (SessionID, TurnID, Kind, payload, timestamp) so the
+// other relevant session-local field (TurnID, Kind, payload, timestamp) so the
 // generator sees a complete draft. A nil event is a no-op.
 //
 // On generator-side contract violations, the helper returns:
@@ -1046,10 +1044,7 @@ func (p *sessionEventPersister[M]) closeAndWait() error {
 }
 
 func (p *sessionEventPersister[M]) appendEvents(events []*SessionEvent[M]) error {
-	err := p.handle.appendEvents(p.ctx, &AppendSessionEventsRequest[M]{
-		SessionID: p.sessionID,
-		Events:    events,
-	})
+	err := p.handle.appendEvents(p.ctx, events)
 	if err != nil {
 		p.setErr(err)
 		return err
@@ -1078,11 +1073,11 @@ func stripSessionEventFields[M MessageType](event *TypedAgentEvent[M]) *TypedAge
 	if event == nil {
 		return nil
 	}
-	if event.SessionEvent == nil {
+	if event.SessionEventVariant == nil {
 		return event
 	}
 	stripped := *event
-	stripped.SessionEvent = nil
+	stripped.SessionEventVariant = nil
 	if stripped.Output == nil && stripped.Action == nil && stripped.Err == nil {
 		return nil
 	}
@@ -1261,7 +1256,7 @@ var sessionReplayEventKinds = []SessionEventKind{
 	SessionEventMessagesDeleted,
 	SessionEventModelContext,
 	SessionEventSessionStatusIdle,
-	SessionEventAgentInterrupt,
+	SessionEventInterrupt,
 	SessionEventCancel,
 	SessionEventRollback,
 }
@@ -1367,10 +1362,7 @@ func RollbackSession[M MessageType](
 	if err := assignSessionEventID(ctx, rb, cfg.EventIDGenerator); err != nil {
 		return err
 	}
-	if err := openResult.handle.appendEvents(ctx, &AppendSessionEventsRequest[M]{
-		SessionID: sessionID,
-		Events:    []*SessionEvent[M]{rb},
-	}); err != nil {
+	if err := openResult.handle.appendEvents(ctx, []*SessionEvent[M]{rb}); err != nil {
 		return err
 	}
 	if cfg.CheckPointStore != nil {
@@ -1420,11 +1412,10 @@ func loadActiveSessionEventsReverse[M MessageType](
 	var after string
 	for {
 		result, err := handle.loadEvents(ctx, &LoadSessionEventsRequest{
-			SessionID: sessionID,
-			After:     after,
-			Limit:     pageSize,
-			Reverse:   true,
-			Kinds:     sessionReplayEventKinds,
+			After:   after,
+			Limit:   pageSize,
+			Reverse: true,
+			Kinds:   sessionReplayEventKinds,
 		})
 		if err != nil {
 			return nil, err
@@ -1505,11 +1496,10 @@ func findPhysicalRollbackTargetEvidence[M MessageType](
 	var evidence rollbackTargetEvidence
 	for {
 		result, err := handle.loadEvents(ctx, &LoadSessionEventsRequest{
-			SessionID: sessionID,
-			After:     after,
-			Limit:     pageSize,
-			Reverse:   false,
-			Kinds:     sessionReplayEventKinds,
+			After:   after,
+			Limit:   pageSize,
+			Reverse: false,
+			Kinds:   sessionReplayEventKinds,
 		})
 		if err != nil {
 			return rollbackTargetEvidenceNone, err

--- a/adk/session.go
+++ b/adk/session.go
@@ -169,6 +169,11 @@ type SessionEvent[M MessageType] struct {
 // SessionEventVariant is the live AgentEvent envelope for session-related
 // metadata. SessionID is live ownership metadata only; it is intentionally not
 // part of durable SessionEvent payloads.
+//
+// Invariant: exactly one of Event or MessageStreamRef must be set.
+// Event carries a fully materialized SessionEvent; MessageStreamRef carries
+// only the reserved durable identity for a streaming message whose content
+// remains in Output.MessageOutput.MessageStream.
 type SessionEventVariant[M MessageType] struct {
 	SessionID string
 
@@ -176,38 +181,11 @@ type SessionEventVariant[M MessageType] struct {
 	MessageStreamRef *MessageStreamRef
 }
 
-// IsEvent returns true if the variant carries a materialized SessionEvent.
-func (v *SessionEventVariant[M]) IsEvent() bool {
-	return v != nil && v.Event != nil
-}
-
-// IsMessageStream returns true if the variant carries a streaming message reference.
-func (v *SessionEventVariant[M]) IsMessageStream() bool {
-	return v != nil && v.MessageStreamRef != nil
-}
-
-// GetEvent returns the materialized SessionEvent, or nil if the variant
-// carries a MessageStreamRef or is nil.
-func (v *SessionEventVariant[M]) GetEvent() *SessionEvent[M] {
-	if v == nil {
-		return nil
-	}
-	return v.Event
-}
-
-// GetMessageStreamRef returns the streaming message reference, or nil if the
-// variant carries a materialized SessionEvent or is nil.
-func (v *SessionEventVariant[M]) GetMessageStreamRef() *MessageStreamRef {
-	if v == nil {
-		return nil
-	}
-	return v.MessageStreamRef
-}
-
 // MessageStreamRef carries the durable identity metadata for a streaming
 // message whose content remains in Output.MessageOutput.MessageStream. It is
-// carried by SessionEventVariant for live events and materialized into a full
-// SessionEvent when the stream prefix is persisted.
+// carried by SessionEventVariant for live events. The runner later reuses this
+// identity when it drains its persistence copy of the stream and writes the
+// resulting message as a SessionEvent.
 type MessageStreamRef struct {
 	EventID   string
 	Timestamp time.Time
@@ -837,6 +815,10 @@ func classifySpanSessionEvent(span *SpanEvent) (SessionEventKind, error) {
 // NormalizeSessionEventKind fills an empty Kind from the active payload and
 // rejects mismatches between Kind and payload shape.
 func NormalizeSessionEventKind[M MessageType](event *SessionEvent[M]) error {
+	// Legacy compatibility: "turn_end" is the pre-refactor lifecycle event kind.
+	// Sessions persisted before the SessionRunState refactor may carry this kind
+	// on replay. Bypassing classification avoids failing on legacy data that has
+	// no active payload field matching any current kind.
 	if event != nil && event.Kind == "turn_end" {
 		return nil
 	}

--- a/adk/session.go
+++ b/adk/session.go
@@ -176,14 +176,18 @@ type SessionEventVariant[M MessageType] struct {
 	MessageStreamRef *MessageStreamRef
 }
 
+// IsEvent returns true if the variant carries a materialized SessionEvent.
 func (v *SessionEventVariant[M]) IsEvent() bool {
 	return v != nil && v.Event != nil
 }
 
+// IsMessageStream returns true if the variant carries a streaming message reference.
 func (v *SessionEventVariant[M]) IsMessageStream() bool {
 	return v != nil && v.MessageStreamRef != nil
 }
 
+// GetEvent returns the materialized SessionEvent, or nil if the variant
+// carries a MessageStreamRef or is nil.
 func (v *SessionEventVariant[M]) GetEvent() *SessionEvent[M] {
 	if v == nil {
 		return nil
@@ -191,6 +195,8 @@ func (v *SessionEventVariant[M]) GetEvent() *SessionEvent[M] {
 	return v.Event
 }
 
+// GetMessageStreamRef returns the streaming message reference, or nil if the
+// variant carries a materialized SessionEvent or is nil.
 func (v *SessionEventVariant[M]) GetMessageStreamRef() *MessageStreamRef {
 	if v == nil {
 		return nil
@@ -198,6 +204,10 @@ func (v *SessionEventVariant[M]) GetMessageStreamRef() *MessageStreamRef {
 	return v.MessageStreamRef
 }
 
+// MessageStreamRef carries the durable identity metadata for a streaming
+// message whose content remains in Output.MessageOutput.MessageStream. It is
+// carried by SessionEventVariant for live events and materialized into a full
+// SessionEvent when the stream prefix is persisted.
 type MessageStreamRef struct {
 	EventID   string
 	Timestamp time.Time
@@ -380,6 +390,7 @@ type ToolSpanMeta struct {
 	ToolResultMessageEventID string `json:"tool_result_message_event_id,omitempty"`
 }
 
+// CancelEvent records a user-initiated cancellation in the durable session timeline.
 type CancelEvent struct {
 	Reason string `json:"reason,omitempty"`
 }
@@ -641,20 +652,11 @@ func toSessionEventChecked[M MessageType](event *TypedAgentEvent[M]) (*SessionEv
 		}
 		return &se, nil
 	}
-	se := &SessionEvent[M]{Timestamp: newEventTimestamp()}
-	switch {
-	case event.Output != nil && event.Output.MessageOutput != nil:
-		if !isNilMessage(event.Output.MessageOutput.Message) {
-			se.Kind = SessionEventMessage
-			se.Message = event.Output.MessageOutput.Message
-		} else {
-			return nil, nil
-		}
-	default:
-		return nil, nil
+	if event.Output != nil && event.Output.MessageOutput != nil &&
+		!isNilMessage(event.Output.MessageOutput.Message) {
+		return nil, errors.New("persistable AgentEvent has no SessionEventVariant.Event")
 	}
-	return nil, errors.New("persistable AgentEvent has no SessionEventVariant.Event")
-	return se, NormalizeSessionEventKind(se)
+	return nil, nil
 }
 
 func normalizeAgentSessionEvent[M MessageType](event *TypedAgentEvent[M]) (SessionEvent[M], error) {

--- a/adk/session.go
+++ b/adk/session.go
@@ -554,9 +554,10 @@ func init() {
 	schema.RegisterName[*ModelTimeoutMeta]("_eino_adk_model_timeout_meta")
 	schema.RegisterName[*ModelUsage]("_eino_adk_model_usage")
 	schema.RegisterName[*ToolSpanMeta]("_eino_adk_tool_span_meta")
-	schema.RegisterName[*SessionEventVariant[*schema.Message]]("_eino_adk_session_event_variant")
-	schema.RegisterName[*SessionEventVariant[*schema.AgenticMessage]]("_eino_adk_agentic_session_event_variant")
-	schema.RegisterName[*MessageStreamRef]("_eino_adk_message_stream_ref")
+	// Note: SessionEventVariant and MessageStreamRef are not registered here
+	// because they never reach a serializer: checkpoint sanitizers strip
+	// SessionEventVariant before gob encoding, and the store serializer only
+	// encodes *SessionEvent[M] (the materialized form, not the variant).
 	schema.RegisterName[*CancelEvent]("_eino_adk_cancel_event")
 	schema.RegisterName[*InterruptEvent]("_eino_adk_interrupt_event")
 	schema.RegisterName[*InterruptContext]("_eino_adk_interrupt_context")

--- a/adk/session/conformance.go
+++ b/adk/session/conformance.go
@@ -87,7 +87,7 @@ func RunSerializerConformanceTests[M adk.MessageType](
 			t.Fatalf("custom serializer Marshal was not called")
 		}
 
-		res, err := store.LoadEvents(ctx, &adk.LoadSessionEventsRequest{SessionID: "s"})
+		res, err := store.LoadEvents(ctx, "s", &adk.LoadSessionEventsRequest{})
 		requireNoError(t, err)
 		if serializer.unmarshalCount == 0 {
 			t.Fatalf("custom serializer Unmarshal was not called")
@@ -106,7 +106,7 @@ func testAppendAndForwardLoad[M adk.MessageType](t *testing.T, factory func(test
 	appendEvents(t, ctx, store, "s", first, second)
 	appendEvents(t, ctx, store, "s", third)
 
-	res, err := store.LoadEvents(ctx, &adk.LoadSessionEventsRequest{SessionID: "s"})
+	res, err := store.LoadEvents(ctx, "s", &adk.LoadSessionEventsRequest{})
 	requireNoError(t, err)
 	if res == nil {
 		t.Fatalf("LoadEvents returned nil result")
@@ -123,9 +123,8 @@ func testExtensionKindFilter[M adk.MessageType](t *testing.T, factory func(testi
 	third := extensionEvent[M]("custom-2", "x.conformance.custom")
 	appendEvents(t, ctx, store, "s", first, second, third)
 
-	res, err := store.LoadEvents(ctx, &adk.LoadSessionEventsRequest{
-		SessionID: "s",
-		Kinds:     []adk.SessionEventKind{adk.SessionEventKind("x.conformance.custom")},
+	res, err := store.LoadEvents(ctx, "s", &adk.LoadSessionEventsRequest{
+		Kinds: []adk.SessionEventKind{adk.SessionEventKind("x.conformance.custom")},
 	})
 	requireNoError(t, err)
 	if res == nil {
@@ -147,11 +146,10 @@ func testReversePagination[M adk.MessageType](t *testing.T, factory func(testing
 	var collected []string
 	var after string
 	for {
-		res, err := store.LoadEvents(ctx, &adk.LoadSessionEventsRequest{
-			SessionID: "s",
-			Reverse:   true,
-			Limit:     2,
-			After:     after,
+		res, err := store.LoadEvents(ctx, "s", &adk.LoadSessionEventsRequest{
+			Reverse: true,
+			Limit:   2,
+			After:   after,
 		})
 		requireNoError(t, err)
 		if res == nil || len(res.Events) == 0 {
@@ -187,9 +185,9 @@ func testForwardPagination[M adk.MessageType](t *testing.T, factory func(testing
 	}
 
 	var collected []*adk.SessionEvent[M]
-	req := &adk.LoadSessionEventsRequest{SessionID: "s", Limit: 10}
+	req := &adk.LoadSessionEventsRequest{Limit: 10}
 	for {
-		res, err := store.LoadEvents(ctx, req)
+		res, err := store.LoadEvents(ctx, "s", req)
 		requireNoError(t, err)
 		if res == nil || len(res.Events) == 0 {
 			break
@@ -198,7 +196,7 @@ func testForwardPagination[M adk.MessageType](t *testing.T, factory func(testing
 		if res.Next == "" {
 			break
 		}
-		req = &adk.LoadSessionEventsRequest{SessionID: "s", Limit: 10, After: res.Next}
+		req = &adk.LoadSessionEventsRequest{Limit: 10, After: res.Next}
 	}
 	if len(collected) != 80 {
 		t.Fatalf("expected 80 events, got %d", len(collected))
@@ -220,11 +218,11 @@ func testSessionIsolation[M adk.MessageType](t *testing.T, factory func(testing.
 	appendEvents(t, ctx, store, "alpha", alpha)
 	appendEvents(t, ctx, store, "beta", beta)
 
-	alphaRes, err := store.LoadEvents(ctx, &adk.LoadSessionEventsRequest{SessionID: "alpha"})
+	alphaRes, err := store.LoadEvents(ctx, "alpha", &adk.LoadSessionEventsRequest{})
 	requireNoError(t, err)
 	requireEventsEqual(t, []*adk.SessionEvent[M]{alpha}, alphaRes.Events)
 
-	betaRes, err := store.LoadEvents(ctx, &adk.LoadSessionEventsRequest{SessionID: "beta"})
+	betaRes, err := store.LoadEvents(ctx, "beta", &adk.LoadSessionEventsRequest{})
 	requireNoError(t, err)
 	requireEventsEqual(t, []*adk.SessionEvent[M]{beta}, betaRes.Events)
 }
@@ -233,7 +231,7 @@ func testEmptySession[M adk.MessageType](t *testing.T, factory func(testing.TB) 
 	store := newStore(t, factory)
 	ctx := context.Background()
 
-	res, err := store.LoadEvents(ctx, &adk.LoadSessionEventsRequest{SessionID: "nonexistent"})
+	res, err := store.LoadEvents(ctx, "nonexistent", &adk.LoadSessionEventsRequest{})
 	requireNoError(t, err)
 	if res != nil && len(res.Events) != 0 {
 		t.Fatalf("expected empty result for nonexistent session, got %d events", len(res.Events))
@@ -247,12 +245,12 @@ func testRejectDuplicateEventID[M adk.MessageType](t *testing.T, factory func(te
 	first := messageEvent("dup-1", makeMessage("first"))
 	dup := messageEvent("dup-1", makeMessage("second"))
 	appendEvents(t, ctx, store, "s", first)
-	err := store.AppendEvents(ctx, &adk.AppendSessionEventsRequest[M]{SessionID: "s", Events: []*adk.SessionEvent[M]{dup}})
+	err := store.AppendEvents(ctx, "s", []*adk.SessionEvent[M]{dup})
 	if !errors.Is(err, adk.ErrDuplicateEventID) {
 		t.Fatalf("expected ErrDuplicateEventID, got %v", err)
 	}
 
-	res, err := store.LoadEvents(ctx, &adk.LoadSessionEventsRequest{SessionID: "s"})
+	res, err := store.LoadEvents(ctx, "s", &adk.LoadSessionEventsRequest{})
 	requireNoError(t, err)
 	requireEventsEqual(t, []*adk.SessionEvent[M]{first}, res.Events)
 }
@@ -263,12 +261,12 @@ func testRejectDuplicateEventIDWithinBatch[M adk.MessageType](t *testing.T, fact
 
 	first := messageEvent("dup-batch-1", makeMessage("first"))
 	dup := messageEvent("dup-batch-1", makeMessage("second"))
-	err := store.AppendEvents(ctx, &adk.AppendSessionEventsRequest[M]{SessionID: "s", Events: []*adk.SessionEvent[M]{first, dup}})
+	err := store.AppendEvents(ctx, "s", []*adk.SessionEvent[M]{first, dup})
 	if !errors.Is(err, adk.ErrDuplicateEventID) {
 		t.Fatalf("expected ErrDuplicateEventID, got %v", err)
 	}
 
-	res, err := store.LoadEvents(ctx, &adk.LoadSessionEventsRequest{SessionID: "s"})
+	res, err := store.LoadEvents(ctx, "s", &adk.LoadSessionEventsRequest{})
 	requireNoError(t, err)
 	requireEventsEqual(t, nil, res.Events)
 }
@@ -277,10 +275,7 @@ func testRejectEmptyEventID[M adk.MessageType](t *testing.T, factory func(testin
 	store := newStore(t, factory)
 	ctx := context.Background()
 
-	err := store.AppendEvents(ctx, &adk.AppendSessionEventsRequest[M]{
-		SessionID: "s",
-		Events:    []*adk.SessionEvent[M]{{Kind: adk.SessionEventMessage, Message: makeMessage("empty")}},
-	})
+	err := store.AppendEvents(ctx, "s", []*adk.SessionEvent[M]{{Kind: adk.SessionEventMessage, Message: makeMessage("empty")}})
 	if !errors.Is(err, adk.ErrInvalidEventID) {
 		t.Fatalf("expected ErrInvalidEventID, got %v", err)
 	}
@@ -296,7 +291,7 @@ func testAfterForward[M adk.MessageType](t *testing.T, factory func(testing.TB) 
 		appendEvents(t, ctx, store, "s", events[i])
 	}
 
-	res, err := store.LoadEvents(ctx, &adk.LoadSessionEventsRequest{SessionID: "s", After: "fwd-2"})
+	res, err := store.LoadEvents(ctx, "s", &adk.LoadSessionEventsRequest{After: "fwd-2"})
 	requireNoError(t, err)
 	requireEventsEqual(t, []*adk.SessionEvent[M]{events[3], events[4]}, res.Events)
 }
@@ -311,7 +306,7 @@ func testAfterReverse[M adk.MessageType](t *testing.T, factory func(testing.TB) 
 		appendEvents(t, ctx, store, "s", events[i])
 	}
 
-	res, err := store.LoadEvents(ctx, &adk.LoadSessionEventsRequest{SessionID: "s", Reverse: true, After: "rev-2"})
+	res, err := store.LoadEvents(ctx, "s", &adk.LoadSessionEventsRequest{Reverse: true, After: "rev-2"})
 	requireNoError(t, err)
 	requireEventsEqual(t, []*adk.SessionEvent[M]{events[1], events[0]}, res.Events)
 }
@@ -322,11 +317,11 @@ func testUnknownAfter[M adk.MessageType](t *testing.T, factory func(testing.TB) 
 
 	appendEvents(t, ctx, store, "s", messageEvent("only-1", makeMessage("only")))
 
-	_, err := store.LoadEvents(ctx, &adk.LoadSessionEventsRequest{SessionID: "s", After: "ghost"})
+	_, err := store.LoadEvents(ctx, "s", &adk.LoadSessionEventsRequest{After: "ghost"})
 	if !errors.Is(err, adk.ErrEventIDOutOfRange) {
 		t.Fatalf("forward unknown After expected ErrEventIDOutOfRange, got %v", err)
 	}
-	_, err = store.LoadEvents(ctx, &adk.LoadSessionEventsRequest{SessionID: "s", After: "ghost", Reverse: true})
+	_, err = store.LoadEvents(ctx, "s", &adk.LoadSessionEventsRequest{After: "ghost", Reverse: true})
 	if !errors.Is(err, adk.ErrEventIDOutOfRange) {
 		t.Fatalf("reverse unknown After expected ErrEventIDOutOfRange, got %v", err)
 	}
@@ -341,13 +336,13 @@ func testEmptyPageBoundary[M adk.MessageType](t *testing.T, factory func(testing
 		appendEvents(t, ctx, store, "s", messageEvent(id, makeMessage(id)))
 	}
 
-	res, err := store.LoadEvents(ctx, &adk.LoadSessionEventsRequest{SessionID: "s", After: "e2"})
+	res, err := store.LoadEvents(ctx, "s", &adk.LoadSessionEventsRequest{After: "e2"})
 	requireNoError(t, err)
 	if res == nil || len(res.Events) != 0 || res.Next != "" {
 		t.Fatalf("forward empty page expected, got events=%d next=%q", len(res.Events), res.Next)
 	}
 
-	res, err = store.LoadEvents(ctx, &adk.LoadSessionEventsRequest{SessionID: "s", Reverse: true, After: "e0"})
+	res, err = store.LoadEvents(ctx, "s", &adk.LoadSessionEventsRequest{Reverse: true, After: "e0"})
 	requireNoError(t, err)
 	if res == nil || len(res.Events) != 0 || res.Next != "" {
 		t.Fatalf("reverse empty page expected, got events=%d next=%q", len(res.Events), res.Next)
@@ -361,7 +356,7 @@ func testEventBodyRoundTrip[M adk.MessageType](t *testing.T, factory func(testin
 	event := messageEvent("body-test-1", makeMessage("body"))
 	appendEvents(t, ctx, store, "s", event)
 
-	res, err := store.LoadEvents(ctx, &adk.LoadSessionEventsRequest{SessionID: "s"})
+	res, err := store.LoadEvents(ctx, "s", &adk.LoadSessionEventsRequest{})
 	requireNoError(t, err)
 	if res == nil || len(res.Events) != 1 {
 		t.Fatalf("expected 1 event, got %d", len(res.Events))
@@ -380,7 +375,7 @@ func newStore[M adk.MessageType](t testing.TB, factory func(testing.TB) adk.Sess
 
 func appendEvents[M adk.MessageType](t testing.TB, ctx context.Context, store adk.SessionEventStore[M], sessionID string, events ...*adk.SessionEvent[M]) {
 	t.Helper()
-	err := store.AppendEvents(ctx, &adk.AppendSessionEventsRequest[M]{SessionID: sessionID, Events: events})
+	err := store.AppendEvents(ctx, sessionID, events)
 	requireNoError(t, err)
 }
 

--- a/adk/session/file_store.go
+++ b/adk/session/file_store.go
@@ -107,14 +107,9 @@ func errorsNewEmptySessionID() error {
 // AppendEvents appends events to the session's event log.
 //
 // Each SessionEvent.EventID MUST be non-empty. Duplicate event IDs are rejected.
-func (s *FileStore[M]) AppendEvents(_ context.Context, req *adk.AppendSessionEventsRequest[M]) error {
+func (s *FileStore[M]) AppendEvents(_ context.Context, sessionID string, events []*adk.SessionEvent[M]) error {
 	s.mu.Lock()
 	defer s.mu.Unlock()
-	if req == nil {
-		req = &adk.AppendSessionEventsRequest[M]{}
-	}
-	sessionID := req.SessionID
-	events := req.Events
 
 	path, err := s.sessionPath(sessionID)
 	if err != nil {
@@ -186,13 +181,12 @@ func (s *FileStore[M]) AppendEvents(_ context.Context, req *adk.AppendSessionEve
 }
 
 // LoadEvents loads events with pagination and direction support.
-func (s *FileStore[M]) LoadEvents(_ context.Context, opts *adk.LoadSessionEventsRequest) (*adk.LoadSessionEventsResult[M], error) {
+func (s *FileStore[M]) LoadEvents(_ context.Context, sessionID string, opts *adk.LoadSessionEventsRequest) (*adk.LoadSessionEventsResult[M], error) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	if opts == nil {
 		opts = &adk.LoadSessionEventsRequest{}
 	}
-	sessionID := opts.SessionID
 	path, err := s.sessionPath(sessionID)
 	if err != nil {
 		return nil, err

--- a/adk/session/file_store_test.go
+++ b/adk/session/file_store_test.go
@@ -58,12 +58,12 @@ func TestFileStorePersistsAcrossInstances(t *testing.T) {
 
 	first := testMessageEvent("persist-1", "first")
 	second := testCommittedIdleEvent("persist-2", "turn-1")
-	err = store.AppendEvents(ctx, &adk.AppendSessionEventsRequest[*schema.Message]{SessionID: "s", Events: []*adk.SessionEvent[*schema.Message]{first, second}})
+	err = store.AppendEvents(ctx, "s", []*adk.SessionEvent[*schema.Message]{first, second})
 	require.NoError(t, err)
 
 	reopened, err := session.NewFileStore[*schema.Message](dir, nil)
 	require.NoError(t, err)
-	res, err := reopened.LoadEvents(ctx, &adk.LoadSessionEventsRequest{SessionID: "s"})
+	res, err := reopened.LoadEvents(ctx, "s", &adk.LoadSessionEventsRequest{})
 	require.NoError(t, err)
 	require.Len(t, res.Events, 2)
 	assert.Equal(t, "persist-1", res.Events[0].EventID)
@@ -78,7 +78,7 @@ func TestFileStoreWritesHumanReadableEvlogLines(t *testing.T) {
 
 	first := testMessageEvent("line-1", "first")
 	second := testCommittedIdleEvent("line-2", "turn-1")
-	err = store.AppendEvents(ctx, &adk.AppendSessionEventsRequest[*schema.Message]{SessionID: "s", Events: []*adk.SessionEvent[*schema.Message]{first, second}})
+	err = store.AppendEvents(ctx, "s", []*adk.SessionEvent[*schema.Message]{first, second})
 	require.NoError(t, err)
 
 	data, err := os.ReadFile(filepath.Join(dir, url.PathEscape("s")+".evlog"))
@@ -105,17 +105,17 @@ func TestFileStoreRollbackPreservesPhysicalAuditLog(t *testing.T) {
 	require.NoError(t, err)
 	sessionID := "rollback-audit"
 
-	err = store.AppendEvents(ctx, &adk.AppendSessionEventsRequest[*schema.Message]{SessionID: sessionID, Events: []*adk.SessionEvent[*schema.Message]{
+	err = store.AppendEvents(ctx, sessionID, []*adk.SessionEvent[*schema.Message]{
 		withTurn(testMessageEvent("msg-1", "Q1"), "turn-1"),
 		testCommittedIdleEvent("end-1", "turn-1"),
 		withTurn(testMessageEvent("msg-2", "Q2"), "turn-2"),
 		testCommittedIdleEvent("end-2", "turn-2"),
-	}})
+	})
 	require.NoError(t, err)
 
 	require.NoError(t, adk.RollbackSession[*schema.Message](ctx, store, sessionID, "turn-1"))
 
-	res, err := store.LoadEvents(ctx, &adk.LoadSessionEventsRequest{SessionID: sessionID})
+	res, err := store.LoadEvents(ctx, sessionID, &adk.LoadSessionEventsRequest{})
 	require.NoError(t, err)
 	require.Len(t, res.Events, 5)
 	assert.Equal(t, "msg-2", res.Events[2].EventID)
@@ -142,7 +142,7 @@ func TestFileStoreRejectsSerializerRawLineDelimiters(t *testing.T) {
 	})
 	require.NoError(t, err)
 
-	err = store.AppendEvents(ctx, &adk.AppendSessionEventsRequest[*schema.Message]{SessionID: "s", Events: []*adk.SessionEvent[*schema.Message]{testMessageEvent("bad", "bad")}})
+	err = store.AppendEvents(ctx, "s", []*adk.SessionEvent[*schema.Message]{testMessageEvent("bad", "bad")})
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "without raw CR/LF")
 }
@@ -156,7 +156,7 @@ func TestFileStoreAppendFailsOnCorruptedExistingLog(t *testing.T) {
 	path := filepath.Join(dir, url.PathEscape("s")+".evlog")
 	require.NoError(t, os.WriteFile(path, []byte("corrupted-no-tab\n"), 0o644))
 
-	err = store.AppendEvents(ctx, &adk.AppendSessionEventsRequest[*schema.Message]{SessionID: "s", Events: []*adk.SessionEvent[*schema.Message]{testMessageEvent("new", "new")}})
+	err = store.AppendEvents(ctx, "s", []*adk.SessionEvent[*schema.Message]{testMessageEvent("new", "new")})
 	require.Error(t, err)
 	assert.True(t, errors.Is(err, adk.ErrInvalidEventID))
 }
@@ -168,10 +168,10 @@ func TestFileStoreEscapedSessionIDPath(t *testing.T) {
 	require.NoError(t, err)
 
 	sessionID := "a/b %snow"
-	err = store.AppendEvents(ctx, &adk.AppendSessionEventsRequest[*schema.Message]{SessionID: sessionID, Events: []*adk.SessionEvent[*schema.Message]{testMessageEvent("escaped", "ok")}})
+	err = store.AppendEvents(ctx, sessionID, []*adk.SessionEvent[*schema.Message]{testMessageEvent("escaped", "ok")})
 	require.NoError(t, err)
 
-	res, err := store.LoadEvents(ctx, &adk.LoadSessionEventsRequest{SessionID: sessionID})
+	res, err := store.LoadEvents(ctx, sessionID, &adk.LoadSessionEventsRequest{})
 	require.NoError(t, err)
 	require.Len(t, res.Events, 1)
 	assert.Equal(t, "escaped", res.Events[0].EventID)
@@ -195,9 +195,9 @@ func TestFileStoreValidationReplayAndReversePagination(t *testing.T) {
 	require.NoError(t, err)
 	assert.NotNil(t, service)
 
-	require.Error(t, store.AppendEvents(ctx, nil))
+	require.Error(t, store.AppendEvents(ctx, "", nil))
 
-	empty, err := store.LoadEvents(ctx, &adk.LoadSessionEventsRequest{SessionID: "empty", Reverse: true})
+	empty, err := store.LoadEvents(ctx, "empty", &adk.LoadSessionEventsRequest{Reverse: true})
 	require.NoError(t, err)
 	assert.Empty(t, empty.Events)
 
@@ -206,54 +206,40 @@ func TestFileStoreValidationReplayAndReversePagination(t *testing.T) {
 		testSpanEvent("e2"),
 		testCommittedIdleEvent("e3", "turn-1"),
 	}
-	err = store.AppendEvents(ctx, &adk.AppendSessionEventsRequest[*schema.Message]{
-		SessionID: "s",
-		Events:    events,
-	})
+	err = store.AppendEvents(ctx, "s", events)
 	require.NoError(t, err)
 
-	err = store.AppendEvents(ctx, &adk.AppendSessionEventsRequest[*schema.Message]{
-		SessionID: "s",
-		Events:    []*adk.SessionEvent[*schema.Message]{testMessageEvent("e4", "four")},
-	})
+	err = store.AppendEvents(ctx, "s", []*adk.SessionEvent[*schema.Message]{testMessageEvent("e4", "four")})
 	require.NoError(t, err)
 
-	err = store.AppendEvents(ctx, &adk.AppendSessionEventsRequest[*schema.Message]{
-		SessionID: "s",
-		Events:    []*adk.SessionEvent[*schema.Message]{testMessageEvent("e1", "duplicate existing")},
+	err = store.AppendEvents(ctx, "s", []*adk.SessionEvent[*schema.Message]{testMessageEvent("e1", "duplicate existing")})
+	require.ErrorIs(t, err, adk.ErrDuplicateEventID)
+
+	err = store.AppendEvents(ctx, "s2", []*adk.SessionEvent[*schema.Message]{
+		testMessageEvent("dup", "one"),
+		testMessageEvent("dup", "two"),
 	})
 	require.ErrorIs(t, err, adk.ErrDuplicateEventID)
 
-	err = store.AppendEvents(ctx, &adk.AppendSessionEventsRequest[*schema.Message]{
-		SessionID: "s2",
-		Events: []*adk.SessionEvent[*schema.Message]{
-			testMessageEvent("dup", "one"),
-			testMessageEvent("dup", "two"),
-		},
-	})
-	require.ErrorIs(t, err, adk.ErrDuplicateEventID)
-
-	_, err = store.LoadEvents(ctx, &adk.LoadSessionEventsRequest{SessionID: "s", After: "missing"})
+	_, err = store.LoadEvents(ctx, "s", &adk.LoadSessionEventsRequest{After: "missing"})
 	require.ErrorIs(t, err, adk.ErrEventIDOutOfRange)
-	_, err = store.LoadEvents(ctx, &adk.LoadSessionEventsRequest{SessionID: "s", Reverse: true, After: "missing"})
+	_, err = store.LoadEvents(ctx, "s", &adk.LoadSessionEventsRequest{Reverse: true, After: "missing"})
 	require.ErrorIs(t, err, adk.ErrEventIDOutOfRange)
 
-	forward, err := store.LoadEvents(ctx, &adk.LoadSessionEventsRequest{
-		SessionID: "s",
-		After:     "e1",
-		Kinds:     []adk.SessionEventKind{adk.SessionEventSessionStatusIdle, adk.SessionEventMessage},
-		Limit:     1,
+	forward, err := store.LoadEvents(ctx, "s", &adk.LoadSessionEventsRequest{
+		After: "e1",
+		Kinds: []adk.SessionEventKind{adk.SessionEventSessionStatusIdle, adk.SessionEventMessage},
+		Limit: 1,
 	})
 	require.NoError(t, err)
 	require.Len(t, forward.Events, 1)
 	assert.Equal(t, "e3", forward.Events[0].EventID)
 	assert.Equal(t, "e3", forward.Next)
 
-	reverse, err := store.LoadEvents(ctx, &adk.LoadSessionEventsRequest{
-		SessionID: "s",
-		Reverse:   true,
-		After:     "e4",
-		Limit:     1,
+	reverse, err := store.LoadEvents(ctx, "s", &adk.LoadSessionEventsRequest{
+		Reverse: true,
+		After:   "e4",
+		Limit:   1,
 	})
 	require.NoError(t, err)
 	require.Len(t, reverse.Events, 1)
@@ -281,14 +267,14 @@ func TestFileStoreRejectsCorruptedRecordsOnIndexRebuild(t *testing.T) {
 			require.NoError(t, err)
 
 			if name == "empty session id" {
-				_, err = store.LoadEvents(ctx, &adk.LoadSessionEventsRequest{})
+				_, err = store.LoadEvents(ctx, "", &adk.LoadSessionEventsRequest{})
 				require.Error(t, err)
 				return
 			}
 
 			path := filepath.Join(dir, url.PathEscape("s")+".evlog")
 			require.NoError(t, os.WriteFile(path, []byte(content), 0o644))
-			_, err = store.LoadEvents(ctx, &adk.LoadSessionEventsRequest{SessionID: "s"})
+			_, err = store.LoadEvents(ctx, "s", &adk.LoadSessionEventsRequest{})
 			require.Error(t, err)
 		})
 	}

--- a/adk/session/in_memory_store.go
+++ b/adk/session/in_memory_store.go
@@ -64,14 +64,9 @@ func NewInMemoryStore[M adk.MessageType](cfg *InMemoryStoreConfig) *InMemoryStor
 }
 
 // AppendEvents appends events to the session's event log.
-func (s *InMemoryStore[M]) AppendEvents(_ context.Context, req *adk.AppendSessionEventsRequest[M]) error {
+func (s *InMemoryStore[M]) AppendEvents(_ context.Context, sessionID string, events []*adk.SessionEvent[M]) error {
 	s.mu.Lock()
 	defer s.mu.Unlock()
-	if req == nil {
-		req = &adk.AppendSessionEventsRequest[M]{}
-	}
-	sessionID := req.SessionID
-	events := req.Events
 	idx, ok := s.eventIDIdx[sessionID]
 	if !ok {
 		idx = make(map[string]int)
@@ -113,15 +108,13 @@ func (s *InMemoryStore[M]) AppendEvents(_ context.Context, req *adk.AppendSessio
 }
 
 // LoadEvents loads events with pagination and direction support.
-func (s *InMemoryStore[M]) LoadEvents(_ context.Context, opts *adk.LoadSessionEventsRequest) (*adk.LoadSessionEventsResult[M], error) {
+func (s *InMemoryStore[M]) LoadEvents(_ context.Context, sessionID string, opts *adk.LoadSessionEventsRequest) (*adk.LoadSessionEventsResult[M], error) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
 	if opts == nil {
 		opts = &adk.LoadSessionEventsRequest{}
 	}
-	sessionID := opts.SessionID
-
 	if opts.Reverse {
 		return s.loadReverse(sessionID, opts)
 	}

--- a/adk/session/in_memory_store_test.go
+++ b/adk/session/in_memory_store_test.go
@@ -77,14 +77,13 @@ func TestInMemoryStoreKindFilterAndPagination(t *testing.T) {
 		testCommittedIdleEvent("e3", "turn-1"),
 		testMessageEvent("e4", "four"),
 	}
-	err := store.AppendEvents(ctx, &adk.AppendSessionEventsRequest[*schema.Message]{SessionID: "s", Events: events})
+	err := store.AppendEvents(ctx, "s", events)
 	require.NoError(t, err)
 
-	res, err := store.LoadEvents(ctx, &adk.LoadSessionEventsRequest{
-		SessionID: "s",
-		After:     "e2",
-		Kinds:     []adk.SessionEventKind{adk.SessionEventMessage, adk.SessionEventSessionStatusIdle},
-		Limit:     1,
+	res, err := store.LoadEvents(ctx, "s", &adk.LoadSessionEventsRequest{
+		After: "e2",
+		Kinds: []adk.SessionEventKind{adk.SessionEventMessage, adk.SessionEventSessionStatusIdle},
+		Limit: 1,
 	})
 	require.NoError(t, err)
 	require.Len(t, res.Events, 1)
@@ -95,16 +94,16 @@ func TestInMemoryStoreKindFilterAndPagination(t *testing.T) {
 func TestInMemoryStoreLoadReturnsIndependentEvents(t *testing.T) {
 	ctx := context.Background()
 	store := session.NewInMemoryStore[*schema.Message](nil)
-	err := store.AppendEvents(ctx, &adk.AppendSessionEventsRequest[*schema.Message]{SessionID: "s", Events: []*adk.SessionEvent[*schema.Message]{
+	err := store.AppendEvents(ctx, "s", []*adk.SessionEvent[*schema.Message]{
 		testMessageEvent("e1", "one"),
-	}})
+	})
 	require.NoError(t, err)
 
-	first, err := store.LoadEvents(ctx, &adk.LoadSessionEventsRequest{SessionID: "s"})
+	first, err := store.LoadEvents(ctx, "s", &adk.LoadSessionEventsRequest{})
 	require.NoError(t, err)
 	first.Events[0].EventID = "mutated"
 
-	second, err := store.LoadEvents(ctx, &adk.LoadSessionEventsRequest{SessionID: "s"})
+	second, err := store.LoadEvents(ctx, "s", &adk.LoadSessionEventsRequest{})
 	require.NoError(t, err)
 	assert.Equal(t, "e1", second.Events[0].EventID)
 }
@@ -113,66 +112,47 @@ func TestInMemoryStoreValidationReplayAndReversePagination(t *testing.T) {
 	ctx := context.Background()
 	store := session.NewInMemoryStore[*schema.Message](nil)
 
-	require.NoError(t, store.AppendEvents(ctx, nil))
+	require.NoError(t, store.AppendEvents(ctx, "", nil))
 
 	events := []*adk.SessionEvent[*schema.Message]{
 		testMessageEvent("e1", "one"),
 		testSpanEvent("e2"),
 		testCommittedIdleEvent("e3", "turn-1"),
 	}
-	err := store.AppendEvents(ctx, &adk.AppendSessionEventsRequest[*schema.Message]{
-		SessionID: "s",
-		Events:    events,
-	})
+	err := store.AppendEvents(ctx, "s", events)
 	require.NoError(t, err)
 
-	err = store.AppendEvents(ctx, &adk.AppendSessionEventsRequest[*schema.Message]{
-		SessionID: "s",
-		Events:    []*adk.SessionEvent[*schema.Message]{testMessageEvent("e4", "four")},
-	})
+	err = store.AppendEvents(ctx, "s", []*adk.SessionEvent[*schema.Message]{testMessageEvent("e4", "four")})
 	require.NoError(t, err)
 
-	err = store.AppendEvents(ctx, &adk.AppendSessionEventsRequest[*schema.Message]{
-		SessionID: "s2",
-		Events:    []*adk.SessionEvent[*schema.Message]{nil},
-	})
+	err = store.AppendEvents(ctx, "s2", []*adk.SessionEvent[*schema.Message]{nil})
 	require.ErrorIs(t, err, adk.ErrInvalidEventID)
 
-	err = store.AppendEvents(ctx, &adk.AppendSessionEventsRequest[*schema.Message]{
-		SessionID: "s2",
-		Events: []*adk.SessionEvent[*schema.Message]{
-			testMessageEvent("dup", "one"),
-			testMessageEvent("dup", "two"),
-		},
+	err = store.AppendEvents(ctx, "s2", []*adk.SessionEvent[*schema.Message]{
+		testMessageEvent("dup", "one"),
+		testMessageEvent("dup", "two"),
 	})
 	require.ErrorIs(t, err, adk.ErrDuplicateEventID)
 
-	err = store.AppendEvents(ctx, &adk.AppendSessionEventsRequest[*schema.Message]{
-		SessionID: "s",
-		Events:    []*adk.SessionEvent[*schema.Message]{testMessageEvent("e1", "duplicate existing")},
-	})
+	err = store.AppendEvents(ctx, "s", []*adk.SessionEvent[*schema.Message]{testMessageEvent("e1", "duplicate existing")})
 	require.ErrorIs(t, err, adk.ErrDuplicateEventID)
 
-	err = store.AppendEvents(ctx, &adk.AppendSessionEventsRequest[*schema.Message]{
-		SessionID: "s2",
-		Events:    []*adk.SessionEvent[*schema.Message]{{EventID: "invalid-kind"}},
-	})
+	err = store.AppendEvents(ctx, "s2", []*adk.SessionEvent[*schema.Message]{{EventID: "invalid-kind"}})
 	require.Error(t, err)
 
-	reverseEmpty, err := store.LoadEvents(ctx, &adk.LoadSessionEventsRequest{SessionID: "empty", Reverse: true})
+	reverseEmpty, err := store.LoadEvents(ctx, "empty", &adk.LoadSessionEventsRequest{Reverse: true})
 	require.NoError(t, err)
 	assert.Empty(t, reverseEmpty.Events)
 
-	_, err = store.LoadEvents(ctx, &adk.LoadSessionEventsRequest{SessionID: "s", After: "missing"})
+	_, err = store.LoadEvents(ctx, "s", &adk.LoadSessionEventsRequest{After: "missing"})
 	require.ErrorIs(t, err, adk.ErrEventIDOutOfRange)
-	_, err = store.LoadEvents(ctx, &adk.LoadSessionEventsRequest{SessionID: "s", Reverse: true, After: "missing"})
+	_, err = store.LoadEvents(ctx, "s", &adk.LoadSessionEventsRequest{Reverse: true, After: "missing"})
 	require.ErrorIs(t, err, adk.ErrEventIDOutOfRange)
 
-	reverse, err := store.LoadEvents(ctx, &adk.LoadSessionEventsRequest{
-		SessionID: "s",
-		Reverse:   true,
-		After:     "e4",
-		Limit:     1,
+	reverse, err := store.LoadEvents(ctx, "s", &adk.LoadSessionEventsRequest{
+		Reverse: true,
+		After:   "e4",
+		Limit:   1,
 	})
 	require.NoError(t, err)
 	require.Len(t, reverse.Events, 1)

--- a/adk/session_admission.go
+++ b/adk/session_admission.go
@@ -86,12 +86,10 @@ func (h *localSessionHandle[M]) loadEvents(ctx context.Context, req *LoadSession
 	if req == nil {
 		req = &LoadSessionEventsRequest{}
 	}
-	clone := *req
-	clone.SessionID = h.sessionID
-	return h.store.LoadEvents(ctx, &clone)
+	return h.store.LoadEvents(ctx, h.sessionID, req)
 }
 
-func (h *localSessionHandle[M]) appendEvents(ctx context.Context, req *AppendSessionEventsRequest[M]) error {
+func (h *localSessionHandle[M]) appendEvents(ctx context.Context, events []*SessionEvent[M]) error {
 	h.mu.Lock()
 	if h.closed {
 		h.mu.Unlock()
@@ -99,12 +97,7 @@ func (h *localSessionHandle[M]) appendEvents(ctx context.Context, req *AppendSes
 	}
 	h.mu.Unlock()
 
-	if req == nil {
-		req = &AppendSessionEventsRequest[M]{}
-	}
-	clone := *req
-	clone.SessionID = h.sessionID
-	if err := h.store.AppendEvents(ctx, &clone); err != nil {
+	if err := h.store.AppendEvents(ctx, h.sessionID, events); err != nil {
 		return err
 	}
 	return nil

--- a/adk/session_test.go
+++ b/adk/session_test.go
@@ -5609,19 +5609,48 @@ func TestAttack_NormalizeSessionEventKindMismatch(t *testing.T) {
 	t.Logf("correctly rejected kind mismatch: %v", err)
 }
 
-func TestAttack_NormalizeSessionEventKindTurnEndLegacy(t *testing.T) {
-	ev := &SessionEvent[Message]{
-		Kind: "turn_end",
+func TestAttack_NormalizeSessionEventKindUnknownKindTolerated(t *testing.T) {
+	unknownKinds := []SessionEventKind{
+		"turn_end",
+		"session_started",
+		"custom_thing",
+		"future.new_kind",
 	}
+	for _, k := range unknownKinds {
+		ev := &SessionEvent[Message]{
+			Kind: k,
+		}
+		err := NormalizeSessionEventKind(ev)
+		if err != nil {
+			t.Fatalf("unknown kind %q should be tolerated, got error: %v", k, err)
+		}
+		if ev.Kind != k {
+			t.Fatalf("unknown kind %q should be preserved, got %q", k, ev.Kind)
+		}
+	}
+}
 
+func TestAttack_NormalizeSessionEventKindKnownKindMissingPayloadStillErrors(t *testing.T) {
+	ev := &SessionEvent[Message]{
+		Kind: SessionEventMessage,
+	}
 	err := NormalizeSessionEventKind(ev)
-	if err != nil {
-		t.Fatalf("legacy turn_end should be accepted, got error: %v", err)
+	if err == nil {
+		t.Fatal("expected error for known kind with missing payload, got nil")
 	}
-	if ev.Kind != "turn_end" {
-		t.Fatalf("legacy turn_end kind should be preserved, got %q", ev.Kind)
+	t.Logf("correctly rejected known kind with missing payload: %v", err)
+}
+
+func TestAttack_NormalizeSessionEventKindUnknownKindWithPayloadStillErrors(t *testing.T) {
+	ev := &SessionEvent[Message]{
+		Kind:    "future.new_kind",
+		Message: schema.UserMessage("hello"),
 	}
-	t.Log("legacy turn_end kind handled correctly")
+	err := NormalizeSessionEventKind(ev)
+	if err == nil {
+		t.Fatal("expected error for unknown kind with recognized payload, got nil")
+	}
+	t.Logf("correctly rejected unknown kind with recognized payload: %v", err)
 }
 
 func TestAttack_ValidateEmittedSessionEventEmptyKind(t *testing.T) {

--- a/adk/session_test.go
+++ b/adk/session_test.go
@@ -5704,37 +5704,41 @@ func TestAttack_SessionEventEncodeDecodeRoundtrip(t *testing.T) {
 	t.Log("encode/decode roundtrip OK")
 }
 
-func TestAttack_SessionEventVariantEncodeDecodeRoundtrip(t *testing.T) {
-	original := &SessionEventVariant[Message]{
-		SessionID: "sess-roundtrip",
-		Event: &SessionEvent[Message]{
-			EventID:   "evt-rt-1",
-			Timestamp: time.Date(2026, 1, 15, 10, 30, 0, 0, time.UTC),
-			Kind:      SessionEventMessage,
-			Message:   schema.UserMessage("variant roundtrip"),
+func TestAttack_SessionEventVariantPayloadEncodeDecodeRoundtrip(t *testing.T) {
+	original := &TypedAgentEvent[Message]{
+		SessionEventVariant: &SessionEventVariant[Message]{
+			SessionID: "sess-roundtrip",
+			Event: &SessionEvent[Message]{
+				EventID:   "evt-rt-1",
+				Timestamp: time.Date(2026, 1, 15, 10, 30, 0, 0, time.UTC),
+				Kind:      SessionEventMessage,
+				Message:   schema.UserMessage("variant roundtrip"),
+			},
 		},
 	}
 
-	data, err := sessionSerializer.Marshal(original)
+	persistable, err := toSessionEventChecked(original)
 	if err != nil {
-		t.Fatalf("encode variant failed: %v", err)
+		t.Fatalf("convert variant payload failed: %v", err)
+	}
+	if persistable == original.SessionEventVariant.Event {
+		t.Fatal("persistable event must be copied out of live SessionEventVariant")
 	}
 
-	var decoded SessionEventVariant[Message]
-	if err := sessionSerializer.Unmarshal(data, &decoded); err != nil {
-		t.Fatalf("decode variant failed: %v", err)
+	data, err := encodeSessionEvent(persistable)
+	if err != nil {
+		t.Fatalf("encode variant payload failed: %v", err)
 	}
 
-	if decoded.SessionID != original.SessionID {
-		t.Errorf("SessionID mismatch: got %q want %q", decoded.SessionID, original.SessionID)
+	decoded, err := decodeSessionEvent[Message](data)
+	if err != nil {
+		t.Fatalf("decode variant payload failed: %v", err)
 	}
-	if decoded.Event == nil {
-		t.Fatal("decoded Event is nil")
+
+	if decoded.EventID != original.SessionEventVariant.Event.EventID {
+		t.Errorf("EventID mismatch: got %q want %q", decoded.EventID, original.SessionEventVariant.Event.EventID)
 	}
-	if decoded.Event.EventID != original.Event.EventID {
-		t.Errorf("Event.EventID mismatch: got %q want %q", decoded.Event.EventID, original.Event.EventID)
-	}
-	t.Log("variant encode/decode roundtrip OK")
+	t.Log("variant payload encode/decode roundtrip OK")
 }
 
 func TestAttack_AssignSessionEventIDEmptyGenerator(t *testing.T) {

--- a/adk/session_test.go
+++ b/adk/session_test.go
@@ -1096,7 +1096,7 @@ func TestRunnerSessionStreamingRefAllocatesMissingEventID(t *testing.T) {
 		}
 	}
 	require.NotNil(t, event.SessionEventVariant)
-	ref := event.SessionEventVariant.GetMessageStreamRef()
+	ref := event.SessionEventVariant.MessageStreamRef
 	require.NotNil(t, ref)
 	assert.Equal(t, businessID, ref.EventID)
 	assert.Equal(t, SessionEventMessage, ref.Kind)
@@ -2020,7 +2020,7 @@ func TestStripSessionEventFields(t *testing.T) {
 		}
 		stripped := stripSessionEventFields(ev)
 		require.NotNil(t, stripped)
-		assert.Nil(t, stripped.SessionEventVariant.GetEvent())
+		assert.Nil(t, stripped.SessionEventVariant)
 		assert.EqualError(t, stripped.Err, "visible")
 	})
 
@@ -2709,7 +2709,7 @@ func TestRunnerSessionInterruptCheckpointTailIsFinalIdle(t *testing.T) {
 	require.NotNil(t, runCtx.Session)
 	for _, event := range runCtx.Session.Events {
 		require.NotNil(t, event.AgentEvent)
-		assert.Nil(t, event.SessionEventVariant.GetEvent())
+		assert.Nil(t, event.SessionEventVariant)
 	}
 }
 
@@ -2732,8 +2732,8 @@ func TestRunnerSessionCheckpointPayloadStripsSessionEvents(t *testing.T) {
 			break
 		}
 		require.NoError(t, event.Err)
-		if event.SessionEventVariant.GetEvent() != nil {
-			liveSessionEventIDs = append(liveSessionEventIDs, event.SessionEventVariant.GetEvent().EventID)
+		if event.SessionEventVariant != nil && event.SessionEventVariant.Event != nil {
+			liveSessionEventIDs = append(liveSessionEventIDs, event.SessionEventVariant.Event.EventID)
 		}
 	}
 	assert.Contains(t, liveSessionEventIDs, "checkpoint-session-only")
@@ -2753,7 +2753,7 @@ func TestRunnerSessionCheckpointPayloadStripsSessionEvents(t *testing.T) {
 	var foundOutput bool
 	for _, event := range runCtx.Session.Events {
 		require.NotNil(t, event.AgentEvent)
-		assert.Nil(t, event.SessionEventVariant.GetEvent())
+		assert.Nil(t, event.SessionEventVariant)
 		assert.True(t, event.Output != nil || event.Action != nil || event.Err != nil)
 		if event.Output != nil &&
 			event.Output.MessageOutput != nil &&
@@ -2799,8 +2799,8 @@ func TestRunnerSessionAgentInterruptBoundaryFailureNotExposed(t *testing.T) {
 		if event.Err != nil {
 			errs = append(errs, event.Err)
 		}
-		if event.SessionEventVariant.GetEvent() != nil {
-			kinds = append(kinds, event.SessionEventVariant.GetEvent().Kind)
+		if event.SessionEventVariant != nil && event.SessionEventVariant.Event != nil {
+			kinds = append(kinds, event.SessionEventVariant.Event.Kind)
 		}
 	}
 	require.NotEmpty(t, errs)
@@ -5152,6 +5152,103 @@ func TestAttack_LeadingSystemMessageExtraChangesArePersisted(t *testing.T) {
 	assert.Equal(t, "b", result.state.Messages[0].Extra["trace"])
 }
 
+func TestAttack_LeadingSystemMessageExtraMutationInGenModelInputStillPersistsUpdate(t *testing.T) {
+	ctx := context.Background()
+	store := newSessionHelperStore()
+	sid := "leading-system-extra-mutation"
+
+	system := schema.SystemMessage("sys")
+	system.Extra = map[string]any{"trace": "a"}
+
+	runTurn := func(trace string) {
+		model := &leadingSystemTestModel[*schema.Message]{response: schema.AssistantMessage("answer "+trace, nil)}
+		agent, err := NewChatModelAgent(ctx, &ChatModelAgentConfig{
+			Name:        "system-extra-mut-agent",
+			Description: "test",
+			Instruction: "ignored by custom input",
+			Model:       model,
+			GenModelInput: func(_ context.Context, _ string, input *AgentInput) ([]*schema.Message, error) {
+				if len(input.Messages) > 0 && input.Messages[0].Role == schema.System {
+					if input.Messages[0].Extra == nil {
+						input.Messages[0].Extra = make(map[string]any)
+					}
+					input.Messages[0].Extra["trace"] = trace
+				}
+				return input.Messages, nil
+			},
+		})
+		require.NoError(t, err)
+		runner := NewRunner(ctx, RunnerConfig{Agent: agent, SessionID: sid, SessionStore: store})
+		drainSessionEvents(t, runner.Run(ctx, []*schema.Message{system, schema.UserMessage(trace)}))
+	}
+
+	runTurn("a")
+	system.Extra = nil
+	runTurn("b")
+
+	var update *MessageUpdatedEvent[*schema.Message]
+	for _, event := range loadMessageSessionEvents(t, ctx, store, sid) {
+		if event.MessageUpdated != nil && event.MessageUpdated.Message.Role == schema.System {
+			update = event.MessageUpdated
+		}
+	}
+	require.NotNil(t, update, "in-place Extra mutation in GenModelInput must still be detected as message_updated")
+	assert.Equal(t, "b", update.Message.Extra["trace"])
+
+	handle := mustOpenTestSession[*schema.Message](t, ctx, store, sid)
+	result, err := reconstructSessionState[*schema.Message](ctx, handle, sid, defaultLoadPageSize)
+	require.NoError(t, err)
+	require.NoError(t, handle.close(ctx))
+	require.NotEmpty(t, result.state.Messages)
+	assert.Equal(t, "b", result.state.Messages[0].Extra["trace"])
+}
+
+func TestAttack_LeadingSystemMessageContentMutationInGenModelInputStillPersistsUpdate(t *testing.T) {
+	ctx := context.Background()
+	store := newSessionHelperStore()
+	sid := "leading-system-content-mutation"
+
+	system := schema.SystemMessage("sys v1")
+
+	runTurn := func(content string) {
+		model := &leadingSystemTestModel[*schema.Message]{response: schema.AssistantMessage("answer "+content, nil)}
+		agent, err := NewChatModelAgent(ctx, &ChatModelAgentConfig{
+			Name:        "system-content-mut-agent",
+			Description: "test",
+			Instruction: "ignored by custom input",
+			Model:       model,
+			GenModelInput: func(_ context.Context, _ string, input *AgentInput) ([]*schema.Message, error) {
+				if len(input.Messages) > 0 && input.Messages[0].Role == schema.System {
+					input.Messages[0].Content = content
+				}
+				return input.Messages, nil
+			},
+		})
+		require.NoError(t, err)
+		runner := NewRunner(ctx, RunnerConfig{Agent: agent, SessionID: sid, SessionStore: store})
+		drainSessionEvents(t, runner.Run(ctx, []*schema.Message{system, schema.UserMessage(content)}))
+	}
+
+	runTurn("sys v1")
+	runTurn("sys v2")
+
+	var update *MessageUpdatedEvent[*schema.Message]
+	for _, event := range loadMessageSessionEvents(t, ctx, store, sid) {
+		if event.MessageUpdated != nil && event.MessageUpdated.Message.Role == schema.System {
+			update = event.MessageUpdated
+		}
+	}
+	require.NotNil(t, update, "in-place Content mutation in GenModelInput must still be detected as message_updated")
+	assert.Equal(t, "sys v2", update.Message.Content)
+
+	handle := mustOpenTestSession[*schema.Message](t, ctx, store, sid)
+	result, err := reconstructSessionState[*schema.Message](ctx, handle, sid, defaultLoadPageSize)
+	require.NoError(t, err)
+	require.NoError(t, handle.close(ctx))
+	require.NotEmpty(t, result.state.Messages)
+	assert.Equal(t, "sys v2", result.state.Messages[0].Content)
+}
+
 func TestSameSystemMessageComparesExtraExceptMessageID(t *testing.T) {
 	oldMsg := schema.SystemMessage("same")
 	oldMsg.Extra = map[string]any{"_eino_msg_id": "old", "trace": "a"}
@@ -5404,4 +5501,491 @@ func TestAgentToolInterruptState_RoundTrip(t *testing.T) {
 	require.NoError(t, json.Unmarshal(encoded, &decoded))
 	assert.Equal(t, wrapped.ChildSessionID, decoded.ChildSessionID)
 	assert.Equal(t, wrapped.BridgeCheckpoint, decoded.BridgeCheckpoint)
+}
+
+func TestAttack_SessionEventVariantBothSet(t *testing.T) {
+	ev := &TypedAgentEvent[Message]{
+		SessionEventVariant: &SessionEventVariant[Message]{
+			Event: &SessionEvent[Message]{
+				EventID: "evt-1",
+				Kind:    SessionEventMessage,
+				Message: schema.UserMessage("hello"),
+			},
+			MessageStreamRef: &MessageStreamRef{
+				EventID: "evt-2",
+				Kind:    SessionEventMessage,
+			},
+		},
+	}
+
+	err := validateAgentSessionEventIdentity(ev)
+	if err == nil {
+		t.Fatal("expected error when both Event and MessageStreamRef are set, got nil")
+	}
+	t.Logf("correctly rejected both-set variant: %v", err)
+}
+
+func TestAttack_SessionEventVariantNeitherSet(t *testing.T) {
+	ev := &TypedAgentEvent[Message]{
+		SessionEventVariant: &SessionEventVariant[Message]{
+			SessionID: "sess-1",
+		},
+	}
+
+	err := validateAgentSessionEventIdentity(ev)
+	if err == nil {
+		t.Fatal("expected error when neither Event nor MessageStreamRef is set, got nil")
+	}
+	t.Logf("correctly rejected neither-set variant: %v", err)
+}
+
+func TestAttack_SessionEventVariantNil(t *testing.T) {
+	ev := &TypedAgentEvent[Message]{}
+	err := validateAgentSessionEventIdentity(ev)
+	if err != nil {
+		t.Fatalf("nil variant should be valid, got error: %v", err)
+	}
+	t.Log("nil variant accepted correctly")
+}
+
+func TestAttack_MessageStreamRefWrongKind(t *testing.T) {
+	ev := &TypedAgentEvent[Message]{
+		SessionEventVariant: &SessionEventVariant[Message]{
+			MessageStreamRef: &MessageStreamRef{
+				EventID: "evt-1",
+				Kind:    SessionEventSessionStatusRunning,
+			},
+		},
+	}
+
+	err := validateAgentSessionEventIdentity(ev)
+	if err == nil {
+		t.Fatal("expected error for MessageStreamRef with non-message kind, got nil")
+	}
+	t.Logf("correctly rejected wrong kind on stream ref: %v", err)
+}
+
+func TestAttack_ClassifySessionEventZeroValue(t *testing.T) {
+	ev := &SessionEvent[Message]{}
+
+	_, err := ClassifySessionEvent(ev)
+	if err == nil {
+		t.Fatal("expected error for zero-value session event with no payload, got nil")
+	}
+	t.Logf("correctly rejected zero-value event: %v", err)
+}
+
+func TestAttack_ClassifySessionEventNil(t *testing.T) {
+	_, err := ClassifySessionEvent[Message](nil)
+	if err == nil {
+		t.Fatal("expected error for nil session event, got nil")
+	}
+	t.Logf("correctly rejected nil event: %v", err)
+}
+
+func TestAttack_ClassifySessionEventMultiplePayloads(t *testing.T) {
+	ev := &SessionEvent[Message]{
+		Message: schema.UserMessage("hello"),
+		Cancel:  &CancelEvent{Reason: "test"},
+	}
+
+	_, err := ClassifySessionEvent(ev)
+	if err == nil {
+		t.Fatal("expected error for event with multiple active payloads, got nil")
+	}
+	t.Logf("correctly rejected multiple-payload event: %v", err)
+}
+
+func TestAttack_NormalizeSessionEventKindMismatch(t *testing.T) {
+	ev := &SessionEvent[Message]{
+		Kind:    SessionEventCancel,
+		Message: schema.UserMessage("hello"),
+	}
+
+	err := NormalizeSessionEventKind(ev)
+	if err == nil {
+		t.Fatal("expected error for kind mismatch, got nil")
+	}
+	t.Logf("correctly rejected kind mismatch: %v", err)
+}
+
+func TestAttack_NormalizeSessionEventKindTurnEndLegacy(t *testing.T) {
+	ev := &SessionEvent[Message]{
+		Kind: "turn_end",
+	}
+
+	err := NormalizeSessionEventKind(ev)
+	if err != nil {
+		t.Fatalf("legacy turn_end should be accepted, got error: %v", err)
+	}
+	if ev.Kind != "turn_end" {
+		t.Fatalf("legacy turn_end kind should be preserved, got %q", ev.Kind)
+	}
+	t.Log("legacy turn_end kind handled correctly")
+}
+
+func TestAttack_ValidateEmittedSessionEventEmptyKind(t *testing.T) {
+	ev := &SessionEvent[Message]{
+		Message: schema.UserMessage("hello"),
+	}
+
+	err := ValidateEmittedSessionEventKind(ev)
+	if err == nil {
+		t.Fatal("expected error for emitted event with empty Kind, got nil")
+	}
+	t.Logf("correctly rejected empty-kind emitted event: %v", err)
+}
+
+func TestAttack_ValidateEmittedSessionEventNil(t *testing.T) {
+	err := ValidateEmittedSessionEventKind[Message](nil)
+	if err == nil {
+		t.Fatal("expected error for nil emitted event, got nil")
+	}
+	t.Logf("correctly rejected nil emitted event: %v", err)
+}
+
+func TestAttack_SessionEventEncodeDecodeRoundtrip(t *testing.T) {
+	original := &SessionEvent[Message]{
+		EventID:   "roundtrip-1",
+		Timestamp: time.Date(2026, 1, 15, 10, 30, 0, 0, time.UTC),
+		Kind:      SessionEventMessage,
+		TurnID:    "turn-abc",
+		Message:   schema.UserMessage("roundtrip test"),
+	}
+
+	data, err := encodeSessionEvent(original)
+	if err != nil {
+		t.Fatalf("encode failed: %v", err)
+	}
+
+	decoded, err := decodeSessionEvent[Message](data)
+	if err != nil {
+		t.Fatalf("decode failed: %v", err)
+	}
+
+	if decoded.EventID != original.EventID {
+		t.Errorf("EventID mismatch: got %q want %q", decoded.EventID, original.EventID)
+	}
+	if decoded.Kind != original.Kind {
+		t.Errorf("Kind mismatch: got %q want %q", decoded.Kind, original.Kind)
+	}
+	if decoded.TurnID != original.TurnID {
+		t.Errorf("TurnID mismatch: got %q want %q", decoded.TurnID, original.TurnID)
+	}
+	t.Log("encode/decode roundtrip OK")
+}
+
+func TestAttack_SessionEventVariantEncodeDecodeRoundtrip(t *testing.T) {
+	original := &SessionEventVariant[Message]{
+		SessionID: "sess-roundtrip",
+		Event: &SessionEvent[Message]{
+			EventID:   "evt-rt-1",
+			Timestamp: time.Date(2026, 1, 15, 10, 30, 0, 0, time.UTC),
+			Kind:      SessionEventMessage,
+			Message:   schema.UserMessage("variant roundtrip"),
+		},
+	}
+
+	data, err := sessionSerializer.Marshal(original)
+	if err != nil {
+		t.Fatalf("encode variant failed: %v", err)
+	}
+
+	var decoded SessionEventVariant[Message]
+	if err := sessionSerializer.Unmarshal(data, &decoded); err != nil {
+		t.Fatalf("decode variant failed: %v", err)
+	}
+
+	if decoded.SessionID != original.SessionID {
+		t.Errorf("SessionID mismatch: got %q want %q", decoded.SessionID, original.SessionID)
+	}
+	if decoded.Event == nil {
+		t.Fatal("decoded Event is nil")
+	}
+	if decoded.Event.EventID != original.Event.EventID {
+		t.Errorf("Event.EventID mismatch: got %q want %q", decoded.Event.EventID, original.Event.EventID)
+	}
+	t.Log("variant encode/decode roundtrip OK")
+}
+
+func TestAttack_AssignSessionEventIDEmptyGenerator(t *testing.T) {
+	emptyGen := func(_ context.Context, _ *SessionEvent[Message]) (string, error) {
+		return "", nil
+	}
+
+	ev := &SessionEvent[Message]{
+		Kind:    SessionEventMessage,
+		Message: schema.UserMessage("test"),
+	}
+
+	err := assignSessionEventID(context.Background(), ev, emptyGen)
+	if !errors.Is(err, ErrSessionEventIDGeneratorEmpty) {
+		t.Fatalf("expected ErrSessionEventIDGeneratorEmpty, got %v", err)
+	}
+	t.Logf("correctly handled empty generator: %v", err)
+}
+
+func TestAttack_AssignSessionEventIDGeneratorError(t *testing.T) {
+	genErr := errors.New("generator failed")
+	errGen := func(_ context.Context, _ *SessionEvent[Message]) (string, error) {
+		return "", genErr
+	}
+
+	ev := &SessionEvent[Message]{
+		Kind:    SessionEventMessage,
+		Message: schema.UserMessage("test"),
+	}
+
+	err := assignSessionEventID(context.Background(), ev, errGen)
+	if err == nil {
+		t.Fatal("expected error from generator, got nil")
+	}
+	if !errors.Is(err, genErr) {
+		t.Fatalf("expected wrapped generator error, got %v", err)
+	}
+	t.Logf("correctly propagated generator error: %v", err)
+}
+
+func TestAttack_ApplySessionEventMessagesDeletedEmptyIDs(t *testing.T) {
+	messages := []Message{schema.UserMessage("a"), schema.UserMessage("b")}
+	ev := &SessionEvent[Message]{
+		Kind: SessionEventMessagesDeleted,
+		MessagesDeleted: &MessagesDeletedEvent{
+			MessageIDs: []string{},
+		},
+	}
+
+	err := applySessionEvent(&messages, ev)
+	if err == nil {
+		t.Fatal("expected error for empty MessageIDs, got nil")
+	}
+	t.Logf("correctly rejected empty MessageIDs: %v", err)
+}
+
+func TestAttack_ApplySessionEventMessagesDeletedDuplicateIDs(t *testing.T) {
+	messages := []Message{schema.UserMessage("a")}
+	ev := &SessionEvent[Message]{
+		Kind: SessionEventMessagesDeleted,
+		MessagesDeleted: &MessagesDeletedEvent{
+			MessageIDs: []string{"dup", "dup"},
+		},
+	}
+
+	err := applySessionEvent(&messages, ev)
+	if err == nil {
+		t.Fatal("expected error for duplicate MessageIDs, got nil")
+	}
+	t.Logf("correctly rejected duplicate MessageIDs: %v", err)
+}
+
+func TestAttack_ApplySessionEventMessageUpdatedIdentityMismatch(t *testing.T) {
+	msg := schema.UserMessage("original")
+	EnsureMessageID(msg)
+
+	messages := []Message{msg}
+	newMsg := schema.UserMessage("updated")
+	EnsureMessageID(newMsg)
+
+	ev := &SessionEvent[Message]{
+		Kind: SessionEventMessageUpdated,
+		MessageUpdated: &MessageUpdatedEvent[Message]{
+			MessageID: GetMessageID(msg),
+			Message:   newMsg,
+		},
+	}
+
+	err := applySessionEvent(&messages, ev)
+	if err == nil {
+		t.Log("MessageUpdated with matching ID applied OK")
+	} else {
+		t.Logf("MessageUpdated result: %v", err)
+	}
+}
+
+func TestAttack_IsContextSessionEventEdgeCases(t *testing.T) {
+	tests := []struct {
+		name string
+		ev   *SessionEvent[Message]
+		want bool
+	}{
+		{"nil event", nil, false},
+		{"empty event", &SessionEvent[Message]{}, false},
+		{"cancel event", &SessionEvent[Message]{Cancel: &CancelEvent{}}, false},
+		{"lifecycle event", &SessionEvent[Message]{Lifecycle: &LifecycleEvent{State: SessionRunStateRunning}}, false},
+		{"error event", &SessionEvent[Message]{Error: &SessionErrorEvent{}}, false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := isContextSessionEvent(tt.ev)
+			if got != tt.want {
+				t.Errorf("isContextSessionEvent() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+	t.Log("all isContextSessionEvent edge cases pass")
+}
+
+func TestAttack_ToSessionEventCheckedStreamingOutput(t *testing.T) {
+	ev := &TypedAgentEvent[Message]{
+		Output: &TypedAgentOutput[Message]{
+			MessageOutput: &TypedMessageVariant[Message]{
+				IsStreaming: true,
+				Message:     nil,
+			},
+		},
+		SessionEventVariant: nil,
+	}
+
+	se, err := toSessionEventChecked(ev)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if se != nil {
+		t.Fatalf("expected nil SessionEvent for streaming output without variant, got %v", se)
+	}
+	t.Log("streaming output without variant correctly returns nil session event")
+}
+
+func TestAttack_StripSessionEventFields(t *testing.T) {
+	tests := []struct {
+		name string
+		ev   *TypedAgentEvent[Message]
+		nil  bool
+	}{
+		{"nil event", nil, true},
+		{"no variant, with output", &TypedAgentEvent[Message]{
+			Output: &TypedAgentOutput[Message]{
+				MessageOutput: &TypedMessageVariant[Message]{Message: schema.UserMessage("test")},
+			},
+		}, false},
+		{"only variant", &TypedAgentEvent[Message]{
+			SessionEventVariant: &SessionEventVariant[Message]{
+				Event: &SessionEvent[Message]{EventID: "x", Kind: SessionEventMessage, Message: schema.UserMessage("test")},
+			},
+		}, true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := stripSessionEventFields(tt.ev)
+			if tt.nil && result != nil {
+				t.Errorf("expected nil result, got %v", result)
+			}
+			if !tt.nil && result == nil {
+				t.Error("expected non-nil result, got nil")
+			}
+			if result != nil && result.SessionEventVariant != nil {
+				t.Error("SessionEventVariant should be stripped")
+			}
+		})
+	}
+	t.Log("stripSessionEventFields all cases pass")
+}
+
+func TestAttack_ClassifySpanEventBothModelAndTool(t *testing.T) {
+	span := &SpanEvent{
+		SpanID: "span-1",
+		Kind:   SpanKindModel,
+		Model:  &ModelSpanMeta{},
+		Tool:   &ToolSpanMeta{ToolUseID: "call-1"},
+	}
+
+	_, err := classifySpanSessionEvent(span)
+	if err == nil {
+		t.Fatal("expected error when both Model and Tool are set, got nil")
+	}
+	t.Logf("correctly rejected both-model-and-tool span: %v", err)
+}
+
+func TestAttack_ClassifySpanEventNeitherModelNorTool(t *testing.T) {
+	span := &SpanEvent{
+		SpanID: "span-1",
+		Kind:   SpanKindModel,
+	}
+
+	_, err := classifySpanSessionEvent(span)
+	if err == nil {
+		t.Fatal("expected error when neither Model nor Tool is set, got nil")
+	}
+	t.Logf("correctly rejected no-meta span: %v", err)
+}
+
+func TestAttack_SessionEventCancelClassification(t *testing.T) {
+	ev := &SessionEvent[Message]{
+		Cancel: &CancelEvent{Reason: "user cancelled"},
+	}
+
+	kind, err := ClassifySessionEvent(ev)
+	if err != nil {
+		t.Fatalf("classification failed: %v", err)
+	}
+	if kind != SessionEventCancel {
+		t.Errorf("kind = %q, want %q", kind, SessionEventCancel)
+	}
+	t.Logf("CancelEvent classified correctly as %q", kind)
+}
+
+func TestAttack_SessionEventInterruptClassification(t *testing.T) {
+	ev := &SessionEvent[Message]{
+		Interrupt: &InterruptEvent{
+			Contexts: []*InterruptContext{
+				{InterruptID: "tool:lookup:call_1", ToolUseID: "call_1"},
+			},
+		},
+	}
+
+	kind, err := ClassifySessionEvent(ev)
+	if err != nil {
+		t.Fatalf("classification failed: %v", err)
+	}
+	if kind != SessionEventInterrupt {
+		t.Errorf("kind = %q, want %q", kind, SessionEventInterrupt)
+	}
+	t.Logf("InterruptEvent classified correctly as %q", kind)
+}
+
+func TestAttack_SessionRollbackEventValidation(t *testing.T) {
+	ev := &SessionEvent[Message]{
+		EventID: "rb-1",
+		Rollback: &SessionRollbackEvent{
+			ToEventID: "target-1",
+		},
+	}
+
+	kind, err := ClassifySessionEvent(ev)
+	if err != nil {
+		t.Fatalf("classification failed: %v", err)
+	}
+	if kind != SessionEventRollback {
+		t.Errorf("kind = %q, want %q", kind, SessionEventRollback)
+	}
+	t.Logf("RollbackEvent classified correctly as %q", kind)
+}
+
+func TestAttack_SessionRollbackEventMissingToEventID(t *testing.T) {
+	ev := &SessionEvent[Message]{
+		EventID:  "rb-1",
+		Rollback: &SessionRollbackEvent{},
+	}
+
+	_, err := ClassifySessionEvent(ev)
+	if err == nil {
+		t.Fatal("expected error for rollback with empty ToEventID, got nil")
+	}
+	t.Logf("correctly rejected rollback with empty ToEventID: %v", err)
+}
+
+func TestAttack_SessionRollbackEventMissingOwnEventID(t *testing.T) {
+	ev := &SessionEvent[Message]{
+		Rollback: &SessionRollbackEvent{
+			ToEventID: "target-1",
+		},
+	}
+
+	_, err := ClassifySessionEvent(ev)
+	if err == nil {
+		t.Fatal("expected error for rollback with empty own EventID, got nil")
+	}
+	t.Logf("correctly rejected rollback with empty own EventID: %v", err)
 }

--- a/adk/session_test.go
+++ b/adk/session_test.go
@@ -71,11 +71,7 @@ type publicSessionHelperStore struct {
 	*sessionHelperStore
 }
 
-func (s *publicSessionHelperStore) LoadEvents(ctx context.Context, req *LoadSessionEventsRequest) (*LoadSessionEventsResult[*schema.Message], error) {
-	sessionID := ""
-	if req != nil {
-		sessionID = req.SessionID
-	}
+func (s *publicSessionHelperStore) LoadEvents(ctx context.Context, sessionID string, req *LoadSessionEventsRequest) (*LoadSessionEventsResult[*schema.Message], error) {
 	res, err := s.sessionHelperStore.LoadEventsForSession(ctx, sessionID, req)
 	if err != nil {
 		return nil, err
@@ -83,15 +79,7 @@ func (s *publicSessionHelperStore) LoadEvents(ctx context.Context, req *LoadSess
 	return res, nil
 }
 
-func (s *publicSessionHelperStore) AppendEvents(ctx context.Context, req *AppendSessionEventsRequest[*schema.Message]) error {
-	sessionID := ""
-	if req != nil {
-		sessionID = req.SessionID
-	}
-	var events []*SessionEvent[*schema.Message]
-	if req != nil {
-		events = req.Events
-	}
+func (s *publicSessionHelperStore) AppendEvents(ctx context.Context, sessionID string, events []*SessionEvent[*schema.Message]) error {
 	return s.sessionHelperStore.AppendEventsForSession(ctx, sessionID, events)
 }
 
@@ -115,11 +103,8 @@ func (s *blockingAppendStore) AppendEventsForSession(ctx context.Context, sessio
 	return s.sessionHelperStore.AppendEventsForSession(ctx, sessionID, events)
 }
 
-func (s *blockingAppendStore) AppendEvents(ctx context.Context, req *AppendSessionEventsRequest[*schema.Message]) error {
-	if req == nil {
-		req = &AppendSessionEventsRequest[*schema.Message]{}
-	}
-	return s.AppendEventsForSession(ctx, req.SessionID, req.Events)
+func (s *blockingAppendStore) AppendEvents(ctx context.Context, sessionID string, events []*SessionEvent[*schema.Message]) error {
+	return s.AppendEventsForSession(ctx, sessionID, events)
 }
 
 func (s *blockingAppendStore) openSession(_ context.Context, req *openSessionRequest) (*openSessionResult[*schema.Message], error) {
@@ -130,11 +115,8 @@ func (s *blockingAppendStore) openSession(_ context.Context, req *openSessionReq
 	return &openSessionResult[*schema.Message]{handle: &legacyMessageTestHandle{store: s, sessionID: sessionID}}, nil
 }
 
-func (s *blockingAppendStore) appendEvents(ctx context.Context, req *AppendSessionEventsRequest[*schema.Message]) error {
-	if req == nil {
-		req = &AppendSessionEventsRequest[*schema.Message]{}
-	}
-	return s.AppendEventsForSession(ctx, req.SessionID, req.Events)
+func (s *blockingAppendStore) appendEvents(ctx context.Context, events []*SessionEvent[*schema.Message]) error {
+	return s.AppendEventsForSession(ctx, "", events)
 }
 
 // withTestEventID assigns a fresh UUIDv4 to the SessionEvent if its EventID is
@@ -274,6 +256,7 @@ func (a *runnerSessionAgent) Run(ctx context.Context, input *AgentInput, _ ...Ag
 
 type streamingSessionAgent struct {
 	release chan struct{}
+	variant *SessionEventVariant[*schema.Message]
 }
 
 func (a *streamingSessionAgent) Name(_ context.Context) string { return "streaming-session-agent" }
@@ -293,6 +276,7 @@ func (a *streamingSessionAgent) Run(_ context.Context, _ *AgentInput, _ ...Agent
 			Output: &AgentOutput{
 				MessageOutput: &MessageVariant{IsStreaming: true, MessageStream: sr, Role: schema.Assistant},
 			},
+			SessionEventVariant: a.variant,
 		})
 		<-a.release
 		sw.Close()
@@ -366,13 +350,7 @@ func (s *sessionHelperStore) Delete(_ context.Context, key string) error {
 	return nil
 }
 
-func (s *sessionHelperStore) AppendEvents(ctx context.Context, req *AppendSessionEventsRequest[*schema.Message]) error {
-	sessionID := ""
-	var events []*SessionEvent[*schema.Message]
-	if req != nil {
-		sessionID = req.SessionID
-		events = req.Events
-	}
+func (s *sessionHelperStore) AppendEvents(ctx context.Context, sessionID string, events []*SessionEvent[*schema.Message]) error {
 	return s.AppendEventsForSession(ctx, sessionID, events)
 }
 
@@ -418,11 +396,7 @@ func (s *sessionHelperStore) AppendEventsForSession(_ context.Context, _ string,
 	return nil
 }
 
-func (s *sessionHelperStore) LoadEvents(ctx context.Context, req *LoadSessionEventsRequest) (*LoadSessionEventsResult[*schema.Message], error) {
-	sessionID := ""
-	if req != nil {
-		sessionID = req.SessionID
-	}
+func (s *sessionHelperStore) LoadEvents(ctx context.Context, sessionID string, req *LoadSessionEventsRequest) (*LoadSessionEventsResult[*schema.Message], error) {
 	return s.LoadEventsForSession(ctx, sessionID, req)
 }
 
@@ -523,18 +497,11 @@ func (s *sessionHelperStore) openSession(_ context.Context, req *openSessionRequ
 }
 
 func (s *sessionHelperStore) loadEvents(ctx context.Context, req *LoadSessionEventsRequest) (*LoadSessionEventsResult[*schema.Message], error) {
-	sessionID := ""
-	if req != nil {
-		sessionID = req.SessionID
-	}
-	return s.LoadEventsForSession(ctx, sessionID, req)
+	return s.LoadEventsForSession(ctx, "", req)
 }
 
-func (s *sessionHelperStore) appendEvents(ctx context.Context, req *AppendSessionEventsRequest[*schema.Message]) error {
-	if req == nil {
-		req = &AppendSessionEventsRequest[*schema.Message]{}
-	}
-	return s.AppendEventsForSession(ctx, req.SessionID, req.Events)
+func (s *sessionHelperStore) appendEvents(ctx context.Context, events []*SessionEvent[*schema.Message]) error {
+	return s.AppendEventsForSession(ctx, "", events)
 }
 
 func (s *sessionHelperStore) close(context.Context) error { return nil }
@@ -551,11 +518,8 @@ func (h *testSessionHandle) loadEvents(ctx context.Context, req *LoadSessionEven
 	return h.store.LoadEventsForSession(ctx, h.sessionID, req)
 }
 
-func (h *testSessionHandle) appendEvents(ctx context.Context, req *AppendSessionEventsRequest[*schema.Message]) error {
-	if req == nil {
-		req = &AppendSessionEventsRequest[*schema.Message]{}
-	}
-	return h.store.AppendEventsForSession(ctx, h.sessionID, req.Events)
+func (h *testSessionHandle) appendEvents(ctx context.Context, events []*SessionEvent[*schema.Message]) error {
+	return h.store.AppendEventsForSession(ctx, h.sessionID, events)
 }
 
 func (h *testSessionHandle) close(context.Context) error { return nil }
@@ -577,11 +541,8 @@ func (h *legacyMessageTestHandle) loadEvents(ctx context.Context, req *LoadSessi
 	return h.store.LoadEventsForSession(ctx, h.sessionID, req)
 }
 
-func (h *legacyMessageTestHandle) appendEvents(ctx context.Context, req *AppendSessionEventsRequest[*schema.Message]) error {
-	if req == nil {
-		req = &AppendSessionEventsRequest[*schema.Message]{}
-	}
-	return h.store.AppendEventsForSession(ctx, h.sessionID, req.Events)
+func (h *legacyMessageTestHandle) appendEvents(ctx context.Context, events []*SessionEvent[*schema.Message]) error {
+	return h.store.AppendEventsForSession(ctx, h.sessionID, events)
 }
 
 func (h *legacyMessageTestHandle) close(context.Context) error { return nil }
@@ -1083,6 +1044,81 @@ func TestRunnerSessionStreamingDoesNotBlockLiveEvent(t *testing.T) {
 	drainSessionEvents(t, iter)
 }
 
+func TestRunnerSessionStreamingRefAllocatesMissingEventID(t *testing.T) {
+	ctx := context.Background()
+	store := newSessionHelperStore()
+	agent := &streamingSessionAgent{
+		release: make(chan struct{}),
+		variant: &SessionEventVariant[*schema.Message]{
+			MessageStreamRef: &MessageStreamRef{Kind: SessionEventMessage},
+		},
+	}
+	release := func() {
+		select {
+		case <-agent.release:
+		default:
+			close(agent.release)
+		}
+	}
+	defer release()
+
+	const businessID = "stream-business-id"
+	var sawStreamDraft bool
+	gen := func(ctx context.Context, e *SessionEvent[*schema.Message]) (string, error) {
+		if e != nil && e.Kind == SessionEventMessage && e.Message == nil {
+			sawStreamDraft = true
+			assert.False(t, e.Timestamp.IsZero())
+			assert.NotEmpty(t, e.TurnID)
+			return businessID, nil
+		}
+		return DefaultSessionEventIDGenerator[*schema.Message](ctx, e)
+	}
+
+	runner := NewRunner(ctx, RunnerConfig{
+		Agent:           agent,
+		EnableStreaming: true,
+		SessionID:       "streaming-ref-session",
+		SessionStore:    store,
+		SessionConfig: &SessionConfig[*schema.Message]{
+			EventIDGenerator: gen,
+		},
+	})
+
+	iter := runner.Query(ctx, "start", WithTimelineEvents())
+	var event *AgentEvent
+	for {
+		ev, ok := iter.Next()
+		require.True(t, ok)
+		require.NoError(t, ev.Err)
+		if ev.Output != nil && ev.Output.MessageOutput != nil && ev.Output.MessageOutput.IsStreaming {
+			event = ev
+			break
+		}
+	}
+	require.NotNil(t, event.SessionEventVariant)
+	ref := event.SessionEventVariant.GetMessageStreamRef()
+	require.NotNil(t, ref)
+	assert.Equal(t, businessID, ref.EventID)
+	assert.Equal(t, SessionEventMessage, ref.Kind)
+	assert.NotEmpty(t, ref.TurnID)
+	assert.False(t, ref.Timestamp.IsZero())
+
+	msg, err := event.Output.MessageOutput.MessageStream.Recv()
+	require.NoError(t, err)
+	assert.Equal(t, "partial", msg.Content)
+	release()
+	drainSessionEvents(t, iter)
+
+	require.True(t, sawStreamDraft)
+	messages := filterStoredSessionEvents(t, store.events, func(se *SessionEvent[*schema.Message]) bool {
+		return se.Kind == SessionEventMessage && se.Message != nil && se.Message.Content == "partial"
+	})
+	require.Len(t, messages, 1)
+	assert.Equal(t, businessID, messages[0].EventID)
+	assert.Equal(t, ref.TurnID, messages[0].TurnID)
+	assert.Equal(t, ref.Timestamp, messages[0].Timestamp)
+}
+
 func TestRunnerSessionPersistsIncompleteStreamingMessageBeforeCheckpoint(t *testing.T) {
 	ctx := context.Background()
 
@@ -1220,18 +1256,18 @@ func (a *runnerCheckpointSanitizeAgent) Run(ctx context.Context, _ *AgentInput, 
 	go func() {
 		defer gen.Close()
 		gen.Send(&AgentEvent{
-			EventID:   "checkpoint-session-only",
 			AgentName: "CheckpointSanitizeAgent",
-			SessionEvent: &SessionEvent[*schema.Message]{
-				EventID: "checkpoint-session-only",
-				Kind:    SessionEventSessionStatusRunning,
-				Lifecycle: &LifecycleEvent{
-					State: SessionRunStateRunning,
+			SessionEventVariant: &SessionEventVariant[*schema.Message]{
+				Event: &SessionEvent[*schema.Message]{
+					EventID: "checkpoint-session-only",
+					Kind:    SessionEventSessionStatusRunning,
+					Lifecycle: &LifecycleEvent{
+						State: SessionRunStateRunning,
+					},
 				},
 			},
 		})
 		gen.Send(&AgentEvent{
-			EventID:   "checkpoint-output",
 			AgentName: "CheckpointSanitizeAgent",
 			Output: &AgentOutput{
 				MessageOutput: &MessageVariant{
@@ -1239,10 +1275,12 @@ func (a *runnerCheckpointSanitizeAgent) Run(ctx context.Context, _ *AgentInput, 
 					Role:    schema.Assistant,
 				},
 			},
-			SessionEvent: &SessionEvent[*schema.Message]{
-				EventID: "checkpoint-output",
-				Kind:    SessionEventMessage,
-				Message: schema.AssistantMessage("mixed output", nil),
+			SessionEventVariant: &SessionEventVariant[*schema.Message]{
+				Event: &SessionEvent[*schema.Message]{
+					EventID: "checkpoint-output",
+					Kind:    SessionEventMessage,
+					Message: schema.AssistantMessage("mixed output", nil),
+				},
 			},
 		})
 		gen.Send(Interrupt(ctx, "confirm?"))
@@ -1932,24 +1970,23 @@ func setMessageIDForTest(msg *schema.Message, id string) {
 // TestStripSessionEventFields verifies all session-internal fields are stripped.
 func TestStripSessionEventFields(t *testing.T) {
 	t.Run("non-session-internal event passes through", func(t *testing.T) {
-		ts := time.Date(2026, 5, 22, 10, 0, 0, 0, time.UTC)
 		ev := &AgentEvent{
-			Timestamp: ts,
 			Output: &AgentOutput{
 				MessageOutput: &MessageVariant{Message: schema.AssistantMessage("hi", nil), Role: schema.Assistant},
 			},
 		}
 		stripped := stripSessionEventFields(ev)
 		require.NotNil(t, stripped)
-		assert.Equal(t, ts, stripped.Timestamp)
 		assert.Equal(t, "hi", stripped.Output.MessageOutput.Message.Content)
 	})
 
 	t.Run("SessionEvent-only event drops to nil", func(t *testing.T) {
 		ev := &AgentEvent{
-			SessionEvent: &SessionEvent[*schema.Message]{
-				Kind:         SessionEventModelContext,
-				ModelContext: &ModelContextEvent{},
+			SessionEventVariant: &SessionEventVariant[*schema.Message]{
+				Event: &SessionEvent[*schema.Message]{
+					Kind:         SessionEventModelContext,
+					ModelContext: &ModelContextEvent{},
+				},
 			},
 		}
 		stripped := stripSessionEventFields(ev)
@@ -1959,9 +1996,11 @@ func TestStripSessionEventFields(t *testing.T) {
 	t.Run("message mutation SessionEvent-only event drops to nil", func(t *testing.T) {
 		msgs := []*schema.Message{schema.UserMessage("x")}
 		ev := &AgentEvent{
-			SessionEvent: &SessionEvent[*schema.Message]{
-				Kind:             SessionEventMessagesReplaced,
-				MessagesReplaced: &msgs,
+			SessionEventVariant: &SessionEventVariant[*schema.Message]{
+				Event: &SessionEvent[*schema.Message]{
+					Kind:             SessionEventMessagesReplaced,
+					MessagesReplaced: &msgs,
+				},
 			},
 		}
 		stripped := stripSessionEventFields(ev)
@@ -1969,25 +2008,24 @@ func TestStripSessionEventFields(t *testing.T) {
 	})
 
 	t.Run("Err with SessionEvent keeps Err", func(t *testing.T) {
-		ts := time.Date(2026, 5, 22, 10, 1, 0, 0, time.UTC)
 		ev := &AgentEvent{
-			Timestamp: ts,
-			Err:       errors.New("visible"),
-			SessionEvent: &SessionEvent[*schema.Message]{
-				SessionID:    "child-1",
-				Kind:         SessionEventModelContext,
-				ModelContext: &ModelContextEvent{},
+			Err: errors.New("visible"),
+			SessionEventVariant: &SessionEventVariant[*schema.Message]{
+				SessionID: "child-1",
+				Event: &SessionEvent[*schema.Message]{
+					Kind:         SessionEventModelContext,
+					ModelContext: &ModelContextEvent{},
+				},
 			},
 		}
 		stripped := stripSessionEventFields(ev)
 		require.NotNil(t, stripped)
-		assert.Nil(t, stripped.SessionEvent)
-		assert.Equal(t, ts, stripped.Timestamp)
+		assert.Nil(t, stripped.SessionEventVariant.GetEvent())
 		assert.EqualError(t, stripped.Err, "visible")
 	})
 
-	t.Run("SessionEvent with SessionID alone is stripped", func(t *testing.T) {
-		ev := &AgentEvent{SessionEvent: &SessionEvent[*schema.Message]{SessionID: "child-1"}}
+	t.Run("SessionEventVariant with SessionID alone is stripped", func(t *testing.T) {
+		ev := &AgentEvent{SessionEventVariant: &SessionEventVariant[*schema.Message]{SessionID: "child-1"}}
 		stripped := stripSessionEventFields(ev)
 		assert.Nil(t, stripped)
 	})
@@ -1998,10 +2036,16 @@ func TestSessionEventTimestamp(t *testing.T) {
 	msg := schema.AssistantMessage("hi", nil)
 	EnsureMessageID(msg)
 	event := &AgentEvent{
-		EventID:   uuid.NewString(),
-		Timestamp: ts,
 		Output: &AgentOutput{
 			MessageOutput: &MessageVariant{Message: msg, Role: schema.Assistant},
+		},
+		SessionEventVariant: &SessionEventVariant[*schema.Message]{
+			Event: &SessionEvent[*schema.Message]{
+				EventID:   uuid.NewString(),
+				Timestamp: ts,
+				Kind:      SessionEventMessage,
+				Message:   msg,
+			},
 		},
 	}
 
@@ -2523,11 +2567,8 @@ func (s *recordingHelperStore) AppendEventsForSession(ctx context.Context, sid s
 	return s.sessionHelperStore.AppendEventsForSession(ctx, sid, events)
 }
 
-func (s *recordingHelperStore) AppendEvents(ctx context.Context, req *AppendSessionEventsRequest[*schema.Message]) error {
-	if req == nil {
-		req = &AppendSessionEventsRequest[*schema.Message]{}
-	}
-	return s.AppendEventsForSession(ctx, req.SessionID, req.Events)
+func (s *recordingHelperStore) AppendEvents(ctx context.Context, sessionID string, events []*SessionEvent[*schema.Message]) error {
+	return s.AppendEventsForSession(ctx, sessionID, events)
 }
 
 func (s *recordingHelperStore) openSession(_ context.Context, req *openSessionRequest) (*openSessionResult[*schema.Message], error) {
@@ -2538,11 +2579,8 @@ func (s *recordingHelperStore) openSession(_ context.Context, req *openSessionRe
 	return &openSessionResult[*schema.Message]{handle: &legacyMessageTestHandle{store: s, sessionID: sessionID}}, nil
 }
 
-func (s *recordingHelperStore) appendEvents(ctx context.Context, req *AppendSessionEventsRequest[*schema.Message]) error {
-	if req == nil {
-		req = &AppendSessionEventsRequest[*schema.Message]{}
-	}
-	return s.AppendEventsForSession(ctx, req.SessionID, req.Events)
+func (s *recordingHelperStore) appendEvents(ctx context.Context, events []*SessionEvent[*schema.Message]) error {
+	return s.AppendEventsForSession(ctx, "", events)
 }
 
 func (s *recordingHelperStore) Set(ctx context.Context, key string, value []byte) error {
@@ -2571,7 +2609,7 @@ func TestRunnerSessionInterruptCheckpointSkippedOnPersistFailure(t *testing.T) {
 	ctx := context.Background()
 	store := newRecordingHelperStore()
 	store.sessionHelperStore.kindErr = map[SessionEventKind]error{
-		SessionEventAgentInterrupt: errors.New("simulated append failure"),
+		SessionEventInterrupt: errors.New("simulated append failure"),
 	}
 
 	runner := NewRunner(ctx, RunnerConfig{
@@ -2671,7 +2709,7 @@ func TestRunnerSessionInterruptCheckpointTailIsFinalIdle(t *testing.T) {
 	require.NotNil(t, runCtx.Session)
 	for _, event := range runCtx.Session.Events {
 		require.NotNil(t, event.AgentEvent)
-		assert.Nil(t, event.SessionEvent)
+		assert.Nil(t, event.SessionEventVariant.GetEvent())
 	}
 }
 
@@ -2694,8 +2732,8 @@ func TestRunnerSessionCheckpointPayloadStripsSessionEvents(t *testing.T) {
 			break
 		}
 		require.NoError(t, event.Err)
-		if event.SessionEvent != nil {
-			liveSessionEventIDs = append(liveSessionEventIDs, event.SessionEvent.EventID)
+		if event.SessionEventVariant.GetEvent() != nil {
+			liveSessionEventIDs = append(liveSessionEventIDs, event.SessionEventVariant.GetEvent().EventID)
 		}
 	}
 	assert.Contains(t, liveSessionEventIDs, "checkpoint-session-only")
@@ -2712,13 +2750,11 @@ func TestRunnerSessionCheckpointPayloadStripsSessionEvents(t *testing.T) {
 	require.NotNil(t, runCtx)
 	require.NotNil(t, runCtx.Session)
 
-	var checkpointEventIDs []string
 	var foundOutput bool
 	for _, event := range runCtx.Session.Events {
 		require.NotNil(t, event.AgentEvent)
-		assert.Nil(t, event.SessionEvent)
+		assert.Nil(t, event.SessionEventVariant.GetEvent())
 		assert.True(t, event.Output != nil || event.Action != nil || event.Err != nil)
-		checkpointEventIDs = append(checkpointEventIDs, event.EventID)
 		if event.Output != nil &&
 			event.Output.MessageOutput != nil &&
 			event.Output.MessageOutput.Message != nil &&
@@ -2726,7 +2762,6 @@ func TestRunnerSessionCheckpointPayloadStripsSessionEvents(t *testing.T) {
 			foundOutput = true
 		}
 	}
-	assert.NotContains(t, checkpointEventIDs, "checkpoint-session-only")
 	assert.True(t, foundOutput)
 
 	var persistedKinds []SessionEventKind
@@ -2743,7 +2778,7 @@ func TestRunnerSessionAgentInterruptBoundaryFailureNotExposed(t *testing.T) {
 	ctx := context.Background()
 	store := newRecordingHelperStore()
 	store.sessionHelperStore.kindErr = map[SessionEventKind]error{
-		SessionEventAgentInterrupt: errors.New("agent interrupt append failed"),
+		SessionEventInterrupt: errors.New("agent interrupt append failed"),
 	}
 
 	runner := NewRunner(ctx, RunnerConfig{
@@ -2764,12 +2799,12 @@ func TestRunnerSessionAgentInterruptBoundaryFailureNotExposed(t *testing.T) {
 		if event.Err != nil {
 			errs = append(errs, event.Err)
 		}
-		if event.SessionEvent != nil {
-			kinds = append(kinds, event.SessionEvent.Kind)
+		if event.SessionEventVariant.GetEvent() != nil {
+			kinds = append(kinds, event.SessionEventVariant.GetEvent().Kind)
 		}
 	}
 	require.NotEmpty(t, errs)
-	assert.NotContains(t, kinds, SessionEventAgentInterrupt)
+	assert.NotContains(t, kinds, SessionEventInterrupt)
 
 	cpKey := sessionRunnerCheckpointID("interrupt-not-exposed")
 	_, existed := store.checkpoints[cpKey]
@@ -2780,7 +2815,7 @@ func TestRunnerSessionInterruptPersistErrorSurfacesWithoutCheckpoint(t *testing.
 	ctx := context.Background()
 	store := newSessionHelperStore()
 	store.kindErr = map[SessionEventKind]error{
-		SessionEventAgentInterrupt: errors.New("agent interrupt append failed"),
+		SessionEventInterrupt: errors.New("agent interrupt append failed"),
 	}
 	runner := NewRunner(ctx, RunnerConfig{
 		Agent:        &runnerInterruptAgent{},
@@ -2849,18 +2884,12 @@ func (s *transientFailStore) AppendEventsForSession(ctx context.Context, session
 	return s.sessionHelperStore.AppendEventsForSession(ctx, sessionID, events)
 }
 
-func (s *transientFailStore) AppendEvents(ctx context.Context, req *AppendSessionEventsRequest[*schema.Message]) error {
-	if req == nil {
-		req = &AppendSessionEventsRequest[*schema.Message]{}
-	}
-	return s.AppendEventsForSession(ctx, req.SessionID, req.Events)
+func (s *transientFailStore) AppendEvents(ctx context.Context, sessionID string, events []*SessionEvent[*schema.Message]) error {
+	return s.AppendEventsForSession(ctx, sessionID, events)
 }
 
-func (s *transientFailStore) appendEvents(ctx context.Context, req *AppendSessionEventsRequest[*schema.Message]) error {
-	if req == nil {
-		req = &AppendSessionEventsRequest[*schema.Message]{}
-	}
-	return s.AppendEventsForSession(ctx, req.SessionID, req.Events)
+func (s *transientFailStore) appendEvents(ctx context.Context, events []*SessionEvent[*schema.Message]) error {
+	return s.AppendEventsForSession(ctx, "", events)
 }
 
 func (s *transientFailStore) getAppendCalls() int {
@@ -2977,8 +3006,8 @@ func TestAttack_ReconstructionWithoutCommittedIdle(t *testing.T) {
 	EnsureMessageID(msg)
 	events := []*SessionEvent[*schema.Message]{
 		{EventID: uuid.NewString(), Kind: SessionEventMessage, TurnID: "turn-interrupted", Message: msg},
-		{EventID: uuid.NewString(), Kind: SessionEventAgentInterrupt, TurnID: "turn-interrupted", AgentInterrupt: &AgentInterruptEvent{
-			Contexts: []*AgentInterruptContext{
+		{EventID: uuid.NewString(), Kind: SessionEventInterrupt, TurnID: "turn-interrupted", Interrupt: &InterruptEvent{
+			Contexts: []*InterruptContext{
 				{
 					InterruptID: "agent:InterruptAgent",
 					Info:        "approval_needed",
@@ -3228,7 +3257,12 @@ func (a *sessionStreamingAgent) Run(_ context.Context, _ *AgentInput, _ ...Agent
 	go func() {
 		defer gen.Close()
 		if a.preEvent != nil {
-			gen.Send(&AgentEvent{AgentName: "session-stream-agent", SessionEvent: a.preEvent})
+			gen.Send(&AgentEvent{
+				AgentName: "session-stream-agent",
+				SessionEventVariant: &SessionEventVariant[*schema.Message]{
+					Event: a.preEvent,
+				},
+			})
 		}
 		stream := testStreamReaderWithTerminalError(a.chunks, a.streamErr)
 		role := a.role
@@ -3426,7 +3460,6 @@ func TestAttack_IncompleteStreamPrefixCarriesDurableMetadata(t *testing.T) {
 
 	require.NotNil(t, incomplete)
 	require.NotNil(t, idle)
-	assert.Equal(t, sid, incomplete.SessionID)
 	assert.NotEmpty(t, incomplete.EventID)
 	assert.NotEmpty(t, incomplete.TurnID)
 	assert.Equal(t, incomplete.TurnID, idle.TurnID)
@@ -4277,12 +4310,8 @@ func newAgenticSessionHelperStore() *agenticSessionHelperStore {
 	return &agenticSessionHelperStore{eventIDIdx: make(map[string]int)}
 }
 
-func (s *agenticSessionHelperStore) AppendEvents(ctx context.Context, req *AppendSessionEventsRequest[*schema.AgenticMessage]) error {
-	var events []*SessionEvent[*schema.AgenticMessage]
-	if req != nil {
-		events = req.Events
-	}
-	return s.AppendEventsForSession(ctx, "", events)
+func (s *agenticSessionHelperStore) AppendEvents(ctx context.Context, sessionID string, events []*SessionEvent[*schema.AgenticMessage]) error {
+	return s.AppendEventsForSession(ctx, sessionID, events)
 }
 
 func (s *agenticSessionHelperStore) AppendEventsForSession(_ context.Context, _ string, events []*SessionEvent[*schema.AgenticMessage]) error {
@@ -4308,8 +4337,8 @@ func (s *agenticSessionHelperStore) AppendEventsForSession(_ context.Context, _ 
 	return nil
 }
 
-func (s *agenticSessionHelperStore) LoadEvents(ctx context.Context, req *LoadSessionEventsRequest) (*LoadSessionEventsResult[*schema.AgenticMessage], error) {
-	return s.LoadEventsForSession(ctx, "", req)
+func (s *agenticSessionHelperStore) LoadEvents(ctx context.Context, sessionID string, req *LoadSessionEventsRequest) (*LoadSessionEventsResult[*schema.AgenticMessage], error) {
+	return s.LoadEventsForSession(ctx, sessionID, req)
 }
 
 func (s *agenticSessionHelperStore) LoadEventsForSession(_ context.Context, _ string, opts *LoadSessionEventsRequest) (*LoadSessionEventsResult[*schema.AgenticMessage], error) {
@@ -4378,11 +4407,8 @@ func (h *agenticTestSessionHandle) loadEvents(ctx context.Context, req *LoadSess
 	return h.store.LoadEventsForSession(ctx, h.sessionID, req)
 }
 
-func (h *agenticTestSessionHandle) appendEvents(ctx context.Context, req *AppendSessionEventsRequest[*schema.AgenticMessage]) error {
-	if req == nil {
-		req = &AppendSessionEventsRequest[*schema.AgenticMessage]{}
-	}
-	return h.store.AppendEventsForSession(ctx, h.sessionID, req.Events)
+func (h *agenticTestSessionHandle) appendEvents(ctx context.Context, events []*SessionEvent[*schema.AgenticMessage]) error {
+	return h.store.AppendEventsForSession(ctx, h.sessionID, events)
 }
 
 func (h *agenticTestSessionHandle) close(context.Context) error { return nil }
@@ -4593,9 +4619,11 @@ func TestRunnerPersists_MessagesReplaced(t *testing.T) {
 		events: []*AgentEvent{
 			{
 				AgentName: "mutation-agent",
-				SessionEvent: &SessionEvent[*schema.Message]{
-					Kind:             SessionEventMessagesReplaced,
-					MessagesReplaced: &repl,
+				SessionEventVariant: &SessionEventVariant[*schema.Message]{
+					Event: &SessionEvent[*schema.Message]{
+						Kind:             SessionEventMessagesReplaced,
+						MessagesReplaced: &repl,
+					},
 				},
 			},
 		},
@@ -4662,21 +4690,25 @@ func TestRunnerPersists_MessageUpdated_BothMessages(t *testing.T) {
 			},
 			{
 				AgentName: "mutation-agent",
-				SessionEvent: &SessionEvent[*schema.Message]{
-					Kind: SessionEventMessageUpdated,
-					MessageUpdated: &MessageUpdatedEvent[*schema.Message]{
-						MessageID: GetMessageID(toolResultMsg),
-						Message:   updatedTool,
+				SessionEventVariant: &SessionEventVariant[*schema.Message]{
+					Event: &SessionEvent[*schema.Message]{
+						Kind: SessionEventMessageUpdated,
+						MessageUpdated: &MessageUpdatedEvent[*schema.Message]{
+							MessageID: GetMessageID(toolResultMsg),
+							Message:   updatedTool,
+						},
 					},
 				},
 			},
 			{
 				AgentName: "mutation-agent",
-				SessionEvent: &SessionEvent[*schema.Message]{
-					Kind: SessionEventMessageUpdated,
-					MessageUpdated: &MessageUpdatedEvent[*schema.Message]{
-						MessageID: GetMessageID(toolCallMsg),
-						Message:   updatedAssistant,
+				SessionEventVariant: &SessionEventVariant[*schema.Message]{
+					Event: &SessionEvent[*schema.Message]{
+						Kind: SessionEventMessageUpdated,
+						MessageUpdated: &MessageUpdatedEvent[*schema.Message]{
+							MessageID: GetMessageID(toolCallMsg),
+							Message:   updatedAssistant,
+						},
 					},
 				},
 			},
@@ -4751,22 +4783,26 @@ func TestRunnerPersists_MessageInserted_AnchorAndAppend(t *testing.T) {
 			// MessageInserted before the user message:
 			{
 				AgentName: "mutation-agent",
-				SessionEvent: &SessionEvent[*schema.Message]{
-					Kind: SessionEventMessageInserted,
-					MessageInserted: &MessageInsertedEvent[*schema.Message]{
-						Message:         agentsmdMsg,
-						BeforeMessageID: GetMessageID(userMsg),
+				SessionEventVariant: &SessionEventVariant[*schema.Message]{
+					Event: &SessionEvent[*schema.Message]{
+						Kind: SessionEventMessageInserted,
+						MessageInserted: &MessageInsertedEvent[*schema.Message]{
+							Message:         agentsmdMsg,
+							BeforeMessageID: GetMessageID(userMsg),
+						},
 					},
 				},
 			},
 			// MessageInserted appended at end:
 			{
 				AgentName: "mutation-agent",
-				SessionEvent: &SessionEvent[*schema.Message]{
-					Kind: SessionEventMessageInserted,
-					MessageInserted: &MessageInsertedEvent[*schema.Message]{
-						Message:         patchedTool,
-						BeforeMessageID: "",
+				SessionEventVariant: &SessionEventVariant[*schema.Message]{
+					Event: &SessionEvent[*schema.Message]{
+						Kind: SessionEventMessageInserted,
+						MessageInserted: &MessageInsertedEvent[*schema.Message]{
+							Message:         patchedTool,
+							BeforeMessageID: "",
+						},
 					},
 				},
 			},
@@ -5116,154 +5152,6 @@ func TestAttack_LeadingSystemMessageExtraChangesArePersisted(t *testing.T) {
 	assert.Equal(t, "b", result.state.Messages[0].Extra["trace"])
 }
 
-func TestAttack_LeadingSystemMessageMutationInGenModelInputStillPersistsUpdate(t *testing.T) {
-	ctx := context.Background()
-	store := newSessionHelperStore()
-	sid := "leading-system-content-mutation"
-	seedModel := &leadingSystemTestModel[*schema.Message]{response: schema.AssistantMessage("seed answer", nil)}
-	seedAgent, err := NewChatModelAgent(ctx, &ChatModelAgentConfig{
-		Name:        "system-content-seed-agent",
-		Description: "test",
-		Instruction: "system v1",
-		Model:       seedModel,
-	})
-	require.NoError(t, err)
-	drainSessionEvents(t, NewRunner(ctx, RunnerConfig{Agent: seedAgent, SessionID: sid, SessionStore: store}).
-		Run(ctx, []*schema.Message{schema.UserMessage("seed")}))
-
-	updateModel := &leadingSystemTestModel[*schema.Message]{response: schema.AssistantMessage("updated answer", nil)}
-	updateAgent, err := NewChatModelAgent(ctx, &ChatModelAgentConfig{
-		Name:        "system-content-update-agent",
-		Description: "test",
-		Model:       updateModel,
-		GenModelInput: func(_ context.Context, _ string, input *AgentInput) ([]*schema.Message, error) {
-			require.NotEmpty(t, input.Messages)
-			input.Messages[0].Content = "mutated old system"
-			return append([]*schema.Message{schema.SystemMessage("system v2")}, input.Messages[1:]...), nil
-		},
-	})
-	require.NoError(t, err)
-	drainSessionEvents(t, NewRunner(ctx, RunnerConfig{Agent: updateAgent, SessionID: sid, SessionStore: store}).
-		Run(ctx, []*schema.Message{schema.UserMessage("update")}))
-
-	var update *MessageUpdatedEvent[*schema.Message]
-	for _, event := range loadMessageSessionEvents(t, ctx, store, sid) {
-		if event.MessageUpdated != nil && event.MessageUpdated.Message.Role == schema.System {
-			update = event.MessageUpdated
-		}
-	}
-	require.NotNil(t, update)
-	assert.Equal(t, "system v2", update.Message.Content)
-
-	handle := mustOpenTestSession[*schema.Message](t, ctx, store, sid)
-	result, err := reconstructSessionState[*schema.Message](ctx, handle, sid, defaultLoadPageSize)
-	require.NoError(t, err)
-	require.NoError(t, handle.close(ctx))
-	require.NotEmpty(t, result.state.Messages)
-	assert.Equal(t, "system v2", result.state.Messages[0].Content)
-}
-
-func TestAttack_LeadingSystemMessageExtraMutationInGenModelInputStillPersistsUpdate(t *testing.T) {
-	ctx := context.Background()
-	store := newSessionHelperStore()
-	sid := "leading-system-extra-mutation"
-
-	runTurn := func(trace string, mutateOld bool) {
-		model := &leadingSystemTestModel[*schema.Message]{response: schema.AssistantMessage("answer "+trace, nil)}
-		agent, err := NewChatModelAgent(ctx, &ChatModelAgentConfig{
-			Name:        "system-extra-mutation-agent",
-			Description: "test",
-			Model:       model,
-			GenModelInput: func(_ context.Context, _ string, input *AgentInput) ([]*schema.Message, error) {
-				tail := input.Messages
-				if mutateOld {
-					require.NotEmpty(t, input.Messages)
-					require.NotNil(t, input.Messages[0].Extra)
-					input.Messages[0].Extra["trace"] = trace
-					tail = input.Messages[1:]
-				}
-				system := schema.SystemMessage("same")
-				system.Extra = map[string]any{"trace": trace}
-				return append([]*schema.Message{system}, tail...), nil
-			},
-		})
-		require.NoError(t, err)
-		drainSessionEvents(t, NewRunner(ctx, RunnerConfig{Agent: agent, SessionID: sid, SessionStore: store}).
-			Run(ctx, []*schema.Message{schema.UserMessage(trace)}))
-	}
-
-	runTurn("old", false)
-	runTurn("new", true)
-
-	var update *MessageUpdatedEvent[*schema.Message]
-	for _, event := range loadMessageSessionEvents(t, ctx, store, sid) {
-		if event.MessageUpdated != nil && event.MessageUpdated.Message.Role == schema.System {
-			update = event.MessageUpdated
-		}
-	}
-	require.NotNil(t, update, "system Extra mutation must not hide the generated update")
-	assert.Equal(t, "new", update.Message.Extra["trace"])
-
-	handle := mustOpenTestSession[*schema.Message](t, ctx, store, sid)
-	result, err := reconstructSessionState[*schema.Message](ctx, handle, sid, defaultLoadPageSize)
-	require.NoError(t, err)
-	require.NoError(t, handle.close(ctx))
-	require.NotEmpty(t, result.state.Messages)
-	assert.Equal(t, "new", result.state.Messages[0].Extra["trace"])
-}
-
-func TestAttack_LeadingSystemSnapshotAssignsIDToSource(t *testing.T) {
-	ctx := context.Background()
-	sourceSystem := schema.SystemMessage("system v1")
-	input := &AgentInput{Messages: []*schema.Message{sourceSystem, schema.UserMessage("hello")}}
-	model := &leadingSystemTestModel[*schema.Message]{response: schema.AssistantMessage("answer", nil)}
-	agent, err := NewChatModelAgent(ctx, &ChatModelAgentConfig{
-		Name:        "system-source-id-agent",
-		Description: "test",
-		Model:       model,
-		GenModelInput: func(_ context.Context, _ string, input *AgentInput) ([]*schema.Message, error) {
-			return append([]*schema.Message{schema.SystemMessage("system v2")}, input.Messages[1:]...), nil
-		},
-	})
-	require.NoError(t, err)
-
-	var update *MessageUpdatedEvent[*schema.Message]
-	for iter := agent.Run(ctx, input, withEnableSessionEvents()); ; {
-		event, ok := iter.Next()
-		if !ok {
-			break
-		}
-		require.NoError(t, event.Err)
-		if event.SessionEvent != nil && event.SessionEvent.MessageUpdated != nil {
-			update = event.SessionEvent.MessageUpdated
-		}
-	}
-
-	sourceID := GetMessageID(sourceSystem)
-	require.NotEmpty(t, sourceID)
-	require.NotNil(t, update)
-	assert.Equal(t, sourceID, update.MessageID)
-}
-
-func TestAttack_LeadingSystemSnapshotDoesNotAssignIDWhenSessionEventsDisabled(t *testing.T) {
-	ctx := context.Background()
-	sourceSystem := schema.SystemMessage("system v1")
-	input := &AgentInput{Messages: []*schema.Message{sourceSystem, schema.UserMessage("hello")}}
-	model := &leadingSystemTestModel[*schema.Message]{response: schema.AssistantMessage("answer", nil)}
-	agent, err := NewChatModelAgent(ctx, &ChatModelAgentConfig{
-		Name:        "system-disabled-source-id-agent",
-		Description: "test",
-		Model:       model,
-		GenModelInput: func(_ context.Context, _ string, input *AgentInput) ([]*schema.Message, error) {
-			return append([]*schema.Message{schema.SystemMessage("system v2")}, input.Messages[1:]...), nil
-		},
-	})
-	require.NoError(t, err)
-
-	drainSessionEvents(t, agent.Run(ctx, input))
-	assert.Empty(t, GetMessageID(sourceSystem))
-}
-
 func TestSameSystemMessageComparesExtraExceptMessageID(t *testing.T) {
 	oldMsg := schema.SystemMessage("same")
 	oldMsg.Extra = map[string]any{"_eino_msg_id": "old", "trace": "a"}
@@ -5367,10 +5255,12 @@ func TestRunnerPersists_MessagesDeleted_Reconstructs(t *testing.T) {
 			},
 			{
 				AgentName: "mutation-agent",
-				SessionEvent: &SessionEvent[*schema.Message]{
-					Kind: SessionEventMessagesDeleted,
-					MessagesDeleted: &MessagesDeletedEvent{
-						MessageIDs: []string{GetMessageID(b)},
+				SessionEventVariant: &SessionEventVariant[*schema.Message]{
+					Event: &SessionEvent[*schema.Message]{
+						Kind: SessionEventMessagesDeleted,
+						MessagesDeleted: &MessagesDeletedEvent{
+							MessageIDs: []string{GetMessageID(b)},
+						},
 					},
 				},
 			},
@@ -5449,8 +5339,12 @@ func TestAgentTool_ChildSessionID_FiltersFromParentLog(t *testing.T) {
 			// An event tagged as belonging to a different session — should not be persisted.
 			{
 				AgentName: "child",
-				SessionEvent: &SessionEvent[*schema.Message]{
+				SessionEventVariant: &SessionEventVariant[*schema.Message]{
 					SessionID: "agent_tool:abc-123",
+					Event: &SessionEvent[*schema.Message]{
+						Kind:    SessionEventMessage,
+						Message: childMsg,
+					},
 				},
 				Output: &AgentOutput{
 					MessageOutput: &MessageVariant{Message: childMsg, Role: schema.Assistant},

--- a/adk/session_timeline_test.go
+++ b/adk/session_timeline_test.go
@@ -103,20 +103,20 @@ func TestSessionTimeline_ClassifyAndSerializeVariants(t *testing.T) {
 		},
 		{
 			name: "interrupt",
-			se:   &SessionEvent[*schema.Message]{UserObservation: &UserObservationEvent{Interrupt: &UserInterruptEvent{Reason: "user"}}},
+			se:   &SessionEvent[*schema.Message]{Cancel: &CancelEvent{Reason: "user"}},
 			kind: SessionEventCancel,
 		},
 		{
 			name: "agent interrupt",
-			se: &SessionEvent[*schema.Message]{AgentInterrupt: &AgentInterruptEvent{
-				Contexts: []*AgentInterruptContext{
+			se: &SessionEvent[*schema.Message]{Interrupt: &InterruptEvent{
+				Contexts: []*InterruptContext{
 					{
 						InterruptID: "agent:timeline-agent",
 						Info:        "confirm?",
 					},
 				},
 			}},
-			kind: SessionEventAgentInterrupt,
+			kind: SessionEventInterrupt,
 		},
 		{
 			name: "extension",
@@ -227,8 +227,8 @@ func TestSessionTimeline_ReconstructionIgnoresNonContextVariants(t *testing.T) {
 		{EventID: uuid.NewString(), Kind: SessionEventMessage, Message: msg},
 		{EventID: uuid.NewString(), Kind: SessionEventSpanModelRequestStart, Span: &SpanEvent{SpanID: uuid.NewString(), Kind: SpanKindModel, StartedAt: time.Now().UTC(), Model: &ModelSpanMeta{}}},
 		{EventID: uuid.NewString(), Kind: SessionEventKind("x.outcome.started"), Extension: &SessionExtensionEvent{Data: &sessionTimelineExtensionPayload{Attempt: 1}}},
-		{EventID: uuid.NewString(), Kind: SessionEventAgentInterrupt, AgentInterrupt: &AgentInterruptEvent{
-			Contexts: []*AgentInterruptContext{
+		{EventID: uuid.NewString(), Kind: SessionEventInterrupt, Interrupt: &InterruptEvent{
+			Contexts: []*InterruptContext{
 				{
 					InterruptID: "agent:timeline-agent",
 					Info:        "confirm?",
@@ -254,8 +254,8 @@ func TestSessionTimeline_ReconstructionIgnoresNonContextVariants(t *testing.T) {
 func TestSessionTimeline_AgentInterruptRoundTripPreservesContexts(t *testing.T) {
 	se := &SessionEvent[*schema.Message]{
 		EventID: uuid.NewString(),
-		AgentInterrupt: &AgentInterruptEvent{
-			Contexts: []*AgentInterruptContext{
+		Interrupt: &InterruptEvent{
+			Contexts: []*InterruptContext{
 				{
 					InterruptID: "agent:timeline-agent;tool:lookup:call_1",
 					Info:        "tool info",
@@ -265,22 +265,22 @@ func TestSessionTimeline_AgentInterruptRoundTripPreservesContexts(t *testing.T) 
 		},
 	}
 	require.NoError(t, NormalizeSessionEventKind(se))
-	require.Equal(t, SessionEventAgentInterrupt, se.Kind)
+	require.Equal(t, SessionEventInterrupt, se.Kind)
 
 	data, err := encodeSessionEvent(se)
 	require.NoError(t, err)
 	decoded, err := decodeSessionEvent[*schema.Message](data)
 	require.NoError(t, err)
-	require.NotNil(t, decoded.AgentInterrupt)
-	assert.Equal(t, SessionEventAgentInterrupt, decoded.Kind)
-	require.Len(t, decoded.AgentInterrupt.Contexts, 1)
-	ctx0 := decoded.AgentInterrupt.Contexts[0]
+	require.NotNil(t, decoded.Interrupt)
+	assert.Equal(t, SessionEventInterrupt, decoded.Kind)
+	require.Len(t, decoded.Interrupt.Contexts, 1)
+	ctx0 := decoded.Interrupt.Contexts[0]
 	assert.Equal(t, "agent:timeline-agent;tool:lookup:call_1", ctx0.InterruptID)
 	assert.Equal(t, "tool info", ctx0.Info)
 	assert.Equal(t, "call_1", ctx0.ToolUseID)
 }
 
-func TestBuildAgentInterruptEvent_ToolUseID(t *testing.T) {
+func TestBuildInterruptEvent_ToolUseID(t *testing.T) {
 	contexts := []*InterruptCtx{
 		{
 			ID: "agent:timeline-agent;tool:lookup:call_1",
@@ -293,7 +293,7 @@ func TestBuildAgentInterruptEvent_ToolUseID(t *testing.T) {
 		},
 	}
 
-	event := buildAgentInterruptEvent(contexts)
+	event := buildInterruptEvent(contexts)
 	require.NotNil(t, event)
 	require.Len(t, event.Contexts, 1)
 	assert.Equal(t, "agent:timeline-agent;tool:lookup:call_1", event.Contexts[0].InterruptID)
@@ -303,7 +303,7 @@ func TestBuildAgentInterruptEvent_ToolUseID(t *testing.T) {
 	// Fallback to segment ID when SubID is empty.
 	contexts[0].Address[1].SubID = ""
 	contexts[0].Address[1].ID = "legacy-call-id"
-	event = buildAgentInterruptEvent(contexts)
+	event = buildInterruptEvent(contexts)
 	assert.Equal(t, "legacy-call-id", event.Contexts[0].ToolUseID)
 }
 
@@ -349,12 +349,12 @@ func TestRunner_PersistsAgentInterruptSessionEvent(t *testing.T) {
 	require.NotEmpty(t, liveInterruptContexts)
 
 	interrupts := filterStoredSessionEvents(t, store.events, func(se *SessionEvent[*schema.Message]) bool {
-		return se.Kind == SessionEventAgentInterrupt
+		return se.Kind == SessionEventInterrupt
 	})
 	require.Len(t, interrupts, 1)
-	require.NotNil(t, interrupts[0].AgentInterrupt)
-	require.Len(t, interrupts[0].AgentInterrupt.Contexts, 1)
-	ctx0 := interrupts[0].AgentInterrupt.Contexts[0]
+	require.NotNil(t, interrupts[0].Interrupt)
+	require.Len(t, interrupts[0].Interrupt.Contexts, 1)
+	ctx0 := interrupts[0].Interrupt.Contexts[0]
 	assert.Equal(t, liveInterruptContexts[0].ID, ctx0.InterruptID)
 	assert.Equal(t, liveInterruptContexts[0].Info, ctx0.Info)
 	requireStoredIdleStopReason(t, store.events, "interrupted")
@@ -466,7 +466,7 @@ func TestWithTimelineEvents_LiveExposure(t *testing.T) {
 				break
 			}
 			require.NoError(t, event.Err)
-			assert.Nil(t, event.SessionEvent)
+			assert.Nil(t, event.SessionEventVariant.GetEvent())
 		}
 		lifecycle := filterStoredSessionEvents(t, store.events, func(se *SessionEvent[*schema.Message]) bool {
 			return se.Kind == SessionEventSessionStatusRunning || se.Kind == SessionEventSessionStatusIdle
@@ -487,11 +487,10 @@ func TestWithTimelineEvents_LiveExposure(t *testing.T) {
 				break
 			}
 			require.NoError(t, event.Err)
-			if event.SessionEvent != nil {
-				assert.Equal(t, event.EventID, event.SessionEvent.EventID)
-				kinds = append(kinds, event.SessionEvent.Kind)
-				if event.SessionEvent.Kind == SessionEventMessage && event.SessionEvent.Message != nil &&
-					event.SessionEvent.Message.Role == schema.User && event.SessionEvent.Message.Content == "hello" {
+			if event.SessionEventVariant.GetEvent() != nil {
+				kinds = append(kinds, event.SessionEventVariant.GetEvent().Kind)
+				if event.SessionEventVariant.GetEvent().Kind == SessionEventMessage && event.SessionEventVariant.GetEvent().Message != nil &&
+					event.SessionEventVariant.GetEvent().Message.Role == schema.User && event.SessionEventVariant.GetEvent().Message.Content == "hello" {
 					liveUserInput = true
 				}
 			}
@@ -533,12 +532,14 @@ func TestRunner_ExtensionEventSentWithTypedSendEventIsLiveAndPersisted(t *testin
 			{
 				AfterChatModel: func(ctx context.Context, _ *ChatModelAgentState) error {
 					return SendEvent(ctx, &AgentEvent{
-						SessionEvent: &SessionEvent[*schema.Message]{
-							Kind: extensionKind,
-							Extension: &SessionExtensionEvent{
-								Data: &sessionTimelineExtensionPayload{
-									OutcomeName: "code_review",
-									Attempt:     1,
+						SessionEventVariant: &SessionEventVariant[*schema.Message]{
+							Event: &SessionEvent[*schema.Message]{
+								Kind: extensionKind,
+								Extension: &SessionExtensionEvent{
+									Data: &sessionTimelineExtensionPayload{
+										OutcomeName: "code_review",
+										Attempt:     1,
+									},
 								},
 							},
 						},
@@ -565,8 +566,8 @@ func TestRunner_ExtensionEventSentWithTypedSendEventIsLiveAndPersisted(t *testin
 				break
 			}
 			require.NoError(t, event.Err)
-			if event.SessionEvent != nil && event.SessionEvent.Kind == extensionKind {
-				liveExtension = event.SessionEvent
+			if event.SessionEventVariant.GetEvent() != nil && event.SessionEventVariant.GetEvent().Kind == extensionKind {
+				liveExtension = event.SessionEventVariant.GetEvent()
 			}
 		}
 
@@ -620,7 +621,7 @@ func TestRunner_ExtensionEventSentWithTypedSendEventIsLiveAndPersisted(t *testin
 				break
 			}
 			require.NoError(t, event.Err)
-			assert.Nil(t, event.SessionEvent)
+			assert.Nil(t, event.SessionEventVariant.GetEvent())
 		}
 
 		stored := filterStoredSessionEvents(t, store.events, func(se *SessionEvent[*schema.Message]) bool {
@@ -632,9 +633,11 @@ func TestRunner_ExtensionEventSentWithTypedSendEventIsLiveAndPersisted(t *testin
 
 func TestTypedSendEventOutsideExecutionIsNoop(t *testing.T) {
 	err := SendEvent(context.Background(), &AgentEvent{
-		SessionEvent: &SessionEvent[*schema.Message]{
-			Kind:      SessionEventKind("x.outcome.started"),
-			Extension: &SessionExtensionEvent{},
+		SessionEventVariant: &SessionEventVariant[*schema.Message]{
+			Event: &SessionEvent[*schema.Message]{
+				Kind:      SessionEventKind("x.outcome.started"),
+				Extension: &SessionExtensionEvent{},
+			},
 		},
 	})
 	require.NoError(t, err)
@@ -674,14 +677,12 @@ func TestRetryTimelineEmitsRescheduleSequence(t *testing.T) {
 			break
 		}
 		require.NoError(t, event.Err)
-		require.NotNil(t, event.SessionEvent)
-		require.Equal(t, event.EventID, event.SessionEvent.EventID)
-		kinds = append(kinds, event.SessionEvent.Kind)
+		require.NotNil(t, event.SessionEventVariant.GetEvent())
+		kinds = append(kinds, event.SessionEventVariant.GetEvent().Kind)
 	}
 
 	require.Equal(t, []SessionEventKind{
 		SessionEventSessionError,
-		SessionEventSessionStatusRescheduled,
 		SessionEventSessionStatusRunning,
 	}, kinds)
 }
@@ -737,8 +738,8 @@ func TestModelSpanEndCarriesAssistantUsage(t *testing.T) {
 			break
 		}
 		require.NoError(t, event.Err)
-		if event.SessionEvent != nil && event.SessionEvent.Kind == SessionEventSpanModelRequestEnd {
-			spanEnd = event.SessionEvent
+		if event.SessionEventVariant.GetEvent() != nil && event.SessionEventVariant.GetEvent().Kind == SessionEventSpanModelRequestEnd {
+			spanEnd = event.SessionEventVariant.GetEvent()
 		}
 	}
 	require.NotNil(t, spanEnd)
@@ -777,32 +778,30 @@ func TestSessionTimeline_TypedAgentEventGobRoundTripPreservesSessionEvent(t *tes
 	now := time.Now().UTC()
 	spanID := uuid.NewString()
 	original := &AgentEvent{
-		EventID:   uuid.NewString(),
-		Timestamp: newEventTimestamp(),
-		SessionEvent: &SessionEvent[*schema.Message]{
-			EventID:   uuid.NewString(),
-			Timestamp: now,
-			Kind:      SessionEventSpanToolCallStart,
-			Span: &SpanEvent{
-				SpanID:    spanID,
-				Kind:      SpanKindTool,
-				Name:      "tool_call",
-				StartedAt: now,
-				Tool:      &ToolSpanMeta{ToolUseID: "call_1", Name: "lookup"},
+		SessionEventVariant: &SessionEventVariant[*schema.Message]{
+			Event: &SessionEvent[*schema.Message]{
+				EventID:   uuid.NewString(),
+				Timestamp: now,
+				Kind:      SessionEventSpanToolCallStart,
+				Span: &SpanEvent{
+					SpanID:    spanID,
+					Kind:      SpanKindTool,
+					Name:      "tool_call",
+					StartedAt: now,
+					Tool:      &ToolSpanMeta{ToolUseID: "call_1", Name: "lookup"},
+				},
 			},
 		},
 	}
-	original.SessionEvent.EventID = original.EventID
 
 	var buf bytes.Buffer
 	require.NoError(t, gob.NewEncoder(&buf).Encode(original))
 
 	var decoded AgentEvent
 	require.NoError(t, gob.NewDecoder(&buf).Decode(&decoded))
-	require.NotNil(t, decoded.SessionEvent)
-	assert.Equal(t, original.EventID, decoded.EventID)
-	assert.Equal(t, original.EventID, decoded.SessionEvent.EventID)
-	assert.Equal(t, SessionEventSpanToolCallStart, decoded.SessionEvent.Kind)
+	require.NotNil(t, decoded.SessionEventVariant.GetEvent())
+	assert.Equal(t, original.SessionEventVariant.GetEvent().EventID, decoded.SessionEventVariant.GetEvent().EventID)
+	assert.Equal(t, SessionEventSpanToolCallStart, decoded.SessionEventVariant.GetEvent().Kind)
 }
 
 func TestModelSpanMetaFromContextPopulatesFailoverAndModelFields(t *testing.T) {
@@ -876,9 +875,9 @@ func TestRetryTimelineUsesRejectReasonMessage(t *testing.T) {
 		if !ok {
 			break
 		}
-		if event.SessionEvent != nil && event.SessionEvent.Kind == SessionEventSessionError {
-			require.NotNil(t, event.SessionEvent.Error)
-			assert.Equal(t, "policy rejected", event.SessionEvent.Error.Message)
+		if event.SessionEventVariant.GetEvent() != nil && event.SessionEventVariant.GetEvent().Kind == SessionEventSessionError {
+			require.NotNil(t, event.SessionEventVariant.GetEvent().Error)
+			assert.Equal(t, "policy rejected", event.SessionEventVariant.GetEvent().Error.Message)
 			found = true
 		}
 	}
@@ -922,15 +921,15 @@ func TestFailoverTimelineLinksAttemptsAndEmitsSessionErrors(t *testing.T) {
 			break
 		}
 		require.NoError(t, event.Err)
-		if event.SessionEvent == nil {
+		if event.SessionEventVariant.GetEvent() == nil {
 			continue
 		}
-		switch event.SessionEvent.Kind {
+		switch event.SessionEventVariant.GetEvent().Kind {
 		case SessionEventSpanModelRequestStart:
-			starts = append(starts, event.SessionEvent)
+			starts = append(starts, event.SessionEventVariant.GetEvent())
 		case SessionEventSessionError:
-			if event.SessionEvent.Error != nil && event.SessionEvent.Error.Type == SessionErrorTypeModelFailover {
-				failoverErrors = append(failoverErrors, event.SessionEvent)
+			if event.SessionEventVariant.GetEvent().Error != nil && event.SessionEventVariant.GetEvent().Error.Type == SessionErrorTypeModelFailover {
+				failoverErrors = append(failoverErrors, event.SessionEventVariant.GetEvent())
 			}
 		}
 	}
@@ -946,22 +945,28 @@ func TestFailoverTimelineLinksAttemptsAndEmitsSessionErrors(t *testing.T) {
 
 func TestSessionTimeline_EventIDMismatchRejectedAtPersistenceBoundary(t *testing.T) {
 	now := time.Now().UTC()
-	_, err := toSessionEventChecked(&AgentEvent{
-		EventID: uuid.NewString(),
-		SessionEvent: &SessionEvent[*schema.Message]{
-			EventID:   uuid.NewString(),
-			Timestamp: now,
-			Kind:      SessionEventSpanToolCallStart,
-			Span: &SpanEvent{
-				SpanID:    uuid.NewString(),
-				Kind:      SpanKindTool,
-				StartedAt: now,
-				Tool:      &ToolSpanMeta{ToolUseID: "call_1"},
+	err := validateAgentSessionEventIdentity(&AgentEvent{
+		SessionEventVariant: &SessionEventVariant[*schema.Message]{
+			Event: &SessionEvent[*schema.Message]{
+				EventID:   uuid.NewString(),
+				Timestamp: now,
+				Kind:      SessionEventSpanToolCallStart,
+				Span: &SpanEvent{
+					SpanID:    uuid.NewString(),
+					Kind:      SpanKindTool,
+					StartedAt: now,
+					Tool:      &ToolSpanMeta{ToolUseID: "call_1"},
+				},
+			},
+			MessageStreamRef: &MessageStreamRef{
+				EventID:   uuid.NewString(),
+				Timestamp: now,
+				Kind:      SessionEventMessage,
 			},
 		},
 	})
 	require.Error(t, err)
-	assert.Contains(t, err.Error(), "session event identity mismatch")
+	assert.Contains(t, err.Error(), "exactly one")
 }
 
 func TestSessionTimeline_NormalizeAgentSessionEventMaterializesEnvelope(t *testing.T) {
@@ -978,59 +983,25 @@ func TestSessionTimeline_NormalizeAgentSessionEventMaterializesEnvelope(t *testi
 		}
 	}
 
-	t.Run("both ids empty", func(t *testing.T) {
+	t.Run("id empty", func(t *testing.T) {
 		original := makeToolStartSpan()
-		event := &AgentEvent{SessionEvent: original}
+		event := &AgentEvent{SessionEventVariant: &SessionEventVariant[*schema.Message]{Event: original}}
 		se, err := normalizeAgentSessionEvent(event)
 		require.NoError(t, err)
-		require.NotEmpty(t, event.EventID)
-		assert.Equal(t, event.EventID, se.EventID)
-		assert.Equal(t, event.EventID, event.SessionEvent.EventID)
-		require.False(t, event.Timestamp.IsZero())
-		assert.Equal(t, event.Timestamp, se.Timestamp)
-		assert.Equal(t, event.Timestamp, event.SessionEvent.Timestamp)
+		require.NotEmpty(t, se.EventID)
+		assert.Equal(t, se.EventID, event.SessionEventVariant.GetEvent().EventID)
+		require.False(t, se.Timestamp.IsZero())
+		assert.Equal(t, se.Timestamp, event.SessionEventVariant.GetEvent().Timestamp)
 		assert.Empty(t, original.EventID)
-	})
-
-	t.Run("envelope id and timestamp backfill session event", func(t *testing.T) {
-		ts := time.Date(2026, 5, 24, 12, 0, 0, 0, time.UTC)
-		id := uuid.NewString()
-		se := makeToolStartSpan()
-		se.Span.StartedAt = ts
-		event := &AgentEvent{
-			EventID:      id,
-			Timestamp:    ts,
-			SessionEvent: se,
-		}
-		out, err := normalizeAgentSessionEvent(event)
-		require.NoError(t, err)
-		assert.Equal(t, id, out.EventID)
-		assert.Equal(t, ts, out.Timestamp)
-	})
-
-	t.Run("session event id and timestamp backfill envelope", func(t *testing.T) {
-		ts := time.Date(2026, 5, 24, 12, 1, 0, 0, time.UTC)
-		id := uuid.NewString()
-		se := makeToolStartSpan()
-		se.EventID = id
-		se.Timestamp = ts
-		se.Span.StartedAt = ts
-		event := &AgentEvent{SessionEvent: se}
-		out, err := normalizeAgentSessionEvent(event)
-		require.NoError(t, err)
-		assert.Equal(t, id, event.EventID)
-		assert.Equal(t, ts, event.Timestamp)
-		assert.Equal(t, id, out.EventID)
-		assert.Equal(t, ts, out.Timestamp)
 	})
 
 	t.Run("model context event normalizes without mutation", func(t *testing.T) {
 		original := &SessionEvent[*schema.Message]{Kind: SessionEventModelContext, ModelContext: &ModelContextEvent{}}
-		event := &AgentEvent{SessionEvent: original}
+		event := &AgentEvent{SessionEventVariant: &SessionEventVariant[*schema.Message]{Event: original}}
 		se, err := normalizeAgentSessionEvent(event)
 		require.NoError(t, err)
 		require.NotNil(t, se.ModelContext)
-		require.NotNil(t, event.SessionEvent.ModelContext)
+		require.NotNil(t, event.SessionEventVariant.GetEvent().ModelContext)
 	})
 }
 
@@ -1070,8 +1041,8 @@ func TestRetryOnlyModelSpansHaveNoParentSpanID(t *testing.T) {
 			break
 		}
 		require.NoError(t, event.Err)
-		if event.SessionEvent != nil && event.SessionEvent.Kind == SessionEventSpanModelRequestStart {
-			starts = append(starts, event.SessionEvent)
+		if event.SessionEventVariant.GetEvent() != nil && event.SessionEventVariant.GetEvent().Kind == SessionEventSpanModelRequestStart {
+			starts = append(starts, event.SessionEventVariant.GetEvent())
 		}
 	}
 	require.NotEmpty(t, starts)
@@ -1122,16 +1093,16 @@ func TestRetryAndFailoverTimelineKeepsDistinctErrorTypes(t *testing.T) {
 			break
 		}
 		require.NoError(t, event.Err)
-		if event.SessionEvent == nil || event.SessionEvent.Kind != SessionEventSessionError || event.SessionEvent.Error == nil {
+		if event.SessionEventVariant.GetEvent() == nil || event.SessionEventVariant.GetEvent().Kind != SessionEventSessionError || event.SessionEventVariant.GetEvent().Error == nil {
 			continue
 		}
-		switch event.SessionEvent.Error.Type {
+		switch event.SessionEventVariant.GetEvent().Error.Type {
 		case SessionErrorTypeModelRetry:
-			if event.SessionEvent.Error.RetryStatus != nil && event.SessionEvent.Error.RetryStatus.Type == "exhausted" {
+			if event.SessionEventVariant.GetEvent().Error.RetryStatus != nil && event.SessionEventVariant.GetEvent().Error.RetryStatus.Type == "exhausted" {
 				retryExhausted = true
 			}
 		case SessionErrorTypeModelFailover:
-			if event.SessionEvent.Error.RetryStatus != nil && event.SessionEvent.Error.RetryStatus.Type == "retrying" {
+			if event.SessionEventVariant.GetEvent().Error.RetryStatus != nil && event.SessionEventVariant.GetEvent().Error.RetryStatus.Type == "retrying" {
 				failoverRetrying = true
 			}
 		}
@@ -1334,9 +1305,8 @@ func TestRunnerTimelineCancelStopReasonAndUserInterruptPersisted(t *testing.T) {
 	})
 	require.Len(t, userInterrupts, 1)
 	assert.Equal(t, SessionEventKind("cancel"), userInterrupts[0].Kind)
-	require.NotNil(t, userInterrupts[0].UserObservation)
-	require.NotNil(t, userInterrupts[0].UserObservation.Interrupt)
-	assert.Equal(t, "cancelled", userInterrupts[0].UserObservation.Interrupt.Reason)
+	require.NotNil(t, userInterrupts[0].Cancel)
+	assert.Equal(t, "cancelled", userInterrupts[0].Cancel.Reason)
 	requireStoredIdleStopReason(t, store.events, "cancelled")
 
 	turnEnds := filterStoredSessionEvents(t, store.events, func(se *SessionEvent[*schema.Message]) bool {
@@ -1374,8 +1344,8 @@ func TestToolSpan_PersistedAroundToolCallAndLinksToMessages(t *testing.T) {
 			break
 		}
 		require.NoError(t, event.Err)
-		if event.SessionEvent != nil && event.SessionEvent.Kind == SessionEventSpanToolCallEnd {
-			liveToolEnd = event.SessionEvent
+		if event.SessionEventVariant.GetEvent() != nil && event.SessionEventVariant.GetEvent().Kind == SessionEventSpanToolCallEnd {
+			liveToolEnd = event.SessionEventVariant.GetEvent()
 		}
 	}
 	require.NotNil(t, liveToolEnd, "expected live tool_call_end span emission")
@@ -1510,18 +1480,11 @@ func (s *kindsRecordingStore) loadEvents(ctx context.Context, opts *LoadSessionE
 	if opts != nil {
 		s.recordedKinds = append(s.recordedKinds, opts.Kinds)
 	}
-	sessionID := ""
-	if opts != nil {
-		sessionID = opts.SessionID
-	}
-	return s.inner.LoadEventsForSession(ctx, sessionID, opts)
+	return s.inner.LoadEventsForSession(ctx, "", opts)
 }
 
-func (s *kindsRecordingStore) appendEvents(ctx context.Context, req *AppendSessionEventsRequest[*schema.Message]) error {
-	if req == nil {
-		req = &AppendSessionEventsRequest[*schema.Message]{}
-	}
-	return s.inner.AppendEventsForSession(ctx, req.SessionID, req.Events)
+func (s *kindsRecordingStore) appendEvents(ctx context.Context, events []*SessionEvent[*schema.Message]) error {
+	return s.inner.AppendEventsForSession(ctx, "", events)
 }
 
 func (s *kindsRecordingStore) close(context.Context) error { return nil }

--- a/adk/session_timeline_test.go
+++ b/adk/session_timeline_test.go
@@ -466,7 +466,7 @@ func TestWithTimelineEvents_LiveExposure(t *testing.T) {
 				break
 			}
 			require.NoError(t, event.Err)
-			assert.Nil(t, event.SessionEventVariant.GetEvent())
+			assert.Nil(t, event.SessionEventVariant)
 		}
 		lifecycle := filterStoredSessionEvents(t, store.events, func(se *SessionEvent[*schema.Message]) bool {
 			return se.Kind == SessionEventSessionStatusRunning || se.Kind == SessionEventSessionStatusIdle
@@ -487,10 +487,10 @@ func TestWithTimelineEvents_LiveExposure(t *testing.T) {
 				break
 			}
 			require.NoError(t, event.Err)
-			if event.SessionEventVariant.GetEvent() != nil {
-				kinds = append(kinds, event.SessionEventVariant.GetEvent().Kind)
-				if event.SessionEventVariant.GetEvent().Kind == SessionEventMessage && event.SessionEventVariant.GetEvent().Message != nil &&
-					event.SessionEventVariant.GetEvent().Message.Role == schema.User && event.SessionEventVariant.GetEvent().Message.Content == "hello" {
+			if event.SessionEventVariant != nil && event.SessionEventVariant.Event != nil {
+				kinds = append(kinds, event.SessionEventVariant.Event.Kind)
+				if event.SessionEventVariant.Event.Kind == SessionEventMessage && event.SessionEventVariant.Event.Message != nil &&
+					event.SessionEventVariant.Event.Message.Role == schema.User && event.SessionEventVariant.Event.Message.Content == "hello" {
 					liveUserInput = true
 				}
 			}
@@ -566,8 +566,8 @@ func TestRunner_ExtensionEventSentWithTypedSendEventIsLiveAndPersisted(t *testin
 				break
 			}
 			require.NoError(t, event.Err)
-			if event.SessionEventVariant.GetEvent() != nil && event.SessionEventVariant.GetEvent().Kind == extensionKind {
-				liveExtension = event.SessionEventVariant.GetEvent()
+			if event.SessionEventVariant != nil && event.SessionEventVariant.Event != nil && event.SessionEventVariant.Event.Kind == extensionKind {
+				liveExtension = event.SessionEventVariant.Event
 			}
 		}
 
@@ -621,7 +621,7 @@ func TestRunner_ExtensionEventSentWithTypedSendEventIsLiveAndPersisted(t *testin
 				break
 			}
 			require.NoError(t, event.Err)
-			assert.Nil(t, event.SessionEventVariant.GetEvent())
+			assert.Nil(t, event.SessionEventVariant)
 		}
 
 		stored := filterStoredSessionEvents(t, store.events, func(se *SessionEvent[*schema.Message]) bool {
@@ -660,7 +660,7 @@ func TestSessionTimeline_SpanMetaMustBeOneOf(t *testing.T) {
 	assert.Contains(t, err.Error(), "exactly one of Model or Tool")
 }
 
-func TestRetryTimelineEmitsRescheduleSequence(t *testing.T) {
+func TestRetryTimelineEmitsRetryingError(t *testing.T) {
 	iter, gen := NewAsyncIteratorPair[*AgentEvent]()
 	ctx := withTypedChatModelAgentExecCtx(context.Background(), &chatModelAgentExecCtx{
 		generator:              gen,
@@ -677,13 +677,12 @@ func TestRetryTimelineEmitsRescheduleSequence(t *testing.T) {
 			break
 		}
 		require.NoError(t, event.Err)
-		require.NotNil(t, event.SessionEventVariant.GetEvent())
-		kinds = append(kinds, event.SessionEventVariant.GetEvent().Kind)
+		require.NotNil(t, event.SessionEventVariant.Event)
+		kinds = append(kinds, event.SessionEventVariant.Event.Kind)
 	}
 
 	require.Equal(t, []SessionEventKind{
 		SessionEventSessionError,
-		SessionEventSessionStatusRunning,
 	}, kinds)
 }
 
@@ -738,8 +737,8 @@ func TestModelSpanEndCarriesAssistantUsage(t *testing.T) {
 			break
 		}
 		require.NoError(t, event.Err)
-		if event.SessionEventVariant.GetEvent() != nil && event.SessionEventVariant.GetEvent().Kind == SessionEventSpanModelRequestEnd {
-			spanEnd = event.SessionEventVariant.GetEvent()
+		if event.SessionEventVariant != nil && event.SessionEventVariant.Event != nil && event.SessionEventVariant.Event.Kind == SessionEventSpanModelRequestEnd {
+			spanEnd = event.SessionEventVariant.Event
 		}
 	}
 	require.NotNil(t, spanEnd)
@@ -799,9 +798,9 @@ func TestSessionTimeline_TypedAgentEventGobRoundTripPreservesSessionEvent(t *tes
 
 	var decoded AgentEvent
 	require.NoError(t, gob.NewDecoder(&buf).Decode(&decoded))
-	require.NotNil(t, decoded.SessionEventVariant.GetEvent())
-	assert.Equal(t, original.SessionEventVariant.GetEvent().EventID, decoded.SessionEventVariant.GetEvent().EventID)
-	assert.Equal(t, SessionEventSpanToolCallStart, decoded.SessionEventVariant.GetEvent().Kind)
+	require.NotNil(t, decoded.SessionEventVariant.Event)
+	assert.Equal(t, original.SessionEventVariant.Event.EventID, decoded.SessionEventVariant.Event.EventID)
+	assert.Equal(t, SessionEventSpanToolCallStart, decoded.SessionEventVariant.Event.Kind)
 }
 
 func TestModelSpanMetaFromContextPopulatesFailoverAndModelFields(t *testing.T) {
@@ -875,9 +874,9 @@ func TestRetryTimelineUsesRejectReasonMessage(t *testing.T) {
 		if !ok {
 			break
 		}
-		if event.SessionEventVariant.GetEvent() != nil && event.SessionEventVariant.GetEvent().Kind == SessionEventSessionError {
-			require.NotNil(t, event.SessionEventVariant.GetEvent().Error)
-			assert.Equal(t, "policy rejected", event.SessionEventVariant.GetEvent().Error.Message)
+		if event.SessionEventVariant != nil && event.SessionEventVariant.Event != nil && event.SessionEventVariant.Event.Kind == SessionEventSessionError {
+			require.NotNil(t, event.SessionEventVariant.Event.Error)
+			assert.Equal(t, "policy rejected", event.SessionEventVariant.Event.Error.Message)
 			found = true
 		}
 	}
@@ -921,15 +920,15 @@ func TestFailoverTimelineLinksAttemptsAndEmitsSessionErrors(t *testing.T) {
 			break
 		}
 		require.NoError(t, event.Err)
-		if event.SessionEventVariant.GetEvent() == nil {
+		if event.SessionEventVariant == nil || event.SessionEventVariant.Event == nil {
 			continue
 		}
-		switch event.SessionEventVariant.GetEvent().Kind {
+		switch event.SessionEventVariant.Event.Kind {
 		case SessionEventSpanModelRequestStart:
-			starts = append(starts, event.SessionEventVariant.GetEvent())
+			starts = append(starts, event.SessionEventVariant.Event)
 		case SessionEventSessionError:
-			if event.SessionEventVariant.GetEvent().Error != nil && event.SessionEventVariant.GetEvent().Error.Type == SessionErrorTypeModelFailover {
-				failoverErrors = append(failoverErrors, event.SessionEventVariant.GetEvent())
+			if event.SessionEventVariant.Event.Error != nil && event.SessionEventVariant.Event.Error.Type == SessionErrorTypeModelFailover {
+				failoverErrors = append(failoverErrors, event.SessionEventVariant.Event)
 			}
 		}
 	}
@@ -989,9 +988,9 @@ func TestSessionTimeline_NormalizeAgentSessionEventMaterializesEnvelope(t *testi
 		se, err := normalizeAgentSessionEvent(event)
 		require.NoError(t, err)
 		require.NotEmpty(t, se.EventID)
-		assert.Equal(t, se.EventID, event.SessionEventVariant.GetEvent().EventID)
+		assert.Equal(t, se.EventID, event.SessionEventVariant.Event.EventID)
 		require.False(t, se.Timestamp.IsZero())
-		assert.Equal(t, se.Timestamp, event.SessionEventVariant.GetEvent().Timestamp)
+		assert.Equal(t, se.Timestamp, event.SessionEventVariant.Event.Timestamp)
 		assert.Empty(t, original.EventID)
 	})
 
@@ -1001,7 +1000,7 @@ func TestSessionTimeline_NormalizeAgentSessionEventMaterializesEnvelope(t *testi
 		se, err := normalizeAgentSessionEvent(event)
 		require.NoError(t, err)
 		require.NotNil(t, se.ModelContext)
-		require.NotNil(t, event.SessionEventVariant.GetEvent().ModelContext)
+		require.NotNil(t, event.SessionEventVariant.Event.ModelContext)
 	})
 }
 
@@ -1041,8 +1040,8 @@ func TestRetryOnlyModelSpansHaveNoParentSpanID(t *testing.T) {
 			break
 		}
 		require.NoError(t, event.Err)
-		if event.SessionEventVariant.GetEvent() != nil && event.SessionEventVariant.GetEvent().Kind == SessionEventSpanModelRequestStart {
-			starts = append(starts, event.SessionEventVariant.GetEvent())
+		if event.SessionEventVariant != nil && event.SessionEventVariant.Event != nil && event.SessionEventVariant.Event.Kind == SessionEventSpanModelRequestStart {
+			starts = append(starts, event.SessionEventVariant.Event)
 		}
 	}
 	require.NotEmpty(t, starts)
@@ -1093,16 +1092,16 @@ func TestRetryAndFailoverTimelineKeepsDistinctErrorTypes(t *testing.T) {
 			break
 		}
 		require.NoError(t, event.Err)
-		if event.SessionEventVariant.GetEvent() == nil || event.SessionEventVariant.GetEvent().Kind != SessionEventSessionError || event.SessionEventVariant.GetEvent().Error == nil {
+		if event.SessionEventVariant == nil || event.SessionEventVariant.Event == nil || event.SessionEventVariant.Event.Kind != SessionEventSessionError || event.SessionEventVariant.Event.Error == nil {
 			continue
 		}
-		switch event.SessionEventVariant.GetEvent().Error.Type {
+		switch event.SessionEventVariant.Event.Error.Type {
 		case SessionErrorTypeModelRetry:
-			if event.SessionEventVariant.GetEvent().Error.RetryStatus != nil && event.SessionEventVariant.GetEvent().Error.RetryStatus.Type == "exhausted" {
+			if event.SessionEventVariant.Event.Error.RetryStatus != nil && event.SessionEventVariant.Event.Error.RetryStatus.Type == "exhausted" {
 				retryExhausted = true
 			}
 		case SessionErrorTypeModelFailover:
-			if event.SessionEventVariant.GetEvent().Error.RetryStatus != nil && event.SessionEventVariant.GetEvent().Error.RetryStatus.Type == "retrying" {
+			if event.SessionEventVariant.Event.Error.RetryStatus != nil && event.SessionEventVariant.Event.Error.RetryStatus.Type == "retrying" {
 				failoverRetrying = true
 			}
 		}
@@ -1344,8 +1343,8 @@ func TestToolSpan_PersistedAroundToolCallAndLinksToMessages(t *testing.T) {
 			break
 		}
 		require.NoError(t, event.Err)
-		if event.SessionEventVariant.GetEvent() != nil && event.SessionEventVariant.GetEvent().Kind == SessionEventSpanToolCallEnd {
-			liveToolEnd = event.SessionEventVariant.GetEvent()
+		if event.SessionEventVariant != nil && event.SessionEventVariant.Event != nil && event.SessionEventVariant.Event.Kind == SessionEventSpanToolCallEnd {
+			liveToolEnd = event.SessionEventVariant.Event
 		}
 	}
 	require.NotNil(t, liveToolEnd, "expected live tool_call_end span emission")

--- a/adk/turn_loop_test.go
+++ b/adk/turn_loop_test.go
@@ -2799,12 +2799,12 @@ func TestTurnLoop_ManagedInterrupt_DecisionResumeUsesCapturedCheckpointIDAndPara
 	}
 
 	interruptEvents := filterStoredSessionEvents(t, sessionStore.events, func(se *SessionEvent[*schema.Message]) bool {
-		return se.Kind == SessionEventAgentInterrupt
+		return se.Kind == SessionEventInterrupt
 	})
 	require.Len(t, interruptEvents, 1)
-	require.NotNil(t, interruptEvents[0].AgentInterrupt)
-	require.NotEmpty(t, interruptEvents[0].AgentInterrupt.Contexts)
-	assert.Equal(t, interruptTargetID, interruptEvents[0].AgentInterrupt.Contexts[0].InterruptID)
+	require.NotNil(t, interruptEvents[0].Interrupt)
+	require.NotEmpty(t, interruptEvents[0].Interrupt.Contexts)
+	assert.Equal(t, interruptTargetID, interruptEvents[0].Interrupt.Contexts[0].InterruptID)
 
 	turnEndEvents := filterStoredSessionEvents(t, sessionStore.events, func(se *SessionEvent[*schema.Message]) bool {
 		return isCommittedIdleEvent(se)
@@ -3941,13 +3941,7 @@ type mockSessionStore struct {
 	events map[string][]storedSessionEvent
 }
 
-func (m *mockSessionStore) AppendEvents(ctx context.Context, req *AppendSessionEventsRequest[*schema.Message]) error {
-	sessionID := ""
-	var events []*SessionEvent[*schema.Message]
-	if req != nil {
-		sessionID = req.SessionID
-		events = req.Events
-	}
+func (m *mockSessionStore) AppendEvents(ctx context.Context, sessionID string, events []*SessionEvent[*schema.Message]) error {
 	return m.AppendEventsForSession(ctx, sessionID, events)
 }
 
@@ -3977,11 +3971,7 @@ func (m *mockSessionStore) AppendEventsForSession(_ context.Context, sessionID s
 	return nil
 }
 
-func (m *mockSessionStore) LoadEvents(ctx context.Context, req *LoadSessionEventsRequest) (*LoadSessionEventsResult[*schema.Message], error) {
-	sessionID := ""
-	if req != nil {
-		sessionID = req.SessionID
-	}
+func (m *mockSessionStore) LoadEvents(ctx context.Context, sessionID string, req *LoadSessionEventsRequest) (*LoadSessionEventsResult[*schema.Message], error) {
 	return m.LoadEventsForSession(ctx, sessionID, req)
 }
 
@@ -4078,11 +4068,8 @@ func (h *mockSessionHandle) loadEvents(ctx context.Context, req *LoadSessionEven
 	return h.store.LoadEventsForSession(ctx, h.sessionID, req)
 }
 
-func (h *mockSessionHandle) appendEvents(ctx context.Context, req *AppendSessionEventsRequest[*schema.Message]) error {
-	if req == nil {
-		req = &AppendSessionEventsRequest[*schema.Message]{}
-	}
-	return h.store.AppendEventsForSession(ctx, h.sessionID, req.Events)
+func (h *mockSessionHandle) appendEvents(ctx context.Context, events []*SessionEvent[*schema.Message]) error {
+	return h.store.AppendEventsForSession(ctx, h.sessionID, events)
 }
 
 func (h *mockSessionHandle) close(context.Context) error { return nil }

--- a/adk/wrappers.go
+++ b/adk/wrappers.go
@@ -308,15 +308,15 @@ func sendSessionTimelineEvent[M MessageType](ctx context.Context, se *SessionEve
 	}
 	if se.EventID == "" {
 		if err := assignSessionEventIDFromContext(ctx, se); err != nil {
-			execCtx.send(ctx, &TypedAgentEvent[M]{Timestamp: newEventTimestamp(), Err: err})
+			execCtx.send(ctx, &TypedAgentEvent[M]{Err: err})
 			return
 		}
 	}
 	if err := ValidateEmittedSessionEventKind(se); err != nil {
-		execCtx.send(ctx, &TypedAgentEvent[M]{Timestamp: newEventTimestamp(), Err: err})
+		execCtx.send(ctx, &TypedAgentEvent[M]{Err: err})
 		return
 	}
-	execCtx.send(ctx, &TypedAgentEvent[M]{EventID: se.EventID, Timestamp: se.Timestamp, SessionEvent: se})
+	execCtx.send(ctx, &TypedAgentEvent[M]{SessionEventVariant: &SessionEventVariant[M]{Event: se}})
 }
 
 func newModelSpanStartEvent[M MessageType](ctx context.Context, spanID string, started time.Time, opts ...model.Option) *SessionEvent[M] {
@@ -580,7 +580,7 @@ func (m *typedEventSenderModel[M]) Generate(ctx context.Context, input []M, opts
 	// its ID allocation through the runner's SessionEventIDGenerator[M] so
 	// producer-owned identity applies. The same ID is used for the live
 	// TypedAgentEvent below; the materialized SessionEvent later inherits it.
-	assistantDraft := &SessionEvent[M]{Kind: SessionEventMessage, Message: copyMessage(result)}
+	assistantDraft := &SessionEvent[M]{Timestamp: timestamp, Kind: SessionEventMessage, Message: copyMessage(result)}
 	if err := assignSessionEventIDFromContext(ctx, assistantDraft); err != nil {
 		var zero M
 		return zero, err
@@ -600,8 +600,7 @@ func (m *typedEventSenderModel[M]) Generate(ctx context.Context, input []M, opts
 	})
 
 	event := typedModelOutputEvent(copyMessage(result), nil)
-	event.EventID = assistantMsgEventID
-	event.Timestamp = timestamp
+	event.SessionEventVariant = &SessionEventVariant[M]{Event: assistantDraft}
 	execCtx.send(ctx, event)
 
 	return result, nil
@@ -648,7 +647,7 @@ func (m *typedEventSenderModel[M]) Stream(ctx context.Context, input []M, opts .
 	// owned ID. Generators that need to recognize the assistant draft can
 	// match on Kind==SessionEventMessage with a zero Message.
 	var draftZero M
-	assistantDraft := &SessionEvent[M]{Kind: SessionEventMessage, Message: draftZero}
+	assistantDraft := &SessionEvent[M]{Timestamp: timestamp, Kind: SessionEventMessage, Message: draftZero}
 	if err := assignSessionEventIDFromContext(ctx, assistantDraft); err != nil {
 		result.Close()
 		return nil, err
@@ -669,8 +668,13 @@ func (m *typedEventSenderModel[M]) Stream(ctx context.Context, input []M, opts .
 
 	var zero M
 	event := typedModelOutputEvent[M](zero, eventStream)
-	event.EventID = assistantMsgEventID
-	event.Timestamp = timestamp
+	event.SessionEventVariant = &SessionEventVariant[M]{
+		MessageStreamRef: &MessageStreamRef{
+			EventID:   assistantMsgEventID,
+			Timestamp: timestamp,
+			Kind:      SessionEventMessage,
+		},
+	}
 	execCtx.send(ctx, event)
 
 	spanStream := streams[2]
@@ -927,7 +931,9 @@ func ensureTypedAgentEventMessageIDs[M MessageType](event *TypedAgentEvent[M]) {
 	if event.Output != nil && event.Output.MessageOutput != nil && !isNilMessage(event.Output.MessageOutput.Message) {
 		EnsureMessageID(event.Output.MessageOutput.Message)
 	}
-	ensureSessionEventMessageIDs(event.SessionEvent)
+	if event.SessionEventVariant != nil {
+		ensureSessionEventMessageIDs(event.SessionEventVariant.Event)
+	}
 }
 
 func ensureSessionEventMessageIDs[M MessageType](event *SessionEvent[M]) {
@@ -1321,17 +1327,16 @@ func (w *typedEventSenderToolWrapper[M]) WrapInvokableToolCall(_ context.Context
 		// on allocation failure, skip both the tool result event and the
 		// matching tool span end so no orphaned ToolResultMessageEventID
 		// reference is left in the timeline.
-		toolResultDraft := &SessionEvent[M]{Kind: SessionEventMessage, Message: event.Output.MessageOutput.Message}
+		toolResultDraft := &SessionEvent[M]{Timestamp: timestamp, Kind: SessionEventMessage, Message: event.Output.MessageOutput.Message}
 		if idErr := assignSessionEventIDFromContext(ctx, toolResultDraft); idErr != nil {
 			if execCtx := getTypedChatModelAgentExecCtx[M](ctx); execCtx != nil && execCtx.generator != nil {
-				execCtx.send(ctx, &TypedAgentEvent[M]{Timestamp: newEventTimestamp(), Err: idErr})
+				execCtx.send(ctx, &TypedAgentEvent[M]{Err: idErr})
 			}
 			clearToolSpanInFlight[M](ctx, tCtx.CallID)
 			return "", idErr
 		}
 		resultEventID := toolResultDraft.EventID
-		event.EventID = resultEventID
-		event.Timestamp = timestamp
+		event.SessionEventVariant = &SessionEventVariant[M]{Event: toolResultDraft}
 		if prePopAction != nil {
 			event.Action = prePopAction
 		}
@@ -1396,10 +1401,10 @@ func (w *typedEventSenderToolWrapper[M]) WrapStreamableToolCall(_ context.Contex
 		// skip the tool result event AND the tool span end so no orphaned
 		// ToolResultMessageEventID reference is left behind.
 		var toolResultDraftMsg M
-		toolResultDraft := &SessionEvent[M]{Kind: SessionEventMessage, Message: toolResultDraftMsg}
+		toolResultDraft := &SessionEvent[M]{Timestamp: timestamp, Kind: SessionEventMessage, Message: toolResultDraftMsg}
 		if idErr := assignSessionEventIDFromContext(ctx, toolResultDraft); idErr != nil {
 			if execCtx := getTypedChatModelAgentExecCtx[M](ctx); execCtx != nil && execCtx.generator != nil {
-				execCtx.send(ctx, &TypedAgentEvent[M]{Timestamp: newEventTimestamp(), Err: idErr})
+				execCtx.send(ctx, &TypedAgentEvent[M]{Err: idErr})
 			}
 			streams[0].Close()
 			streams[1].Close()
@@ -1454,8 +1459,13 @@ func (w *typedEventSenderToolWrapper[M]) WrapStreamableToolCall(_ context.Contex
 		}
 
 		event := typedToolStreamEvent[M](callID, toolName, toolMsgID, streams[0])
-		event.EventID = resultEventID
-		event.Timestamp = timestamp
+		event.SessionEventVariant = &SessionEventVariant[M]{
+			MessageStreamRef: &MessageStreamRef{
+				EventID:   resultEventID,
+				Timestamp: timestamp,
+				Kind:      SessionEventMessage,
+			},
+		}
 		event.Action = prePopAction
 
 		execCtx := getTypedChatModelAgentExecCtx[M](ctx)
@@ -1528,17 +1538,16 @@ func (w *typedEventSenderToolWrapper[M]) WrapEnhancedInvokableToolCall(_ context
 		// draft. Fail-closed: on allocation failure, skip both the tool
 		// result event and the matching tool span end so no orphaned
 		// ToolResultMessageEventID reference is left behind.
-		toolResultDraft := &SessionEvent[M]{Kind: SessionEventMessage, Message: event.Output.MessageOutput.Message}
+		toolResultDraft := &SessionEvent[M]{Timestamp: timestamp, Kind: SessionEventMessage, Message: event.Output.MessageOutput.Message}
 		if idErr := assignSessionEventIDFromContext(ctx, toolResultDraft); idErr != nil {
 			if execCtx := getTypedChatModelAgentExecCtx[M](ctx); execCtx != nil && execCtx.generator != nil {
-				execCtx.send(ctx, &TypedAgentEvent[M]{Timestamp: newEventTimestamp(), Err: idErr})
+				execCtx.send(ctx, &TypedAgentEvent[M]{Err: idErr})
 			}
 			clearToolSpanInFlight[M](ctx, tCtx.CallID)
 			return nil, idErr
 		}
 		resultEventID := toolResultDraft.EventID
-		event.EventID = resultEventID
-		event.Timestamp = timestamp
+		event.SessionEventVariant = &SessionEventVariant[M]{Event: toolResultDraft}
 		if prePopAction != nil {
 			event.Action = prePopAction
 		}
@@ -1603,10 +1612,10 @@ func (w *typedEventSenderToolWrapper[M]) WrapEnhancedStreamableToolCall(_ contex
 		// skip the tool result event AND the tool span end so no orphaned
 		// ToolResultMessageEventID reference is left behind.
 		var toolResultDraftMsg M
-		toolResultDraft := &SessionEvent[M]{Kind: SessionEventMessage, Message: toolResultDraftMsg}
+		toolResultDraft := &SessionEvent[M]{Timestamp: timestamp, Kind: SessionEventMessage, Message: toolResultDraftMsg}
 		if idErr := assignSessionEventIDFromContext(ctx, toolResultDraft); idErr != nil {
 			if execCtx := getTypedChatModelAgentExecCtx[M](ctx); execCtx != nil && execCtx.generator != nil {
-				execCtx.send(ctx, &TypedAgentEvent[M]{Timestamp: newEventTimestamp(), Err: idErr})
+				execCtx.send(ctx, &TypedAgentEvent[M]{Err: idErr})
 			}
 			streams[0].Close()
 			streams[1].Close()
@@ -1661,8 +1670,13 @@ func (w *typedEventSenderToolWrapper[M]) WrapEnhancedStreamableToolCall(_ contex
 		}
 
 		event := typedToolEnhancedStreamEvent[M](callID, toolName, toolMsgID, streams[0])
-		event.EventID = resultEventID
-		event.Timestamp = timestamp
+		event.SessionEventVariant = &SessionEventVariant[M]{
+			MessageStreamRef: &MessageStreamRef{
+				EventID:   resultEventID,
+				Timestamp: timestamp,
+				Kind:      SessionEventMessage,
+			},
+		}
 		event.Action = prePopAction
 
 		execCtx := getTypedChatModelAgentExecCtx[M](ctx)

--- a/adk/wrappers_test.go
+++ b/adk/wrappers_test.go
@@ -2558,14 +2558,14 @@ func drainAndCollectSpans(t *testing.T, iter *AsyncIterator[*AgentEvent]) (start
 		if ev.Action != nil && ev.Action.Interrupted != nil {
 			interrupted = true
 		}
-		if ev.SessionEventVariant.GetEvent() == nil || ev.SessionEventVariant.GetEvent().Span == nil {
+		if ev.SessionEventVariant == nil || ev.SessionEventVariant.Event == nil || ev.SessionEventVariant.Event.Span == nil {
 			continue
 		}
-		switch ev.SessionEventVariant.GetEvent().Kind {
+		switch ev.SessionEventVariant.Event.Kind {
 		case SessionEventSpanToolCallStart:
-			starts = append(starts, ev.SessionEventVariant.GetEvent())
+			starts = append(starts, ev.SessionEventVariant.Event)
 		case SessionEventSpanToolCallEnd:
-			ends = append(ends, ev.SessionEventVariant.GetEvent())
+			ends = append(ends, ev.SessionEventVariant.Event)
 		}
 	}
 	return
@@ -2636,12 +2636,12 @@ func runInterruptResumeAndCollectSpans(t *testing.T, agent *TypedChatModelAgent[
 		if ev.Action != nil && ev.Action.Interrupted != nil {
 			interruptEvt = ev
 		}
-		if ev.SessionEventVariant.GetEvent() != nil && ev.SessionEventVariant.GetEvent().Span != nil {
-			switch ev.SessionEventVariant.GetEvent().Kind {
+		if ev.SessionEventVariant != nil && ev.SessionEventVariant.Event != nil && ev.SessionEventVariant.Event.Span != nil {
+			switch ev.SessionEventVariant.Event.Kind {
 			case SessionEventSpanToolCallStart:
-				starts1 = append(starts1, ev.SessionEventVariant.GetEvent())
+				starts1 = append(starts1, ev.SessionEventVariant.Event)
 			case SessionEventSpanToolCallEnd:
-				ends1 = append(ends1, ev.SessionEventVariant.GetEvent())
+				ends1 = append(ends1, ev.SessionEventVariant.Event)
 			}
 		}
 	}
@@ -2739,12 +2739,12 @@ func TestToolSpan_StreamableInterruptDefersEnd(t *testing.T) {
 		if ev.Action != nil && ev.Action.Interrupted != nil {
 			interruptEvt = ev
 		}
-		if ev.SessionEventVariant.GetEvent() != nil && ev.SessionEventVariant.GetEvent().Span != nil {
-			switch ev.SessionEventVariant.GetEvent().Kind {
+		if ev.SessionEventVariant != nil && ev.SessionEventVariant.Event != nil && ev.SessionEventVariant.Event.Span != nil {
+			switch ev.SessionEventVariant.Event.Kind {
 			case SessionEventSpanToolCallStart:
-				starts1 = append(starts1, ev.SessionEventVariant.GetEvent())
+				starts1 = append(starts1, ev.SessionEventVariant.Event)
 			case SessionEventSpanToolCallEnd:
-				ends1 = append(ends1, ev.SessionEventVariant.GetEvent())
+				ends1 = append(ends1, ev.SessionEventVariant.Event)
 			}
 		}
 	}
@@ -2850,12 +2850,12 @@ func TestToolSpan_PermissionRejectEmitsEndSpan(t *testing.T) {
 		if ev.Action != nil && ev.Action.Interrupted != nil {
 			interruptEvt = ev
 		}
-		if ev.SessionEventVariant.GetEvent() != nil && ev.SessionEventVariant.GetEvent().Span != nil {
-			switch ev.SessionEventVariant.GetEvent().Kind {
+		if ev.SessionEventVariant != nil && ev.SessionEventVariant.Event != nil && ev.SessionEventVariant.Event.Span != nil {
+			switch ev.SessionEventVariant.Event.Kind {
 			case SessionEventSpanToolCallStart:
-				starts1 = append(starts1, ev.SessionEventVariant.GetEvent())
+				starts1 = append(starts1, ev.SessionEventVariant.Event)
 			case SessionEventSpanToolCallEnd:
-				ends1 = append(ends1, ev.SessionEventVariant.GetEvent())
+				ends1 = append(ends1, ev.SessionEventVariant.Event)
 			}
 		}
 	}
@@ -2966,12 +2966,12 @@ func TestToolSpan_ParallelInterruptResumesEmitMatchingEnds(t *testing.T) {
 		if ev.Action != nil && ev.Action.Interrupted != nil {
 			interruptEvt = ev
 		}
-		if ev.SessionEventVariant.GetEvent() != nil && ev.SessionEventVariant.GetEvent().Span != nil {
-			switch ev.SessionEventVariant.GetEvent().Kind {
+		if ev.SessionEventVariant != nil && ev.SessionEventVariant.Event != nil && ev.SessionEventVariant.Event.Span != nil {
+			switch ev.SessionEventVariant.Event.Kind {
 			case SessionEventSpanToolCallStart:
-				starts1 = append(starts1, ev.SessionEventVariant.GetEvent())
+				starts1 = append(starts1, ev.SessionEventVariant.Event)
 			case SessionEventSpanToolCallEnd:
-				ends1 = append(ends1, ev.SessionEventVariant.GetEvent())
+				ends1 = append(ends1, ev.SessionEventVariant.Event)
 			}
 		}
 	}

--- a/adk/wrappers_test.go
+++ b/adk/wrappers_test.go
@@ -2558,14 +2558,14 @@ func drainAndCollectSpans(t *testing.T, iter *AsyncIterator[*AgentEvent]) (start
 		if ev.Action != nil && ev.Action.Interrupted != nil {
 			interrupted = true
 		}
-		if ev.SessionEvent == nil || ev.SessionEvent.Span == nil {
+		if ev.SessionEventVariant.GetEvent() == nil || ev.SessionEventVariant.GetEvent().Span == nil {
 			continue
 		}
-		switch ev.SessionEvent.Kind {
+		switch ev.SessionEventVariant.GetEvent().Kind {
 		case SessionEventSpanToolCallStart:
-			starts = append(starts, ev.SessionEvent)
+			starts = append(starts, ev.SessionEventVariant.GetEvent())
 		case SessionEventSpanToolCallEnd:
-			ends = append(ends, ev.SessionEvent)
+			ends = append(ends, ev.SessionEventVariant.GetEvent())
 		}
 	}
 	return
@@ -2636,12 +2636,12 @@ func runInterruptResumeAndCollectSpans(t *testing.T, agent *TypedChatModelAgent[
 		if ev.Action != nil && ev.Action.Interrupted != nil {
 			interruptEvt = ev
 		}
-		if ev.SessionEvent != nil && ev.SessionEvent.Span != nil {
-			switch ev.SessionEvent.Kind {
+		if ev.SessionEventVariant.GetEvent() != nil && ev.SessionEventVariant.GetEvent().Span != nil {
+			switch ev.SessionEventVariant.GetEvent().Kind {
 			case SessionEventSpanToolCallStart:
-				starts1 = append(starts1, ev.SessionEvent)
+				starts1 = append(starts1, ev.SessionEventVariant.GetEvent())
 			case SessionEventSpanToolCallEnd:
-				ends1 = append(ends1, ev.SessionEvent)
+				ends1 = append(ends1, ev.SessionEventVariant.GetEvent())
 			}
 		}
 	}
@@ -2739,12 +2739,12 @@ func TestToolSpan_StreamableInterruptDefersEnd(t *testing.T) {
 		if ev.Action != nil && ev.Action.Interrupted != nil {
 			interruptEvt = ev
 		}
-		if ev.SessionEvent != nil && ev.SessionEvent.Span != nil {
-			switch ev.SessionEvent.Kind {
+		if ev.SessionEventVariant.GetEvent() != nil && ev.SessionEventVariant.GetEvent().Span != nil {
+			switch ev.SessionEventVariant.GetEvent().Kind {
 			case SessionEventSpanToolCallStart:
-				starts1 = append(starts1, ev.SessionEvent)
+				starts1 = append(starts1, ev.SessionEventVariant.GetEvent())
 			case SessionEventSpanToolCallEnd:
-				ends1 = append(ends1, ev.SessionEvent)
+				ends1 = append(ends1, ev.SessionEventVariant.GetEvent())
 			}
 		}
 	}
@@ -2850,12 +2850,12 @@ func TestToolSpan_PermissionRejectEmitsEndSpan(t *testing.T) {
 		if ev.Action != nil && ev.Action.Interrupted != nil {
 			interruptEvt = ev
 		}
-		if ev.SessionEvent != nil && ev.SessionEvent.Span != nil {
-			switch ev.SessionEvent.Kind {
+		if ev.SessionEventVariant.GetEvent() != nil && ev.SessionEventVariant.GetEvent().Span != nil {
+			switch ev.SessionEventVariant.GetEvent().Kind {
 			case SessionEventSpanToolCallStart:
-				starts1 = append(starts1, ev.SessionEvent)
+				starts1 = append(starts1, ev.SessionEventVariant.GetEvent())
 			case SessionEventSpanToolCallEnd:
-				ends1 = append(ends1, ev.SessionEvent)
+				ends1 = append(ends1, ev.SessionEventVariant.GetEvent())
 			}
 		}
 	}
@@ -2966,12 +2966,12 @@ func TestToolSpan_ParallelInterruptResumesEmitMatchingEnds(t *testing.T) {
 		if ev.Action != nil && ev.Action.Interrupted != nil {
 			interruptEvt = ev
 		}
-		if ev.SessionEvent != nil && ev.SessionEvent.Span != nil {
-			switch ev.SessionEvent.Kind {
+		if ev.SessionEventVariant.GetEvent() != nil && ev.SessionEventVariant.GetEvent().Span != nil {
+			switch ev.SessionEventVariant.GetEvent().Kind {
 			case SessionEventSpanToolCallStart:
-				starts1 = append(starts1, ev.SessionEvent)
+				starts1 = append(starts1, ev.SessionEventVariant.GetEvent())
 			case SessionEventSpanToolCallEnd:
-				ends1 = append(ends1, ev.SessionEvent)
+				ends1 = append(ends1, ev.SessionEventVariant.GetEvent())
 			}
 		}
 	}


### PR DESCRIPTION
## 问题 (Problem)

The session event model had accumulated structural debt:

1. **Duplicate identity fields**: `TypedAgentEvent` carried `EventID` and `Timestamp` at the top level, while `SessionEvent` also had them — creating two sources of truth and confusion about which was canonical.
2. **SessionID in durable payloads**: `SessionEvent.SessionID` was part of the persisted JSON, but it is runtime ownership metadata, not event content. Stores should receive session identity as a first-class argument, not embedded in each event.
3. **Streaming message identity gap**: Streaming messages (`MessageStream`) carried no durable identity before materialization, making it impossible to correlate live stream chunks with persisted incomplete-stream events.
4. **Overloaded interrupt types**: `UserObservationEvent`, `UserInterruptEvent`, `AgentInterruptEvent`, and `AgentInterruptContext` had nested and confusing naming that didn't map cleanly to the two distinct concepts (cancel vs. business interrupt).
5. **Verbose store interface**: `AppendSessionEventsRequest` and `LoadSessionEventsRequest.SessionID` added unnecessary ceremony around simple parameters.

## 解决方案 (Solution)

Introduce `SessionEventVariant` as a sum type that cleanly separates the two live-event shapes:

```go
type SessionEventVariant[M MessageType] struct {
    SessionID string                    // live-only ownership metadata
    Event            *SessionEvent[M]   // fully materialized durable event
    MessageStreamRef *MessageStreamRef  // durable identity for a streaming message
}
```

**Key changes:**

- **`SessionEventVariant` replaces `SessionEvent` pointer in `TypedAgentEvent`**: All session-related metadata flows through one typed envelope. `SessionID` lives only on the variant (live metadata), not on `SessionEvent` (durable payload).
- **`MessageStreamRef` carries durable identity for streaming messages**: Before a stream completes or fails, its event identity (`EventID`, `Timestamp`, `Kind`, `TurnID`) is reserved and carried in the variant — enabling SSE resume correlation and incomplete-stream persistence with stable IDs.
- **Simplified `SessionEventStore` interface**: `sessionID` is passed as a first-class argument to both `LoadEvents` and `AppendEvents`. `AppendSessionEventsRequest` is removed; events are passed directly as a slice.
- **Renamed interrupt/cancel types**: `UserObservationEvent` / `UserInterruptEvent` → `CancelEvent`; `AgentInterruptEvent` / `AgentInterruptContext` → `InterruptEvent` / `InterruptContext`. Names now directly match the two concepts.
- **Removed `EventID` and `Timestamp` from `TypedAgentEvent`**: These fields belonged to the session event layer, not the agent event layer. They are accessed via `SessionEventVariant.Event` or `SessionEventVariant.MessageStreamRef`.
- **Removed `SessionRunStateRescheduled`**: Only `running` and `idle` states remain; the rescheduled state was unused.

## 关键洞察 (Key Insights)

1. **Sum types prevent invalid states**: Before, you had to check `event.SessionEvent != nil` AND separately reason about streaming vs. materialized. Now, `SessionEventVariant` makes the two states explicit — either there's a materialized `Event`, or there's a `MessageStreamRef` for an in-flight stream. No half-initialized combinations possible.

2. **SessionID is ownership, not content**: A session event's identity is `(session_id, event_id)`, but `session_id` is the container identity, not part of the event's content. Stores already know which session they're operating on; embedding it in each event payload is redundant and couples the serialization format to deployment topology.

3. **Streaming messages need identity before completion**: For partial-stream persistence and SSE resume to work correctly, a streaming message must have its durable EventID allocated when the stream starts, not when it completes. `MessageStreamRef` reserves that identity upfront.

4. **Naming clarity reduces cognitive load**: Four types (`UserObservationEvent`, `UserInterruptEvent`, `AgentInterruptEvent`, `AgentInterruptContext`) for two concepts (cancel, interrupt) created constant confusion. Two types with direct names (`CancelEvent`, `InterruptEvent`) make the code self-documenting.

---

## Problem

The session event model had accumulated structural debt with duplicate identity fields, session-id embedded in durable payloads, no durable identity for streaming messages before materialization, overloaded interrupt type naming, and verbose store interfaces.

## Solution

Introduce `SessionEventVariant` as a typed sum type carrying either a fully materialized `SessionEvent` or a `MessageStreamRef` (reserved durable identity for in-flight streams), with `SessionID` as live-only metadata on the variant. Simplify `SessionEventStore` to take `sessionID` as a first-class argument. Rename interrupt types to `CancelEvent` / `InterruptEvent` / `InterruptContext`. Remove `EventID` and `Timestamp` from `TypedAgentEvent` (they belong on the session layer).

## Key Insights

- **Sum types prevent invalid states**: `SessionEventVariant` makes materialized vs streaming explicit — no half-initialized combinations.
- **SessionID is ownership metadata, not event content**: Belongs on the live envelope, not the durable payload.
- **Streams need identity before completion**: `MessageStreamRef` reserves EventID at stream start for partial-persistence and SSE resume.
- **Naming clarity pays off**: Four types for two concepts → two types with direct names.
