### PR TITLE
fix(adk/filesystem): mark directories and show file sizes in ls tool output

### DIFF
--- a/adk/middlewares/filesystem/filesystem.go
+++ b/adk/middlewares/filesystem/filesystem.go
@@ -575,12 +575,36 @@ func newLsTool(fs filesystem.Backend, name string, desc string) (tool.BaseTool, 
 		if len(infos) == 0 {
 			return noFilesFound, nil
 		}
-		paths := make([]string, 0, len(infos))
+		lines := make([]string, 0, len(infos))
 		for _, fi := range infos {
-			paths = append(paths, fi.Path)
+			if fi.IsDir {
+				// Append a trailing slash so the model can tell directories
+				// from files and does not explore a directory as if it were a file.
+				lines = append(lines, fi.Path+"/")
+				continue
+			}
+			// Include the file size so the model can avoid reading very large
+			// (e.g. binary) files that would pollute the context window.
+			lines = append(lines, fmt.Sprintf("%s (%s)", fi.Path, formatFileSize(fi.Size)))
 		}
-		return strings.Join(paths, "\n"), nil
+		return strings.Join(lines, "\n"), nil
 	})
+}
+
+// formatFileSize renders a byte count in a compact, human-readable form
+// (e.g. "29 B", "1.2 KB", "3.4 MB"). The ls tool uses it so the model can
+// gauge a file's size before deciding whether to read it.
+func formatFileSize(n int64) string {
+	const unit = 1024
+	if n < unit {
+		return fmt.Sprintf("%d B", n)
+	}
+	div, exp := int64(unit), 0
+	for x := n / unit; x >= unit; x /= unit {
+		div *= unit
+		exp++
+	}
+	return fmt.Sprintf("%.1f %cB", float64(n)/float64(div), "KMGTPE"[exp])
 }
 
 type readFileArgs struct {

--- a/adk/middlewares/filesystem/filesystem_test.go
+++ b/adk/middlewares/filesystem/filesystem_test.go
@@ -118,6 +118,47 @@ func TestLsTool(t *testing.T) {
 	}
 }
 
+func TestLsToolEntryDetails(t *testing.T) {
+	backend := setupTestBackend()
+	lsTool, err := newLsTool(backend, "", "")
+	if err != nil {
+		t.Fatalf("Failed to create ls tool: %v", err)
+	}
+
+	result, err := invokeTool(t, lsTool, `{"path": "/"}`)
+	if err != nil {
+		t.Fatalf("ls tool failed: %v", err)
+	}
+
+	// Directories must be marked with a trailing slash so the model does not
+	// mistake them for files.
+	if !strings.Contains(result, "dir1/") {
+		t.Errorf("expected directory dir1 to be marked with a trailing slash, got: %s", result)
+	}
+	// Files must include a human-readable size annotation.
+	if !strings.Contains(result, "file1.txt (") {
+		t.Errorf("expected file1.txt to include a size annotation, got: %s", result)
+	}
+}
+
+func TestFormatFileSize(t *testing.T) {
+	cases := []struct {
+		in   int64
+		want string
+	}{
+		{0, "0 B"},
+		{512, "512 B"},
+		{1024, "1.0 KB"},
+		{1536, "1.5 KB"},
+		{1048576, "1.0 MB"},
+	}
+	for _, c := range cases {
+		if got := formatFileSize(c.in); got != c.want {
+			t.Errorf("formatFileSize(%d) = %q, want %q", c.in, got, c.want)
+		}
+	}
+}
+
 func TestReadFileTool(t *testing.T) {
 	backend := setupTestBackend()
 	readTool, err := newReadFileTool(backend, "", "")


### PR DESCRIPTION
#### What type of PR is this?

fix

#### Check the PR title.

- [x] This PR title match the format: \<type\>(optional scope): \<description\>
- [x] The description of this PR title is user-oriented and clear enough for others to understand.

#### (Optional) More detailed description for this PR(en: English/zh: Chinese).

en:
Right now `ls` only prints each entry's path. The backend's `LsInfo` already
returns `IsDir` and `Size`, but `newLsTool` drops them, so the model can't tell
a directory from a file and has no idea how big a file is before reading it (#1100).

So I put that info back: directories get a trailing `/`, files show their size, e.g.

```
main.go (1.2 KB)
pkg/
README.md (842 B)
```

Small `formatFileSize` helper, plus a couple of tests. The existing `TestLsTool`
still passes since it only checks the paths are present.

#### (Optional) Which issue(s) this PR fixes:

Fixes #1100
