### PR TITLE
fix(summarization): prefer UserInputMultiContent for user text content

### DIFF
--- a/adk/middlewares/summarization/finalizer_builder.go
+++ b/adk/middlewares/summarization/finalizer_builder.go
@@ -263,7 +263,7 @@ func extractSkillInfos[M adk.MessageType](messages []M, skillTool string) ([]*sk
 				}
 				skills = append(skills, &skillInfo{
 					Name:    arg.Skill,
-					Content: m.Content,
+					Content: messageUserTextContent(m),
 				})
 			}
 

--- a/adk/middlewares/summarization/summarization.go
+++ b/adk/middlewares/summarization/summarization.go
@@ -981,22 +981,26 @@ func isUserRole[M adk.MessageType](msg M) bool {
 	panic("unreachable")
 }
 
+func messageUserTextContent(m *schema.Message) string {
+	if m == nil {
+		return ""
+	}
+	var parts []string
+	for _, part := range m.UserInputMultiContent {
+		if part.Type == schema.ChatMessagePartTypeText && part.Text != "" {
+			parts = append(parts, part.Text)
+		}
+	}
+	if len(parts) > 0 {
+		return strings.Join(parts, "\n")
+	}
+	return m.Content
+}
+
 func getUserMsgTextContent[M adk.MessageType](msg M) string {
 	switch m := any(msg).(type) {
 	case *schema.Message:
-		if m == nil {
-			return ""
-		}
-		var parts []string
-		for _, part := range m.UserInputMultiContent {
-			if part.Type == schema.ChatMessagePartTypeText && part.Text != "" {
-				parts = append(parts, part.Text)
-			}
-		}
-		if len(parts) > 0 {
-			return strings.Join(parts, "\n")
-		}
-		return m.Content
+		return messageUserTextContent(m)
 
 	case *schema.AgenticMessage:
 		if m == nil {


### PR DESCRIPTION
## Summary

When extracting user text content from `*schema.Message`, the summarization middleware should prefer `UserInputMultiContent` text parts (joined with `\n`) over the raw `Content` field. Previously, `extractSkillInfos` read `m.Content` directly, bypassing multimodal-aware extraction.

## Key Changes

1. Extracted a reusable `messageUserTextContent` helper that checks `UserInputMultiContent` first and falls back to `Content`.
2. Applied the helper in both `getUserMsgTextContent` and `extractSkillInfos` for consistent behavior.