### PR TITLE
feat(schema): expose stream writer close signal

### DIFF
--- a/schema/stream.go
+++ b/schema/stream.go
@@ -127,6 +127,12 @@ func (sw *StreamWriter[T]) Send(chunk T, err error) (closed bool) {
 	return sw.stm.send(chunk, err)
 }
 
+// Closed returns a channel that is closed when the stream receiver stops
+// receiving, for example after StreamReader.Close is called.
+func (sw *StreamWriter[T]) Closed() <-chan struct{} {
+	return sw.stm.closed
+}
+
 // Close notify the receiver that the stream sender has finished.
 // The stream receiver will get an error of io.EOF from StreamReader.Recv().
 // Notice: always remember to call Close() after sending all data.

--- a/schema/stream_test.go
+++ b/schema/stream_test.go
@@ -62,6 +62,26 @@ func TestStream(t *testing.T) {
 	wg.Wait()
 }
 
+func TestStreamWriterClosedClosesWhenReaderCloses(t *testing.T) {
+	sr, sw := Pipe[int](0)
+
+	select {
+	case <-sw.Closed():
+		t.Fatal("writer close notification should not fire before reader closes")
+	default:
+	}
+
+	sr.Close()
+
+	select {
+	case <-sw.Closed():
+	case <-time.After(time.Second):
+		t.Fatal("writer close notification did not fire after reader closed")
+	}
+
+	assert.True(t, sw.Send(1, nil))
+}
+
 func TestStreamCopy(t *testing.T) {
 	s := newStream[string](10)
 	srs := s.asReader().Copy(2)


### PR DESCRIPTION
#### What type of PR is this?
feat

#### Check the PR title.
- [x] This PR title match the format: <type>(optional scope): <description>
- [x] The description of this PR title is user-oriented and clear enough for others to understand.
- [ ] Attach the PR updating the user documentation if the current PR requires user awareness at the usage level.

#### More detailed description

This exposes the existing receiver-close notification on `StreamWriter`.

Problem:
A stream producer can currently observe reader closure only when `Send` returns `closed=true`. If the producer is blocked outside `Send` (for example reading a stalled SSE/network stream), it cannot observe that the consumer has called `StreamReader.Close()`, so the producer goroutine and upstream connection may remain alive until an external context cancels.

Root cause:
The stream already has an internal `closed` channel closed by `closeRecv`, but `StreamWriter` does not expose it.

Change:
Add `StreamWriter.Closed() <-chan struct{}` so producers can select on receiver closure and cancel blocked upstream work.

Scope:
This only exposes the existing close signal. It does not change `Send`, `Close`, buffering, copy, merge, or automatic-close behavior.

#### Which issue(s) this PR fixes:
Fixes #1068

#### Test
- `go test ./schema -run TestStreamWriterClosedClosesWhenReaderCloses -count=1`
- `go test ./schema`
- `go test ./... -count=1`
- `git diff --check`