### PR TITLE
fix(adk): isolate agent tool interrupt state

### DIFF
--- a/adk/agent_tool.go
+++ b/adk/agent_tool.go
@@ -19,6 +19,7 @@ package adk
 
 import (
 	"context"
+	"encoding/base64"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -30,6 +31,8 @@ import (
 	"github.com/cloudwego/eino/compose"
 	"github.com/cloudwego/eino/schema"
 )
+
+const agentToolInterruptAddressPrefix = "agent_tool_"
 
 var (
 	defaultAgentToolParam = schema.NewParamsOneOfByParams(map[string]*schema.ParameterInfo{
@@ -132,6 +135,13 @@ type agentToolRequest struct {
 	Request string `json:"request"`
 }
 
+func agentToolInterruptAddressID(agentName string) string {
+	if agentName == "" {
+		return "agent_tool"
+	}
+	return agentToolInterruptAddressPrefix + base64.RawURLEncoding.EncodeToString([]byte(agentName))
+}
+
 func (at *typedAgentTool[M]) Info(ctx context.Context) (*schema.ToolInfo, error) {
 	name := at.agent.Name(ctx)
 	if name == "" {
@@ -163,6 +173,9 @@ type agentToolInterruptState struct {
 }
 
 func (at *typedAgentTool[M]) InvokableRun(ctx context.Context, argumentsInJSON string, opts ...tool.Option) (string, error) {
+	agentName := at.agent.Name(ctx)
+	ctx = AppendAddressSegment(ctx, AddressSegmentTool, agentToolInterruptAddressID(agentName))
+
 	if cancelCtx := getCancelContext(ctx); cancelCtx != nil {
 		cancelCtx.markAgentToolDescendant()
 	}
@@ -183,7 +196,7 @@ func (at *typedAgentTool[M]) InvokableRun(ctx context.Context, argumentsInJSON s
 		// (which may be reused across turns) and with user-assigned session IDs.
 		childSessionID = "agent_tool:" + uuid.NewString()
 	} else if !hasState {
-		return "", fmt.Errorf("agent tool '%s' interrupt has happened, but cannot find interrupt state", at.agent.Name(ctx))
+		return "", fmt.Errorf("agent tool '%s' interrupt has happened, but cannot find interrupt state", agentName)
 	} else {
 		// Resume — try the JSON envelope (introduced when SessionID-based event
 		// filtering landed). If the envelope does not parse or carries no bridge
@@ -210,7 +223,7 @@ func (at *typedAgentTool[M]) InvokableRun(ctx context.Context, argumentsInJSON s
 			if _, ok := any(zero).(*schema.Message); !ok {
 				return "", fmt.Errorf("fullChatHistoryAsInput is only supported for *schema.Message agents")
 			}
-			msgInput, histErr := getReactChatHistory(ctx, at.agent.Name(ctx))
+			msgInput, histErr := getReactChatHistory(ctx, agentName)
 			if histErr != nil {
 				return "", histErr
 			}
@@ -229,11 +242,11 @@ func (at *typedAgentTool[M]) InvokableRun(ctx context.Context, argumentsInJSON s
 
 		runner := newTypedInvokableAgentToolRunner(at.agent, ms, enableStreaming)
 		iter = runner.Run(ctx, input,
-			append(extractAndDeriveAgentToolCancelCtx(ctx, at.agent.Name(ctx), opts), WithCheckPointID(bridgeCheckpointID), withSharedParentSession())...)
+			append(extractAndDeriveAgentToolCancelCtx(ctx, agentName, opts), WithCheckPointID(bridgeCheckpointID), withSharedParentSession())...)
 	} else {
 		ms = newResumeBridgeStore(bridgeCheckpointID, bridgeCheckpoint)
 
-		agentOpts := extractAndDeriveAgentToolCancelCtx(ctx, at.agent.Name(ctx), opts)
+		agentOpts := extractAndDeriveAgentToolCancelCtx(ctx, agentName, opts)
 		agentOpts = append(agentOpts, withSharedParentSession())
 
 		runner := newTypedInvokableAgentToolRunner(at.agent, ms, enableStreaming)

--- a/adk/agent_tool_test.go
+++ b/adk/agent_tool_test.go
@@ -18,6 +18,7 @@ package adk
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"strings"
 	"sync"
@@ -30,6 +31,7 @@ import (
 	"github.com/cloudwego/eino/components/model"
 	"github.com/cloudwego/eino/components/tool"
 	"github.com/cloudwego/eino/compose"
+	"github.com/cloudwego/eino/internal/core"
 	"github.com/cloudwego/eino/schema"
 )
 
@@ -296,6 +298,41 @@ func TestAgentTool_InvokableRun(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestAgentTool_UsesInnerAddressWhenOuterToolWasInterrupted(t *testing.T) {
+	ctx := context.Background()
+
+	mockAgent := newMockAgentForTool("TestAgent", "Test agent description", []*AgentEvent{
+		{
+			AgentName: "TestAgent",
+			Output: &AgentOutput{
+				MessageOutput: &MessageVariant{
+					IsStreaming: false,
+					Message:     schema.AssistantMessage("Test response", nil),
+					Role:        schema.Assistant,
+				},
+			},
+		},
+	})
+	agentTool := NewAgentTool(ctx, mockAgent).(tool.InvokableTool)
+
+	outerCtx := AppendAddressSegment(ctx, AddressSegmentAgent, "OuterAgent")
+	outerCtx = AppendAddressSegment(outerCtx, AddressSegmentTool, "agent")
+	err := tool.StatefulInterrupt(outerCtx, "permission ask", "permission-state")
+	require.Error(t, err)
+	var permissionSignal *core.InterruptSignal
+	require.True(t, errors.As(err, &permissionSignal))
+
+	id2Addr, id2State := core.SignalToPersistenceMaps(permissionSignal)
+	resumeCtx := core.PopulateInterruptState(context.Background(), id2Addr, id2State)
+	resumeCtx = core.BatchResumeWithData(resumeCtx, map[string]any{permissionSignal.ID: "approved"})
+	resumeCtx = AppendAddressSegment(resumeCtx, AddressSegmentAgent, "OuterAgent")
+	resumeCtx = AppendAddressSegment(resumeCtx, AddressSegmentTool, "agent")
+
+	output, err := agentTool.InvokableRun(resumeCtx, `{"request":"Test request"}`)
+	require.NoError(t, err)
+	assert.Equal(t, "Test response", output)
 }
 
 func TestGetReactHistory(t *testing.T) {

--- a/adk/interrupt_test.go
+++ b/adk/interrupt_test.go
@@ -1241,6 +1241,7 @@ func TestChatModelAgentToolInterrupt(t *testing.T) {
 			assert.Equal(t, Address{
 				{Type: AddressSegmentAgent, ID: "name"},
 				{Type: AddressSegmentTool, ID: "myAgent", SubID: "1"},
+				{Type: AddressSegmentTool, ID: agentToolInterruptAddressID("myAgent")},
 				{Type: AddressSegmentAgent, ID: "myAgent"},
 			}, ctx.Address)
 			assert.Equal(t, "interrupt again", ctx.Info)
@@ -1757,6 +1758,7 @@ func TestNestedChatModelAgentWithAgentTool(t *testing.T) {
 	expectedAddress := Address{
 		{Type: AddressSegmentAgent, ID: "OuterAgent"},
 		{Type: AddressSegmentTool, ID: "InnerAgent", SubID: "1"},
+		{Type: AddressSegmentTool, ID: agentToolInterruptAddressID("InnerAgent")},
 		{Type: AddressSegmentAgent, ID: "InnerAgent"},
 		{Type: AddressSegmentTool, ID: "innerTool", SubID: "1"},
 	}

--- a/adk/middlewares/permission/permission.go
+++ b/adk/middlewares/permission/permission.go
@@ -177,6 +177,11 @@ func (m *Middleware[M]) permissionGate(
 	wasInterrupted, hasState, savedState := tool.GetInterruptState[*AskState](ctx)
 	isTarget, hasData, response := tool.GetResumeContext[*ResumeResponse](ctx)
 
+	// A descendant interrupt is being resumed; this wrapper is only a conduit.
+	if !wasInterrupted && isTarget && !hasData {
+		return &gateResult{allowed: true, argument: argument}, nil
+	}
+
 	if wasInterrupted && !hasState {
 		return &gateResult{allowed: true, argument: argument}, nil
 	}

--- a/adk/middlewares/permission/permission_test.go
+++ b/adk/middlewares/permission/permission_test.go
@@ -219,6 +219,51 @@ func TestWrapInvokableToolCall_PassesThroughBusinessInterruptResume(t *testing.T
 	assert.Equal(t, 2, endpointCalls)
 }
 
+func TestWrapInvokableToolCall_PassesThroughDescendantInterruptResume(t *testing.T) {
+	checkerCalls := 0
+	m := NewTyped[*schema.Message](func(ctx context.Context, tCtx *adk.ToolContext, args *schema.ToolArgument) (*GateCheckResult, error) {
+		checkerCalls++
+		return &GateCheckResult{Decision: GateAsk, Message: "approve tool?"}, nil
+	})
+
+	endpointCalls := 0
+	endpoint := adk.InvokableToolCallEndpoint(func(ctx context.Context, argumentsInJSON string, opts ...tool.Option) (string, error) {
+		endpointCalls++
+		childCtx := adk.AppendAddressSegment(ctx, adk.AddressSegmentTool, "agent_tool_inner")
+		wasInterrupted, hasState, state := tool.GetInterruptState[string](childCtx)
+		isTarget, hasData, data := tool.GetResumeContext[string](childCtx)
+		if wasInterrupted && hasState {
+			assert.Equal(t, "descendant-state", state)
+			require.True(t, isTarget)
+			require.True(t, hasData)
+			assert.Equal(t, "descendant-resume", data)
+			assert.Equal(t, `{"path":"/tmp/approved"}`, argumentsInJSON)
+			return "descendant resumed", nil
+		}
+		return "", tool.StatefulInterrupt(childCtx, "descendant interrupt", "descendant-state")
+	})
+
+	tCtx := &adk.ToolContext{Name: "NestedTool", CallID: "call_nested_descendant"}
+	wrapped, err := m.WrapInvokableToolCall(context.Background(), endpoint, tCtx)
+	require.NoError(t, err)
+
+	_, err = wrapped(withAddress(context.Background()), `{"path":"/tmp/approved"}`)
+	require.Error(t, err)
+	var permissionSignal *core.InterruptSignal
+	require.True(t, errors.As(err, &permissionSignal))
+
+	_, err = wrapped(resumeContext(permissionSignal, &ResumeResponse{Action: ResumeActionApprove}), `{"path":"/tmp/ignored"}`)
+	require.Error(t, err)
+	var descendantSignal *core.InterruptSignal
+	require.True(t, errors.As(err, &descendantSignal))
+
+	result, err := wrapped(genericResumeContext(descendantSignal, "descendant-resume"), `{"path":"/tmp/approved"}`)
+	require.NoError(t, err)
+	assert.Equal(t, "descendant resumed", result)
+	assert.Equal(t, 1, checkerCalls)
+	assert.Equal(t, 2, endpointCalls)
+}
+
 func TestAttack_BusinessInterruptNonTargetReplayPassesThrough(t *testing.T) {
 	m := NewTyped[*schema.Message](func(ctx context.Context, tCtx *adk.ToolContext, args *schema.ToolArgument) (*GateCheckResult, error) {
 		return &GateCheckResult{Decision: GateAllow}, nil


### PR DESCRIPTION
## Summary
- isolate agent-tool interrupt state by addressing nested tool interrupts with stable child paths
- preserve permission interrupt metadata across agent tool execution
- cover nested agent-tool permission/resume behavior with regression tests

## Tests
- go test ./adk/...