### PR TITLE
fix(plantask): normalize listed file paths

### DIFF
--- a/adk/middlewares/plantask/backend_test.go
+++ b/adk/middlewares/plantask/backend_test.go
@@ -78,3 +78,23 @@ func (b *inMemoryBackend) Delete(ctx context.Context, req *DeleteRequest) error 
 	delete(b.files, req.FilePath)
 	return nil
 }
+
+type baseNameLsBackend struct {
+	*inMemoryBackend
+}
+
+func newBaseNameLsBackend() *baseNameLsBackend {
+	return &baseNameLsBackend{inMemoryBackend: newInMemoryBackend()}
+}
+
+func (b *baseNameLsBackend) LsInfo(ctx context.Context, req *LsInfoRequest) ([]FileInfo, error) {
+	infos, err := b.inMemoryBackend.LsInfo(ctx, req)
+	if err != nil {
+		return nil, err
+	}
+
+	for i := range infos {
+		infos[i].Path = filepath.Base(infos[i].Path)
+	}
+	return infos, nil
+}

--- a/adk/middlewares/plantask/task_create.go
+++ b/adk/middlewares/plantask/task_create.go
@@ -106,11 +106,15 @@ func (t *taskCreateTool) InvokableRun(ctx context.Context, argumentsInJSON strin
 	for _, file := range files {
 		fileName := filepath.Base(file.Path)
 		if fileName == highWatermarkFileName {
+			filePath := file.Path
+			if !filepath.IsAbs(filePath) {
+				filePath = filepath.Join(t.BaseDir, filePath)
+			}
 			content, readErr := t.Backend.Read(ctx, &ReadRequest{
-				FilePath: file.Path,
+				FilePath: filePath,
 			})
 			if readErr != nil {
-				return "", fmt.Errorf("%s read highwatermark file %s failed, err: %w", TaskCreateToolName, file.Path, readErr)
+				return "", fmt.Errorf("%s read highwatermark file %s failed, err: %w", TaskCreateToolName, filePath, readErr)
 			}
 			if content.Content != "" {
 				var val int64

--- a/adk/middlewares/plantask/task_create_test.go
+++ b/adk/middlewares/plantask/task_create_test.go
@@ -89,3 +89,28 @@ func TestTaskCreateToolWithMetadata(t *testing.T) {
 	assert.Equal(t, "value1", taskData.Metadata["key1"])
 	assert.Equal(t, "value2", taskData.Metadata["key2"])
 }
+
+func TestTaskCreateToolWithBaseNameLsInfo(t *testing.T) {
+	ctx := context.Background()
+	backend := newBaseNameLsBackend()
+	baseDir := "/tmp/tasks"
+	lock := &sync.Mutex{}
+
+	err := backend.Write(ctx, &WriteRequest{FilePath: filepath.Join(baseDir, highWatermarkFileName), Content: "1"})
+	assert.NoError(t, err)
+
+	tool := newTaskCreateTool(backend, baseDir, lock)
+
+	result, err := tool.InvokableRun(ctx, `{"subject": "Second Task", "description": "Second description"}`)
+	assert.NoError(t, err)
+	assert.Equal(t, `{"result":"Task #2 created successfully: Second Task"}`, result)
+
+	content, err := backend.Read(ctx, &ReadRequest{FilePath: filepath.Join(baseDir, "2.json")})
+	assert.NoError(t, err)
+
+	var taskData task
+	err = sonic.UnmarshalString(content.Content, &taskData)
+	assert.NoError(t, err)
+	assert.Equal(t, "2", taskData.ID)
+	assert.Equal(t, "Second Task", taskData.Subject)
+}

--- a/adk/middlewares/plantask/task_list.go
+++ b/adk/middlewares/plantask/task_list.go
@@ -74,17 +74,21 @@ func listTasks(ctx context.Context, backend Backend, baseDir string) ([]*task, e
 			continue
 		}
 
+		filePath := file.Path
+		if !filepath.IsAbs(filePath) {
+			filePath = filepath.Join(baseDir, filePath)
+		}
 		content, err := backend.Read(ctx, &ReadRequest{
-			FilePath: file.Path,
+			FilePath: filePath,
 		})
 		if err != nil {
-			return nil, fmt.Errorf("%s read task file %s failed, err: %w", TaskListToolName, file.Path, err)
+			return nil, fmt.Errorf("%s read task file %s failed, err: %w", TaskListToolName, filePath, err)
 		}
 
 		taskData := &task{}
 		err = sonic.UnmarshalString(content.Content, taskData)
 		if err != nil {
-			return nil, fmt.Errorf("%s parse task file %s failed, err: %w", TaskListToolName, file.Path, err)
+			return nil, fmt.Errorf("%s parse task file %s failed, err: %w", TaskListToolName, filePath, err)
 		}
 
 		tasks = append(tasks, taskData)

--- a/adk/middlewares/plantask/task_list_test.go
+++ b/adk/middlewares/plantask/task_list_test.go
@@ -58,3 +58,25 @@ func TestTaskListTool(t *testing.T) {
 	assert.Contains(t, result, "#2 ["+taskStatusInProgress+"] Task 2")
 	assert.Contains(t, result, "[owner: agent1]")
 }
+
+func TestTaskListToolWithBaseNameLsInfo(t *testing.T) {
+	ctx := context.Background()
+	backend := newBaseNameLsBackend()
+	baseDir := "/tmp/tasks"
+	lock := &sync.Mutex{}
+
+	task1 := &task{ID: "1", Subject: "Task 1", Status: taskStatusPending}
+	task1JSON, _ := sonic.MarshalString(task1)
+	_ = backend.Write(ctx, &WriteRequest{FilePath: filepath.Join(baseDir, "1.json"), Content: task1JSON})
+
+	task2 := &task{ID: "2", Subject: "Task 2", Status: taskStatusCompleted}
+	task2JSON, _ := sonic.MarshalString(task2)
+	_ = backend.Write(ctx, &WriteRequest{FilePath: filepath.Join(baseDir, "2.json"), Content: task2JSON})
+
+	tool := newTaskListTool(backend, baseDir, lock)
+
+	result, err := tool.InvokableRun(ctx, `{}`)
+	assert.NoError(t, err)
+	assert.Contains(t, result, "#1 ["+taskStatusPending+"] Task 1")
+	assert.Contains(t, result, "#2 ["+taskStatusCompleted+"] Task 2")
+}


### PR DESCRIPTION
#### What type of PR is this?

fix

#### Check the PR title.

- [x] This PR title match the format: \<type\>(optional scope): \<description\>
- [x] The description of this PR title is user-oriented and clear enough for others to understand.
- [x] Attach the PR updating the user documentation if the current PR requires user awareness at the usage level. [User docs repo](https://github.com/cloudwego/cloudwego.github.io)

#### (Optional) Translate the PR title into Chinese.

修复 plantask 读取列表文件路径时的归一化处理

#### (Optional) More detailed description for this PR(en: English/zh: Chinese).

en:

This PR normalizes paths returned by `Backend.LsInfo` before `plantask` calls `Backend.Read`.

`filesystem.FileInfo.Path` may be a filename, relative path, or absolute path. Some filesystem backends, including the in-memory backend and the local backend in `eino-ext`, return filenames from `LsInfo`. `plantask` previously passed those values directly to `Read`, which could read from the process working directory instead of the configured task `BaseDir`.

This change follows the existing pattern used by `adk/middlewares/skill/filesystem_backend.go`: if the listed path is not absolute, join it with the configured base directory before reading.

Added regression tests for `TaskCreate` and `TaskList` with a backend whose `LsInfo` returns basenames.

zh(optional):

本 PR 在 `plantask` 调用 `Backend.Read` 前，对 `Backend.LsInfo` 返回的路径进行归一化处理。

`filesystem.FileInfo.Path` 可以是文件名、相对路径或绝对路径。部分 backend（包括 in-memory backend 和 `eino-ext` 中的 local backend）会在 `LsInfo` 中返回文件名。此前 `plantask` 会直接把该值传给 `Read`，可能导致从进程当前工作目录读取，而不是从配置的任务 `BaseDir` 读取。

本改动对齐 `adk/middlewares/skill/filesystem_backend.go` 中的已有处理方式：如果列表返回路径不是绝对路径，则先与配置的 base directory 拼接后再读取。

同时补充了 `TaskCreate` 和 `TaskList` 在 `LsInfo` 返回 basename 时的回归测试。

#### (Optional) Which issue(s) this PR fixes:

Related to cloudwego/eino-ext#908

#### (optional) The PR that updates user documentation:

N/A
