### PR TITLE
fix(adk): preserve pre-run turnloop resume items

### DIFF
--- a/adk/turn_loop.go
+++ b/adk/turn_loop.go
@@ -1145,10 +1145,15 @@ func (l *TurnLoop[T, M]) tryLoadCheckpoint(ctx context.Context) error {
 			// No checkpoint to resume into; treat preLoad as Push items so they
 			// don't silently disappear.
 			l.buffer.PushFront(preLoad)
+		case pr != nil && pr.resumeSubmitted && len(preLoad) > 0:
+			// The restored checkpoint already carries accepted resume intent.
+			// Preserve the pre-load Resume items as normal unhandled input rather
+			// than silently dropping them or overriding the checkpoint intent.
+			pr.unhandled = append(pr.unhandled, preLoad...)
 		}
 		// If pr != nil && pr.resumeSubmitted (checkpoint carried accepted resume
-		// items), those win: the cases above skip, preLoad is left unused, and a
-		// later post-load Resume() would return ErrTurnLoopResumeInProgress.
+		// items), those win as resume intent; preLoad is retained as unhandled
+		// input so Resume before Run remains non-lossy.
 
 		l.checkpointLoaded = true
 	}()

--- a/adk/turn_loop_test.go
+++ b/adk/turn_loop_test.go
@@ -8204,13 +8204,15 @@ func TestAttack_PreLoadResumeLosesToAcceptedCheckpointResume(t *testing.T) {
 	require.NoError(t, store.Set(ctx, cpID, data))
 
 	gotResume := make(chan []string, 1)
+	gotUnhandled := make(chan []string, 1)
 	loop := NewTurnLoop(TurnLoopConfig[string, *schema.Message]{
 		InterruptMode: TurnLoopInterruptWaitsForExplicitResume,
 		Store:         store,
 		CheckpointID:  cpID,
 		GenInput:      genInputConsumeAllWithMsg,
-		GenResume: func(_ context.Context, _ *TurnLoop[string, *schema.Message], interrupted, _, resumeItems []string) (*GenResumeResult[string, *schema.Message], error) {
+		GenResume: func(_ context.Context, _ *TurnLoop[string, *schema.Message], interrupted, unhandled, resumeItems []string) (*GenResumeResult[string, *schema.Message], error) {
 			gotResume <- append([]string{}, resumeItems...)
+			gotUnhandled <- append([]string{}, unhandled...)
 			return &GenResumeResult[string, *schema.Message]{
 				Decision: TurnLoopResumeDecisionStartNewTurn,
 				Input:    &AgentInput{Messages: []Message{schema.UserMessage("resumed")}},
@@ -8242,7 +8244,14 @@ func TestAttack_PreLoadResumeLosesToAcceptedCheckpointResume(t *testing.T) {
 	case <-time.After(2 * time.Second):
 		t.Fatal("GenResume not invoked")
 	}
-	t.Logf("pre-load Resume return value (informational): %v", preErr)
+	select {
+	case unhandled := <-gotUnhandled:
+		assert.Contains(t, unhandled, "preload-should-lose",
+			"pre-load Resume must be preserved as unhandled input when checkpoint resume intent wins")
+	case <-time.After(2 * time.Second):
+		t.Fatal("GenResume unhandled items not captured")
+	}
+	require.NoError(t, preErr)
 }
 
 // TestAttack_TimeoutWithNilInterruptContexts ensures a timeout still produces an


### PR DESCRIPTION
# Preserve pre-Run TurnLoop Resume Items

## Problem
`TurnLoop.Resume` is meant to be safe before `TurnLoop.Run`, like `Push` and `Stop`. Most pre-run paths already worked, but one restored-checkpoint case was lossy.

When the checkpoint already carried accepted `ResumeItems`, a caller could still invoke `Resume(...)` before `Run()`. That call returned `nil`, but its payload was neither used as resume intent nor preserved as normal input.

Expected: checkpoint resume intent stays authoritative, and the pre-run `Resume` payload remains available.
Actual: checkpoint resume intent won, but the pre-run payload was dropped.

## Solution
Keep the restored checkpoint's accepted `ResumeItems` as the resume intent, and move the pre-load `Resume(...)` payload into `unhandled` input.

This preserves the existing priority rule while making the pre-`Run` API non-lossy: a successful `Resume` call always has an observable effect after `Run` loads the checkpoint.

## Key Insight
Checkpoint loading has to classify pre-run items after the pending resume state is known:

1. No checkpoint: pre-run `Resume` becomes normal buffered input.
2. Managed restore waiting for explicit intent: pre-run `Resume` becomes resume intent.
3. Restored checkpoint already has accepted resume intent: pre-run `Resume` becomes unhandled input.

The classification depends on the loaded checkpoint state, so `Resume` before `Run` must buffer first and be adopted during checkpoint load.

## Summary
| Problem | Solution |
|---------|----------|
| `Resume(...)` before `Run()` could drop payload when restored checkpoint resume intent already existed | Preserve the payload as `unhandled` input while keeping checkpoint `ResumeItems` authoritative |

---

# 保留 pre-Run TurnLoop Resume 输入

## 问题
`TurnLoop.Resume` 应该和 `Push`、`Stop` 一样，可以在 `TurnLoop.Run` 之前安全调用。大多数 pre-run 路径已经满足这一点，但 restored-checkpoint 的一个分支会丢数据。

当 checkpoint 已经携带已接受的 `ResumeItems` 时，调用方仍然可以在 `Run()` 之前调用 `Resume(...)`。这个调用返回 `nil`，但传入的 payload 既没有作为 resume intent 使用，也没有作为普通输入保留下来。

期望：checkpoint 中的 resume intent 仍然优先，同时 pre-run `Resume` payload 不丢失。
实际：checkpoint resume intent 胜出，但 pre-run payload 被丢弃。

## 方案
继续让 restored checkpoint 中已接受的 `ResumeItems` 作为 resume intent，同时把 pre-load `Resume(...)` payload 放入 `unhandled` input。

这样既保留现有优先级规则，也让 pre-`Run` API 变成非丢失语义：只要 `Resume` 成功返回，`Run` 加载 checkpoint 后就能观察到这部分输入。

## Key Insight
checkpoint loading 必须在 pending resume 状态明确之后再分类 pre-run items：

1. 没有 checkpoint：pre-run `Resume` 变成普通 buffered input。
2. managed restore 正在等待显式 intent：pre-run `Resume` 变成 resume intent。
3. restored checkpoint 已经有 accepted resume intent：pre-run `Resume` 变成 unhandled input。

这个分类依赖加载后的 checkpoint 状态，所以 `Resume` before `Run` 必须先 buffer，再由 checkpoint load 阶段采用。

## Summary
| Problem | Solution |
|---------|----------|
| `Resume(...)` before `Run()` 在 restored checkpoint 已有 resume intent 时可能丢 payload | 保留 payload 为 `unhandled` input，同时维持 checkpoint `ResumeItems` 的权威性 |
