### PR TITLE
feat(summarization): add ReusePromptCaching option

### DIFF
--- a/adk/middlewares/summarization/summarization.go
+++ b/adk/middlewares/summarization/summarization.go
@@ -61,6 +61,23 @@ type TypedConfig[M adk.MessageType] struct {
 	// Optional.
 	ModelOptions []model.Option
 
+	// ReusePromptCaching indicates whether the summarization call should
+	// reuse the main conversation's cached prompt instead of rebuilding a
+	// fresh input. For example, the input becomes
+	// [sysMsg, userMsg1, assistantMsg1, ..., userInstruction] rather than
+	// [innerSysInstruction, userMsg1, assistantMsg1, ..., userInstruction].
+	// The current state's ToolInfos and DeferredToolInfos are also passed
+	// via model.WithTools/model.WithDeferredTools so the tool envelope
+	// matches the main conversation's, preserving the cache.
+	//
+	// Because the model still sees the original messages and tools, there is
+	// a small chance that it chooses to call a tool instead of producing a
+	// summary directly. It is therefore recommended to also configure Retry
+	// or Failover to handle this case.
+	//
+	// Optional. Defaults to false.
+	ReusePromptCaching bool
+
 	// TokenCounter calculates the token count for given messages and tools.
 	//
 	// Parameters:
@@ -293,7 +310,7 @@ func (m *TypedMiddleware[M]) Summarize(ctx context.Context, state *adk.TypedChat
 		}
 	}
 
-	rawSummary, modelInput, err := m.summarize(ctx, beforeState.Messages)
+	rawSummary, modelInput, err := m.summarize(ctx, beforeState)
 	if err != nil {
 		return nil, err
 	}
@@ -499,18 +516,20 @@ func estimateTokenBytes(tokens int) int {
 	return tokens * 4
 }
 
-func (m *TypedMiddleware[M]) summarize(ctx context.Context, originalMsgs []M) (M, []M, error) {
+func (m *TypedMiddleware[M]) summarize(ctx context.Context, state adk.TypedChatModelAgentState[M]) (M, []M, error) {
 	var zero M
-	_, contextMsgs := splitSystemAndContextMsgs(originalMsgs)
+	_, contextMsgs := splitSystemAndContextMsgs(state.Messages)
 
-	modelInput, err := m.buildSummarizationModelInput(ctx, originalMsgs, contextMsgs)
+	modelInput, err := m.buildSummarizationModelInput(ctx, state.Messages, contextMsgs)
 	if err != nil {
 		return zero, nil, err
 	}
 
-	rawSummary, err := m.generateWithRetry(ctx, m.cfg.Model, modelInput, m.cfg.ModelOptions, m.cfg.Retry)
+	opts := m.summarizeModelOptions(state.ToolInfos, state.DeferredToolInfos)
+
+	rawSummary, err := m.generateWithRetry(ctx, m.cfg.Model, modelInput, opts, m.cfg.Retry)
 	if typedShouldFailover(ctx, m.cfg.Failover, rawSummary, err) {
-		rawSummary, modelInput, err = m.runFailover(ctx, originalMsgs, modelInput, rawSummary, err)
+		rawSummary, modelInput, err = m.runFailover(ctx, state.Messages, modelInput, opts, rawSummary, err)
 		if err != nil {
 			return zero, nil, err
 		}
@@ -519,6 +538,17 @@ func (m *TypedMiddleware[M]) summarize(ctx context.Context, originalMsgs []M) (M
 	}
 
 	return rawSummary, modelInput, nil
+}
+
+func (m *TypedMiddleware[M]) summarizeModelOptions(toolInfos, deferredToolInfos []*schema.ToolInfo) []model.Option {
+	if !m.cfg.ReusePromptCaching {
+		return m.cfg.ModelOptions
+	}
+	opts := make([]model.Option, len(m.cfg.ModelOptions), len(m.cfg.ModelOptions)+2)
+	copy(opts, m.cfg.ModelOptions)
+	opts = append(opts, model.WithTools(toolInfos))
+	opts = append(opts, model.WithDeferredTools(deferredToolInfos))
+	return opts
 }
 
 func splitSystemAndContextMsgs[M adk.MessageType](msgs []M) ([]M, []M) {
@@ -534,8 +564,8 @@ func splitSystemAndContextMsgs[M adk.MessageType](msgs []M) ([]M, []M) {
 	return systemMsgs, contextMsgs
 }
 
-func (m *TypedMiddleware[M]) runFailover(ctx context.Context, originalMsgs, defaultInput []M, lastResp M,
-	lastErr error) (M, []M, error) {
+func (m *TypedMiddleware[M]) runFailover(ctx context.Context, originalMsgs, defaultInput []M, opts []model.Option,
+	lastResp M, lastErr error) (M, []M, error) {
 
 	var zero M
 	const defaultMaxRetries = 3
@@ -577,7 +607,7 @@ func (m *TypedMiddleware[M]) runFailover(ctx context.Context, originalMsgs, defa
 			}
 		} else {
 			modelInput = nextInput
-			lastResp, lastErr = m.generateAndEmit(ctx, failoverModel, modelInput, m.cfg.ModelOptions, attempt, GenerateSummaryPhaseFailover)
+			lastResp, lastErr = m.generateAndEmit(ctx, failoverModel, modelInput, opts, attempt, GenerateSummaryPhaseFailover)
 		}
 
 		if !typedShouldFailover(ctx, m.cfg.Failover, lastResp, lastErr) {
@@ -629,6 +659,13 @@ func (m *TypedMiddleware[M]) buildSummarizationModelInput(ctx context.Context, o
 		if err != nil {
 			return nil, fmt.Errorf("failed to generate model input: %w", err)
 		}
+		return input, nil
+	}
+
+	if m.cfg.ReusePromptCaching {
+		input := make([]M, 0, len(originMsgs)+1)
+		input = append(input, originMsgs...)
+		input = append(input, userInstruction)
 		return input, nil
 	}
 

--- a/adk/middlewares/summarization/summarization_test.go
+++ b/adk/middlewares/summarization/summarization_test.go
@@ -613,6 +613,188 @@ func TestMiddlewareBeforeModelRewriteState(t *testing.T) {
 		assert.NoError(t, err)
 	})
 
+	t.Run("ReusePromptCaching appends user instruction to original messages without rebuilding", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		cm := mockModel.NewMockBaseChatModel(ctrl)
+
+		sysMsg := schema.SystemMessage("caller supplied system")
+		userMsg := schema.UserMessage(strings.Repeat("a", 100))
+		assistantMsg := schema.AssistantMessage(strings.Repeat("b", 100), nil)
+
+		cm.EXPECT().Generate(gomock.Any(), gomock.Any(), gomock.Any()).
+			DoAndReturn(func(ctx context.Context, msgs []*schema.Message, opts ...interface{}) (*schema.Message, error) {
+				require.Len(t, msgs, 4)
+				assert.Same(t, sysMsg, msgs[0])
+				assert.Same(t, userMsg, msgs[1])
+				assert.Same(t, assistantMsg, msgs[2])
+				assert.Equal(t, schema.User, msgs[3].Role)
+				return &schema.Message{
+					Role:    schema.Assistant,
+					Content: "Summary content",
+				}, nil
+			}).Times(1)
+
+		mw := &TypedMiddleware[*schema.Message]{
+			cfg: &Config{
+				Model:              cm,
+				Trigger:            &TriggerCondition{ContextTokens: 10},
+				ReusePromptCaching: true,
+			},
+			TypedBaseChatModelAgentMiddleware: &adk.TypedBaseChatModelAgentMiddleware[*schema.Message]{},
+		}
+
+		state := &adk.ChatModelAgentState{
+			Messages: []adk.Message{sysMsg, userMsg, assistantMsg},
+		}
+
+		_, newState, err := mw.BeforeModelRewriteState(ctx, state, mtx)
+		assert.NoError(t, err)
+		assert.Len(t, newState.Messages, 2)
+		assert.Equal(t, schema.System, newState.Messages[0].Role)
+		assert.Equal(t, "caller supplied system", newState.Messages[0].Content)
+		assert.Equal(t, schema.User, newState.Messages[1].Role)
+	})
+
+	t.Run("ReusePromptCaching injects state tool infos as model.WithTools", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		cm := mockModel.NewMockBaseChatModel(ctrl)
+
+		stateTools := []*schema.ToolInfo{
+			{Name: "state_tool_a"},
+			{Name: "state_tool_b"},
+		}
+
+		cm.EXPECT().Generate(gomock.Any(), gomock.Any(), gomock.Any()).
+			DoAndReturn(func(ctx context.Context, msgs []*schema.Message, opts ...model.Option) (*schema.Message, error) {
+				common := model.GetCommonOptions(&model.Options{}, opts...)
+				require.Len(t, common.Tools, 2)
+				assert.Equal(t, "state_tool_a", common.Tools[0].Name)
+				assert.Equal(t, "state_tool_b", common.Tools[1].Name)
+				return &schema.Message{
+					Role:    schema.Assistant,
+					Content: "Summary content",
+				}, nil
+			}).Times(1)
+
+		mw := &TypedMiddleware[*schema.Message]{
+			cfg: &Config{
+				Model:              cm,
+				Trigger:            &TriggerCondition{ContextTokens: 10},
+				ReusePromptCaching: true,
+			},
+			TypedBaseChatModelAgentMiddleware: &adk.TypedBaseChatModelAgentMiddleware[*schema.Message]{},
+		}
+
+		state := &adk.ChatModelAgentState{
+			Messages: []adk.Message{
+				schema.UserMessage(strings.Repeat("a", 100)),
+				schema.AssistantMessage(strings.Repeat("b", 100), nil),
+			},
+			ToolInfos: stateTools,
+		}
+
+		_, _, err := mw.BeforeModelRewriteState(ctx, state, mtx)
+		assert.NoError(t, err)
+	})
+
+	t.Run("ReusePromptCaching injects state deferred tool infos as model.WithDeferredTools", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		cm := mockModel.NewMockBaseChatModel(ctrl)
+
+		stateTools := []*schema.ToolInfo{
+			{Name: "state_tool_a"},
+		}
+		deferredTools := []*schema.ToolInfo{
+			{Name: "deferred_tool_a"},
+			{Name: "deferred_tool_b"},
+		}
+
+		cm.EXPECT().Generate(gomock.Any(), gomock.Any(), gomock.Any()).
+			DoAndReturn(func(ctx context.Context, msgs []*schema.Message, opts ...model.Option) (*schema.Message, error) {
+				common := model.GetCommonOptions(&model.Options{}, opts...)
+				require.Len(t, common.Tools, 1)
+				assert.Equal(t, "state_tool_a", common.Tools[0].Name)
+				require.Len(t, common.DeferredTools, 2)
+				assert.Equal(t, "deferred_tool_a", common.DeferredTools[0].Name)
+				assert.Equal(t, "deferred_tool_b", common.DeferredTools[1].Name)
+				return &schema.Message{
+					Role:    schema.Assistant,
+					Content: "Summary content",
+				}, nil
+			}).Times(1)
+
+		mw := &TypedMiddleware[*schema.Message]{
+			cfg: &Config{
+				Model:              cm,
+				Trigger:            &TriggerCondition{ContextTokens: 10},
+				ReusePromptCaching: true,
+			},
+			TypedBaseChatModelAgentMiddleware: &adk.TypedBaseChatModelAgentMiddleware[*schema.Message]{},
+		}
+
+		state := &adk.ChatModelAgentState{
+			Messages: []adk.Message{
+				schema.UserMessage(strings.Repeat("a", 100)),
+				schema.AssistantMessage(strings.Repeat("b", 100), nil),
+			},
+			ToolInfos:         stateTools,
+			DeferredToolInfos: deferredTools,
+		}
+
+		_, _, err := mw.BeforeModelRewriteState(ctx, state, mtx)
+		assert.NoError(t, err)
+	})
+
+	t.Run("ReusePromptCaching with failover injects state tool infos into failover model call", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		primary := mockModel.NewMockBaseChatModel(ctrl)
+		failover := mockModel.NewMockBaseChatModel(ctrl)
+
+		stateTools := []*schema.ToolInfo{
+			{Name: "state_tool_a"},
+		}
+
+		primary.EXPECT().Generate(gomock.Any(), gomock.Any(), gomock.Any()).
+			Return(&schema.Message{
+				Role:    schema.Assistant,
+				Content: "partial output",
+			}, fmt.Errorf("primary error")).Times(1)
+		failover.EXPECT().Generate(gomock.Any(), gomock.Any(), gomock.Any()).
+			DoAndReturn(func(ctx context.Context, msgs []*schema.Message, opts ...model.Option) (*schema.Message, error) {
+				common := model.GetCommonOptions(&model.Options{}, opts...)
+				require.Len(t, common.Tools, 1)
+				assert.Equal(t, "state_tool_a", common.Tools[0].Name)
+				return &schema.Message{
+					Role:    schema.Assistant,
+					Content: "Summary from failover",
+				}, nil
+			}).Times(1)
+
+		mw := &TypedMiddleware[*schema.Message]{
+			cfg: &Config{
+				Model:              primary,
+				Trigger:            &TriggerCondition{ContextTokens: 10},
+				ReusePromptCaching: true,
+				Failover: &FailoverConfig{
+					GetFailoverModel: func(ctx context.Context, failoverCtx *FailoverContext) (model.BaseChatModel, []*schema.Message, error) {
+						return failover, []*schema.Message{schema.UserMessage("failover input")}, nil
+					},
+				},
+			},
+			TypedBaseChatModelAgentMiddleware: &adk.TypedBaseChatModelAgentMiddleware[*schema.Message]{},
+		}
+
+		state := &adk.ChatModelAgentState{
+			Messages: []adk.Message{
+				schema.UserMessage(strings.Repeat("a", 100)),
+			},
+			ToolInfos: stateTools,
+		}
+
+		_, _, err := mw.BeforeModelRewriteState(ctx, state, mtx)
+		assert.NoError(t, err)
+	})
+
 }
 
 func TestMiddlewareShouldSummarize(t *testing.T) {


### PR DESCRIPTION
## Summary

The summarization middleware always rebuilds a fresh model input (`[innerSysInstruction, contextMessages..., userInstruction]`) on every trigger, which fully invalidates the main conversation's cached prompt on the provider side. This change adds a `ReusePromptCaching` option so callers can opt into reusing that cache for the summarize call instead.

## API Changes

1. **Added**: `TypedConfig.ReusePromptCaching bool` (and its `Config` alias). When enabled, the summarization input becomes `[sysMsg, userMsg1, assistantMsg1, ..., userInstruction]` — the original message history is kept byte-identical and only the user instruction is appended — and the summarize call additionally passes `model.WithTools(state.ToolInfos)` and, when set, `model.WithDeferredTools(state.DeferredToolInfos)`, so the full tool envelope matches the main conversation's and the cache is preserved. Has no effect when `GenModelInput` is set.

## Key Changes

1. Because the model still sees the original messages and tools under `ReusePromptCaching`, there is a small chance it calls a tool instead of producing a summary directly — it's recommended to also configure `Retry` or `Failover` when enabling this option.
2. `summarize`/`runFailover` now thread the state's `ToolInfos` and `DeferredToolInfos` through to the model options builder so both the primary and failover calls apply the same cache-preserving options.