### PR TITLE
feat(adk): add read tool hint to truncation notice

### DIFF
--- a/adk/middlewares/reduction/consts.go
+++ b/adk/middlewares/reduction/consts.go
@@ -32,6 +32,7 @@ Preview (first {preview_size}):
 Preview (last {preview_size}):
 {preview_last}
 
+Use {read_tool_name} to view
 </persisted-output>`
 	truncFmtZh = `<persisted-output>
 输出结果过大 ({original_size}). 完整输出保存到: {file_path}
@@ -41,6 +42,7 @@ Preview (last {preview_size}):
 预览 (后 {preview_size}):
 {preview_last}
 
+使用 {read_tool_name} 进行查看
 </persisted-output>`
 )
 
@@ -81,11 +83,11 @@ func getStreamTruncFmt() string {
 	})
 }
 
-func formatStreamOffloadSavedNotify(filePath string) string {
+func formatStreamOffloadSavedNotify(filePath, readFileToolName string) string {
 	return fmt.Sprintf(internal.SelectPrompt(internal.I18nPrompts{
-		English: "Full output saved to: %s.",
-		Chinese: "完整输出保存到: %s。",
-	}), filePath)
+		English: "Full output saved to: %s. Use %s to view.",
+		Chinese: "完整输出保存到: %s。使用 %s 进行查看。",
+	}), filePath, readFileToolName)
 }
 
 func formatStreamOffloadFailedNotify(err error) string {

--- a/adk/middlewares/reduction/reduction.go
+++ b/adk/middlewares/reduction/reduction.go
@@ -330,7 +330,7 @@ func NewTyped[M adk.MessageType](_ context.Context, config *TypedConfig[M]) (adk
 		SkipClear:      config.SkipClear,
 	}
 	if !defaultReductionConfig.SkipTruncation {
-		defaultReductionConfig.TruncHandler = defaultTruncHandler(config.GenTruncOffloadFilePath, config.MaxLengthForTrunc)
+		defaultReductionConfig.TruncHandler = defaultTruncHandler(config.GenTruncOffloadFilePath, config.MaxLengthForTrunc, config.ReadFileToolName)
 	}
 	if !defaultReductionConfig.SkipClear {
 		defaultReductionConfig.ClearHandler = defaultClearHandler(config.GenClearOffloadFilePath, config.Backend != nil, config.ReadFileToolName)
@@ -634,7 +634,7 @@ func (t *typedToolReductionMiddleware[M]) wrapDefaultStreamableTruncation(
 		}); err != nil {
 			errorNotify = formatStreamOffloadFailedNotify(err)
 		} else {
-			offloadNotify = formatStreamOffloadSavedNotify(filePath)
+			offloadNotify = formatStreamOffloadSavedNotify(filePath, t.config.ReadFileToolName)
 		}
 
 		notice, err := formatStreamTruncNotice(t.config.MaxLengthForTrunc, offloadNotify, errorNotify)
@@ -858,7 +858,7 @@ func (t *typedToolReductionMiddleware[M]) wrapDefaultEnhancedStreamableTruncatio
 		}); err != nil {
 			errorNotify = formatStreamOffloadFailedNotify(err)
 		} else {
-			offloadNotify = formatStreamOffloadSavedNotify(filePath)
+			offloadNotify = formatStreamOffloadSavedNotify(filePath, t.config.ReadFileToolName)
 		}
 
 		notice, err := formatStreamTruncNotice(t.config.MaxLengthForTrunc, offloadNotify, errorNotify)
@@ -1704,6 +1704,7 @@ func defaultTokenCounter(_ context.Context, msgs []*schema.Message, tools []*sch
 func defaultTruncHandler(
 	genOffloadFilePathFn func(ctx context.Context, toolDetail *ToolDetail) (filePath string, err error),
 	truncMaxLength int,
+	readFileToolName string,
 ) func(ctx context.Context, detail *ToolDetail) (truncResult *TruncResult, err error) {
 
 	return func(ctx context.Context, detail *ToolDetail) (offloadInfo *TruncResult, err error) {
@@ -1745,11 +1746,12 @@ func defaultTruncHandler(
 				continue
 			}
 			truncNotify, fmtErr := pyfmt.Fmt(getTruncFmt(), map[string]any{
-				"original_size": len(part.Text),
-				"file_path":     filePath,
-				"preview_size":  previewSize,
-				"preview_first": clampPrefixToUTF8Boundary(text, previewSize),
-				"preview_last":  clampSuffixToUTF8Boundary(text, previewSize),
+				"original_size":  len(part.Text),
+				"file_path":      filePath,
+				"preview_size":   previewSize,
+				"preview_first":  clampPrefixToUTF8Boundary(text, previewSize),
+				"preview_last":   clampSuffixToUTF8Boundary(text, previewSize),
+				"read_tool_name": readFileToolName,
 			})
 			if fmtErr != nil {
 				return nil, fmtErr

--- a/adk/middlewares/reduction/reduction_test.go
+++ b/adk/middlewares/reduction/reduction_test.go
@@ -146,14 +146,14 @@ func TestReductionMiddlewareTrunc(t *testing.T) {
 				"mock_invokable_tool": {
 					Backend:        backend,
 					SkipTruncation: false,
-					TruncHandler:   defaultTruncHandler(testTruncOffloadPath("/tmp"), 70),
+					TruncHandler:   defaultTruncHandler(testTruncOffloadPath("/tmp"), 70, "read_file"),
 				},
 			},
 		}
 
 		mw, err := New(ctx, config)
 		assert.NoError(t, err)
-		exp := "<persisted-output>\nOutput too large (199). Full output saved to: /tmp/trunc/12345\nPreview (first 35):\nhello worldhello worldhello worldhe\n\nPreview (last 35):\nldhello worldhello worldhello world\n\n</persisted-output>"
+		exp := "<persisted-output>\nOutput too large (199). Full output saved to: /tmp/trunc/12345\nPreview (first 35):\nhello worldhello worldhello worldhe\n\nPreview (last 35):\nldhello worldhello worldhello world\n\nUse read_file to view\n</persisted-output>"
 
 		edp, err := mw.WrapInvokableToolCall(ctx, it.InvokableRun, tCtx)
 		assert.NoError(t, err)
@@ -165,6 +165,28 @@ func TestReductionMiddlewareTrunc(t *testing.T) {
 		expOrigContent := `hello worldhello worldhello worldhello worldhello worldhello worldhello worldhello worldhello worldhello world
 hello worldhello worldhello worldhello worldhello worldhello worldhello worldhello world`
 		assert.Equal(t, expOrigContent, content.Content)
+	})
+
+	t.Run("test default truncation notice includes configured read tool name", func(t *testing.T) {
+		tCtx := &adk.ToolContext{
+			Name:   "mock_invokable_tool",
+			CallID: "12345",
+		}
+		backend := filesystem.NewInMemoryBackend()
+		config := &Config{
+			Backend:           backend,
+			MaxLengthForTrunc: 70,
+			ReadFileToolName:  "cat_file",
+		}
+
+		mw, err := New(ctx, config)
+		assert.NoError(t, err)
+
+		edp, err := mw.WrapInvokableToolCall(ctx, it.InvokableRun, tCtx)
+		assert.NoError(t, err)
+		resp, err := edp(ctx, `{"value":"asd"}`)
+		assert.NoError(t, err)
+		assert.Contains(t, resp, "Use cat_file to view")
 	})
 
 	t.Run("test streamable line and max length trunc", func(t *testing.T) {
@@ -179,13 +201,13 @@ hello worldhello worldhello worldhello worldhello worldhello worldhello worldhel
 				"mock_streamable_tool": {
 					Backend:        backend,
 					SkipTruncation: false,
-					TruncHandler:   defaultTruncHandler(testTruncOffloadPath("/tmp"), 70),
+					TruncHandler:   defaultTruncHandler(testTruncOffloadPath("/tmp"), 70, "read_file"),
 				},
 			},
 		}
 		mw, err := New(ctx, config)
 		assert.NoError(t, err)
-		exp := "<persisted-output>\nOutput too large (199). Full output saved to: /tmp/trunc/54321\nPreview (first 35):\nhello worldhello worldhello worldhe\n\nPreview (last 35):\nldhello worldhello worldhello world\n\n</persisted-output>"
+		exp := "<persisted-output>\nOutput too large (199). Full output saved to: /tmp/trunc/54321\nPreview (first 35):\nhello worldhello worldhello worldhe\n\nPreview (last 35):\nldhello worldhello worldhello world\n\nUse read_file to view\n</persisted-output>"
 
 		edp, err := mw.WrapStreamableToolCall(ctx, st.StreamableRun, tCtx)
 		assert.NoError(t, err)
@@ -505,6 +527,25 @@ hello worldhello worldhello worldhello worldhello worldhello worldhello worldhel
 			assert.Equal(t, strings.Repeat("x", 20)+"tail", content.Content)
 		})
 
+		t.Run("truncation notice includes configured read tool name", func(t *testing.T) {
+			mwWithReadTool := &typedToolReductionMiddleware[*schema.Message]{
+				config: &TypedConfig[*schema.Message]{
+					MaxLengthForTrunc:       10,
+					GenTruncOffloadFilePath: testTruncOffloadPath("/tmp"),
+					ReadFileToolName:        "cat_file",
+				},
+			}
+			cfg := &ToolReductionConfig{Backend: backend}
+			resp := mwWithReadTool.wrapDefaultStreamableTruncation(ctx, cfg, tCtx, `{}`, stringStream(strings.Repeat("x", 20)))
+			defer resp.Close()
+
+			got, err := resp.Recv()
+			assert.NoError(t, err)
+			assert.Contains(t, got, "Use cat_file to view")
+			_, err = resp.Recv()
+			assert.Equal(t, io.EOF, err)
+		})
+
 		t.Run("write error is rendered in truncation notice after source EOF", func(t *testing.T) {
 			wantErr := errors.New("stream write error")
 			cfg := &ToolReductionConfig{
@@ -700,6 +741,25 @@ hello worldhello worldhello worldhello worldhello worldhello worldhello worldhel
 			assert.Contains(t, content.Content, `"text": "tail"`)
 		})
 
+		t.Run("truncation notice includes configured read tool name", func(t *testing.T) {
+			mwWithReadTool := &typedToolReductionMiddleware[*schema.Message]{
+				config: &TypedConfig[*schema.Message]{
+					MaxLengthForTrunc:       10,
+					GenTruncOffloadFilePath: testTruncOffloadPath("/tmp"),
+					ReadFileToolName:        "cat_file",
+				},
+			}
+			cfg := &ToolReductionConfig{Backend: backend}
+			resp := mwWithReadTool.wrapDefaultEnhancedStreamableTruncation(ctx, cfg, tCtx, toolArg, toolResultStream(longResult))
+			defer resp.Close()
+
+			got, err := resp.Recv()
+			assert.NoError(t, err)
+			assert.Contains(t, stringifyToolOutputParts(got.Parts), "Use cat_file to view")
+			_, err = resp.Recv()
+			assert.Equal(t, io.EOF, err)
+		})
+
 		t.Run("write error is rendered in truncation notice after source EOF", func(t *testing.T) {
 			wantErr := errors.New("enhanced write error")
 			cfg := &ToolReductionConfig{
@@ -759,7 +819,7 @@ hello worldhello worldhello worldhello worldhello worldhello worldhello worldhel
 				"mock_streamable_tool": {
 					Backend:        backend,
 					SkipTruncation: false,
-					TruncHandler:   defaultTruncHandler(testTruncOffloadPath("/tmp"), 70),
+					TruncHandler:   defaultTruncHandler(testTruncOffloadPath("/tmp"), 70, "read_file"),
 				},
 			},
 		}
@@ -1763,7 +1823,7 @@ func TestDefaultTruncHandlerWithStreamToolResult(t *testing.T) {
 			StreamToolResult: sr,
 		}
 
-		fn := defaultTruncHandler(testTruncOffloadPath("/tmp"), 100)
+		fn := defaultTruncHandler(testTruncOffloadPath("/tmp"), 100, "read_file")
 		result, err := fn(ctx, detail)
 		assert.NoError(t, err)
 		assert.False(t, result.NeedTrunc)
@@ -1785,7 +1845,7 @@ func TestDefaultTruncHandlerWithStreamToolResult(t *testing.T) {
 			StreamToolResult: sr,
 		}
 
-		fn := defaultTruncHandler(testTruncOffloadPath("/tmp"), 100)
+		fn := defaultTruncHandler(testTruncOffloadPath("/tmp"), 100, "read_file")
 		result, err := fn(ctx, detail)
 		assert.NoError(t, err)
 		assert.True(t, result.NeedTrunc)
@@ -1805,7 +1865,7 @@ func TestDefaultTruncHandlerWithStreamToolResult(t *testing.T) {
 
 		fn := defaultTruncHandler(func(context.Context, *ToolDetail) (string, error) {
 			return "", fmt.Errorf("gen path error")
-		}, 10)
+		}, 10, "read_file")
 		_, err := fn(ctx, detail)
 		assert.Error(t, err)
 		assert.Contains(t, err.Error(), "gen path error")


### PR DESCRIPTION
## Summary
- add the configured read tool name to default truncation notices, matching clear-stage notices
- pass `ReadFileToolName` into the default truncation handler
- cover custom read tool names in default truncation output

Fixes #1110.

## Tests
- `go test ./adk/middlewares/reduction -run 'TestReductionMiddlewareTrunc/test_default_truncation_notice_includes_configured_read_tool_name' -count=1`
- `go test ./adk/middlewares/reduction -count=1`
- `go test ./adk/middlewares/reduction -coverprofile=/tmp/eino-reduction-1110.cover -covermode=count -count=1`
- local patch coverage estimate: 100% (7/7 changed statements)
- `go test ./adk/... -count=1`
- `git diff --check`