### PR TITLE
fix(compose): normalize typed nil inputs in checkpoint and runnable

### DIFF
--- a/adk/agentic_react_test.go
+++ b/adk/agentic_react_test.go
@@ -210,6 +210,15 @@ func lastAgenticEvent(events []*agenticAgentEvent) *agenticAgentEvent {
 	return events[len(events)-1]
 }
 
+func firstAgenticEventError(events []*agenticAgentEvent) error {
+	for _, ev := range events {
+		if ev.Err != nil {
+			return ev.Err
+		}
+	}
+	return nil
+}
+
 func findInterruptEvent(events []*agenticAgentEvent) *agenticAgentEvent {
 	for _, ev := range events {
 		if ev.Action != nil && ev.Action.Interrupted != nil {
@@ -578,6 +587,7 @@ func TestAgenticReact_DoubleInterruptResume(t *testing.T) {
 	runner := newAgenticRunnerWithStore(t, ctx, mdl, []tool.BaseTool{&agenticInterruptTool{name: "approval_tool"}}, store)
 
 	events1 := drainAgenticEvents(runner.Query(ctx, "approve twice", WithCheckPointID("dbl-cp")))
+	require.NoError(t, firstAgenticEventError(events1))
 	int1Event := findInterruptEvent(events1)
 	require.NotNil(t, int1Event, "expected first interrupt")
 	int1ID := int1Event.Action.Interrupted.InterruptContexts[0].ID
@@ -588,6 +598,7 @@ func TestAgenticReact_DoubleInterruptResume(t *testing.T) {
 	require.NoError(t, err)
 
 	events2 := drainAgenticEvents(iter2)
+	require.NoError(t, firstAgenticEventError(events2))
 	int2Event := findInterruptEvent(events2)
 	require.NotNil(t, int2Event, "expected second interrupt")
 	int2ID := int2Event.Action.Interrupted.InterruptContexts[0].ID
@@ -598,6 +609,7 @@ func TestAgenticReact_DoubleInterruptResume(t *testing.T) {
 	require.NoError(t, err)
 
 	events3 := drainAgenticEvents(iter3)
+	require.NoError(t, firstAgenticEventError(events3))
 	last := lastAgenticEvent(events3)
 
 	require.NotNil(t, last)
@@ -605,6 +617,53 @@ func TestAgenticReact_DoubleInterruptResume(t *testing.T) {
 	require.NotNil(t, last.Output)
 	require.NotNil(t, last.Output.MessageOutput)
 	assert.Contains(t, agenticTextContent(last.Output.MessageOutput.Message), "all approved")
+}
+
+func TestAgenticReact_ResumeThenCancelAfterChatModelCheckpoint(t *testing.T) {
+	ctx := context.Background()
+
+	var modelCallCount int32
+	mdl := &mockAgenticModel{
+		generateFn: func(ctx context.Context, input []*schema.AgenticMessage, opts ...model.Option) (*schema.AgenticMessage, error) {
+			count := atomic.AddInt32(&modelCallCount, 1)
+			switch count {
+			case 1:
+				return agenticToolCallMsg("approval_tool", "c1", `"first"`), nil
+			case 2:
+				return agenticToolCallMsg("approval_tool", "c2", `"second"`), nil
+			default:
+				return nil, fmt.Errorf("unexpected call #%d", count)
+			}
+		},
+	}
+
+	store := &agenticReactTestStore{m: map[string][]byte{}}
+	runner := newAgenticRunnerWithStore(t, ctx, mdl, []tool.BaseTool{&agenticInterruptTool{name: "approval_tool"}}, store)
+
+	events1 := drainAgenticEvents(runner.Query(ctx, "approve then cancel", WithCheckPointID("resume-cancel-cp")))
+	require.NoError(t, firstAgenticEventError(events1))
+	int1Event := findInterruptEvent(events1)
+	require.NotNil(t, int1Event, "expected tool interrupt")
+	int1ID := int1Event.Action.Interrupted.InterruptContexts[0].ID
+
+	cancelOpt, cancelFn := WithCancel()
+	handle, contributed := cancelFn(WithAgentCancelMode(CancelAfterChatModel))
+	require.True(t, contributed)
+
+	iter2, err := runner.ResumeWithParams(ctx, "resume-cancel-cp", &ResumeParams{
+		Targets: map[string]any{int1ID: "approved"},
+	}, cancelOpt)
+	require.NoError(t, err)
+
+	events2 := drainAgenticEvents(iter2)
+	require.NoError(t, handle.Wait())
+	for _, event := range events2 {
+		if event.Err == nil {
+			continue
+		}
+		var cancelErr *CancelError
+		require.ErrorAs(t, event.Err, &cancelErr)
+	}
 }
 
 func TestAgenticReact_ChatModelAgent_NoTools(t *testing.T) {

--- a/compose/checkpoint.go
+++ b/compose/checkpoint.go
@@ -19,6 +19,7 @@ package compose
 import (
 	"context"
 	"fmt"
+	"reflect"
 
 	"github.com/cloudwego/eino/internal/core"
 	"github.com/cloudwego/eino/internal/serialization"
@@ -204,12 +205,41 @@ func (c *checkPointer) get(ctx context.Context, id string) (*checkpoint, bool, e
 }
 
 func (c *checkPointer) set(ctx context.Context, id string, cp *checkpoint) error {
+	normalizeCheckpointTypedNilInputs(cp)
+
 	data, err := c.serializer.Marshal(cp)
 	if err != nil {
 		return err
 	}
 
 	return c.store.Set(ctx, id, data)
+}
+
+func normalizeCheckpointTypedNilInputs(cp *checkpoint) {
+	if cp == nil {
+		return
+	}
+	for key, input := range cp.Inputs {
+		if isTypedNil(input) {
+			cp.Inputs[key] = nil
+		}
+	}
+	for _, sub := range cp.SubGraphs {
+		normalizeCheckpointTypedNilInputs(sub)
+	}
+}
+
+func isTypedNil(v any) bool {
+	if v == nil {
+		return false
+	}
+	rv := reflect.ValueOf(v)
+	switch rv.Kind() {
+	case reflect.Chan, reflect.Func, reflect.Interface, reflect.Map, reflect.Ptr, reflect.Slice:
+		return rv.IsNil()
+	default:
+		return false
+	}
 }
 
 // MigrateCheckpointState is an advanced compatibility utility for checkpoint upgrades.

--- a/compose/checkpoint_test.go
+++ b/compose/checkpoint_test.go
@@ -17,7 +17,9 @@
 package compose
 
 import (
+	"bytes"
 	"context"
+	"encoding/gob"
 	"errors"
 	"io"
 	"sync"
@@ -54,12 +56,65 @@ func newInMemoryStore() *inMemoryStore {
 	}
 }
 
+type checkpointTypedNilInput struct {
+	Value string
+}
+
+type checkpointGobSerializer struct{}
+
+func (g *checkpointGobSerializer) Marshal(v any) ([]byte, error) {
+	buf := new(bytes.Buffer)
+	err := gob.NewEncoder(buf).Encode(v)
+	if err != nil {
+		return nil, err
+	}
+	return buf.Bytes(), nil
+}
+
+func (g *checkpointGobSerializer) Unmarshal(data []byte, v any) error {
+	return gob.NewDecoder(bytes.NewBuffer(data)).Decode(v)
+}
+
+func TestCheckpointGobSerializerNormalizesTypedNilInput(t *testing.T) {
+	store := newInMemoryStore()
+	cpr := newCheckPointer(nil, nil, store, &checkpointGobSerializer{})
+	cp := &checkpoint{
+		Channels:       map[string]channel{},
+		Inputs:         map[string]any{"node": (*checkpointTypedNilInput)(nil)},
+		SkipPreHandler: map[string]bool{},
+	}
+
+	err := cpr.set(context.Background(), "cp", cp)
+	assert.NoError(t, err)
+	if err != nil {
+		return
+	}
+
+	got, existed, err := cpr.get(context.Background(), "cp")
+	assert.NoError(t, err)
+	assert.True(t, existed)
+	assert.Contains(t, got.Inputs, "node")
+	assert.Nil(t, got.Inputs["node"])
+}
+
+func TestRunnableInvokeAcceptsNilForPointerInput(t *testing.T) {
+	lambda := InvokableLambda(func(ctx context.Context, input *checkpointTypedNilInput) (string, error) {
+		assert.Nil(t, input)
+		return "ok", nil
+	})
+
+	out, err := lambda.executor.i(context.Background(), nil)
+	assert.NoError(t, err)
+	assert.Equal(t, "ok", out)
+}
+
 type testStruct struct {
 	A string
 }
 
 func init() {
 	schema.Register[testStruct]()
+	schema.RegisterName[*checkpointTypedNilInput]("compose_checkpoint_typed_nil_input")
 }
 
 func TestSimpleCheckPoint(t *testing.T) {

--- a/compose/runnable.go
+++ b/compose/runnable.go
@@ -69,6 +69,15 @@ func runnableLambda[I, O, TOption any](i Invoke[I, O, TOption], s Stream[I, O, T
 	return rp.toComposableRunnable()
 }
 
+func isNilAssignableType(t reflect.Type) bool {
+	switch t.Kind() {
+	case reflect.Chan, reflect.Func, reflect.Interface, reflect.Map, reflect.Ptr, reflect.Slice:
+		return true
+	default:
+		return false
+	}
+}
+
 type runnablePacker[I, O, TOption any] struct {
 	i Invoke[I, O, TOption]
 	s Stream[I, O, TOption]
@@ -112,9 +121,9 @@ func (rp *runnablePacker[I, O, TOption]) toComposableRunnable() *composableRunna
 		in, ok := input.(I)
 		if !ok {
 			// When a nil is passed as an 'any' type, its original type information is lost,
-			// becoming an untyped nil. This would cause type assertions to fail.
-			// So if the input is nil and the target type I is an interface, we need to explicitly create a nil of type I.
-			if input == nil && reflect.TypeOf((*I)(nil)).Elem().Kind() == reflect.Interface {
+			// becoming an untyped nil. This would cause type assertions to fail for nil-able
+			// input types, so recreate the zero value of I when nil is valid for I.
+			if input == nil && isNilAssignableType(reflect.TypeOf((*I)(nil)).Elem()) {
 				var i I
 				in = i
 			} else {


### PR DESCRIPTION
# Fix Typed Nil Handling in Checkpoint Serialization and Runnable Inputs

## Problem

When a node's input is a typed nil pointer (e.g. `(*T)(nil)` from a canceled
streaming lambda), the checkpoint system fails in two ways:

1. **Checkpoint serialization failure**: `GobSerializer.Marshal` errors with
   `"cannot encode nil pointer of type T inside interface"` because typed nils
   pass through `input == nil` checks (the interface is non-nil, it just wraps
   a nil concrete value).

2. **Runnable nil input mismatch**: When resuming from a checkpoint where an
   input was missing (and thus passed as untyped nil), the runnable type
   assertion `input.(I)` fails for pointer/slice/map input types because
   untyped nil cannot be asserted to a concrete nil-able type. The previous
   code only handled the `interface{}` case.

Concrete scenario: A streaming lambda is canceled mid-execution via
`WithGraphInterrupt`. Its `originalInput` becomes a typed-nil pointer. When
the checkpoint tries to persist, gob serialization panics.

## Solution

Two complementary fixes:

### 1. Checkpoint normalization (defense in depth)

Before serializing a checkpoint, normalize typed-nil values in `cp.Inputs` to
untyped nil using `reflect`:

```go
func normalizeCheckpointTypedNilInputs(cp *checkpoint) {
    for key, input := range cp.Inputs {
        if isTypedNil(input) {
            cp.Inputs[key] = nil
        }
    }
    for _, sub := range cp.SubGraphs {
        normalizeCheckpointTypedNilInputs(sub)
    }
}
```

This ensures any serializer (gob, json, or custom) receives clean untyped nil
values that it can handle correctly. The normalization runs at
`checkPointer.set` time, so it covers all code paths that write checkpoints,
not just the graph submit path.

### 2. Runnable nil input reconstruction

Extend the nil-handling in `runnablePacker` from interface-only to all
nil-able kinds (ptr, slice, map, chan, func):

```go
if input == nil && isNilAssignableType(reflect.TypeOf((*I)(nil)).Elem()) {
    var i I
    in = i
}
```

When an untyped nil is passed as input (e.g. from checkpoint resume where the
input was not persisted), reconstruct the zero value of `I` so that the type
assertion `input.(I)` succeeds. This is correct because nil pointer/slice/map
inputs are valid — the node code should handle nil gracefully.

Resume correctness: `restoreTasks` already reconstructs zero-valued inputs via
`inputZeroValue` / `inputEmptyStream` for any rerun node missing from
`cp.Inputs`. Normalizing typed nils to untyped nils (and thus dropping them
from `cp.Inputs` after a set/get round-trip through a serializer that
represents nil as absence) aligns with this existing behavior.

## Decisions

**Why normalize at set time rather than submit time?**

A previous approach filtered typed-nil inputs at submit time in
`graph_run.go`. Normalizing at `checkPointer.set` is more robust because:
- It covers all checkpoint writers (graph nodes, subgraphs, manual
  checkpoints), not just the graph submit path.
- It's a defense-in-depth measure — any typed nil that reaches the checkpoint
  store gets normalized, regardless of how it got there.
- The normalization is a serializer concern (typed nils cause serialization
  failures), so it belongs at the serialization boundary.

## Key Insight

**Typed nil vs untyped nil is a persistent Go interface gotcha.** An
`interface{}` holding a nil concrete value is not equal to `nil` — the
interface has a type. This means `input == nil` checks pass when they
shouldn't, and serializers that introspect the concrete type fail on nil
pointers/slices/maps inside interfaces.

The reliable way to detect "this value is semantically nil" is:
1. Check `v == nil` (untyped nil)
2. If not, use `reflect.ValueOf(v).IsNil()` for nil-able kinds

Any time you store `any`-typed values and later serialize or compare them,
you need to account for typed nils.

## Summary

| Problem | Solution |
|---------|----------|
| Gob serialization fails on typed-nil pointer inputs in checkpoints | Normalize typed nils to untyped nils in `checkPointer.set` before serialization |
| Runnable type assertion fails for nil-able input types when input is untyped nil | Reconstruct zero value of `I` for all nil-able kinds, not just interfaces |

---

# 修复 Checkpoint 序列化和 Runnable 输入中的 Typed Nil 问题

## 问题

当节点的输入是一个 typed nil 指针（例如来自被取消的流式 lambda 的
`(*T)(nil)`）时，checkpoint 系统会在两个层面出现问题：

1. **Checkpoint 序列化失败**：`GobSerializer.Marshal` 报错
   `"cannot encode nil pointer of type T inside interface"`，因为 typed nil
   能够通过 `input == nil` 检查（接口本身非 nil，只是包装了一个 nil 的
   具体值）。

2. **Runnable nil 输入不匹配**：当从 checkpoint 恢复时，如果某个输入
   丢失（因此以 untyped nil 的形式传入），runnable 的类型断言
   `input.(I)` 会对指针/slice/map 等输入类型失败，因为 untyped nil
   无法被断言为一个具体的 nil-able 类型。之前的代码只处理了
   `interface{}` 的情况。

具体场景：一个流式 lambda 通过 `WithGraphInterrupt` 在执行中途被取消，
其 `originalInput` 变成了 typed-nil 指针。当 checkpoint 尝试持久化时，
gob 序列化会报错。

## 解决方案

两个互补的修复：

### 1. Checkpoint 规范化（纵深防御）

在序列化 checkpoint 之前，使用 `reflect` 将 `cp.Inputs` 中的 typed-nil
值规范化为 untyped nil：

```go
func normalizeCheckpointTypedNilInputs(cp *checkpoint) {
    for key, input := range cp.Inputs {
        if isTypedNil(input) {
            cp.Inputs[key] = nil
        }
    }
    for _, sub := range cp.SubGraphs {
        normalizeCheckpointTypedNilInputs(sub)
    }
}
```

这确保任何序列化器（gob、json 或自定义）收到的都是干净的 untyped nil
值，可以正确处理。规范化在 `checkPointer.set` 时执行，因此覆盖了所有
写入 checkpoint 的代码路径，而不仅仅是 graph submit 路径。

### 2. Runnable nil 输入重建

将 `runnablePacker` 中的 nil 处理从仅接口扩展到所有 nil-able 类型
（ptr、slice、map、chan、func）：

```go
if input == nil && isNilAssignableType(reflect.TypeOf((*I)(nil)).Elem()) {
    var i I
    in = i
}
```

当 untyped nil 作为输入传入时（例如从 checkpoint 恢复时输入未被持久
化），重建 `I` 的零值，使类型断言 `input.(I)` 能够成功。这是正确的，
因为 nil 指针/slice/map 输入本身是合法的 —— 节点代码应该能够优雅地
处理 nil。

恢复正确性：`restoreTasks` 已经通过 `inputZeroValue` /
`inputEmptyStream` 为所有不在 `cp.Inputs` 中的重跑节点重建零值输入。
将 typed nil 规范化为 untyped nil（从而在经过序列化器的 set/get 往返
后从 `cp.Inputs` 中消失）与这一现有行为保持一致。

## 决策

**为什么在 set 时而不是 submit 时规范化？**

之前的方案在 `graph_run.go` 的 submit 时过滤 typed-nil 输入。在
`checkPointer.set` 处规范化更加健壮，因为：
- 它覆盖了所有 checkpoint 写入者（图节点、子图、手动 checkpoint），
  而不仅仅是 graph submit 路径。
- 这是一种纵深防御措施 —— 任何到达 checkpoint 存储的 typed nil 都会
  被规范化，无论它是如何到达的。
- 规范化是序列化器的关注点（typed nil 导致序列化失败），因此应该
  放在序列化边界处。

## 核心洞察

**Typed nil 与 untyped nil 是 Go 接口中一个顽固的陷阱。** 一个持有 nil
具体值的 `interface{}` 不等于 `nil` —— 接口有类型。这意味着 `input == nil`
检查会在不该通过的时候通过，而内省具体类型的序列化器会因为接口内的
nil 指针/slice/map 而失败。

检测"这个值在语义上是 nil"的可靠方法是：
1. 检查 `v == nil`（untyped nil）
2. 如果不是，对 nil-able 种类使用 `reflect.ValueOf(v).IsNil()`

任何时候你存储 `any` 类型的值然后序列化或比较它们，都需要考虑 typed
nil 的问题。

## 总结

| 问题 | 解决方案 |
|------|----------|
| Gob 序列化在 checkpoint 中遇到 typed-nil 指针输入时失败 | 在 `checkPointer.set` 序列化前将 typed nil 规范化为 untyped nil |
| 当输入为 untyped nil 时，nil-able 输入类型的 runnable 类型断言失败 | 为所有 nil-able 类型重建 `I` 的零值，而不仅限于接口 |
