### PR TITLE
refactor(adk): remove FailoverProxyModel callback aspect

### DIFF
--- a/adk/failover_chatmodel.go
+++ b/adk/failover_chatmodel.go
@@ -23,7 +23,6 @@ import (
 	"io"
 	"log"
 
-	"github.com/cloudwego/eino/callbacks"
 	"github.com/cloudwego/eino/components"
 	"github.com/cloudwego/eino/components/model"
 	"github.com/cloudwego/eino/compose"
@@ -76,63 +75,22 @@ func (m *typedFailoverProxyModel[M]) prepareTarget(ctx context.Context) (model.B
 }
 
 func (m *typedFailoverProxyModel[M]) Generate(ctx context.Context, input []M, opts ...model.Option) (M, error) {
-	target, targetType, err := m.prepareTarget(ctx)
+	target, _, err := m.prepareTarget(ctx)
 	if err != nil {
 		var zero M
 		return zero, err
 	}
 
-	// Override compose-level RunInfo with FailoverChatModel identity for the outer span.
-	ctx = callbacks.ReuseHandlers(ctx, &callbacks.RunInfo{
-		Type:      "FailoverChatModel",
-		Component: components.ComponentOfChatModel,
-	})
-	ctx = callbacks.OnStart(ctx, input)
-
-	// Create child RunInfo for the target model.
-	nCtx := callbacks.ReuseHandlers(ctx, &callbacks.RunInfo{
-		Type:      targetType,
-		Component: components.ComponentOfChatModel,
-	})
-
-	result, err := target.Generate(nCtx, input, opts...)
-	if err != nil {
-		callbacks.OnError(ctx, err)
-		return result, err
-	}
-
-	callbacks.OnEnd(ctx, result)
-
-	return result, nil
+	return target.Generate(ctx, input, opts...)
 }
 
 func (m *typedFailoverProxyModel[M]) Stream(ctx context.Context, input []M, opts ...model.Option) (*schema.StreamReader[M], error) {
-	target, targetType, err := m.prepareTarget(ctx)
+	target, _, err := m.prepareTarget(ctx)
 	if err != nil {
 		return nil, err
 	}
 
-	// Override compose-level RunInfo with FailoverChatModel identity for the outer span.
-	ctx = callbacks.ReuseHandlers(ctx, &callbacks.RunInfo{
-		Type:      "FailoverChatModel",
-		Component: components.ComponentOfChatModel,
-	})
-	ctx = callbacks.OnStart(ctx, input)
-
-	// Create child RunInfo for the target model.
-	nCtx := callbacks.ReuseHandlers(ctx, &callbacks.RunInfo{
-		Type:      targetType,
-		Component: components.ComponentOfChatModel,
-	})
-
-	result, err := target.Stream(nCtx, input, opts...)
-	if err != nil {
-		callbacks.OnError(ctx, err)
-		return nil, err
-	}
-
-	_, wrappedStream := callbacks.OnEndWithStreamOutput(ctx, result)
-	return wrappedStream, nil
+	return target.Stream(ctx, input, opts...)
 }
 
 func (m *typedFailoverProxyModel[M]) IsCallbacksEnabled() bool {

--- a/adk/failover_chatmodel.go
+++ b/adk/failover_chatmodel.go
@@ -59,23 +59,21 @@ func getFailoverHasMoreAttempts(ctx context.Context) bool {
 type typedFailoverProxyModel[M MessageType] struct {
 }
 
-func (m *typedFailoverProxyModel[M]) prepareTarget(ctx context.Context) (model.BaseModel[M], string, error) {
+func (m *typedFailoverProxyModel[M]) prepareTarget(ctx context.Context) (model.BaseModel[M], error) {
 	target, ok := typedGetFailoverCurrentModel[M](ctx)
 	if !ok {
-		return nil, "", errors.New("failover current model not found in context")
+		return nil, errors.New("failover current model not found in context")
 	}
-
-	targetType, _ := components.GetType(target)
 
 	if !components.IsCallbacksEnabled(target) {
 		target = typedCallbackInjectionModelWrapper[M]{}.wrapModel(target)
 	}
 
-	return target, targetType, nil
+	return target, nil
 }
 
 func (m *typedFailoverProxyModel[M]) Generate(ctx context.Context, input []M, opts ...model.Option) (M, error) {
-	target, _, err := m.prepareTarget(ctx)
+	target, err := m.prepareTarget(ctx)
 	if err != nil {
 		var zero M
 		return zero, err
@@ -85,7 +83,7 @@ func (m *typedFailoverProxyModel[M]) Generate(ctx context.Context, input []M, op
 }
 
 func (m *typedFailoverProxyModel[M]) Stream(ctx context.Context, input []M, opts ...model.Option) (*schema.StreamReader[M], error) {
-	target, _, err := m.prepareTarget(ctx)
+	target, err := m.prepareTarget(ctx)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
## Summary
- Removes the `FailoverChatModel` callback aspect from `typedFailoverProxyModel.Generate`/`Stream`: the proxy no longer overrides compose-level `RunInfo` nor emits its own `OnStart`/`OnEnd`/`OnError`, so the `FailoverProxyModel` layer no longer appears as a separate span at the callback level. Calls now pass straight through to the target model.
- Drops the now-unused `callbacks` import.

This cherry-picks just the `failover_chatmodel.go` change out of the `alpha/10` background-task commit (#1107) so `main` gets this behavior on its own.

## Test plan
- [x] `go build ./adk/...`
- [x] `go test -race ./adk/ -run 'Failover'`

🤖 Generated with [Claude Code](https://claude.com/claude-code)