### PR TITLE
fix(schema): truncate by rune in truncateString to avoid splitting UTF-8

### DIFF
--- a/schema/agentic_message.go
+++ b/schema/agentic_message.go
@@ -2227,12 +2227,19 @@ func (a *AgenticResponseMeta) String() string {
 	return sb.String()
 }
 
-// truncateString truncates a string to maxLen characters, adding "..." if truncated
+// truncateString truncates a string to maxLen runes (not bytes), adding "..."
+// if truncated. Counting and slicing by rune keeps multi-byte UTF-8 characters
+// intact instead of cutting one in half, matching truncateTextByChars and
+// truncateSkillContent elsewhere in the repo.
 func truncateString(s string, maxLen int) string {
-	if len(s) <= maxLen {
+	if maxLen < 0 {
+		maxLen = 0
+	}
+	runes := []rune(s)
+	if len(runes) <= maxLen {
 		return s
 	}
-	return s[:maxLen] + "..."
+	return string(runes[:maxLen]) + "..."
 }
 
 // formatMediaString formats URL, Base64Data, MIMEType and Detail for media content

--- a/schema/agentic_message_test.go
+++ b/schema/agentic_message_test.go
@@ -1727,3 +1727,21 @@ func TestConcatFunctionToolResults(t *testing.T) {
 		assert.Equal(t, "http://img.png", got.Content[1].Image.URL)
 	})
 }
+
+
+func TestTruncateString(t *testing.T) {
+	// Shorter than or equal to the limit is returned unchanged.
+	assert.Equal(t, "hello", truncateString("hello", 10))
+	assert.Equal(t, "hello", truncateString("hello", 5))
+
+	// ASCII longer than the limit is truncated by character count.
+	assert.Equal(t, "hel...", truncateString("hello", 3))
+
+	// maxLen counts runes, so multi-byte characters are never split in half
+	// and the output stays valid UTF-8.
+	assert.Equal(t, "你好世界", truncateString("你好世界", 4))
+	assert.Equal(t, "你好世界...", truncateString("你好世界你好", 4))
+
+	// Non-positive maxLen does not panic.
+	assert.Equal(t, "...", truncateString("你好", 0))
+}


### PR DESCRIPTION
#### What type of PR is this?

fix

#### Check the PR title.

- [x] This PR title match the format: \<type\>(optional scope): \<description\>
- [x] The description of this PR title is user-oriented and clear enough for others to understand.

#### (Optional) More detailed description for this PR(en: English/zh: Chinese).

en:
`truncateString` says it "truncates a string to maxLen characters", but it uses `len(s)` and `s[:maxLen]`, which count and slice by *byte*. For multi-byte UTF-8 input (CJK, emoji, ...) this can cut a rune in half and emit invalid UTF-8.

This counts and slices by rune instead, so `maxLen` really means characters and the output is always valid UTF-8. It now matches how `truncateTextByChars` and `truncateSkillContent` already handle truncation in this repo. A non-positive `maxLen` is also handled without panicking. Added `TestTruncateString`.

#### (Optional) Which issue(s) this PR fixes:

