### PR TITLE
refactor(adk): stream background output through append writers

### DIFF
--- a/adk/agent_tool.go
+++ b/adk/agent_tool.go
@@ -77,8 +77,8 @@ func withAgentToolEnableStreaming(enabled bool) tool.Option {
 //
 // Event Streaming:
 // When EmitInternalEvents is enabled in ToolsConfig, the agent tool will emit AgentEvent
-// from the inner agent to the parent agent's AsyncGenerator, allowing real-time streaming
-// of the inner agent's output to the end-user via Runner.
+// from the inner agent to a receiver backed by the parent agent's AsyncGenerator, allowing
+// real-time streaming of the inner agent's output to the end-user via Runner.
 //
 // Note that these forwarded events are NOT recorded in the parent agent's runSession.
 // They are only emitted to the end-user and have no effect on the parent agent's state
@@ -168,13 +168,7 @@ func (at *typedAgentTool[M]) InvokableRun(ctx context.Context, argumentsInJSON s
 		cancelCtx.markAgentToolDescendant()
 	}
 
-	gen, enableStreaming := getEmitGeneratorAndEnableStreaming[M](opts)
-	// A background-capable invocation bounds event forwarding to the caller by a
-	// "backgrounded" signal and uses a non-panicking send: once the run detaches it
-	// outlives the parent turn, whose generator is then closed. A plain foreground
-	// invocation sets neither, so it forwards with a panicking Send — a send on an
-	// unexpectedly-closed generator is a bug there and must surface.
-	forwardGate := tool.GetImplSpecificOptions[agenttool.ForwardGate](nil, opts...)
+	receivers, enableStreaming := getEventReceiversAndEnableStreaming[M](opts)
 	var ms *bridgeStore
 	var iter *AsyncIterator[*TypedAgentEvent[M]]
 	var err error
@@ -268,7 +262,7 @@ func (at *typedAgentTool[M]) InvokableRun(ctx context.Context, argumentsInJSON s
 			return "", event.Err
 		}
 
-		if gen != nil {
+		if len(receivers) > 0 {
 			if event.Action == nil || event.Action.Interrupted == nil {
 				if parentRunCtx := getRunCtx(ctx); parentRunCtx != nil && len(parentRunCtx.RunPath) > 0 {
 					rp := make([]RunStep, 0, len(parentRunCtx.RunPath)+len(event.RunPath))
@@ -280,18 +274,13 @@ func (at *typedAgentTool[M]) InvokableRun(ctx context.Context, argumentsInJSON s
 				// can distinguish child timeline events and the parent's persistence
 				// loop can skip them.
 				stampAgentToolSessionEvent(event, childSessionID)
-				tmp := copyTypedAgentEvent(event)
-				if forwardGate.Enabled {
-					// Background-capable: forward only until the run is backgrounded,
-					// then drop (the run outlives the parent turn). trySend, not Send:
-					// after detach the parent generator may be closed.
-					if !backgrounded(forwardGate.Until) {
-						gen.trySend(event)
-					}
-				} else {
-					gen.Send(event)
+				// Each receiver gets an independent copy. In particular, streaming
+				// MessageStreams are read-once, so sharing one event across the parent
+				// generator, an output-file receiver, and AgentTool's own final-result
+				// extraction would race or consume another recipient's stream.
+				for _, receiver := range receivers {
+					receiver(copyTypedAgentEvent(event))
 				}
-				event = tmp
 			}
 		}
 
@@ -347,13 +336,6 @@ type agentToolOptions struct {
 	enableStreaming bool
 }
 
-// typedAgentToolEventOptions carries the event-forward target (the caller's event
-// generator) for a specific message type. This keeps forwarded internal events
-// type-compatible with the caller's event stream.
-type typedAgentToolEventOptions[M MessageType] struct {
-	generator *AsyncGenerator[*TypedAgentEvent[M]]
-}
-
 func withAgentToolOptions(agentName string, opts []AgentRunOption) tool.Option {
 	return tool.WrapImplSpecificOptFn(func(opt *agentToolOptions) {
 		opt.agentName = agentName
@@ -361,25 +343,15 @@ func withAgentToolOptions(agentName string, opts []AgentRunOption) tool.Option {
 	})
 }
 
-func withTypedAgentToolEventForwardTarget[M MessageType](gen *AsyncGenerator[*TypedAgentEvent[M]]) tool.Option {
-	return tool.WrapImplSpecificOptFn(func(o *typedAgentToolEventOptions[M]) {
-		o.generator = gen
+func withParentEventReceiver[M MessageType](gen *AsyncGenerator[*TypedAgentEvent[M]]) tool.Option {
+	return agenttool.WithEventReceiverTransform(func(current []agenttool.EventReceiver[*TypedAgentEvent[M]]) []agenttool.EventReceiver[*TypedAgentEvent[M]] {
+		return append(current, func(event *TypedAgentEvent[M]) {
+			// A parent turn may close its generator while a background-capable
+			// AgentTool invocation is still finishing. EventReceiver is best-effort,
+			// so a stopped downstream consumer drops the event rather than panicking.
+			gen.trySend(event)
+		})
 	})
-}
-
-// backgrounded reports whether the done signal has fired (the run has been moved
-// to the background). A nil done never fires — the run stays foreground for its
-// whole lifetime.
-func backgrounded(done <-chan struct{}) bool {
-	if done == nil {
-		return false
-	}
-	select {
-	case <-done:
-		return true
-	default:
-		return false
-	}
 }
 
 func getOptionsByAgentName(agentName string, opts []tool.Option) []AgentRunOption {
@@ -410,24 +382,16 @@ func extractAndDeriveAgentToolCancelCtx(ctx context.Context, agentName string, o
 	return agentOpts
 }
 
-func getEmitGeneratorAndEnableStreaming[M MessageType](opts []tool.Option) (*AsyncGenerator[*TypedAgentEvent[M]], bool) {
+func getEventReceiversAndEnableStreaming[M MessageType](opts []tool.Option) ([]agenttool.EventReceiver[*TypedAgentEvent[M]], bool) {
 	o := tool.GetImplSpecificOptions[agentToolOptions](nil, opts...)
-	eventOptions := tool.GetImplSpecificOptions[typedAgentToolEventOptions[M]](nil, opts...)
-	if o == nil && eventOptions == nil {
-		return nil, false
-	}
-
-	var gen *AsyncGenerator[*TypedAgentEvent[M]]
-	if eventOptions != nil {
-		gen = eventOptions.generator
-	}
+	receivers := agenttool.ResolveEventReceivers[*TypedAgentEvent[M]](opts...)
 
 	var enableStreaming bool
 	if o != nil {
 		enableStreaming = o.enableStreaming
 	}
 
-	return gen, enableStreaming
+	return receivers, enableStreaming
 }
 
 func getReactChatHistory(ctx context.Context, destAgentName string) ([]Message, error) {

--- a/adk/agent_tool_test.go
+++ b/adk/agent_tool_test.go
@@ -1279,7 +1279,7 @@ func TestCrossTypeAgentToolGracefulError(t *testing.T) {
 	}
 }
 
-// --- Event-forward gate ---
+// --- Event receivers ---
 
 // collectForwarded drains a parent generator's iterator and returns the content of
 // every non-streaming message event forwarded to it. Runs in a goroutine; the
@@ -1298,10 +1298,7 @@ func collectForwarded(iter *AsyncIterator[*AgentEvent], out *[]string, done chan
 	}
 }
 
-// With the gate open (done never fires), a background-capable invocation forwards
-// the inner agent's events to the parent generator — same as a plain foreground
-// agent-as-tool call.
-func TestAgentToolEventForwardGate_OpenGateForwards(t *testing.T) {
+func TestAgentToolEventReceiver_ParentReceives(t *testing.T) {
 	ctx := context.Background()
 	sub := &emitEventsAgent{events: []*AgentEvent{
 		EventFromMessage(schema.AssistantMessage("child output", nil), nil, schema.Assistant, ""),
@@ -1313,10 +1310,8 @@ func TestAgentToolEventForwardGate_OpenGateForwards(t *testing.T) {
 	done := make(chan struct{})
 	go collectForwarded(iter, &got, done)
 
-	// nil done => never backgrounded => gate stays open the whole run.
 	_, err := at.InvokableRun(ctx, `{"request":"q"}`,
-		withTypedAgentToolEventForwardTarget(gen),
-		agenttool.WithForwardGate(nil))
+		withParentEventReceiver(gen))
 	require.NoError(t, err)
 
 	gen.Close()
@@ -1324,9 +1319,7 @@ func TestAgentToolEventForwardGate_OpenGateForwards(t *testing.T) {
 	assert.Contains(t, got, "child output")
 }
 
-// With the gate already closed (the run is backgrounded before it starts), a
-// background-capable invocation forwards nothing to the parent generator.
-func TestAgentToolEventForwardGate_ClosedGateDropsForwarding(t *testing.T) {
+func TestAgentToolEventReceiver_LaterTransformCanSuppressParent(t *testing.T) {
 	ctx := context.Background()
 	sub := &emitEventsAgent{events: []*AgentEvent{
 		EventFromMessage(schema.AssistantMessage("child output", nil), nil, schema.Assistant, ""),
@@ -1338,12 +1331,12 @@ func TestAgentToolEventForwardGate_ClosedGateDropsForwarding(t *testing.T) {
 	done := make(chan struct{})
 	go collectForwarded(iter, &got, done)
 
-	backgrounded := make(chan struct{})
-	close(backgrounded) // already backgrounded
-
 	_, err := at.InvokableRun(ctx, `{"request":"q"}`,
-		withTypedAgentToolEventForwardTarget(gen),
-		agenttool.WithForwardGate(backgrounded))
+		withParentEventReceiver(gen),
+		agenttool.WithEventReceiverTransform(func(current []agenttool.EventReceiver[*AgentEvent]) []agenttool.EventReceiver[*AgentEvent] {
+			require.Len(t, current, 1)
+			return current[:0]
+		}))
 	require.NoError(t, err)
 
 	gen.Close()
@@ -1351,24 +1344,49 @@ func TestAgentToolEventForwardGate_ClosedGateDropsForwarding(t *testing.T) {
 	assert.Empty(t, got)
 }
 
-// On the gated (background-capable) path, forwarding to an already-closed parent
-// generator must not panic — a backgrounded run outlives the turn that closes it.
-func TestAgentToolEventForwardGate_ClosedParentGeneratorNoPanic(t *testing.T) {
+// EventReceiver delivery is best-effort: a parent generator that has already
+// stopped drops the event instead of panicking.
+func TestAgentToolEventReceiver_ClosedParentGeneratorNoPanic(t *testing.T) {
 	ctx := context.Background()
 	sub := &emitEventsAgent{events: []*AgentEvent{
 		EventFromMessage(schema.AssistantMessage("child output", nil), nil, schema.Assistant, ""),
 	}}
 	at := NewAgentTool(ctx, sub).(tool.InvokableTool)
 
-	// A parent generator that is already closed, with the gate still open: the
-	// gated path uses a non-panicking send, so this must not panic.
 	_, gen := NewAsyncIteratorPair[*AgentEvent]()
 	gen.Close()
 
 	require.NotPanics(t, func() {
 		_, err := at.InvokableRun(ctx, `{"request":"q"}`,
-			withTypedAgentToolEventForwardTarget(gen),
-			agenttool.WithForwardGate(nil))
+			withParentEventReceiver(gen))
 		require.NoError(t, err)
 	})
+}
+
+func TestAgentToolEventReceiver_StreamingFanoutCopiesPerReceiver(t *testing.T) {
+	ctx := context.Background()
+	stream := schema.StreamReaderFromArray([]*schema.Message{
+		schema.AssistantMessage("first ", nil),
+		schema.AssistantMessage("second", nil),
+	})
+	sub := &emitEventsAgent{events: []*AgentEvent{
+		EventFromMessage(nil, stream, schema.Assistant, ""),
+	}}
+	at := NewAgentTool(ctx, sub).(tool.InvokableTool)
+
+	var got []string
+	addReceiver := func(current []agenttool.EventReceiver[*AgentEvent]) []agenttool.EventReceiver[*AgentEvent] {
+		return append(current, func(event *AgentEvent) {
+			msg, err := event.Output.MessageOutput.GetMessage()
+			require.NoError(t, err)
+			got = append(got, msg.Content)
+		})
+	}
+
+	result, err := at.InvokableRun(ctx, `{"request":"q"}`,
+		agenttool.WithEventReceiverTransform(addReceiver),
+		agenttool.WithEventReceiverTransform(addReceiver))
+	require.NoError(t, err)
+	assert.Equal(t, "first second", result)
+	assert.Equal(t, []string{"first second", "first second"}, got)
 }

--- a/adk/agent_tool_test.go
+++ b/adk/agent_tool_test.go
@@ -1319,6 +1319,26 @@ func TestAgentToolEventReceiver_ParentReceives(t *testing.T) {
 	assert.Contains(t, got, "child output")
 }
 
+func TestAgentToolEventReceiver_PreservesChildSessionEnvelope(t *testing.T) {
+	ctx := context.Background()
+	sub := &emitEventsAgent{events: []*AgentEvent{
+		EventFromMessage(schema.AssistantMessage("child output", nil), nil, schema.Assistant, ""),
+	}}
+	at := NewAgentTool(ctx, sub).(tool.InvokableTool)
+
+	var got *AgentEvent
+	_, err := at.InvokableRun(ctx, `{"request":"q"}`,
+		agenttool.WithEventReceiverTransform(func(current []agenttool.EventReceiver[*AgentEvent]) []agenttool.EventReceiver[*AgentEvent] {
+			return append(current, func(event *AgentEvent) { got = event })
+		}))
+	require.NoError(t, err)
+	require.NotNil(t, got)
+	require.NotNil(t, got.SessionEventVariant)
+	assert.Contains(t, got.SessionEventVariant.SessionID, "agent_tool:")
+	require.NotNil(t, got.SessionEventVariant.Event)
+	assert.Equal(t, SessionEventMessage, got.SessionEventVariant.Event.Kind)
+}
+
 func TestAgentToolEventReceiver_LaterTransformCanSuppressParent(t *testing.T) {
 	ctx := context.Background()
 	sub := &emitEventsAgent{events: []*AgentEvent{

--- a/adk/backgroundtask/manager.go
+++ b/adk/backgroundtask/manager.go
@@ -153,16 +153,21 @@ type RunInput struct {
 	// ToolUseID is the optional id of the tool call launching this task, stored in
 	// Task.ToolUseID. See Task.ToolUseID.
 	ToolUseID string
-	// RunInBackground controls execution mode. Run returns immediately with
-	// StatusRunning; RunStream returns a caller stream that normally contains the
-	// background notice, optionally preceded by a bounded startup preview.
+	// RunInBackground starts the task in the background. Run returns an initial
+	// StatusRunning snapshot without waiting for the work. RunStream returns its
+	// caller-facing stream without waiting; consuming that stream normally yields
+	// the background notice, optionally preceded by a bounded startup preview. If
+	// the work reaches a terminal state during the preview, the stream instead
+	// ends after forwarding all work chunks, without a background notice.
 	RunInBackground bool
 	// BackgroundStartupPreviewMs keeps an explicit-background RunStream caller's
 	// stream open for up to this many milliseconds and forwards work chunks emitted
 	// during that startup window. When the window expires, RunStream appends the
 	// normal background notice, closes the caller stream, and drains the remaining
 	// work output in the background. This lets launch-time information such as an
-	// OAuth URL remain visible without changing the task's background lifecycle.
+	// OAuth URL remain visible without changing the task's background lifecycle. If
+	// the work finishes during the window, all chunks are forwarded and the caller
+	// stream closes without a background notice; the task is already terminal then.
 	// A value <= 0 disables the preview. Ignored by Run and by foreground RunStream
 	// executions (including their later auto-background transition).
 	BackgroundStartupPreviewMs int
@@ -888,7 +893,9 @@ func (c detachedCtx) Value(key any) any { return c.parent.Value(key) }
 // The execution mode depends on input.RunInBackground and the effective foreground
 // budget (input.ForegroundTimeoutMs if set, else the Manager's configured default):
 //   - Foreground (RunInBackground=false, budget<=0): blocks until completion
-//   - Background (RunInBackground=true): returns immediately with StatusRunning
+//   - Background (RunInBackground=true): returns an initial StatusRunning snapshot
+//     without waiting for work. The task may complete immediately afterward; use
+//     Get or task events to observe its current state.
 //   - Deadline (budget>0): runs in foreground up to the budget, then — if still
 //     running — consults the Manager's ShouldAutoBackground hook. If it permits,
 //     the run is moved to the background (kept running) and Run returns
@@ -1023,8 +1030,10 @@ type StreamWorkFunc func(ctx context.Context, task TaskInfo) (*schema.StreamRead
 //   - Explicit background (input.RunInBackground): the work runs detached from the
 //     start. By default no execution chunks reach the caller; when
 //     input.BackgroundStartupPreviewMs is positive, chunks emitted during that
-//     bounded startup window are forwarded before the background notice. The
-//     remaining output is drained into the task's Result/OutputFile.
+//     bounded startup window are forwarded. If work finishes during the preview,
+//     all chunks are forwarded and the stream closes with no background notice.
+//     Otherwise the notice ends the preview and the remaining output is drained
+//     into the task's Result/OutputFile.
 //
 // The returned reader is always non-nil on a nil error. The Manager is the sole
 // writer of that stream, so there is never a write race with the work.

--- a/adk/backgroundtask/manager.go
+++ b/adk/backgroundtask/manager.go
@@ -153,8 +153,19 @@ type RunInput struct {
 	// ToolUseID is the optional id of the tool call launching this task, stored in
 	// Task.ToolUseID. See Task.ToolUseID.
 	ToolUseID string
-	// RunInBackground controls execution mode: true returns immediately with StatusRunning.
+	// RunInBackground controls execution mode. Run returns immediately with
+	// StatusRunning; RunStream returns a caller stream that normally contains the
+	// background notice, optionally preceded by a bounded startup preview.
 	RunInBackground bool
+	// BackgroundStartupPreviewMs keeps an explicit-background RunStream caller's
+	// stream open for up to this many milliseconds and forwards work chunks emitted
+	// during that startup window. When the window expires, RunStream appends the
+	// normal background notice, closes the caller stream, and drains the remaining
+	// work output in the background. This lets launch-time information such as an
+	// OAuth URL remain visible without changing the task's background lifecycle.
+	// A value <= 0 disables the preview. Ignored by Run and by foreground RunStream
+	// executions (including their later auto-background transition).
+	BackgroundStartupPreviewMs int
 	// Metadata is optional caller-supplied data attached to the task's Task.Metadata.
 	// It is for observers (Get/List, the task_output tool, the host) to correlate or
 	// label background tasks — e.g. an originating tool-call ID, session, or trace.
@@ -1010,8 +1021,10 @@ type StreamWorkFunc func(ctx context.Context, task TaskInfo) (*schema.StreamRead
 //     caller's stream, while the work keeps running in the background — its
 //     remaining output is drained into the task's Result/OutputFile.
 //   - Explicit background (input.RunInBackground): the work runs detached from the
-//     start, so no execution chunks reach the caller; the stream carries only the
-//     background notice and then closes.
+//     start. By default no execution chunks reach the caller; when
+//     input.BackgroundStartupPreviewMs is positive, chunks emitted during that
+//     bounded startup window are forwarded before the background notice. The
+//     remaining output is drained into the task's Result/OutputFile.
 //
 // The returned reader is always non-nil on a nil error. The Manager is the sole
 // writer of that stream, so there is never a write race with the work.
@@ -1096,11 +1109,15 @@ func (m *Manager) forwardStream(r *streamRun) {
 
 	var buf strings.Builder
 
-	// Explicit background: no foreground phase to stream and no deadline to race
-	// (RunStream forces budgetMs=0), so skip the pumpStream goroutine entirely.
-	// Emit the notice, close the caller stream, and drain the reader directly into
-	// the result.
+	// Explicit background: the lifecycle is already detached, but a caller may opt
+	// into a bounded startup preview so launch-time output (for example an OAuth
+	// URL) remains visible. After the preview, or immediately when it is disabled,
+	// cap the caller stream with a notice and drain the rest into the result.
 	if r.input.RunInBackground {
+		if r.input.BackgroundStartupPreviewMs > 0 {
+			m.previewBackgroundStartup(r, ws, &buf)
+			return
+		}
 		r.sw.Send(m.backgroundStartNotice(r.runCtx, r.id), nil)
 		r.sw.Close()
 		m.drainReader(r.id, ws, &buf)
@@ -1156,6 +1173,53 @@ func (m *Manager) forwardStream(r *streamRun) {
 			}
 			m.timeoutTask(r.id, r.budgetMs)
 			r.sw.Close()
+			return
+		}
+	}
+}
+
+// previewBackgroundStartup forwards the initial chunks of an explicitly
+// backgrounded stream for a bounded time. The task is backgrounded before this
+// function starts; the preview affects only caller visibility, not lifecycle.
+// Once the window expires it emits the normal background notice, closes the
+// caller stream, and continues draining the same pumped stream in the background.
+func (m *Manager) previewBackgroundStartup(r *streamRun, ws *schema.StreamReader[string], buf *strings.Builder) {
+	chunks := pumpStream(r.runCtx, ws)
+	timer := time.NewTimer(time.Duration(r.input.BackgroundStartupPreviewMs) * time.Millisecond)
+	defer timer.Stop()
+
+	for {
+		select {
+		case c := <-chunks:
+			if c.err == io.EOF {
+				m.completeTask(r.id, buf.String())
+				r.sw.Close()
+				return
+			}
+			if c.err != nil {
+				m.failTask(r.id, c.err)
+				r.sw.Send("", c.err)
+				r.sw.Close()
+				return
+			}
+			buf.WriteString(c.text)
+			if r.sw.Send(c.text, nil) {
+				// The caller stopped reading the preview. The task was explicitly
+				// backgrounded, so keep it running and drain the remaining output.
+				r.sw.Close()
+				m.drainStream(r.runCtx, r.id, chunks, buf)
+				return
+			}
+		case <-r.callerCtx.Done():
+			// Caller cancellation does not stop an explicitly backgrounded task.
+			// Stop previewing and keep draining under the detached run context.
+			r.sw.Close()
+			m.drainStream(r.runCtx, r.id, chunks, buf)
+			return
+		case <-timer.C:
+			r.sw.Send(m.backgroundStartNotice(r.runCtx, r.id), nil)
+			r.sw.Close()
+			m.drainStream(r.runCtx, r.id, chunks, buf)
 			return
 		}
 	}

--- a/adk/backgroundtask/manager.go
+++ b/adk/backgroundtask/manager.go
@@ -1091,7 +1091,8 @@ func (m *Manager) forwardStream(r *streamRun) {
 	// A panic constructing the work stream (r.work below) lands here, before sw is
 	// closed: fail the task and surface it on the caller stream. Panics while reading
 	// chunks are recovered closer to their source — pumpStream for the foreground
-	// loop, drainReader for the background drain — so this never double-closes sw.
+	// and preview loops, drainReader for the direct background drain — so this never
+	// double-closes sw.
 	defer func() {
 		if p := recover(); p != nil {
 			err := safe.NewPanicErr(p, debug.Stack())
@@ -1123,21 +1124,43 @@ func (m *Manager) forwardStream(r *streamRun) {
 	// URL) remains visible. After the preview, or immediately when it is disabled,
 	// cap the caller stream with a notice and drain the rest into the result.
 	if r.input.RunInBackground {
-		if r.input.BackgroundStartupPreviewMs > 0 {
-			m.previewBackgroundStartup(r, ws, &buf)
+		if r.input.BackgroundStartupPreviewMs <= 0 {
+			r.sw.Send(m.backgroundStartNotice(r.runCtx, r.id), nil)
+			r.sw.Close()
+			m.drainReader(r.id, ws, &buf)
 			return
 		}
-		r.sw.Send(m.backgroundStartNotice(r.runCtx, r.id), nil)
-		r.sw.Close()
-		m.drainReader(r.id, ws, &buf)
+		m.forwardPumpedStream(r, ws, &buf, pumpedStreamBackgroundPreview)
 		return
 	}
 
+	m.forwardPumpedStream(r, ws, &buf, pumpedStreamForeground)
+}
+
+// pumpedStreamMode describes the caller-visible phase handled by
+// forwardPumpedStream. Both modes need pumpStream so they can select on blocking
+// work output together with a timer and caller cancellation. Explicit background
+// runs without a preview bypass this path and use drainReader directly.
+type pumpedStreamMode uint8
+
+const (
+	pumpedStreamForeground pumpedStreamMode = iota
+	pumpedStreamBackgroundPreview
+)
+
+// forwardPumpedStream forwards chunks during a foreground or explicit-background
+// preview phase. The chunk, completion, and error paths are shared; only caller
+// abandonment and timer expiry have mode-specific lifecycle semantics.
+func (m *Manager) forwardPumpedStream(r *streamRun, ws *schema.StreamReader[string], buf *strings.Builder, mode pumpedStreamMode) {
 	chunks := pumpStream(r.runCtx, ws)
 
 	var timerC <-chan time.Time
-	if r.budgetMs > 0 {
-		timer := time.NewTimer(time.Duration(r.budgetMs) * time.Millisecond)
+	timerMs := r.budgetMs
+	if mode == pumpedStreamBackgroundPreview {
+		timerMs = r.input.BackgroundStartupPreviewMs
+	}
+	if timerMs > 0 {
+		timer := time.NewTimer(time.Duration(timerMs) * time.Millisecond)
 		defer timer.Stop()
 		timerC = timer.C
 	}
@@ -1158,16 +1181,36 @@ func (m *Manager) forwardStream(r *streamRun) {
 			}
 			buf.WriteString(c.text)
 			if r.sw.Send(c.text, nil) {
-				// Caller closed the stream early (abandoned the read): stop the work.
+				if mode == pumpedStreamBackgroundPreview {
+					// The caller stopped reading the preview. The task was explicitly
+					// backgrounded, so keep it running and drain the remaining output.
+					r.sw.Close()
+					m.drainStream(r.runCtx, r.id, chunks, buf)
+					return
+				}
+				// Caller closed a foreground stream early: stop the work.
 				m.cancelIfRunning(r.id)
 				return
 			}
 		case <-r.callerCtx.Done():
+			if mode == pumpedStreamBackgroundPreview {
+				// Caller cancellation does not stop an explicitly backgrounded task.
+				// Stop previewing and keep draining under the detached run context.
+				r.sw.Close()
+				m.drainStream(r.runCtx, r.id, chunks, buf)
+				return
+			}
 			// Caller abandoned the foreground wait before the deadline: stop work.
 			m.cancelIfRunning(r.id)
 			r.sw.Close()
 			return
 		case <-timerC:
+			if mode == pumpedStreamBackgroundPreview {
+				r.sw.Send(m.backgroundStartNotice(r.runCtx, r.id), nil)
+				r.sw.Close()
+				m.drainStream(r.runCtx, r.id, chunks, buf)
+				return
+			}
 			task, ok := m.Get(r.id)
 			if !ok || task.DoneAt != nil {
 				continue // finished right at the deadline; let the chunks case end it
@@ -1177,58 +1220,11 @@ func (m *Manager) forwardStream(r *streamRun) {
 				// keep draining the rest into the task result.
 				r.sw.Send(m.backgroundMoveNotice(r.runCtx, r.id), nil)
 				r.sw.Close()
-				m.drainStream(r.runCtx, r.id, chunks, &buf)
+				m.drainStream(r.runCtx, r.id, chunks, buf)
 				return
 			}
 			m.timeoutTask(r.id, r.budgetMs)
 			r.sw.Close()
-			return
-		}
-	}
-}
-
-// previewBackgroundStartup forwards the initial chunks of an explicitly
-// backgrounded stream for a bounded time. The task is backgrounded before this
-// function starts; the preview affects only caller visibility, not lifecycle.
-// Once the window expires it emits the normal background notice, closes the
-// caller stream, and continues draining the same pumped stream in the background.
-func (m *Manager) previewBackgroundStartup(r *streamRun, ws *schema.StreamReader[string], buf *strings.Builder) {
-	chunks := pumpStream(r.runCtx, ws)
-	timer := time.NewTimer(time.Duration(r.input.BackgroundStartupPreviewMs) * time.Millisecond)
-	defer timer.Stop()
-
-	for {
-		select {
-		case c := <-chunks:
-			if c.err == io.EOF {
-				m.completeTask(r.id, buf.String())
-				r.sw.Close()
-				return
-			}
-			if c.err != nil {
-				m.failTask(r.id, c.err)
-				r.sw.Send("", c.err)
-				r.sw.Close()
-				return
-			}
-			buf.WriteString(c.text)
-			if r.sw.Send(c.text, nil) {
-				// The caller stopped reading the preview. The task was explicitly
-				// backgrounded, so keep it running and drain the remaining output.
-				r.sw.Close()
-				m.drainStream(r.runCtx, r.id, chunks, buf)
-				return
-			}
-		case <-r.callerCtx.Done():
-			// Caller cancellation does not stop an explicitly backgrounded task.
-			// Stop previewing and keep draining under the detached run context.
-			r.sw.Close()
-			m.drainStream(r.runCtx, r.id, chunks, buf)
-			return
-		case <-timer.C:
-			r.sw.Send(m.backgroundStartNotice(r.runCtx, r.id), nil)
-			r.sw.Close()
-			m.drainStream(r.runCtx, r.id, chunks, buf)
 			return
 		}
 	}

--- a/adk/backgroundtask/manager.go
+++ b/adk/backgroundtask/manager.go
@@ -106,7 +106,7 @@ type Task struct {
 	Error string
 	// RunInBackground indicates whether this task is running (or ran) in the
 	// background — either launched with RunInBackground, or moved to the background
-	// after exhausting its foreground budget. It distinguishes background tasks
+	// after reaching its foreground timeout. It distinguishes background tasks
 	// from foreground ones when inspecting task state.
 	RunInBackground bool
 	// CreatedAt is the time the task was registered.
@@ -182,7 +182,7 @@ type RunInput struct {
 	// (a domain adapter) owns writing, so the file may carry interim output while
 	// the task runs. Empty means the task has no output file.
 	OutputFile string
-	// ForegroundTimeoutMs optionally overrides the Manager's foreground budget for
+	// ForegroundTimeoutMs optionally overrides the Manager's foreground timeout for
 	// this run only. When nil, the Manager's configured default applies. When non-nil,
 	// it bounds how long the run may occupy the foreground before its deadline fires
 	// (see Config.ShouldAutoBackground for what happens at the deadline). A value <= 0
@@ -191,7 +191,7 @@ type RunInput struct {
 	ForegroundTimeoutMs *int
 }
 
-// defaultForegroundTimeoutMs is the default foreground budget (120 seconds).
+// defaultForegroundTimeoutMs is the default foreground timeout (120 seconds).
 const defaultForegroundTimeoutMs = 120_000
 
 // IDGenerator returns the complete ID for a new task.
@@ -203,7 +203,7 @@ type IDGenerator func(ctx context.Context, input *RunInput) (string, error)
 
 // Config configures a Manager.
 type Config struct {
-	// ForegroundTimeoutMs sets the foreground budget: the time a foreground run is
+	// ForegroundTimeoutMs sets the foreground timeout: the time a foreground run is
 	// allowed to occupy the foreground before its deadline fires.
 	// When > 0, a foreground run that hasn't completed within this many
 	// milliseconds reaches its deadline (see ShouldAutoBackground for what happens then).
@@ -314,9 +314,9 @@ type taskRecord struct {
 }
 
 // New creates a new Manager.
-// By default, the foreground budget is 120 seconds; set Config.ForegroundTimeoutMs
+// By default, the foreground timeout is 120 seconds; set Config.ForegroundTimeoutMs
 // to 0 to remove the deadline (foreground runs block until completion). What
-// happens when the budget is reached is governed by Config.ShouldAutoBackground
+// happens when the timeout is reached is governed by Config.ShouldAutoBackground
 // (default: cancel the run and report it timed out).
 func New(_ context.Context, conf *Config) *Manager {
 	m := &Manager{
@@ -690,7 +690,7 @@ func (m *Manager) failTask(id string, err error) {
 // foreground run hits its deadline and the ShouldAutoBackground hook declined to
 // background it. No-op if the task is already terminal (idempotent), so the
 // timed-out reason wins the race against the work goroutine's own ctx-canceled error.
-func (m *Manager) timeoutTask(id string, budgetMs int) {
+func (m *Manager) timeoutTask(id string, foregroundTimeoutMs int) {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 
@@ -703,7 +703,7 @@ func (m *Manager) timeoutTask(id string, budgetMs int) {
 	}
 	m.finalize(id, func(rec *taskRecord) {
 		rec.task.Status = StatusFailed
-		rec.task.Error = fmt.Sprintf("timed out after %dms", budgetMs)
+		rec.task.Error = fmt.Sprintf("timed out after %dms", foregroundTimeoutMs)
 	})
 }
 
@@ -891,12 +891,12 @@ func (c detachedCtx) Value(key any) any { return c.parent.Value(key) }
 // Run executes work as a managed task on m.
 //
 // The execution mode depends on input.RunInBackground and the effective foreground
-// budget (input.ForegroundTimeoutMs if set, else the Manager's configured default):
-//   - Foreground (RunInBackground=false, budget<=0): blocks until completion
+// timeout (input.ForegroundTimeoutMs if set, else the Manager's configured default):
+//   - Foreground (RunInBackground=false, timeout<=0): blocks until completion
 //   - Background (RunInBackground=true): returns an initial StatusRunning snapshot
 //     without waiting for work. The task may complete immediately afterward; use
 //     Get or task events to observe its current state.
-//   - Deadline (budget>0): runs in foreground up to the budget, then — if still
+//   - Deadline (timeout>0): runs in foreground up to the timeout, then — if still
 //     running — consults the Manager's ShouldAutoBackground hook. If it permits,
 //     the run is moved to the background (kept running) and Run returns
 //     StatusRunning. Otherwise the run is canceled and reported as timed out
@@ -951,20 +951,20 @@ func (m *Manager) Run(ctx context.Context, input *RunInput, work WorkFunc) (*Tas
 
 	// Foreground: run in a goroutine and wait. The wait honors caller cancellation
 	// (the detached work ctx does not, so it is canceled explicitly here) and, when a
-	// budget is set, the foreground deadline.
+	// timeout is set, the foreground deadline.
 	done := make(chan struct{}, 1)
 	go func() { run(); done <- struct{}{} }()
 
-	budgetMs := m.foregroundTimeoutMs
+	foregroundTimeoutMs := m.foregroundTimeoutMs
 	if input.ForegroundTimeoutMs != nil {
-		budgetMs = *input.ForegroundTimeoutMs
+		foregroundTimeoutMs = *input.ForegroundTimeoutMs
 	}
 
-	if budgetMs > 0 {
-		// Foreground with a deadline: wait up to the effective budget (per-run
+	if foregroundTimeoutMs > 0 {
+		// Foreground with a deadline: wait up to the effective timeout (per-run
 		// override takes precedence over the Manager default). On the deadline,
 		// either move to the background (if the hook permits) or cancel as timed out.
-		timer := time.NewTimer(time.Duration(budgetMs) * time.Millisecond)
+		timer := time.NewTimer(time.Duration(foregroundTimeoutMs) * time.Millisecond)
 		defer timer.Stop()
 		select {
 		case <-done:
@@ -987,7 +987,7 @@ func (m *Manager) Run(ctx context.Context, input *RunInput, work WorkFunc) (*Tas
 				return m.taskSnapshot(id), nil
 			}
 			// Hook declined (or work finished during the hook): stop if still running.
-			m.timeoutTask(id, budgetMs)
+			m.timeoutTask(id, foregroundTimeoutMs)
 			return m.taskSnapshot(id), nil
 		}
 	}
@@ -1020,7 +1020,7 @@ type StreamWorkFunc func(ctx context.Context, task TaskInfo) (*schema.StreamRead
 // RunStream executes streaming work as a managed task, returning a stream of
 // output chunks to consume in real time.
 //
-// It mirrors Run's lifecycle (tracking, foreground budget, auto-background) but
+// It mirrors Run's lifecycle (tracking, foreground timeout, auto-background) but
 // preserves streaming for the foreground phase:
 //   - Foreground completion: every chunk is forwarded live, then the stream closes.
 //   - Auto-background at the deadline: chunks forwarded so far are kept; the
@@ -1048,25 +1048,25 @@ func (m *Manager) RunStream(ctx context.Context, input *RunInput, work StreamWor
 
 	sr, sw := schema.Pipe[string](streamBufferCap)
 
-	budgetMs := m.foregroundTimeoutMs
+	foregroundTimeoutMs := m.foregroundTimeoutMs
 	if input.ForegroundTimeoutMs != nil {
-		budgetMs = *input.ForegroundTimeoutMs
+		foregroundTimeoutMs = *input.ForegroundTimeoutMs
 	}
 	// An explicit background launch has no foreground phase to stream, so its
-	// budget is irrelevant: forward nothing, just emit the notice.
+	// foreground timeout is irrelevant: forward nothing, just emit the notice.
 	if input.RunInBackground {
-		budgetMs = 0
+		foregroundTimeoutMs = 0
 	}
 
 	go m.forwardStream(&streamRun{
-		callerCtx: ctx,
-		runCtx:    runCtx,
-		cancel:    cancel,
-		id:        id,
-		input:     input,
-		work:      work,
-		sw:        sw,
-		budgetMs:  budgetMs,
+		callerCtx:           ctx,
+		runCtx:              runCtx,
+		cancel:              cancel,
+		id:                  id,
+		input:               input,
+		work:                work,
+		sw:                  sw,
+		foregroundTimeoutMs: foregroundTimeoutMs,
 	})
 	return sr, nil
 }
@@ -1074,14 +1074,14 @@ func (m *Manager) RunStream(ctx context.Context, input *RunInput, work StreamWor
 // streamRun bundles the per-run state for forwardStream (kept as one value to stay
 // within the argument limit and to make the goroutine launch self-documenting).
 type streamRun struct {
-	callerCtx context.Context
-	runCtx    context.Context
-	cancel    context.CancelFunc
-	id        string
-	input     *RunInput
-	work      StreamWorkFunc
-	sw        *schema.StreamWriter[string]
-	budgetMs  int
+	callerCtx           context.Context
+	runCtx              context.Context
+	cancel              context.CancelFunc
+	id                  string
+	input               *RunInput
+	work                StreamWorkFunc
+	sw                  *schema.StreamWriter[string]
+	foregroundTimeoutMs int
 }
 
 // forwardStream owns the caller-facing stream writer sw: it is the only goroutine
@@ -1103,7 +1103,7 @@ func (m *Manager) forwardStream(r *streamRun) {
 	}()
 
 	// Explicit background: the run is background from the start, so signal it before
-	// the work starts (RunStream forces budgetMs=0 for this case).
+	// the work starts (RunStream forces foregroundTimeoutMs=0 for this case).
 	if r.input.RunInBackground {
 		m.markBackgrounded(r.id)
 	}
@@ -1155,12 +1155,12 @@ func (m *Manager) forwardPumpedStream(r *streamRun, ws *schema.StreamReader[stri
 	chunks := pumpStream(r.runCtx, ws)
 
 	var timerC <-chan time.Time
-	timerMs := r.budgetMs
+	phaseTimeoutMs := r.foregroundTimeoutMs
 	if mode == pumpedStreamBackgroundPreview {
-		timerMs = r.input.BackgroundStartupPreviewMs
+		phaseTimeoutMs = r.input.BackgroundStartupPreviewMs
 	}
-	if timerMs > 0 {
-		timer := time.NewTimer(time.Duration(timerMs) * time.Millisecond)
+	if phaseTimeoutMs > 0 {
+		timer := time.NewTimer(time.Duration(phaseTimeoutMs) * time.Millisecond)
 		defer timer.Stop()
 		timerC = timer.C
 	}
@@ -1223,7 +1223,7 @@ func (m *Manager) forwardPumpedStream(r *streamRun, ws *schema.StreamReader[stri
 				m.drainStream(r.runCtx, r.id, chunks, buf)
 				return
 			}
-			m.timeoutTask(r.id, r.budgetMs)
+			m.timeoutTask(r.id, r.foregroundTimeoutMs)
 			r.sw.Close()
 			return
 		}

--- a/adk/backgroundtask/manager.go
+++ b/adk/backgroundtask/manager.go
@@ -170,6 +170,11 @@ type RunInput struct {
 	// stream closes without a background notice; the task is already terminal then.
 	// A value <= 0 disables the preview. Ignored by Run and by foreground RunStream
 	// executions (including their later auto-background transition).
+	//
+	// The window is measured from when the StreamWorkFunc returns its reader (see
+	// StreamWorkFunc), so it bounds the preview of streamed output, not the work's
+	// initialization; streaming work must return its reader promptly for the window
+	// to be meaningful.
 	BackgroundStartupPreviewMs int
 	// Metadata is optional caller-supplied data attached to the task's Task.Metadata.
 	// It is for observers (Get/List, the task_output tool, the host) to correlate or
@@ -188,6 +193,10 @@ type RunInput struct {
 	// (see Config.ShouldAutoBackground for what happens at the deadline). A value <= 0
 	// removes the deadline for this run (blocks until completion). Ignored when
 	// RunInBackground is true.
+	//
+	// For Run the deadline is measured from when the work starts; for RunStream it is
+	// measured from when the work returns its stream reader (see StreamWorkFunc), so
+	// streaming work must return its reader promptly for the two to coincide.
 	ForegroundTimeoutMs *int
 }
 
@@ -1015,6 +1024,16 @@ func (m *Manager) Run(ctx context.Context, input *RunInput, work WorkFunc) (*Tas
 // ctx behaves exactly as for WorkFunc (see WorkFunc): detached from the caller's
 // cancellation, stopped by Cancel/deadline/Close. Work should honor it and close
 // the returned reader when ctx is done.
+//
+// Return the reader promptly. The Manager's foreground timeout and
+// RunInput.BackgroundStartupPreviewMs windows are measured from when this function
+// returns its reader, not from the RunStream call — RunStream calls it synchronously
+// and only starts those timers afterward. So blocking initialization (spawning a
+// process, waiting for a subprocess to be ready, dialing) must be done in the
+// producer goroutine that writes to the reader and surfaced as its first chunks, not
+// before returning. Work that blocks before returning makes the caller wait for
+// init-time plus the window rather than the window alone, and that extra wait is not
+// bounded by either timeout.
 type StreamWorkFunc func(ctx context.Context, task TaskInfo) (*schema.StreamReader[string], error)
 
 // RunStream executes streaming work as a managed task, returning a stream of
@@ -1034,6 +1053,13 @@ type StreamWorkFunc func(ctx context.Context, task TaskInfo) (*schema.StreamRead
 //     all chunks are forwarded and the stream closes with no background notice.
 //     Otherwise the notice ends the preview and the remaining output is drained
 //     into the task's Result/OutputFile.
+//
+// The foreground and preview windows are both measured from when the work returns
+// its stream reader (see StreamWorkFunc), not from this call: RunStream invokes the
+// work synchronously and starts the timers only afterward. Blocking initialization
+// performed before the reader is returned is therefore not counted against either
+// window — streaming work must return its reader promptly for the windows to reflect
+// output time rather than startup time.
 //
 // The returned reader is always non-nil on a nil error. The Manager is the sole
 // writer of that stream, so there is never a write race with the work.

--- a/adk/backgroundtask/manager.go
+++ b/adk/backgroundtask/manager.go
@@ -1055,11 +1055,11 @@ type StreamWorkFunc func(ctx context.Context, task TaskInfo) (*schema.StreamRead
 //     into the task's Result/OutputFile.
 //
 // The foreground and preview windows are both measured from when the work returns
-// its stream reader (see StreamWorkFunc), not from this call: RunStream invokes the
-// work synchronously and starts the timers only afterward. Blocking initialization
-// performed before the reader is returned is therefore not counted against either
-// window — streaming work must return its reader promptly for the windows to reflect
-// output time rather than startup time.
+// its stream reader (see StreamWorkFunc), not from this call: RunStream's forwarding
+// goroutine starts the timers only after work returns its reader. Blocking
+// initialization performed before the reader is returned is therefore not counted
+// against either window — streaming work must return its reader promptly for the
+// windows to reflect output time rather than startup time.
 //
 // The returned reader is always non-nil on a nil error. The Manager is the sole
 // writer of that stream, so there is never a write race with the work.

--- a/adk/backgroundtask/run_stream_test.go
+++ b/adk/backgroundtask/run_stream_test.go
@@ -184,6 +184,31 @@ func TestRunStream_ExplicitBackgroundStartupPreview(t *testing.T) {
 	assert.Equal(t, "authenticate at https://example.com/oauth\nauthenticated\n", task.Result)
 }
 
+// TestRunStream_ExplicitBackgroundStartupPreviewCompleted forwards all output and
+// omits the background notice when work finishes inside the preview window.
+func TestRunStream_ExplicitBackgroundStartupPreviewCompleted(t *testing.T) {
+	m := New(context.Background(), &Config{})
+	defer closeWithTimeout(m)
+
+	sr, err := m.RunStream(context.Background(), &RunInput{
+		Description:                "quick",
+		Type:                       "bash",
+		RunInBackground:            true,
+		BackgroundStartupPreviewMs: 500,
+	}, streamWorkChunks(0, "done"))
+	require.NoError(t, err)
+
+	got := drainStringStream(t, sr)
+	assert.Equal(t, "done", got)
+	assert.NotContains(t, got, "is running in the background")
+
+	tasks := m.List()
+	require.Len(t, tasks, 1)
+	assert.True(t, tasks[0].RunInBackground)
+	assert.Equal(t, StatusCompleted, tasks[0].Status)
+	assert.Equal(t, "done", tasks[0].Result)
+}
+
 // TestRunStream_WorkError: an error from the stream finalizes the task as failed
 // and surfaces on the caller's stream.
 func TestRunStream_WorkError(t *testing.T) {

--- a/adk/backgroundtask/run_stream_test.go
+++ b/adk/backgroundtask/run_stream_test.go
@@ -140,6 +140,50 @@ func TestRunStream_ExplicitBackground(t *testing.T) {
 	assert.Equal(t, "chunk-1chunk-2", task.Result)
 }
 
+// TestRunStream_ExplicitBackgroundStartupPreview forwards launch-time chunks for
+// the configured preview window, then emits the normal background notice and
+// drains later output into the task result without forwarding it to the caller.
+func TestRunStream_ExplicitBackgroundStartupPreview(t *testing.T) {
+	m := New(context.Background(), &Config{})
+	defer closeWithTimeout(m)
+
+	release := make(chan struct{})
+	work := func(ctx context.Context, _ TaskInfo) (*schema.StreamReader[string], error) {
+		sr, sw := schema.Pipe[string](2)
+		sw.Send("authenticate at https://example.com/oauth\n", nil)
+		go func() {
+			defer sw.Close()
+			select {
+			case <-release:
+				sw.Send("authenticated\n", nil)
+			case <-ctx.Done():
+			}
+		}()
+		return sr, nil
+	}
+
+	sr, err := m.RunStream(context.Background(), &RunInput{
+		Description:                "oauth",
+		Type:                       "bash",
+		RunInBackground:            true,
+		BackgroundStartupPreviewMs: 500,
+	}, work)
+	require.NoError(t, err)
+
+	got := drainStringStream(t, sr)
+	assert.Contains(t, got, "https://example.com/oauth")
+	assert.Contains(t, got, "is running in the background")
+	assert.NotContains(t, got, "authenticated")
+
+	close(release)
+	tasks := m.List()
+	require.Len(t, tasks, 1)
+	task := waitTask(t, m, tasks[0].ID)
+	assert.True(t, task.RunInBackground)
+	assert.Equal(t, StatusCompleted, task.Status)
+	assert.Equal(t, "authenticate at https://example.com/oauth\nauthenticated\n", task.Result)
+}
+
 // TestRunStream_WorkError: an error from the stream finalizes the task as failed
 // and surfaces on the caller's stream.
 func TestRunStream_WorkError(t *testing.T) {

--- a/adk/chatmodel.go
+++ b/adk/chatmodel.go
@@ -1461,7 +1461,7 @@ func (a *TypedChatModelAgent[M]) buildMessageReActRunFunc(_ context.Context, bc 
 		var runOpts []compose.Option
 		runOpts = append(runOpts, mp.composeOpts...)
 		if a.toolsConfig.EmitInternalEvents {
-			runOpts = append(runOpts, compose.WithToolsNodeOption(compose.WithToolOption(withTypedAgentToolEventForwardTarget(mp.generator))))
+			runOpts = append(runOpts, compose.WithToolsNodeOption(compose.WithToolOption(withParentEventReceiver(mp.generator))))
 		}
 		if mp.input.EnableStreaming {
 			runOpts = append(runOpts, compose.WithToolsNodeOption(compose.WithToolOption(withAgentToolEnableStreaming(true))))
@@ -1602,7 +1602,7 @@ func (a *TypedChatModelAgent[M]) buildAgenticReActRunFunc(_ context.Context, bc 
 		var runOpts []compose.Option
 		runOpts = append(runOpts, ap.composeOpts...)
 		if a.toolsConfig.EmitInternalEvents {
-			runOpts = append(runOpts, compose.WithToolsNodeOption(compose.WithToolOption(withTypedAgentToolEventForwardTarget[*schema.AgenticMessage](ap.generator))))
+			runOpts = append(runOpts, compose.WithToolsNodeOption(compose.WithToolOption(withParentEventReceiver[*schema.AgenticMessage](ap.generator))))
 		}
 		if ap.input.EnableStreaming {
 			runOpts = append(runOpts, compose.WithToolsNodeOption(compose.WithToolOption(withAgentToolEnableStreaming(true))))

--- a/adk/filesystem/backend.go
+++ b/adk/filesystem/backend.go
@@ -19,6 +19,7 @@ package filesystem
 
 import (
 	"context"
+	"io"
 
 	"github.com/cloudwego/eino/schema"
 )
@@ -158,12 +159,10 @@ type WriteRequest struct {
 	Content string
 }
 
-// AppendRequest contains parameters for appending content to a file.
-type AppendRequest struct {
-	// FilePath is the path of the file to append to.
+// OpenAppendRequest contains parameters for opening an append stream.
+type OpenAppendRequest struct {
+	// FilePath is the path of the file to append to; it is created if absent.
 	FilePath string
-	// Content is the data to append at the end of the file.
-	Content string
 }
 
 // EditRequest contains parameters for editing file content.
@@ -244,13 +243,53 @@ type MultiModalReader interface {
 	MultiModalRead(ctx context.Context, req *MultiModalReadRequest) (*MultiFileContent, error)
 }
 
-// Appender appends content to the end of a file without rewriting the whole file,
-// enabling efficient incremental writes — e.g. streaming a long-running background
-// task's output to its output file as chunks arrive.
-type Appender interface {
-	// Append adds req.Content to the end of the file at req.FilePath, creating the
-	// file if it does not exist.
-	Append(ctx context.Context, req *AppendRequest) error
+// AppendStream is a write-only, tail-appending session to a single file, obtained
+// from StreamAppender.OpenAppend. Its contract is exactly io.WriteCloser:
+//
+//   - Write appends bytes to the end of the file. It MAY buffer: a nil error does
+//     NOT guarantee the bytes are durable or yet visible to a concurrent Read. If a
+//     prior buffered write already failed, the stream is permanently broken and
+//     Write returns that sticky error; callers should stop writing.
+//   - Close flushes any buffered content, finalizes the session, and returns the
+//     first error observed over the stream's lifetime (nil if all writes landed).
+//     Closing a session in which nothing was written yields an empty file (the file
+//     is created on open).
+//
+// A handle is single-consumer: it is not safe for concurrent use.
+//
+// Two obligations fall on a backend that holds OS or network resources (an fd, an
+// RPC stream), because callers may abandon a session without a clean Close:
+//
+//   - The ctx passed to OpenAppend bounds the whole session. Callers guarantee Close
+//     on normal completion and on a stream error, but NOT on every abandonment
+//     (a canceled or timed-out run may just drop the handle). So the implementation
+//     MUST release its resources when that ctx is canceled — not only in Close, or
+//     it leaks a handle on those paths. Canceling the ctx aborts pending writes.
+//   - When Write buffers, the implementation SHOULD flush on its own cadence (time or
+//     size based) so a concurrent Read of a still-running task sees recent interim
+//     output; the caller does not drive flushing, since a per-write flush would
+//     reintroduce the per-write latency this abstraction exists to amortize.
+//
+// Implementations SHOULD additionally implement io.StringWriter so text callers can
+// append without a []byte copy (use io.WriteString, which detects it). They MAY
+// implement interface{ Flush() error } to expose a mid-stream durability/visibility
+// checkpoint without ending the session.
+type AppendStream interface {
+	io.WriteCloser
+}
+
+// StreamAppender opens an append stream to a file, letting callers stream content
+// to the end of the file incrementally without rewriting the whole file — e.g.
+// teeing a long-running background task's output to its output file as chunks
+// arrive.
+//
+// It is an optional Backend extension (like MultiModalReader): a Backend that can
+// keep a file handle or RPC stream open implements it directly, so per-chunk backend
+// latency is paid once at open rather than on every write.
+type StreamAppender interface {
+	// OpenAppend opens an append stream to req.FilePath, creating the file if it
+	// does not exist. See AppendStream for the returned handle's contract.
+	OpenAppend(ctx context.Context, req *OpenAppendRequest) (AppendStream, error)
 }
 
 // Backend is a pluggable, unified file backend protocol interface.

--- a/adk/filesystem/backend.go
+++ b/adk/filesystem/backend.go
@@ -261,7 +261,8 @@ type MultiModalReader interface {
 //   - Close flushes any buffered content, finalizes the session, and returns the
 //     first error observed over the stream's lifetime (nil if all writes landed).
 //     Closing a session in which nothing was written yields an empty file (the file
-//     is created on open).
+//     is created on open). Close is idempotent, and a Write after Close is rejected
+//     (it returns an error, e.g. io.ErrClosedPipe, and does not modify the file).
 //
 // A handle is single-consumer: it is not safe for concurrent use.
 //

--- a/adk/filesystem/backend.go
+++ b/adk/filesystem/backend.go
@@ -243,8 +243,16 @@ type MultiModalReader interface {
 	MultiModalRead(ctx context.Context, req *MultiModalReadRequest) (*MultiFileContent, error)
 }
 
-// AppendStream is a write-only, tail-appending session to a single file, obtained
-// from StreamAppender.OpenAppend. Its contract is exactly io.WriteCloser:
+// AppendOpener opens a write-only, tail-appending session to a file, letting
+// callers stream content to the end of the file incrementally without rewriting
+// the whole file — e.g. teeing a long-running background task's output to its
+// output file as chunks arrive.
+//
+// It is an optional Backend extension (like MultiModalReader): a Backend that can
+// keep a file handle or RPC stream open implements it directly, so per-chunk backend
+// latency can be amortized over the session.
+//
+// The io.WriteCloser returned by OpenAppend has the following contract:
 //
 //   - Write appends bytes to the end of the file. It MAY buffer: a nil error does
 //     NOT guarantee the bytes are durable or yet visible to a concurrent Read. If a
@@ -274,22 +282,10 @@ type MultiModalReader interface {
 // append without a []byte copy (use io.WriteString, which detects it). They MAY
 // implement interface{ Flush() error } to expose a mid-stream durability/visibility
 // checkpoint without ending the session.
-type AppendStream interface {
-	io.WriteCloser
-}
-
-// StreamAppender opens an append stream to a file, letting callers stream content
-// to the end of the file incrementally without rewriting the whole file — e.g.
-// teeing a long-running background task's output to its output file as chunks
-// arrive.
-//
-// It is an optional Backend extension (like MultiModalReader): a Backend that can
-// keep a file handle or RPC stream open implements it directly, so per-chunk backend
-// latency is paid once at open rather than on every write.
-type StreamAppender interface {
+type AppendOpener interface {
 	// OpenAppend opens an append stream to req.FilePath, creating the file if it
-	// does not exist. See AppendStream for the returned handle's contract.
-	OpenAppend(ctx context.Context, req *OpenAppendRequest) (AppendStream, error)
+	// does not exist.
+	OpenAppend(ctx context.Context, req *OpenAppendRequest) (io.WriteCloser, error)
 }
 
 // Backend is a pluggable, unified file backend protocol interface.

--- a/adk/filesystem/backend_inmemory.go
+++ b/adk/filesystem/backend_inmemory.go
@@ -642,12 +642,12 @@ func (b *InMemoryBackend) Write(ctx context.Context, req *WriteRequest) error {
 }
 
 // OpenAppend opens an append stream to the file at req.FilePath, creating it if it
-// does not exist. It implements the optional StreamAppender interface, letting
+// does not exist. It implements the optional AppendOpener interface, letting
 // callers stream task output incrementally without rewriting the whole file.
 //
 // In-memory writes have no latency, so the returned handle writes through under the
 // backend lock on every Write (immediately visible to Read); Close is a no-op.
-func (b *InMemoryBackend) OpenAppend(ctx context.Context, req *OpenAppendRequest) (AppendStream, error) {
+func (b *InMemoryBackend) OpenAppend(ctx context.Context, req *OpenAppendRequest) (io.WriteCloser, error) {
 	filePath := normalizePath(req.FilePath)
 
 	// Create-on-open: an open + close with no writes yields an empty file.
@@ -657,27 +657,27 @@ func (b *InMemoryBackend) OpenAppend(ctx context.Context, req *OpenAppendRequest
 	}
 	b.mu.Unlock()
 
-	return &inMemoryAppendStream{b: b, path: filePath}, nil
+	return &inMemoryAppendWriter{b: b, path: filePath}, nil
 }
 
-// inMemoryAppendStream is the append handle returned by InMemoryBackend.OpenAppend.
+// inMemoryAppendWriter is the append handle returned by InMemoryBackend.OpenAppend.
 // It is single-consumer; each write appends to the file entry under the backend lock.
-type inMemoryAppendStream struct {
+type inMemoryAppendWriter struct {
 	b    *InMemoryBackend
 	path string
 }
 
-func (s *inMemoryAppendStream) Write(p []byte) (int, error) {
+func (s *inMemoryAppendWriter) Write(p []byte) (int, error) {
 	return s.WriteString(string(p))
 }
 
 // WriteString appends str without a []byte round-trip; io.WriteString detects it.
-func (s *inMemoryAppendStream) WriteString(str string) (int, error) {
+func (s *inMemoryAppendWriter) WriteString(str string) (int, error) {
 	s.append(str)
 	return len(str), nil
 }
 
-func (s *inMemoryAppendStream) append(content string) {
+func (s *inMemoryAppendWriter) append(content string) {
 	if content == "" {
 		return
 	}
@@ -694,11 +694,11 @@ func (s *inMemoryAppendStream) append(content string) {
 
 // Close finalizes the session. In-memory writes are already applied, so there is
 // nothing to flush.
-func (s *inMemoryAppendStream) Close() error { return nil }
+func (s *inMemoryAppendWriter) Close() error { return nil }
 
 var (
-	_ AppendStream    = (*inMemoryAppendStream)(nil)
-	_ io.StringWriter = (*inMemoryAppendStream)(nil)
+	_ io.WriteCloser  = (*inMemoryAppendWriter)(nil)
+	_ io.StringWriter = (*inMemoryAppendWriter)(nil)
 )
 
 // Edit replaces string occurrences in a file.

--- a/adk/filesystem/backend_inmemory.go
+++ b/adk/filesystem/backend_inmemory.go
@@ -672,11 +672,15 @@ func (b *InMemoryBackend) OpenAppend(ctx context.Context, req *OpenAppendRequest
 // inMemoryAppendWriter is the append handle returned by InMemoryBackend.OpenAppend.
 // It is single-consumer; each write appends to the file entry under the backend lock.
 type inMemoryAppendWriter struct {
-	b    *InMemoryBackend
-	path string
+	b      *InMemoryBackend
+	path   string
+	closed bool // set by Close; further writes are rejected. Single-consumer: no lock needed.
 }
 
 func (s *inMemoryAppendWriter) Write(p []byte) (int, error) {
+	if s.closed {
+		return 0, io.ErrClosedPipe
+	}
 	if len(p) == 0 {
 		return 0, nil
 	}
@@ -692,6 +696,9 @@ func (s *inMemoryAppendWriter) Write(p []byte) (int, error) {
 
 // WriteString appends str without a []byte round-trip; io.WriteString detects it.
 func (s *inMemoryAppendWriter) WriteString(str string) (int, error) {
+	if s.closed {
+		return 0, io.ErrClosedPipe
+	}
 	if str == "" {
 		return 0, nil
 	}
@@ -716,9 +723,13 @@ func (s *inMemoryAppendWriter) entryLocked() *fileEntry {
 	return entry
 }
 
-// Close finalizes the session. In-memory writes are already applied, so there is
-// nothing to flush.
-func (s *inMemoryAppendWriter) Close() error { return nil }
+// Close finalizes the session: it is idempotent and rejects any later Write /
+// WriteString with io.ErrClosedPipe. In-memory writes are already applied, so there
+// is nothing to flush.
+func (s *inMemoryAppendWriter) Close() error {
+	s.closed = true
+	return nil
+}
 
 var (
 	_ io.WriteCloser  = (*inMemoryAppendWriter)(nil)

--- a/adk/filesystem/backend_inmemory.go
+++ b/adk/filesystem/backend_inmemory.go
@@ -19,6 +19,7 @@ package filesystem
 import (
 	"context"
 	"fmt"
+	"io"
 	"path/filepath"
 	"regexp"
 	"strings"
@@ -640,25 +641,65 @@ func (b *InMemoryBackend) Write(ctx context.Context, req *WriteRequest) error {
 	return nil
 }
 
-// Append adds content to the end of a file, creating it if it does not exist.
-// It implements the optional Appender interface, letting OutputWriter stream
-// task output incrementally without rewriting the whole file each time.
-func (b *InMemoryBackend) Append(ctx context.Context, req *AppendRequest) error {
-	b.mu.Lock()
-	defer b.mu.Unlock()
-
+// OpenAppend opens an append stream to the file at req.FilePath, creating it if it
+// does not exist. It implements the optional StreamAppender interface, letting
+// callers stream task output incrementally without rewriting the whole file.
+//
+// In-memory writes have no latency, so the returned handle writes through under the
+// backend lock on every Write (immediately visible to Read); Close is a no-op.
+func (b *InMemoryBackend) OpenAppend(ctx context.Context, req *OpenAppendRequest) (AppendStream, error) {
 	filePath := normalizePath(req.FilePath)
-	if entry, ok := b.files[filePath]; ok {
-		entry.content += req.Content
-		entry.modifiedAt = time.Now()
-		return nil
+
+	// Create-on-open: an open + close with no writes yields an empty file.
+	b.mu.Lock()
+	if _, ok := b.files[filePath]; !ok {
+		b.files[filePath] = &fileEntry{content: "", modifiedAt: time.Now()}
 	}
-	b.files[filePath] = &fileEntry{
-		content:    req.Content,
-		modifiedAt: time.Now(),
-	}
-	return nil
+	b.mu.Unlock()
+
+	return &inMemoryAppendStream{b: b, path: filePath}, nil
 }
+
+// inMemoryAppendStream is the append handle returned by InMemoryBackend.OpenAppend.
+// It is single-consumer; each write appends to the file entry under the backend lock.
+type inMemoryAppendStream struct {
+	b    *InMemoryBackend
+	path string
+}
+
+func (s *inMemoryAppendStream) Write(p []byte) (int, error) {
+	return s.WriteString(string(p))
+}
+
+// WriteString appends str without a []byte round-trip; io.WriteString detects it.
+func (s *inMemoryAppendStream) WriteString(str string) (int, error) {
+	s.append(str)
+	return len(str), nil
+}
+
+func (s *inMemoryAppendStream) append(content string) {
+	if content == "" {
+		return
+	}
+	s.b.mu.Lock()
+	defer s.b.mu.Unlock()
+
+	if entry, ok := s.b.files[s.path]; ok {
+		entry.content += content
+		entry.modifiedAt = time.Now()
+		return
+	}
+	s.b.files[s.path] = &fileEntry{content: content, modifiedAt: time.Now()}
+}
+
+// Close finalizes the session. In-memory writes are already applied, so there is
+// nothing to flush.
+func (s *inMemoryAppendStream) Close() error { return nil }
+
+var (
+	_ AppendStream    = (*inMemoryAppendStream)(nil)
+	_ io.StringWriter = (*inMemoryAppendStream)(nil)
+)
 
 // Edit replaces string occurrences in a file.
 func (b *InMemoryBackend) Edit(ctx context.Context, req *EditRequest) error {

--- a/adk/filesystem/backend_inmemory.go
+++ b/adk/filesystem/backend_inmemory.go
@@ -30,8 +30,16 @@ import (
 )
 
 type fileEntry struct {
-	content    string
+	// content must not be copied after the first write. Overwrites replace the
+	// entire *fileEntry instead of resetting or copying the builder.
+	content    strings.Builder
 	modifiedAt time.Time
+}
+
+func newFileEntry(content string, modifiedAt time.Time) *fileEntry {
+	entry := &fileEntry{modifiedAt: modifiedAt}
+	entry.content.WriteString(content)
+	return entry
 }
 
 // InMemoryBackend is an in-memory implementation of the Backend interface.
@@ -75,7 +83,7 @@ func (b *InMemoryBackend) LsInfo(ctx context.Context, req *LsInfoRequest) ([]Fil
 					result = append(result, FileInfo{
 						Path:       filepath.Base(normalizedFilePath),
 						IsDir:      false,
-						Size:       int64(len(entry.content)),
+						Size:       int64(entry.content.Len()),
 						ModifiedAt: entry.modifiedAt.Format(time.RFC3339Nano),
 					})
 					seen[normalizedFilePath] = true
@@ -105,7 +113,7 @@ func (b *InMemoryBackend) LsInfo(ctx context.Context, req *LsInfoRequest) ([]Fil
 						result = append(result, FileInfo{
 							Path:       parts[0],
 							IsDir:      false,
-							Size:       int64(len(entry.content)),
+							Size:       int64(entry.content.Len()),
 							ModifiedAt: entry.modifiedAt.Format(time.RFC3339Nano),
 						})
 					}
@@ -152,7 +160,7 @@ func (b *InMemoryBackend) Read(ctx context.Context, req *ReadRequest) (*FileCont
 	}
 	limit := req.Limit
 
-	content := entry.content
+	content := entry.content.String()
 
 	// Fast path: no offset and no limit — return as-is
 	if offset == 0 && limit <= 0 {
@@ -229,7 +237,7 @@ func (b *InMemoryBackend) GrepRaw(ctx context.Context, req *GrepRequest) ([]Grep
 	if len(filteredFiles) == 1 {
 		collector := newGrepCollector()
 		entry := b.files[filteredFiles[0]]
-		collector.processFile(filteredFiles[0], entry.content, re, req)
+		collector.processFile(filteredFiles[0], entry.content.String(), re, req)
 		return collector.buildResults(b, req)
 	}
 
@@ -285,7 +293,7 @@ func (b *InMemoryBackend) grepFilesInParallel(filteredFiles []string, re *regexp
 		entry := b.files[filePath]
 		tasks <- fileTask{
 			path:    filePath,
-			content: entry.content,
+			content: entry.content.String(),
 		}
 	}
 	close(tasks)
@@ -538,6 +546,10 @@ func (b *InMemoryBackend) applyContext(matches []GrepMatch, req *GrepRequest) []
 		// Get file content once per file
 		b.mu.RLock()
 		entry, exists := b.files[filePath]
+		var content string
+		if exists {
+			content = entry.content.String()
+		}
 		b.mu.RUnlock()
 
 		if !exists {
@@ -546,7 +558,7 @@ func (b *InMemoryBackend) applyContext(matches []GrepMatch, req *GrepRequest) []
 			continue
 		}
 
-		lines := strings.Split(entry.content, "\n")
+		lines := strings.Split(content, "\n")
 		processedLines := make(map[int]bool)
 
 		// Process all matches for this file
@@ -618,7 +630,7 @@ func (b *InMemoryBackend) GlobInfo(ctx context.Context, req *GlobInfoRequest) ([
 			result = append(result, FileInfo{
 				Path:       resultPath,
 				IsDir:      false,
-				Size:       int64(len(entry.content)),
+				Size:       int64(entry.content.Len()),
 				ModifiedAt: entry.modifiedAt.Format(time.RFC3339Nano),
 			})
 		}
@@ -633,10 +645,7 @@ func (b *InMemoryBackend) Write(ctx context.Context, req *WriteRequest) error {
 	defer b.mu.Unlock()
 
 	filePath := normalizePath(req.FilePath)
-	b.files[filePath] = &fileEntry{
-		content:    req.Content,
-		modifiedAt: time.Now(),
-	}
+	b.files[filePath] = newFileEntry(req.Content, time.Now())
 
 	return nil
 }
@@ -653,7 +662,7 @@ func (b *InMemoryBackend) OpenAppend(ctx context.Context, req *OpenAppendRequest
 	// Create-on-open: an open + close with no writes yields an empty file.
 	b.mu.Lock()
 	if _, ok := b.files[filePath]; !ok {
-		b.files[filePath] = &fileEntry{content: "", modifiedAt: time.Now()}
+		b.files[filePath] = newFileEntry("", time.Now())
 	}
 	b.mu.Unlock()
 
@@ -668,28 +677,43 @@ type inMemoryAppendWriter struct {
 }
 
 func (s *inMemoryAppendWriter) Write(p []byte) (int, error) {
-	return s.WriteString(string(p))
+	if len(p) == 0 {
+		return 0, nil
+	}
+
+	s.b.mu.Lock()
+	defer s.b.mu.Unlock()
+
+	entry := s.entryLocked()
+	n, _ := entry.content.Write(p)
+	entry.modifiedAt = time.Now()
+	return n, nil
 }
 
 // WriteString appends str without a []byte round-trip; io.WriteString detects it.
 func (s *inMemoryAppendWriter) WriteString(str string) (int, error) {
-	s.append(str)
-	return len(str), nil
-}
-
-func (s *inMemoryAppendWriter) append(content string) {
-	if content == "" {
-		return
+	if str == "" {
+		return 0, nil
 	}
+
 	s.b.mu.Lock()
 	defer s.b.mu.Unlock()
 
+	entry := s.entryLocked()
+	n, _ := entry.content.WriteString(str)
+	entry.modifiedAt = time.Now()
+	return n, nil
+}
+
+// entryLocked returns the current file entry, recreating it if another caller
+// removed it after OpenAppend. The backend write lock must be held by the caller.
+func (s *inMemoryAppendWriter) entryLocked() *fileEntry {
 	if entry, ok := s.b.files[s.path]; ok {
-		entry.content += content
-		entry.modifiedAt = time.Now()
-		return
+		return entry
 	}
-	s.b.files[s.path] = &fileEntry{content: content, modifiedAt: time.Now()}
+	entry := newFileEntry("", time.Now())
+	s.b.files[s.path] = entry
+	return entry
 }
 
 // Close finalizes the session. In-memory writes are already applied, so there is
@@ -717,7 +741,7 @@ func (b *InMemoryBackend) Edit(ctx context.Context, req *EditRequest) error {
 		return fmt.Errorf("oldString must be non-empty")
 	}
 
-	content := entry.content
+	content := entry.content.String()
 	if !strings.Contains(content, req.OldString) {
 		return fmt.Errorf("oldString not found in file: %s", filePath)
 	}
@@ -739,10 +763,7 @@ func (b *InMemoryBackend) Edit(ctx context.Context, req *EditRequest) error {
 		newContent = strings.Replace(content, req.OldString, req.NewString, 1)
 	}
 
-	b.files[filePath] = &fileEntry{
-		content:    newContent,
-		modifiedAt: time.Now(),
-	}
+	b.files[filePath] = newFileEntry(newContent, time.Now())
 
 	return nil
 }

--- a/adk/filesystem/backend_inmemory_test.go
+++ b/adk/filesystem/backend_inmemory_test.go
@@ -2515,6 +2515,6 @@ func TestInMemoryBackend_OpenAppend(t *testing.T) {
 		}
 	})
 
-	// InMemoryBackend must satisfy the optional StreamAppender extension.
-	var _ StreamAppender = NewInMemoryBackend()
+	// InMemoryBackend must satisfy the optional AppendOpener extension.
+	var _ AppendOpener = NewInMemoryBackend()
 }

--- a/adk/filesystem/backend_inmemory_test.go
+++ b/adk/filesystem/backend_inmemory_test.go
@@ -2515,6 +2515,38 @@ func TestInMemoryBackend_OpenAppend(t *testing.T) {
 		}
 	})
 
+	t.Run("write after close is rejected and does not mutate the file", func(t *testing.T) {
+		b := NewInMemoryBackend()
+		w, err := b.OpenAppend(ctx, &OpenAppendRequest{FilePath: "/closed.output"})
+		if err != nil {
+			t.Fatalf("OpenAppend failed: %v", err)
+		}
+		if _, err := io.WriteString(w, "kept\n"); err != nil {
+			t.Fatalf("write failed: %v", err)
+		}
+		if err := w.Close(); err != nil {
+			t.Fatalf("Close failed: %v", err)
+		}
+		// Close is idempotent.
+		if err := w.Close(); err != nil {
+			t.Fatalf("second Close failed: %v", err)
+		}
+		// Both write paths reject after Close with io.ErrClosedPipe.
+		if _, err := w.Write([]byte("dropped\n")); err != io.ErrClosedPipe {
+			t.Fatalf("Write after Close: got %v, want io.ErrClosedPipe", err)
+		}
+		if _, err := io.WriteString(w, "dropped\n"); err != io.ErrClosedPipe {
+			t.Fatalf("WriteString after Close: got %v, want io.ErrClosedPipe", err)
+		}
+		got, err := b.Read(ctx, &ReadRequest{FilePath: "/closed.output"})
+		if err != nil {
+			t.Fatalf("Read failed: %v", err)
+		}
+		if got.Content != "kept\n" {
+			t.Fatalf("file mutated after Close: got %q, want %q", got.Content, "kept\n")
+		}
+	})
+
 	// InMemoryBackend must satisfy the optional AppendOpener extension.
 	var _ AppendOpener = NewInMemoryBackend()
 }

--- a/adk/filesystem/backend_inmemory_test.go
+++ b/adk/filesystem/backend_inmemory_test.go
@@ -19,6 +19,7 @@ package filesystem
 import (
 	"context"
 	"fmt"
+	"io"
 	"path/filepath"
 	"strconv"
 	"strings"
@@ -2438,4 +2439,82 @@ func TestInMemoryBackend_Read_NoLimit(t *testing.T) {
 				totalLines, strings.Count(content.Content, "\n")+1)
 		}
 	})
+}
+
+func TestInMemoryBackend_OpenAppend(t *testing.T) {
+	ctx := context.Background()
+
+	t.Run("create on open, empty when closed with no writes", func(t *testing.T) {
+		b := NewInMemoryBackend()
+		w, err := b.OpenAppend(ctx, &OpenAppendRequest{FilePath: "/reserved.output"})
+		if err != nil {
+			t.Fatalf("OpenAppend failed: %v", err)
+		}
+		if err := w.Close(); err != nil {
+			t.Fatalf("Close failed: %v", err)
+		}
+		got, err := b.Read(ctx, &ReadRequest{FilePath: "/reserved.output"})
+		if err != nil {
+			t.Fatalf("Read failed (file should exist after open): %v", err)
+		}
+		if got.Content != "" {
+			t.Fatalf("expected empty file, got %q", got.Content)
+		}
+	})
+
+	t.Run("multiple writes append in order", func(t *testing.T) {
+		b := NewInMemoryBackend()
+		w, err := b.OpenAppend(ctx, &OpenAppendRequest{FilePath: "/out.txt"})
+		if err != nil {
+			t.Fatalf("OpenAppend failed: %v", err)
+		}
+		// Write via io.WriteString to exercise the io.StringWriter fast path.
+		if _, err := io.WriteString(w, "alpha\n"); err != nil {
+			t.Fatalf("write failed: %v", err)
+		}
+		// Write via the []byte path as well.
+		if _, err := w.Write([]byte("beta\n")); err != nil {
+			t.Fatalf("write failed: %v", err)
+		}
+		if _, err := io.WriteString(w, "gamma"); err != nil {
+			t.Fatalf("write failed: %v", err)
+		}
+		if err := w.Close(); err != nil {
+			t.Fatalf("Close failed: %v", err)
+		}
+		got, err := b.Read(ctx, &ReadRequest{FilePath: "/out.txt"})
+		if err != nil {
+			t.Fatalf("Read failed: %v", err)
+		}
+		if want := "alpha\nbeta\ngamma"; got.Content != want {
+			t.Fatalf("expected %q, got %q", want, got.Content)
+		}
+	})
+
+	t.Run("append to existing file continues from the end", func(t *testing.T) {
+		b := NewInMemoryBackend()
+		if err := b.Write(ctx, &WriteRequest{FilePath: "/log", Content: "start\n"}); err != nil {
+			t.Fatalf("Write failed: %v", err)
+		}
+		w, err := b.OpenAppend(ctx, &OpenAppendRequest{FilePath: "/log"})
+		if err != nil {
+			t.Fatalf("OpenAppend failed: %v", err)
+		}
+		if _, err := io.WriteString(w, "more\n"); err != nil {
+			t.Fatalf("write failed: %v", err)
+		}
+		if err := w.Close(); err != nil {
+			t.Fatalf("Close failed: %v", err)
+		}
+		got, err := b.Read(ctx, &ReadRequest{FilePath: "/log"})
+		if err != nil {
+			t.Fatalf("Read failed: %v", err)
+		}
+		if want := "start\nmore\n"; got.Content != want {
+			t.Fatalf("expected %q, got %q", want, got.Content)
+		}
+	})
+
+	// InMemoryBackend must satisfy the optional StreamAppender extension.
+	var _ StreamAppender = NewInMemoryBackend()
 }

--- a/adk/filesystem/backend_inmemory_test.go
+++ b/adk/filesystem/backend_inmemory_test.go
@@ -2518,3 +2518,38 @@ func TestInMemoryBackend_OpenAppend(t *testing.T) {
 	// InMemoryBackend must satisfy the optional AppendOpener extension.
 	var _ AppendOpener = NewInMemoryBackend()
 }
+
+func BenchmarkInMemoryBackend_OpenAppend(b *testing.B) {
+	const (
+		chunkSize  = 1024
+		chunkCount = 1024
+	)
+	ctx := context.Background()
+	chunk := strings.Repeat("x", chunkSize)
+
+	b.ReportAllocs()
+	b.SetBytes(chunkSize * chunkCount)
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		backend := NewInMemoryBackend()
+		writer, err := backend.OpenAppend(ctx, &OpenAppendRequest{FilePath: "/out"})
+		if err != nil {
+			b.Fatal(err)
+		}
+		for j := 0; j < chunkCount; j++ {
+			if _, err = io.WriteString(writer, chunk); err != nil {
+				b.Fatal(err)
+			}
+		}
+		if err = writer.Close(); err != nil {
+			b.Fatal(err)
+		}
+		content, err := backend.Read(ctx, &ReadRequest{FilePath: "/out"})
+		if err != nil {
+			b.Fatal(err)
+		}
+		if got, want := len(content.Content), chunkSize*chunkCount; got != want {
+			b.Fatalf("unexpected content length: got %d, want %d", got, want)
+		}
+	}
+}

--- a/adk/internal/agenttool/options.go
+++ b/adk/internal/agenttool/options.go
@@ -20,21 +20,49 @@ package agenttool
 
 import "github.com/cloudwego/eino/components/tool"
 
-// ForwardGate controls the internal AgentTool event-forwarding gate.
-type ForwardGate struct {
-	// Enabled marks the AgentTool invocation as background-capable: forwarding to
-	// the caller is bounded by Until and uses a non-panicking send.
-	Enabled bool
-	// Until stops forwarding to the caller once closed. Nil means "never
-	// backgrounded".
-	Until <-chan struct{}
+// EventReceiver is a caller-provided function that receives an event emitted by
+// the AgentTool's inner agent. Receivers must be best-effort and safe to call
+// after their downstream consumer has stopped.
+type EventReceiver[E any] func(event E)
+
+// EventReceiverTransform derives the receiver list for an AgentTool invocation
+// from the receivers configured so far. Transforms run in tool-option order and
+// receive a non-nil, possibly empty slice.
+type EventReceiverTransform[E any] func(current []EventReceiver[E]) []EventReceiver[E]
+
+type eventReceiverOptions[E any] struct {
+	transforms []EventReceiverTransform[E]
 }
 
-// WithForwardGate marks an AgentTool invocation as background-capable and
-// forwards inner-agent events to the caller until done is closed.
-func WithForwardGate(done <-chan struct{}) tool.Option {
-	return tool.WrapImplSpecificOptFn(func(o *ForwardGate) {
-		o.Enabled = true
-		o.Until = done
+// WithEventReceiverTransform adds an internal receiver-list transform to an
+// AgentTool invocation.
+func WithEventReceiverTransform[E any](transform EventReceiverTransform[E]) tool.Option {
+	return tool.WrapImplSpecificOptFn(func(o *eventReceiverOptions[E]) {
+		if transform != nil {
+			o.transforms = append(o.transforms, transform)
+		}
 	})
+}
+
+// ResolveEventReceivers applies the configured transforms in option order.
+func ResolveEventReceivers[E any](opts ...tool.Option) []EventReceiver[E] {
+	o := tool.GetImplSpecificOptions[eventReceiverOptions[E]](nil, opts...)
+	receivers := make([]EventReceiver[E], 0)
+	for _, transform := range o.transforms {
+		receivers = transform(receivers)
+		if receivers == nil {
+			receivers = make([]EventReceiver[E], 0)
+		}
+	}
+
+	// A nil receiver is not a valid endpoint. Ignore one defensively so a bad
+	// internal transform cannot turn event dispatch into a nil-function panic.
+	n := 0
+	for _, receiver := range receivers {
+		if receiver != nil {
+			receivers[n] = receiver
+			n++
+		}
+	}
+	return receivers[:n]
 }

--- a/adk/internal/agenttool/options.go
+++ b/adk/internal/agenttool/options.go
@@ -47,7 +47,7 @@ func WithEventReceiverTransform[E any](transform EventReceiverTransform[E]) tool
 // ResolveEventReceivers applies the configured transforms in option order.
 func ResolveEventReceivers[E any](opts ...tool.Option) []EventReceiver[E] {
 	o := tool.GetImplSpecificOptions[eventReceiverOptions[E]](nil, opts...)
-	receivers := make([]EventReceiver[E], 0)
+	receivers := make([]EventReceiver[E], 0, len(o.transforms))
 	for _, transform := range o.transforms {
 		receivers = transform(receivers)
 	}

--- a/adk/internal/agenttool/options.go
+++ b/adk/internal/agenttool/options.go
@@ -26,8 +26,8 @@ import "github.com/cloudwego/eino/components/tool"
 type EventReceiver[E any] func(event E)
 
 // EventReceiverTransform derives the receiver list for an AgentTool invocation
-// from the receivers configured so far. Transforms run in tool-option order and
-// receive a non-nil, possibly empty slice.
+// from the receivers configured so far. Transforms run in tool-option order.
+// The receiver list may be empty, but must not contain nil elements.
 type EventReceiverTransform[E any] func(current []EventReceiver[E]) []EventReceiver[E]
 
 type eventReceiverOptions[E any] struct {
@@ -50,19 +50,6 @@ func ResolveEventReceivers[E any](opts ...tool.Option) []EventReceiver[E] {
 	receivers := make([]EventReceiver[E], 0)
 	for _, transform := range o.transforms {
 		receivers = transform(receivers)
-		if receivers == nil {
-			receivers = make([]EventReceiver[E], 0)
-		}
 	}
-
-	// A nil receiver is not a valid endpoint. Ignore one defensively so a bad
-	// internal transform cannot turn event dispatch into a nil-function panic.
-	n := 0
-	for _, receiver := range receivers {
-		if receiver != nil {
-			receivers[n] = receiver
-			n++
-		}
-	}
-	return receivers[:n]
+	return receivers
 }

--- a/adk/internal/agenttool/options_test.go
+++ b/adk/internal/agenttool/options_test.go
@@ -23,6 +23,11 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+func TestResolveEventReceivers_NoTransforms(t *testing.T) {
+	receivers := ResolveEventReceivers[int]()
+	assert.Len(t, receivers, 0)
+}
+
 func TestResolveEventReceivers_TransformsInOptionOrder(t *testing.T) {
 	var calls []string
 	receivers := ResolveEventReceivers[int](
@@ -38,7 +43,7 @@ func TestResolveEventReceivers_TransformsInOptionOrder(t *testing.T) {
 				calls = append(calls, "before")
 				previous(event)
 			}
-			return append(current, nil, func(int) { calls = append(calls, "second") })
+			return append(current, func(int) { calls = append(calls, "second") })
 		}),
 	)
 

--- a/adk/internal/agenttool/options_test.go
+++ b/adk/internal/agenttool/options_test.go
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2026 CloudWeGo Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package agenttool
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestResolveEventReceivers_TransformsInOptionOrder(t *testing.T) {
+	var calls []string
+	receivers := ResolveEventReceivers[int](
+		WithEventReceiverTransform(func(current []EventReceiver[int]) []EventReceiver[int] {
+			require.NotNil(t, current)
+			require.Empty(t, current)
+			return append(current, func(int) { calls = append(calls, "first") })
+		}),
+		WithEventReceiverTransform(func(current []EventReceiver[int]) []EventReceiver[int] {
+			require.Len(t, current, 1)
+			previous := current[0]
+			current[0] = func(event int) {
+				calls = append(calls, "before")
+				previous(event)
+			}
+			return append(current, nil, func(int) { calls = append(calls, "second") })
+		}),
+	)
+
+	require.Len(t, receivers, 2)
+	for _, receiver := range receivers {
+		receiver(1)
+	}
+	assert.Equal(t, []string{"before", "first", "second"}, calls)
+}

--- a/adk/middlewares/backgroundtask/middleware.go
+++ b/adk/middlewares/backgroundtask/middleware.go
@@ -313,7 +313,11 @@ func formatTask(task *bgtask.Task) string {
 		result += fmt.Sprintf("\nError: %s", task.Error)
 	}
 	if task.DoneAt != nil {
-		result += fmt.Sprintf("\nCompleted at: %s", task.DoneAt.Format("2006-01-02 15:04:05"))
+		// Report elapsed time rather than an absolute timestamp: a wall-clock time
+		// carries no zone here and is ambiguous, while the duration is zone-independent
+		// and more useful. Duration.String() picks a readable unit (ms/s/m); Round trims
+		// sub-millisecond noise.
+		result += fmt.Sprintf("\nElapsed: %s", task.DoneAt.Sub(task.CreatedAt).Round(time.Millisecond))
 	}
 
 	return result

--- a/adk/middlewares/filesystem/bash_run.go
+++ b/adk/middlewares/filesystem/bash_run.go
@@ -62,19 +62,20 @@ func CommandFromTask(t *backgroundtask.Task) string {
 	return cmd
 }
 
-// outputSink bundles the output-file configuration for a managed execute tool: an
-// Appender to write through and the directory to reserve paths under. Both must be
-// set to enable output files; a zero outputSink disables them.
+// outputSink bundles the output-file configuration for a managed execute tool: a
+// StreamAppender to open append streams through and the directory to reserve paths
+// under. Both must be set to enable output files; a zero outputSink disables them.
 type outputSink struct {
-	appender  filesystem.Appender
+	store     filesystem.StreamAppender
 	outputDir string
 }
 
-// bashOutputWriter appends a managed execute task's output to a file via a
-// filesystem.Appender. It is built per invocation: when both an Appender and an
-// outputDir are configured it reserves outputDir/<uuid>.output and appends there;
-// otherwise it is disabled and every method is a no-op, so the task has no output
-// file. There is no rewrite fallback — output files require an Appender.
+// bashOutputWriter tees a managed execute task's output to a file via a
+// filesystem.StreamAppender. It is built per invocation: when both a StreamAppender
+// and an outputDir are configured it reserves outputDir/<uuid>.output (created empty
+// up front) and opens an append stream when the work starts; otherwise it is
+// disabled and every method is a no-op, so the task has no output file. There is no
+// rewrite fallback — output files require a StreamAppender.
 //
 // The execute tool — not the Manager — owns writing, so streaming runs tee interim
 // output as chunks arrive. It is single-consumer: append is called serially on
@@ -85,45 +86,102 @@ type outputSink struct {
 // func receives from the Manager and sets on the writer before its first append)
 // and stops attempting further writes.
 type bashOutputWriter struct {
-	mgr      *backgroundtask.Manager
-	appender filesystem.Appender // nil => disabled
-	path     string
-	taskID   string // set by the work func once the Manager assigns it
-	failed   bool   // set after the first append error: the file is now partial
+	mgr    *backgroundtask.Manager
+	store  filesystem.StreamAppender // nil => disabled
+	path   string
+	stream filesystem.AppendStream // opened lazily by the streaming work; nil => not open
+	taskID string                  // set by the work func once the Manager assigns it
+	failed bool                    // set after the first append error: the file is now partial
 }
 
-// reserveBashOutput builds a writer that appends under the sink, or a disabled
-// writer when output files are not configured (no appender / no dir). It creates
-// the file empty up front so the advertised path exists before any output; if even
-// that reservation write fails, it returns a disabled writer so the task advertises
-// no output file and consumers fall back to the in-memory Result. The file is
-// named after the launching tool-call id (so it matches Task.ToolUseID), falling
-// back to a uuid when no tool-call id is in context.
+// reserveBashOutput builds a writer that tees under the sink, or a disabled writer
+// when output files are not configured (no store / no dir). It creates the file
+// empty up front (open+close, which creates the file on open) so the advertised path
+// exists before any output; if even that reservation fails, it returns a disabled
+// writer so the task advertises no output file and consumers fall back to the
+// in-memory Result. The file is named after the launching tool-call id (so it matches
+// Task.ToolUseID), falling back to a uuid when no tool-call id is in context.
+//
+// The streaming append session is not opened here: it is opened by the work func
+// (see open) under the work's context, so it survives the run being backgrounded.
 func reserveBashOutput(ctx context.Context, mgr *backgroundtask.Manager, sink outputSink) *bashOutputWriter {
-	if sink.appender == nil || sink.outputDir == "" {
+	if sink.store == nil || sink.outputDir == "" {
 		return &bashOutputWriter{}
 	}
 	path := filepath.Join(sink.outputDir, outputFileName(ctx)+".output")
-	if err := sink.appender.Append(ctx, &filesystem.AppendRequest{FilePath: path, Content: ""}); err != nil {
+	s, err := sink.store.OpenAppend(ctx, &filesystem.OpenAppendRequest{FilePath: path})
+	if err != nil {
+		return &bashOutputWriter{}
+	}
+	if err := s.Close(); err != nil {
 		return &bashOutputWriter{}
 	}
 	return &bashOutputWriter{
-		mgr:      mgr,
-		appender: sink.appender,
-		path:     path,
+		mgr:   mgr,
+		store: sink.store,
+		path:  path,
 	}
 }
 
-func (w *bashOutputWriter) append(ctx context.Context, content string) {
-	if w.appender == nil || w.failed {
+// fail records that a write to the output file failed: it stops further writes and
+// marks the file unreliable (by task id) so task_output reports the file's failed
+// state instead of trusting the partial file.
+func (w *bashOutputWriter) fail(err error) {
+	w.failed = true
+	w.mgr.MarkOutputFileUnreliable(w.taskID, err.Error())
+}
+
+// open opens the streaming append session for a streaming run. ctx is the work's
+// context (detached from the caller), so the session outlives a backgrounded run.
+// On failure the writer is marked failed and the file unreliable, so subsequent
+// appends are no-ops. It is a no-op for a disabled writer.
+func (w *bashOutputWriter) open(ctx context.Context) {
+	if w.store == nil || w.failed {
 		return
 	}
-	if err := w.appender.Append(ctx, &filesystem.AppendRequest{FilePath: w.path, Content: content}); err != nil {
-		// The file now has a gap: stop writing and mark it unreliable (by task id) so
-		// task_output reports the file's failed state instead of trusting the partial file.
-		w.failed = true
+	stream, err := w.store.OpenAppend(ctx, &filesystem.OpenAppendRequest{FilePath: w.path})
+	if err != nil {
+		w.fail(err)
+		return
+	}
+	w.stream = stream
+}
+
+// append tees content to the open streaming session. The session binds its context
+// at open, so no ctx is needed here.
+func (w *bashOutputWriter) append(content string) {
+	if w.stream == nil || w.failed {
+		return
+	}
+	if _, err := io.WriteString(w.stream, content); err != nil {
+		w.fail(err)
+	}
+}
+
+// closeStream finalizes the streaming session, flushing buffered content and
+// releasing the backend handle. It always attempts Close (even when a prior write
+// already broke the stream) so the handle is released promptly rather than waiting
+// on context cancellation; only a fresh Close error marks the file unreliable, since
+// a stream broken by an earlier write was already marked there. No-op for a disabled
+// writer.
+func (w *bashOutputWriter) closeStream() {
+	if w.stream == nil {
+		return
+	}
+	if err := w.stream.Close(); err != nil && !w.failed {
 		w.mgr.MarkOutputFileUnreliable(w.taskID, err.Error())
 	}
+	w.stream = nil
+}
+
+// appendResult writes the full buffered result to the output file. Used by the
+// buffered (non-streaming) work, which produces no incremental chunks: it is just a
+// single-chunk stream, so it reuses the same open→append→close session as the
+// streaming path. It is a no-op for a disabled writer.
+func (w *bashOutputWriter) appendResult(ctx context.Context, content string) {
+	w.open(ctx)
+	w.append(content)
+	w.closeStream()
 }
 
 // outputFileName returns the base name (without extension) for a task's output
@@ -150,7 +208,7 @@ func bashWork(sb filesystem.Shell, req *filesystem.ExecuteRequest, w *bashOutput
 			return "", err
 		}
 		out := convExecuteResponse(result)
-		w.append(ctx, out)
+		w.appendResult(ctx, out)
 		return out, nil
 	}
 }
@@ -162,9 +220,16 @@ func bashWork(sb filesystem.Shell, req *filesystem.ExecuteRequest, w *bashOutput
 // final chunk so it is part of both the live stream and the persisted result.
 //
 // Each emitted chunk (and the terminal note) is also teed to the output file via w,
-// so the file carries interim output while the task runs. Teeing happens inside the
-// convert/OnEOF callbacks, which run on the Recv stack for both the foreground loop
-// and the background drain — so the Manager never has to write.
+// so the file carries interim output while the task runs. The append session is
+// opened once under the work's context (so it survives backgrounding); teeing then
+// happens inside the convert callback, which runs on the Recv stack for both the
+// foreground loop and the background drain, and the session is closed in the OnEOF
+// hook on clean exhaustion and via the WithErrWrapper hook on a source error — the
+// two terminal outcomes the convert reader observes — so the handle is flushed and
+// released on both. On the rarer caller-abandon / timeout paths the source ends
+// without either hook firing; the session is then released by the work context's
+// cancellation (the file is already incomplete in that case), which the AppendStream
+// contract requires a resource-holding backend to honor.
 func bashStreamWork(sb filesystem.StreamingShell, req *filesystem.ExecuteRequest, w *bashOutputWriter) backgroundtask.StreamWorkFunc {
 	return func(ctx context.Context, task backgroundtask.TaskInfo) (*schema.StreamReader[string], error) {
 		w.taskID = task.ID
@@ -172,12 +237,16 @@ func bashStreamWork(sb filesystem.StreamingShell, req *filesystem.ExecuteRequest
 		if err != nil {
 			return nil, err
 		}
+		// Open the streaming append session under the work's (detached) context, so a
+		// backgrounded run keeps writing after the launching turn ends.
+		w.open(ctx)
 
 		// exitCode/hasContent accumulate across chunks: convert writes them per
 		// chunk, the OnEOF hook reads them to build the terminal note. The convert
 		// model has no per-stream state of its own, so they live in this closure.
 		// Safe without synchronization because StreamReaderWithConvert is pull-driven
-		// and single-consumer — convert and OnEOF run serially on the same Recv stack.
+		// and single-consumer — convert, OnEOF and the error wrapper run serially on
+		// the same Recv stack.
 		var exitCode *int
 		var hasContent bool
 		return schema.StreamReaderWithConvert(stream,
@@ -193,15 +262,28 @@ func bashStreamWork(sb filesystem.StreamingShell, req *filesystem.ExecuteRequest
 					return "", schema.ErrNoValue
 				}
 				hasContent = true
-				w.append(ctx, text)
+				w.append(text)
 				return text, nil
 			},
 			schema.WithOnEOF(func() (any, error) {
-				if note := execTerminalNote(exitCode, hasContent); note != "" {
-					w.append(ctx, note)
+				note := execTerminalNote(exitCode, hasContent)
+				if note != "" {
+					w.append(note)
+				}
+				// Source exhausted: flush and finalize the file before ending the stream.
+				w.closeStream()
+				if note != "" {
 					return note, nil
 				}
 				return nil, io.EOF
+			}),
+			schema.WithErrWrapper(func(err error) error {
+				// Source errored (including ctx-cancellation surfaced as an error):
+				// finalize the file so the handle is released rather than leaked to
+				// context cancellation. closeStream is idempotent, so this never
+				// races OnEOF (a stream ends with either EOF or an error).
+				w.closeStream()
+				return err
 			}),
 		), nil
 	}

--- a/adk/middlewares/filesystem/bash_run.go
+++ b/adk/middlewares/filesystem/bash_run.go
@@ -304,15 +304,12 @@ func bashStreamWork(sb filesystem.StreamingShell, req *filesystem.ExecuteRequest
 // With a StreamingShell backend the tool is itself a StreamableTool: the
 // foreground phase streams output to the caller in real time. An explicit
 // background launch first exposes a bounded startup preview, then caps the stream
-// with a notice; a run moved to the background after its foreground budget caps
+// with a notice; a run moved to the background after its foreground timeout caps
 // the stream immediately. In both cases the rest is drained into the task result.
 // With a plain Shell backend the tool is buffered and has no startup preview.
 //
-// Exactly one of sb / streaming must be non-nil. appender and outputDir, when both
-// set, enable per-task output files (the tool appends output to
-// outputDir/<id>.output); otherwise runs have no output file.
 // Exactly one of sb / streaming must be non-nil. sink, when fully configured
-// (appender + dir), enables per-task output files (the tool appends output to
+// (AppendOpener + dir), enables per-task output files (the tool appends output to
 // outputDir/<id>.output); otherwise runs have no output file.
 func newManagedExecuteTool(
 	mgr *backgroundtask.Manager,
@@ -346,7 +343,7 @@ func managedRunInput(ctx context.Context, input executeManagedArgs, w *bashOutpu
 		Metadata:        map[string]any{MetadataKeyCommand: input.Command},
 		OutputFile:      w.path,
 	}
-	// A positive timeout overrides the Manager's default foreground budget for
+	// A positive timeout overrides the Manager's default foreground timeout for
 	// this command. When the deadline expires, the Manager's policy decides
 	// whether to move the task to the background or stop it.
 	if input.TimeoutMS > 0 {

--- a/adk/middlewares/filesystem/bash_run.go
+++ b/adk/middlewares/filesystem/bash_run.go
@@ -63,19 +63,19 @@ func CommandFromTask(t *backgroundtask.Task) string {
 }
 
 // outputSink bundles the output-file configuration for a managed execute tool: a
-// StreamAppender to open append streams through and the directory to reserve paths
+// AppendOpener to open append streams through and the directory to reserve paths
 // under. Both must be set to enable output files; a zero outputSink disables them.
 type outputSink struct {
-	store     filesystem.StreamAppender
+	store     filesystem.AppendOpener
 	outputDir string
 }
 
 // bashOutputWriter tees a managed execute task's output to a file via a
-// filesystem.StreamAppender. It is built per invocation: when both a StreamAppender
+// filesystem.AppendOpener. It is built per invocation: when both an AppendOpener
 // and an outputDir are configured it reserves outputDir/<uuid>.output (created empty
 // up front) and opens an append stream when the work starts; otherwise it is
 // disabled and every method is a no-op, so the task has no output file. There is no
-// rewrite fallback — output files require a StreamAppender.
+// rewrite fallback — output files require an AppendOpener.
 //
 // The execute tool — not the Manager — owns writing, so streaming runs tee interim
 // output as chunks arrive. It is single-consumer: append is called serially on
@@ -87,11 +87,11 @@ type outputSink struct {
 // and stops attempting further writes.
 type bashOutputWriter struct {
 	mgr    *backgroundtask.Manager
-	store  filesystem.StreamAppender // nil => disabled
+	store  filesystem.AppendOpener // nil => disabled
 	path   string
-	stream filesystem.AppendStream // opened lazily by the streaming work; nil => not open
-	taskID string                  // set by the work func once the Manager assigns it
-	failed bool                    // set after the first append error: the file is now partial
+	stream io.WriteCloser // opened lazily by the streaming work; nil => not open
+	taskID string         // set by the work func once the Manager assigns it
+	failed bool           // set after the first append error: the file is now partial
 }
 
 // reserveBashOutput builds a writer that tees under the sink, or a disabled writer
@@ -228,7 +228,7 @@ func bashWork(sb filesystem.Shell, req *filesystem.ExecuteRequest, w *bashOutput
 // two terminal outcomes the convert reader observes — so the handle is flushed and
 // released on both. On the rarer caller-abandon / timeout paths the source ends
 // without either hook firing; the session is then released by the work context's
-// cancellation (the file is already incomplete in that case), which the AppendStream
+// cancellation (the file is already incomplete in that case), which the AppendOpener
 // contract requires a resource-holding backend to honor.
 func bashStreamWork(sb filesystem.StreamingShell, req *filesystem.ExecuteRequest, w *bashOutputWriter) backgroundtask.StreamWorkFunc {
 	return func(ctx context.Context, task backgroundtask.TaskInfo) (*schema.StreamReader[string], error) {

--- a/adk/middlewares/filesystem/bash_run.go
+++ b/adk/middlewares/filesystem/bash_run.go
@@ -44,6 +44,12 @@ import (
 // Manager itself never writes — the execute tool owns it.
 const ExecuteTaskType = "bash"
 
+// defaultBashStartupPreviewMs is the caller-visible startup window for an
+// explicitly backgrounded StreamingShell run. The task is backgrounded from the
+// start; only its initial output remains attached briefly so launch-time prompts
+// such as OAuth URLs are not hidden in the background output file.
+const defaultBashStartupPreviewMs = 1_000
+
 // MetadataKeyCommand is the RunInput.Metadata / Task.Metadata key under which the
 // execute tool records the shell command for a task. A ShouldAutoBackground hook
 // reads it (via CommandFromTask) to apply command-specific policy without parsing
@@ -296,9 +302,11 @@ func bashStreamWork(sb filesystem.StreamingShell, req *filesystem.ExecuteRequest
 // can later query it via task_output.
 //
 // With a StreamingShell backend the tool is itself a StreamableTool: the
-// foreground phase streams output to the caller in real time, and a run that moves
-// to the background caps the stream with a notice (the rest is drained into the
-// task result). With a plain Shell backend the tool is buffered.
+// foreground phase streams output to the caller in real time. An explicit
+// background launch first exposes a bounded startup preview, then caps the stream
+// with a notice; a run moved to the background after its foreground budget caps
+// the stream immediately. In both cases the rest is drained into the task result.
+// With a plain Shell backend the tool is buffered and has no startup preview.
 //
 // Exactly one of sb / streaming must be non-nil. appender and outputDir, when both
 // set, enable per-task output files (the tool appends output to
@@ -383,10 +391,12 @@ func newManagedStreamingExecuteTool(mgr *backgroundtask.Manager, streaming files
 	return utils.InferStreamTool(toolName, desc, func(ctx context.Context, input executeManagedArgs) (*schema.StreamReader[string], error) {
 		req := &filesystem.ExecuteRequest{Command: input.Command}
 		w := reserveBashOutput(ctx, mgr, sink)
+		runInput := managedRunInput(ctx, input, w)
+		runInput.BackgroundStartupPreviewMs = defaultBashStartupPreviewMs
 		// RunStream owns the returned stream: it forwards work chunks to this caller
-		// in real time, and on auto-background caps the stream with a notice while
-		// draining the rest into the task result. A background launch (or timeout)
-		// is therefore surfaced inline as a final chunk, not as an error.
-		return mgr.RunStream(ctx, managedRunInput(ctx, input, w), bashStreamWork(streaming, req, w))
+		// in real time. An explicit background launch exposes only its bounded startup
+		// preview before the notice; auto-background caps the stream at the transition.
+		// In either case the remaining output is drained into the task result.
+		return mgr.RunStream(ctx, runInput, bashStreamWork(streaming, req, w))
 	})
 }

--- a/adk/middlewares/filesystem/bash_run_test.go
+++ b/adk/middlewares/filesystem/bash_run_test.go
@@ -267,8 +267,9 @@ func TestManagedExecuteTool_StreamingForeground(t *testing.T) {
 	assert.Contains(t, tasks[0].Result, "chunk3")
 }
 
-// An explicit background launch on a streaming managed tool emits only the
-// background notice on the caller's stream; the output lands in the task result.
+// An explicit background launch on a streaming managed tool exposes startup
+// output. This quick command completes inside the preview window, so its complete
+// output reaches the caller without a stale background notice.
 func TestManagedExecuteTool_StreamingExplicitBackground(t *testing.T) {
 	backend := setupTestBackend()
 	mgr := backgroundtask.New(context.Background(), &backgroundtask.Config{})
@@ -285,9 +286,9 @@ func TestManagedExecuteTool_StreamingExplicitBackground(t *testing.T) {
 	sr, err := st.StreamableRun(context.Background(), `{"command":"echo hi","run_in_background":true}`)
 	require.NoError(t, err)
 	got := drainToolStream(t, sr)
-	assert.Contains(t, got, "is running in the background")
-	assert.NotContains(t, got, "moved to the background")
-	assert.NotContains(t, got, "chunk1")
+	assert.Contains(t, got, "chunk1")
+	assert.Contains(t, got, "chunk3")
+	assert.NotContains(t, got, "is running in the background")
 
 	waitAllTasks(t, mgr)
 	tasks := mgr.List()

--- a/adk/middlewares/filesystem/bash_run_test.go
+++ b/adk/middlewares/filesystem/bash_run_test.go
@@ -21,6 +21,7 @@ import (
 	"errors"
 	"io"
 	"strings"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -277,7 +278,7 @@ func TestManagedExecuteTool_StreamingExplicitBackground(t *testing.T) {
 		_ = mgr.Close(ctx)
 	}()
 
-	executeTool, err := newManagedExecuteTool(mgr, nil, &mockStreamingShellMultiChunk{}, outputSink{appender: backend, outputDir: "/tasks"}, "", "")
+	executeTool, err := newManagedExecuteTool(mgr, nil, &mockStreamingShellMultiChunk{}, outputSink{store: backend, outputDir: "/tasks"}, "", "")
 	require.NoError(t, err)
 	st := executeTool.(tool.StreamableTool)
 
@@ -331,7 +332,7 @@ func TestManagedExecuteTool_StreamingInterimOutput(t *testing.T) {
 	}()
 
 	gate := &gatedStreamingShell{release: make(chan struct{})}
-	executeTool, err := newManagedExecuteTool(mgr, nil, gate, outputSink{appender: backend, outputDir: "/tasks"}, "", "")
+	executeTool, err := newManagedExecuteTool(mgr, nil, gate, outputSink{store: backend, outputDir: "/tasks"}, "", "")
 	require.NoError(t, err)
 	st := executeTool.(tool.StreamableTool)
 
@@ -427,22 +428,24 @@ func TestExecuteTool_NoManager_NotTracked(t *testing.T) {
 	assert.Equal(t, "ok", result)
 }
 
-// failingAppender wraps a Backend but fails Append after failAfter successful
-// appends (failAfter=0 fails the very first append, i.e. the reservation write).
-// Reads delegate to the backend so the partial file is still observable.
-type failingAppender struct {
+// failingStreamAppender wraps a Backend but fails to open an append stream after
+// failAfter successful opens (failAfter=0 fails the very first open, i.e. the
+// reservation). Reads delegate to the backend so any partial file is still
+// observable. In the buffered path the reservation and the result are each one
+// OpenAppend, so failAfter selects which logical append fails.
+type failingStreamAppender struct {
 	backend   *filesystem.InMemoryBackend
 	failAfter int
-	calls     int
+	opens     int
 }
 
-func (f *failingAppender) Append(ctx context.Context, req *filesystem.AppendRequest) error {
-	if f.calls >= f.failAfter {
-		f.calls++
-		return errors.New("append failed")
+func (f *failingStreamAppender) OpenAppend(ctx context.Context, req *filesystem.OpenAppendRequest) (filesystem.AppendStream, error) {
+	if f.opens >= f.failAfter {
+		f.opens++
+		return nil, errors.New("append failed")
 	}
-	f.calls++
-	return f.backend.Append(ctx, req)
+	f.opens++
+	return f.backend.OpenAppend(ctx, req)
 }
 
 // When the up-front reservation write fails, the task advertises no output file,
@@ -456,9 +459,9 @@ func TestManagedExecuteTool_ReservationFailure_NoOutputFile(t *testing.T) {
 		_ = mgr.Close(ctx)
 	}()
 
-	appender := &failingAppender{backend: backend, failAfter: 0}
+	appender := &failingStreamAppender{backend: backend, failAfter: 0}
 	executeTool, err := newManagedExecuteTool(mgr, &mockShellBackend{resp: &filesystem.ExecuteResponse{Output: "the output"}}, nil,
-		outputSink{appender: appender, outputDir: "/tasks"}, "", "")
+		outputSink{store: appender, outputDir: "/tasks"}, "", "")
 	require.NoError(t, err)
 
 	result, err := invokeTool(t, executeTool, `{"command":"echo hi"}`)
@@ -483,10 +486,10 @@ func TestManagedExecuteTool_WriteFailure_MarksUnreliable(t *testing.T) {
 		_ = mgr.Close(ctx)
 	}()
 
-	// failAfter=1: the reservation write succeeds, the result write fails.
-	appender := &failingAppender{backend: backend, failAfter: 1}
+	// failAfter=1: the reservation open succeeds, the result open fails.
+	appender := &failingStreamAppender{backend: backend, failAfter: 1}
 	executeTool, err := newManagedExecuteTool(mgr, &mockShellBackend{resp: &filesystem.ExecuteResponse{Output: "the output"}}, nil,
-		outputSink{appender: appender, outputDir: "/tasks"}, "", "")
+		outputSink{store: appender, outputDir: "/tasks"}, "", "")
 	require.NoError(t, err)
 
 	result, err := invokeTool(t, executeTool, `{"command":"echo hi"}`)
@@ -498,4 +501,84 @@ func TestManagedExecuteTool_WriteFailure_MarksUnreliable(t *testing.T) {
 	assert.NotEmpty(t, tasks[0].OutputFile, "the path was reserved, so it is still recorded")
 	assert.NotEmpty(t, tasks[0].OutputFileErr, "the failed write must mark the file unreliable")
 	assert.Equal(t, "the output", tasks[0].Result, "Result stays complete regardless of file writes")
+}
+
+// countingStreamAppender wraps a Backend and counts every OpenAppend and every
+// handle Close, so a test can assert that no opened append session was leaked
+// (opens == closes).
+type countingStreamAppender struct {
+	backend *filesystem.InMemoryBackend
+	opens   int32
+	closes  int32
+}
+
+func (c *countingStreamAppender) OpenAppend(ctx context.Context, req *filesystem.OpenAppendRequest) (filesystem.AppendStream, error) {
+	inner, err := c.backend.OpenAppend(ctx, req)
+	if err != nil {
+		return nil, err
+	}
+	atomic.AddInt32(&c.opens, 1)
+	return &countingAppendStream{AppendStream: inner, parent: c}, nil
+}
+
+type countingAppendStream struct {
+	filesystem.AppendStream
+	parent *countingStreamAppender
+}
+
+func (s *countingAppendStream) Close() error {
+	atomic.AddInt32(&s.parent.closes, 1)
+	return s.AppendStream.Close()
+}
+
+// erroringStreamingShell emits one chunk then a non-EOF error (no clean EOF), so the
+// OnEOF hook never fires — only the error path does.
+type erroringStreamingShell struct{}
+
+func (e *erroringStreamingShell) ExecuteStreaming(ctx context.Context, _ *filesystem.ExecuteRequest) (*schema.StreamReader[*filesystem.ExecuteResponse], error) {
+	sr, sw := schema.Pipe[*filesystem.ExecuteResponse](2)
+	go func() {
+		defer sw.Close()
+		sw.Send(&filesystem.ExecuteResponse{Output: "partial\n"}, nil)
+		sw.Send(nil, errors.New("shell blew up"))
+	}()
+	return sr, nil
+}
+
+// When the streaming source errors (never reaching EOF), the append session must
+// still be closed — via the error path, not only OnEOF — so a resource-holding
+// backend does not leak the handle. Asserted by opens == closes.
+func TestManagedExecuteTool_StreamingSourceError_ClosesStream(t *testing.T) {
+	backend := setupTestBackend()
+	counter := &countingStreamAppender{backend: backend}
+	mgr := backgroundtask.New(context.Background(), &backgroundtask.Config{})
+	defer func() {
+		ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+		defer cancel()
+		_ = mgr.Close(ctx)
+	}()
+
+	executeTool, err := newManagedExecuteTool(mgr, nil, &erroringStreamingShell{},
+		outputSink{store: counter, outputDir: "/tasks"}, "", "")
+	require.NoError(t, err)
+	st := executeTool.(tool.StreamableTool)
+
+	sr, err := st.StreamableRun(context.Background(), `{"command":"boom"}`)
+	require.NoError(t, err)
+	// Drain to termination, tolerating the terminal shell error (the point of the
+	// test is the append session lifecycle, not the surfaced error).
+	for {
+		if _, rerr := sr.Recv(); rerr != nil {
+			break
+		}
+	}
+	sr.Close()
+
+	waitAllTasks(t, mgr)
+
+	opens := atomic.LoadInt32(&counter.opens)
+	closes := atomic.LoadInt32(&counter.closes)
+	assert.Equal(t, opens, closes,
+		"every opened append session must be closed even when the source errors (opens=%d closes=%d)", opens, closes)
+	assert.Greater(t, opens, int32(0), "the streaming run must have opened at least one append session")
 }

--- a/adk/middlewares/filesystem/bash_run_test.go
+++ b/adk/middlewares/filesystem/bash_run_test.go
@@ -428,18 +428,18 @@ func TestExecuteTool_NoManager_NotTracked(t *testing.T) {
 	assert.Equal(t, "ok", result)
 }
 
-// failingStreamAppender wraps a Backend but fails to open an append stream after
+// failingAppendOpener wraps a Backend but fails to open an append stream after
 // failAfter successful opens (failAfter=0 fails the very first open, i.e. the
 // reservation). Reads delegate to the backend so any partial file is still
 // observable. In the buffered path the reservation and the result are each one
 // OpenAppend, so failAfter selects which logical append fails.
-type failingStreamAppender struct {
+type failingAppendOpener struct {
 	backend   *filesystem.InMemoryBackend
 	failAfter int
 	opens     int
 }
 
-func (f *failingStreamAppender) OpenAppend(ctx context.Context, req *filesystem.OpenAppendRequest) (filesystem.AppendStream, error) {
+func (f *failingAppendOpener) OpenAppend(ctx context.Context, req *filesystem.OpenAppendRequest) (io.WriteCloser, error) {
 	if f.opens >= f.failAfter {
 		f.opens++
 		return nil, errors.New("append failed")
@@ -459,9 +459,9 @@ func TestManagedExecuteTool_ReservationFailure_NoOutputFile(t *testing.T) {
 		_ = mgr.Close(ctx)
 	}()
 
-	appender := &failingStreamAppender{backend: backend, failAfter: 0}
+	opener := &failingAppendOpener{backend: backend, failAfter: 0}
 	executeTool, err := newManagedExecuteTool(mgr, &mockShellBackend{resp: &filesystem.ExecuteResponse{Output: "the output"}}, nil,
-		outputSink{store: appender, outputDir: "/tasks"}, "", "")
+		outputSink{store: opener, outputDir: "/tasks"}, "", "")
 	require.NoError(t, err)
 
 	result, err := invokeTool(t, executeTool, `{"command":"echo hi"}`)
@@ -487,9 +487,9 @@ func TestManagedExecuteTool_WriteFailure_MarksUnreliable(t *testing.T) {
 	}()
 
 	// failAfter=1: the reservation open succeeds, the result open fails.
-	appender := &failingStreamAppender{backend: backend, failAfter: 1}
+	opener := &failingAppendOpener{backend: backend, failAfter: 1}
 	executeTool, err := newManagedExecuteTool(mgr, &mockShellBackend{resp: &filesystem.ExecuteResponse{Output: "the output"}}, nil,
-		outputSink{store: appender, outputDir: "/tasks"}, "", "")
+		outputSink{store: opener, outputDir: "/tasks"}, "", "")
 	require.NoError(t, err)
 
 	result, err := invokeTool(t, executeTool, `{"command":"echo hi"}`)
@@ -503,32 +503,32 @@ func TestManagedExecuteTool_WriteFailure_MarksUnreliable(t *testing.T) {
 	assert.Equal(t, "the output", tasks[0].Result, "Result stays complete regardless of file writes")
 }
 
-// countingStreamAppender wraps a Backend and counts every OpenAppend and every
+// countingAppendOpener wraps a Backend and counts every OpenAppend and every
 // handle Close, so a test can assert that no opened append session was leaked
 // (opens == closes).
-type countingStreamAppender struct {
+type countingAppendOpener struct {
 	backend *filesystem.InMemoryBackend
 	opens   int32
 	closes  int32
 }
 
-func (c *countingStreamAppender) OpenAppend(ctx context.Context, req *filesystem.OpenAppendRequest) (filesystem.AppendStream, error) {
+func (c *countingAppendOpener) OpenAppend(ctx context.Context, req *filesystem.OpenAppendRequest) (io.WriteCloser, error) {
 	inner, err := c.backend.OpenAppend(ctx, req)
 	if err != nil {
 		return nil, err
 	}
 	atomic.AddInt32(&c.opens, 1)
-	return &countingAppendStream{AppendStream: inner, parent: c}, nil
+	return &countingAppendWriter{WriteCloser: inner, parent: c}, nil
 }
 
-type countingAppendStream struct {
-	filesystem.AppendStream
-	parent *countingStreamAppender
+type countingAppendWriter struct {
+	io.WriteCloser
+	parent *countingAppendOpener
 }
 
-func (s *countingAppendStream) Close() error {
+func (s *countingAppendWriter) Close() error {
 	atomic.AddInt32(&s.parent.closes, 1)
-	return s.AppendStream.Close()
+	return s.WriteCloser.Close()
 }
 
 // erroringStreamingShell emits one chunk then a non-EOF error (no clean EOF), so the
@@ -550,7 +550,7 @@ func (e *erroringStreamingShell) ExecuteStreaming(ctx context.Context, _ *filesy
 // backend does not leak the handle. Asserted by opens == closes.
 func TestManagedExecuteTool_StreamingSourceError_ClosesStream(t *testing.T) {
 	backend := setupTestBackend()
-	counter := &countingStreamAppender{backend: backend}
+	counter := &countingAppendOpener{backend: backend}
 	mgr := backgroundtask.New(context.Background(), &backgroundtask.Config{})
 	defer func() {
 		ctx, cancel := context.WithTimeout(context.Background(), time.Second)

--- a/adk/middlewares/filesystem/filesystem.go
+++ b/adk/middlewares/filesystem/filesystem.go
@@ -1086,7 +1086,7 @@ type executeArgs struct {
 type executeManagedArgs struct {
 	executeArgs
 	RunInBackground bool `json:"run_in_background,omitempty" jsonschema_description:"Set to true to run the command in the background. You will be notified when it completes; use task_output to query it and task_stop to cancel it."`
-	// TimeoutMS is the foreground budget in milliseconds. When omitted, the configured
+	// TimeoutMS is the foreground timeout in milliseconds. When omitted, the configured
 	// default applies. Ignored when run_in_background is true. What happens at the
 	// deadline (move to background vs. stop) is decided by the Manager's
 	// ShouldAutoBackground policy and is intentionally not surfaced to the model.

--- a/adk/middlewares/filesystem/filesystem.go
+++ b/adk/middlewares/filesystem/filesystem.go
@@ -102,10 +102,10 @@ type BackgroundConfig struct {
 	// file at OutputDir/<id>.output: streaming runs append their chunks to it as
 	// they arrive (interim output), buffered runs append their result on completion.
 	// The path is recorded on Task.OutputFile and surfaced in the background notice.
-	// OutputStore is a filesystem.Appender (filesystem.InMemoryBackend implements
-	// it); supply your own to direct output elsewhere. When either is unset, runs
-	// have no output file.
-	OutputStore filesystem.Appender
+	// OutputStore is a filesystem.StreamAppender (filesystem.InMemoryBackend
+	// implements it); supply your own to direct output elsewhere. When either is
+	// unset, runs have no output file.
+	OutputStore filesystem.StreamAppender
 	OutputDir   string
 }
 
@@ -597,7 +597,7 @@ func createExecuteTool(middlewareConfig *MiddlewareConfig) (tool.BaseTool, error
 				middlewareConfig.Shell,
 				middlewareConfig.StreamingShell,
 				outputSink{
-					appender:  middlewareConfig.Background.OutputStore,
+					store:     middlewareConfig.Background.OutputStore,
 					outputDir: middlewareConfig.Background.OutputDir,
 				},
 				executeConfig.Name,

--- a/adk/middlewares/filesystem/filesystem.go
+++ b/adk/middlewares/filesystem/filesystem.go
@@ -102,10 +102,10 @@ type BackgroundConfig struct {
 	// file at OutputDir/<id>.output: streaming runs append their chunks to it as
 	// they arrive (interim output), buffered runs append their result on completion.
 	// The path is recorded on Task.OutputFile and surfaced in the background notice.
-	// OutputStore is a filesystem.StreamAppender (filesystem.InMemoryBackend
+	// OutputStore is a filesystem.AppendOpener (filesystem.InMemoryBackend
 	// implements it); supply your own to direct output elsewhere. When either is
 	// unset, runs have no output file.
-	OutputStore filesystem.StreamAppender
+	OutputStore filesystem.AppendOpener
 	OutputDir   string
 }
 

--- a/adk/middlewares/filesystem/filesystem.go
+++ b/adk/middlewares/filesystem/filesystem.go
@@ -88,9 +88,10 @@ type ExecuteToolConfig struct {
 // When set, the execute tool gains a run_in_background field and routes runs
 // through the shared Manager, so background and auto-background runs are tracked
 // and visible to the task_output/task_stop control tools. With a StreamingShell
-// backend the foreground phase still streams in real time; once a run moves to the
-// background its stream is capped with a notice and the rest is collected into the
-// task result.
+// backend the foreground phase still streams in real time. An explicit background
+// launch briefly previews startup output before its stream is capped with a notice;
+// an auto-background transition caps it immediately. The remaining output is
+// collected into the task result.
 type BackgroundConfig struct {
 	// Manager is the shared background-task Manager. Required (a nil Manager is the
 	// same as no BackgroundConfig). It may be shared with other middlewares (e.g.

--- a/adk/middlewares/filesystem/prompt.go
+++ b/adk/middlewares/filesystem/prompt.go
@@ -289,7 +289,7 @@ Before executing the command, please follow these steps:
 
 Usage notes:
 - The command parameter is required
-- Set run_in_background=true for servers, watchers, and other long-running commands you do not need to wait for. You will be notified when it completes; use the task_output tool to check its status or retrieve its result, and the task_stop tool to cancel it.
+- Set run_in_background=true for servers, watchers, and other long-running commands you do not need to wait for. Streaming commands briefly expose startup output (such as an OAuth URL) before the caller stream closes. You will be notified when the command completes; use the task_output tool to check its status or retrieve its result, and the task_stop tool to cancel it.
 - The optional timeout parameter (in milliseconds) sets the maximum time to wait for the command. Omit to use the default.
 - Commands run in an isolated sandbox environment
 - Returns combined stdout/stderr output with exit code
@@ -333,7 +333,7 @@ Bad examples (avoid these):
 
 使用说明：
 - command 参数是必需的
-- 对于服务器、监听器等你无需等待的长时间运行命令，设置 run_in_background=true。命令完成时你会收到通知；使用 task_output 工具查询其状态或获取结果，使用 task_stop 工具取消它。
+- 对于服务器、监听器等你无需等待的长时间运行命令，设置 run_in_background=true。流式命令会在调用方输出流关闭前短暂展示启动输出（例如 OAuth 链接）。命令完成时你会收到通知；使用 task_output 工具查询其状态或获取结果，使用 task_stop 工具取消它。
 - 可选的 timeout 参数（毫秒）设置等待命令的最长时间。不传则使用默认值。
 - 命令在隔离的沙箱环境中运行
 - 返回合并的 stdout/stderr 输出和退出代码

--- a/adk/middlewares/subagent/agent_tool.go
+++ b/adk/middlewares/subagent/agent_tool.go
@@ -21,7 +21,6 @@ import (
 	"fmt"
 	"io"
 	"path/filepath"
-	"reflect"
 	"strings"
 
 	"github.com/bytedance/sonic"
@@ -36,7 +35,6 @@ import (
 	"github.com/cloudwego/eino/components/tool"
 	"github.com/cloudwego/eino/components/tool/utils"
 	"github.com/cloudwego/eino/compose"
-	"github.com/cloudwego/eino/schema"
 )
 
 const (
@@ -268,60 +266,27 @@ func (r *agentEventFileReceiver[M]) fail(err error) {
 	}
 }
 
-var schemaPackagePath = reflect.TypeOf(schema.Message{}).PkgPath()
-
 // sanitizedMessageValue makes a non-mutating copy of a schema message and
-// removes every formal Extra field before JSON serialization. Interface-valued
-// extension fields are deliberately kept opaque, so custom and provider
-// extensions remain part of the output.
+// removes its root Extra field before JSON serialization. Nested Extra fields,
+// custom extensions, and provider extensions remain part of the output.
 func sanitizedMessageValue[M adk.MessageType](msg M) any {
-	return cloneSchemaValueWithoutExtra(reflect.ValueOf(msg)).Interface()
-}
-
-func cloneSchemaValueWithoutExtra(value reflect.Value) reflect.Value {
-	if !value.IsValid() {
-		return value
+	switch m := any(msg).(type) {
+	case adk.Message:
+		if m == nil {
+			return nil
+		}
+		cloned := *m
+		cloned.Extra = nil
+		return &cloned
+	case adk.AgenticMessage:
+		if m == nil {
+			return nil
+		}
+		cloned := *m
+		cloned.Extra = nil
+		return &cloned
 	}
-
-	switch value.Kind() {
-	case reflect.Pointer:
-		if value.IsNil() || value.Type().Elem().Kind() != reflect.Struct || value.Type().Elem().PkgPath() != schemaPackagePath {
-			return value
-		}
-		cloned := reflect.New(value.Type().Elem())
-		cloned.Elem().Set(cloneSchemaValueWithoutExtra(value.Elem()))
-		return cloned
-	case reflect.Struct:
-		if value.Type().PkgPath() != schemaPackagePath {
-			return value
-		}
-		cloned := reflect.New(value.Type()).Elem()
-		for i := 0; i < value.NumField(); i++ {
-			field := value.Type().Field(i)
-			if !field.IsExported() || field.Name == "Extra" {
-				continue
-			}
-			cloned.Field(i).Set(cloneSchemaValueWithoutExtra(value.Field(i)))
-		}
-		return cloned
-	case reflect.Slice:
-		if value.IsNil() {
-			return value
-		}
-		cloned := reflect.MakeSlice(value.Type(), value.Len(), value.Len())
-		for i := 0; i < value.Len(); i++ {
-			cloned.Index(i).Set(cloneSchemaValueWithoutExtra(value.Index(i)))
-		}
-		return cloned
-	case reflect.Array:
-		cloned := reflect.New(value.Type()).Elem()
-		for i := 0; i < value.Len(); i++ {
-			cloned.Index(i).Set(cloneSchemaValueWithoutExtra(value.Index(i)))
-		}
-		return cloned
-	default:
-		return value
-	}
+	return msg
 }
 
 // agentOutputFilePath allocates an output-file path under outputDir without

--- a/adk/middlewares/subagent/agent_tool.go
+++ b/adk/middlewares/subagent/agent_tool.go
@@ -19,6 +19,7 @@ package subagent
 import (
 	"context"
 	"fmt"
+	"io"
 	"path/filepath"
 	"strings"
 
@@ -100,8 +101,8 @@ func newAgentTool(subAgents map[string]tool.InvokableTool, name, desc string) (t
 // outputDir/<uuid>.output: the file is created empty up front so its advertised
 // path exists immediately, and the sub-agent's final result is appended there on
 // completion. The Manager never writes — the tool owns it. store is a
-// filesystem.Appender; output files require one (no rewrite fallback).
-func newManagedAgentTool(mgr *backgroundtask.Manager, subAgents map[string]tool.InvokableTool, store filesystem.Appender, outputDir, name, desc string) (tool.BaseTool, error) {
+// filesystem.StreamAppender; output files require one (no rewrite fallback).
+func newManagedAgentTool(mgr *backgroundtask.Manager, subAgents map[string]tool.InvokableTool, store filesystem.StreamAppender, outputDir, name, desc string) (tool.BaseTool, error) {
 	return utils.InferOptionableTool(name, desc,
 		func(ctx context.Context, in agentManagedInput, opts ...tool.Option) (string, error) {
 			a, params, err := resolveSubAgent(subAgents, in.SubagentType, in.Prompt, in.Description)
@@ -133,7 +134,7 @@ func newManagedAgentTool(mgr *backgroundtask.Manager, subAgents map[string]tool.
 					return "", runErr
 				}
 				if outputFile != "" {
-					if appendErr := store.Append(workCtx, &filesystem.AppendRequest{FilePath: outputFile, Content: out}); appendErr != nil {
+					if appendErr := appendOnce(workCtx, store, outputFile, out); appendErr != nil {
 						// The result never reached the file: mark it unreliable (by task id)
 						// so task_output reports the file's failed state instead of trusting
 						// the empty/partial file.
@@ -172,13 +173,13 @@ func newManagedAgentTool(mgr *backgroundtask.Manager, subAgents map[string]tool.
 }
 
 // reserveAgentOutputFile reserves an output-file path under outputDir and creates
-// it empty (via Append) so the path exists before the run completes. The file is
-// named after the launching tool-call id (so it matches Task.ToolUseID), falling
-// back to a uuid when no tool-call id is in context. Returns "" when output files
-// are not configured (no store / no dir) or when the up-front reservation write
-// fails — in the latter case the task advertises no output file, so consumers
-// fall back to the in-memory Result.
-func reserveAgentOutputFile(ctx context.Context, store filesystem.Appender, outputDir string) string {
+// it empty (open+close, which creates the file on open) so the path exists before
+// the run completes. The file is named after the launching tool-call id (so it
+// matches Task.ToolUseID), falling back to a uuid when no tool-call id is in context.
+// Returns "" when output files are not configured (no store / no dir) or when the
+// up-front reservation fails — in the latter case the task advertises no output
+// file, so consumers fall back to the in-memory Result.
+func reserveAgentOutputFile(ctx context.Context, store filesystem.StreamAppender, outputDir string) string {
 	if store == nil || outputDir == "" {
 		return ""
 	}
@@ -187,10 +188,27 @@ func reserveAgentOutputFile(ctx context.Context, store filesystem.Appender, outp
 		name = uuid.NewString()
 	}
 	path := filepath.Join(outputDir, name+".output")
-	if err := store.Append(ctx, &filesystem.AppendRequest{FilePath: path, Content: ""}); err != nil {
+	if err := appendOnce(ctx, store, path, ""); err != nil {
 		return ""
 	}
 	return path
+}
+
+// appendOnce opens an append stream to path, writes content (skipped when empty,
+// which just creates/reserves the file via create-on-open), and closes it, returning
+// the first write or close error. It always closes the handle.
+func appendOnce(ctx context.Context, store filesystem.StreamAppender, path, content string) error {
+	w, err := store.OpenAppend(ctx, &filesystem.OpenAppendRequest{FilePath: path})
+	if err != nil {
+		return err
+	}
+	if content != "" {
+		if _, werr := io.WriteString(w, content); werr != nil {
+			_ = w.Close()
+			return werr
+		}
+	}
+	return w.Close()
 }
 
 // resolveSubAgent looks up the agent-as-tool adapter for subagentType and builds

--- a/adk/middlewares/subagent/agent_tool.go
+++ b/adk/middlewares/subagent/agent_tool.go
@@ -101,8 +101,8 @@ func newAgentTool(subAgents map[string]tool.InvokableTool, name, desc string) (t
 // outputDir/<uuid>.output: the file is created empty up front so its advertised
 // path exists immediately, and the sub-agent's final result is appended there on
 // completion. The Manager never writes — the tool owns it. store is a
-// filesystem.StreamAppender; output files require one (no rewrite fallback).
-func newManagedAgentTool(mgr *backgroundtask.Manager, subAgents map[string]tool.InvokableTool, store filesystem.StreamAppender, outputDir, name, desc string) (tool.BaseTool, error) {
+// filesystem.AppendOpener; output files require one (no rewrite fallback).
+func newManagedAgentTool(mgr *backgroundtask.Manager, subAgents map[string]tool.InvokableTool, store filesystem.AppendOpener, outputDir, name, desc string) (tool.BaseTool, error) {
 	return utils.InferOptionableTool(name, desc,
 		func(ctx context.Context, in agentManagedInput, opts ...tool.Option) (string, error) {
 			a, params, err := resolveSubAgent(subAgents, in.SubagentType, in.Prompt, in.Description)
@@ -179,7 +179,7 @@ func newManagedAgentTool(mgr *backgroundtask.Manager, subAgents map[string]tool.
 // Returns "" when output files are not configured (no store / no dir) or when the
 // up-front reservation fails — in the latter case the task advertises no output
 // file, so consumers fall back to the in-memory Result.
-func reserveAgentOutputFile(ctx context.Context, store filesystem.StreamAppender, outputDir string) string {
+func reserveAgentOutputFile(ctx context.Context, store filesystem.AppendOpener, outputDir string) string {
 	if store == nil || outputDir == "" {
 		return ""
 	}
@@ -197,7 +197,7 @@ func reserveAgentOutputFile(ctx context.Context, store filesystem.StreamAppender
 // appendOnce opens an append stream to path, writes content (skipped when empty,
 // which just creates/reserves the file via create-on-open), and closes it, returning
 // the first write or close error. It always closes the handle.
-func appendOnce(ctx context.Context, store filesystem.StreamAppender, path, content string) error {
+func appendOnce(ctx context.Context, store filesystem.AppendOpener, path, content string) error {
 	w, err := store.OpenAppend(ctx, &filesystem.OpenAppendRequest{FilePath: path})
 	if err != nil {
 		return err

--- a/adk/middlewares/subagent/agent_tool.go
+++ b/adk/middlewares/subagent/agent_tool.go
@@ -18,10 +18,10 @@ package subagent
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"io"
 	"path/filepath"
+	"reflect"
 	"strings"
 
 	"github.com/bytedance/sonic"
@@ -100,11 +100,11 @@ func newAgentTool(subAgents map[string]tool.InvokableTool, name, desc string) (t
 // and only lifecycle/background switching is layered on top.
 //
 // When store and outputDir are both set, each run is given an output file at
-// outputDir/<uuid>.output: the file is created empty up front so its advertised
-// path exists immediately, then one append writer remains open while the
-// sub-agent runs and receives its AgentEvents in real time. The Manager never
-// writes — the tool owns the writer. store is a filesystem.AppendOpener; output
-// files require one (no rewrite fallback).
+// outputDir/<uuid>.output. The path is allocated before the run, then the work
+// callback lazily creates it and keeps one append writer open while the sub-agent
+// runs, writing one JSONL record for each materialized AgentEvent. The Manager
+// never writes — the tool owns the writer. store is a filesystem.AppendOpener;
+// output files require one (no rewrite fallback).
 func newManagedAgentTool[M adk.MessageType](mgr *backgroundtask.Manager, subAgents map[string]tool.InvokableTool, store filesystem.AppendOpener, outputDir, name, desc string) (tool.BaseTool, error) {
 	return utils.InferOptionableTool(name, desc,
 		func(ctx context.Context, in agentManagedInput, opts ...tool.Option) (string, error) {
@@ -113,7 +113,7 @@ func newManagedAgentTool[M adk.MessageType](mgr *backgroundtask.Manager, subAgen
 				return "", err
 			}
 
-			outputFile := reserveAgentOutputFile(ctx, store, outputDir)
+			outputFile := agentOutputFilePath(ctx, store, outputDir)
 
 			result, err := mgr.Run(ctx, &backgroundtask.RunInput{
 				Description:     in.Description,
@@ -222,45 +222,40 @@ type agentEventFileReceiver[M adk.MessageType] struct {
 	failed  bool
 }
 
+type agentEventRecord struct {
+	Type      string `json:"type"`
+	AgentName string `json:"agent_name,omitempty"`
+	Message   any    `json:"message"`
+}
+
 func (r *agentEventFileReceiver[M]) receive(event *adk.TypedAgentEvent[M]) {
 	if r.failed || event == nil || event.Output == nil || event.Output.MessageOutput == nil {
 		return
 	}
 
-	output := event.Output.MessageOutput
-	if !output.IsStreaming {
-		r.writeMessage(output.Message)
+	msg, err := event.Output.MessageOutput.GetMessage()
+	if err != nil {
+		r.fail(fmt.Errorf("materialize agent output message: %w", err))
 		return
 	}
-	if output.MessageStream == nil {
+	message := sanitizedMessageValue(msg)
+	data, err := sonic.Marshal(&agentEventRecord{
+		Type:      "message",
+		AgentName: event.AgentName,
+		Message:   message,
+	})
+	if err != nil {
+		r.fail(fmt.Errorf("marshal agent output event: %w", err))
 		return
 	}
-	defer output.MessageStream.Close()
-	for {
-		chunk, err := output.MessageStream.Recv()
-		if errors.Is(err, io.EOF) {
-			return
-		}
-		if err != nil {
-			r.fail(fmt.Errorf("receive agent output stream: %w", err))
-			return
-		}
-		if !r.writeMessage(chunk) {
-			return
-		}
+	data = append(data, '\n')
+	n, err := r.writer.Write(data)
+	if err == nil && n != len(data) {
+		err = io.ErrShortWrite
 	}
-}
-
-func (r *agentEventFileReceiver[M]) writeMessage(msg M) bool {
-	content := agentEventText(msg)
-	if content == "" {
-		return true
-	}
-	if _, err := io.WriteString(r.writer, content); err != nil {
+	if err != nil {
 		r.fail(fmt.Errorf("write agent output: %w", err))
-		return false
 	}
-	return true
 }
 
 func (r *agentEventFileReceiver[M]) fail(err error) {
@@ -273,35 +268,68 @@ func (r *agentEventFileReceiver[M]) fail(err error) {
 	}
 }
 
-func agentEventText[M adk.MessageType](msg M) string {
-	switch v := any(msg).(type) {
-	case *schema.Message:
-		if v != nil {
-			return v.Content
-		}
-	case *schema.AgenticMessage:
-		if v == nil {
-			return ""
-		}
-		var texts []string
-		for _, block := range v.ContentBlocks {
-			if block != nil && block.Type == schema.ContentBlockTypeAssistantGenText && block.AssistantGenText != nil {
-				texts = append(texts, block.AssistantGenText.Text)
-			}
-		}
-		return strings.Join(texts, "\n")
-	}
-	return ""
+var schemaPackagePath = reflect.TypeOf(schema.Message{}).PkgPath()
+
+// sanitizedMessageValue makes a non-mutating copy of a schema message and
+// removes every formal Extra field before JSON serialization. Interface-valued
+// extension fields are deliberately kept opaque, so custom and provider
+// extensions remain part of the output.
+func sanitizedMessageValue[M adk.MessageType](msg M) any {
+	return cloneSchemaValueWithoutExtra(reflect.ValueOf(msg)).Interface()
 }
 
-// reserveAgentOutputFile reserves an output-file path under outputDir and creates
-// it empty (open+close, which creates the file on open) so the path exists before
-// the run completes. The file is named after the launching tool-call id (so it
-// matches Task.ToolUseID), falling back to a uuid when no tool-call id is in context.
-// Returns "" when output files are not configured (no store / no dir) or when the
-// up-front reservation fails — in the latter case the task advertises no output
-// file, so consumers fall back to the in-memory Result.
-func reserveAgentOutputFile(ctx context.Context, store filesystem.AppendOpener, outputDir string) string {
+func cloneSchemaValueWithoutExtra(value reflect.Value) reflect.Value {
+	if !value.IsValid() {
+		return value
+	}
+
+	switch value.Kind() {
+	case reflect.Pointer:
+		if value.IsNil() || value.Type().Elem().Kind() != reflect.Struct || value.Type().Elem().PkgPath() != schemaPackagePath {
+			return value
+		}
+		cloned := reflect.New(value.Type().Elem())
+		cloned.Elem().Set(cloneSchemaValueWithoutExtra(value.Elem()))
+		return cloned
+	case reflect.Struct:
+		if value.Type().PkgPath() != schemaPackagePath {
+			return value
+		}
+		cloned := reflect.New(value.Type()).Elem()
+		for i := 0; i < value.NumField(); i++ {
+			field := value.Type().Field(i)
+			if !field.IsExported() || field.Name == "Extra" {
+				continue
+			}
+			cloned.Field(i).Set(cloneSchemaValueWithoutExtra(value.Field(i)))
+		}
+		return cloned
+	case reflect.Slice:
+		if value.IsNil() {
+			return value
+		}
+		cloned := reflect.MakeSlice(value.Type(), value.Len(), value.Len())
+		for i := 0; i < value.Len(); i++ {
+			cloned.Index(i).Set(cloneSchemaValueWithoutExtra(value.Index(i)))
+		}
+		return cloned
+	case reflect.Array:
+		cloned := reflect.New(value.Type()).Elem()
+		for i := 0; i < value.Len(); i++ {
+			cloned.Index(i).Set(cloneSchemaValueWithoutExtra(value.Index(i)))
+		}
+		return cloned
+	default:
+		return value
+	}
+}
+
+// agentOutputFilePath allocates an output-file path under outputDir without
+// opening it. The work callback creates the file lazily through its single
+// append session. The file is named after the launching tool-call id (so it
+// matches Task.ToolUseID), falling back to a uuid when no tool-call id is in
+// context. Returns "" when output files are not configured.
+func agentOutputFilePath(ctx context.Context, store filesystem.AppendOpener, outputDir string) string {
 	if store == nil || outputDir == "" {
 		return ""
 	}
@@ -309,28 +337,7 @@ func reserveAgentOutputFile(ctx context.Context, store filesystem.AppendOpener, 
 	if name == "" {
 		name = uuid.NewString()
 	}
-	path := filepath.Join(outputDir, name+".output")
-	if err := appendOnce(ctx, store, path, ""); err != nil {
-		return ""
-	}
-	return path
-}
-
-// appendOnce opens an append stream to path, writes content (skipped when empty,
-// which just creates/reserves the file via create-on-open), and closes it, returning
-// the first write or close error. It always closes the handle.
-func appendOnce(ctx context.Context, store filesystem.AppendOpener, path, content string) error {
-	w, err := store.OpenAppend(ctx, &filesystem.OpenAppendRequest{FilePath: path})
-	if err != nil {
-		return err
-	}
-	if content != "" {
-		if _, werr := io.WriteString(w, content); werr != nil {
-			_ = w.Close()
-			return werr
-		}
-	}
-	return w.Close()
+	return filepath.Join(outputDir, name+".output")
 }
 
 // resolveSubAgent looks up the agent-as-tool adapter for subagentType and builds

--- a/adk/middlewares/subagent/agent_tool.go
+++ b/adk/middlewares/subagent/agent_tool.go
@@ -270,8 +270,15 @@ func (r *agentEventFileReceiver[M]) receive(event *adk.TypedAgentEvent[M]) {
 	// Write the line and its newline in one call: a single write halves per-write
 	// backend overhead (lock/RPC) and keeps the line and its terminator atomic at the
 	// write boundary; the extra newline concat is cheap. io.WriteString uses the
-	// backend's StringWriter fast path when available, avoiding a []byte copy.
-	if _, err := io.WriteString(r.writer, line+"\n"); err != nil {
+	// backend's StringWriter fast path when available, avoiding a []byte copy. Treat a
+	// short write as an error even when the writer reports nil, so a truncated line
+	// marks the file unreliable rather than being trusted as authoritative.
+	data := line + "\n"
+	n, err := io.WriteString(r.writer, data)
+	if err == nil && n != len(data) {
+		err = io.ErrShortWrite
+	}
+	if err != nil {
 		r.fail(fmt.Errorf("write agent output: %w", err))
 	}
 }

--- a/adk/middlewares/subagent/agent_tool.go
+++ b/adk/middlewares/subagent/agent_tool.go
@@ -97,13 +97,29 @@ func newAgentTool(subAgents map[string]tool.InvokableTool, name, desc string) (t
 // agent-as-tool invocation in a managed task, so foreground behavior is identical
 // and only lifecycle/background switching is layered on top.
 //
-// When store and outputDir are both set, each run is given an output file at
-// outputDir/<uuid>.output. The path is allocated before the run, then the work
-// callback lazily creates it and keeps one append writer open while the sub-agent
-// runs, writing one JSONL record for each materialized AgentEvent. The Manager
-// never writes — the tool owns the writer. store is a filesystem.AppendOpener;
-// output files require one (no rewrite fallback).
-func newManagedAgentTool[M adk.MessageType](mgr *backgroundtask.Manager, subAgents map[string]tool.InvokableTool, store filesystem.AppendOpener, outputDir, name, desc string) (tool.BaseTool, error) {
+// agentOutput bundles the output-file configuration for a managed agent tool: the
+// AppendOpener to write through, the directory to reserve paths under, and the
+// per-event encoder. A zero store or outputDir disables output files. A nil format
+// selects the built-in default encoder (see defaultAgentEventFormat).
+type agentOutput[M adk.MessageType] struct {
+	store     filesystem.AppendOpener
+	outputDir string
+	format    AgentEventFormat[M]
+}
+
+// When sink.store and sink.outputDir are both set, each run is given an output file
+// at outputDir/<uuid>.output, and the work callback lazily creates it and keeps one
+// append writer open while the sub-agent runs, writing one line per materialized
+// AgentEvent through sink.format (or the default encoder when it is nil). The path is
+// allocated before the run. The Manager never writes — the tool owns the writer.
+// sink.store is a filesystem.AppendOpener; output files require one (no rewrite
+// fallback).
+func newManagedAgentTool[M adk.MessageType](mgr *backgroundtask.Manager, subAgents map[string]tool.InvokableTool, sink agentOutput[M], name, desc string) (tool.BaseTool, error) {
+	format := sink.format
+	var formatHint string // set only for the default encoder, whose format we can describe
+	if format == nil {
+		format, formatHint = defaultAgentEventFormat[M], outputFileFormatHint
+	}
 	return utils.InferOptionableTool(name, desc,
 		func(ctx context.Context, in agentManagedInput, opts ...tool.Option) (string, error) {
 			a, params, err := resolveSubAgent(subAgents, in.SubagentType, in.Prompt, in.Description)
@@ -111,7 +127,7 @@ func newManagedAgentTool[M adk.MessageType](mgr *backgroundtask.Manager, subAgen
 				return "", err
 			}
 
-			outputFile := agentOutputFilePath(ctx, store, outputDir)
+			outputFile := agentOutputFilePath(ctx, sink.store, sink.outputDir)
 
 			result, err := mgr.Run(ctx, &backgroundtask.RunInput{
 				Description:     in.Description,
@@ -123,12 +139,14 @@ func newManagedAgentTool[M adk.MessageType](mgr *backgroundtask.Manager, subAgen
 			}, func(workCtx context.Context, task backgroundtask.TaskInfo) (string, error) {
 				var outputReceiver agenttool.EventReceiver[*adk.TypedAgentEvent[M]]
 				if outputFile != "" {
-					writer, openErr := store.OpenAppend(workCtx, &filesystem.OpenAppendRequest{FilePath: outputFile})
+					writer, openErr := sink.store.OpenAppend(workCtx, &filesystem.OpenAppendRequest{FilePath: outputFile})
 					if openErr != nil {
 						mgr.MarkOutputFileUnreliable(task.ID, openErr.Error())
 					} else {
 						fileReceiver := &agentEventFileReceiver[M]{
+							ctx:    workCtx,
 							writer: writer,
+							format: format,
 							onError: func(err error) {
 								mgr.MarkOutputFileUnreliable(task.ID, err.Error())
 							},
@@ -144,7 +162,8 @@ func newManagedAgentTool[M adk.MessageType](mgr *backgroundtask.Manager, subAgen
 
 				// Existing receivers came from the launching parent agent. Gate only
 				// those receivers when the task is backgrounded, then append the task's
-				// output-file receiver after the gate so it continues receiving events.
+				// output-file receiver (nil when output files are off) after the gate so
+				// it continues receiving events.
 				runOpts := append(opts, agenttool.WithEventReceiverTransform(
 					managedEventReceiverTransform(task.Backgrounded, outputReceiver)))
 				out, runErr := a.InvokableRun(workCtx, params, runOpts...)
@@ -167,7 +186,11 @@ func newManagedAgentTool[M adk.MessageType](mgr *backgroundtask.Manager, subAgen
 				}
 				msg += " You will be notified when it completes."
 				if result.OutputFile != "" {
-					msg += " To check interim output, use Read on that file path."
+					if formatHint != "" {
+						msg += fmt.Sprintf(" To check interim output, use Read on that file path (%s).", formatHint)
+					} else {
+						msg += " To check interim output, use Read on that file path."
+					}
 				}
 				return msg, nil
 			case backgroundtask.StatusFailed:
@@ -215,45 +238,65 @@ func signalClosed(done <-chan struct{}) bool {
 }
 
 type agentEventFileReceiver[M adk.MessageType] struct {
+	ctx     context.Context
 	writer  io.Writer
+	format  AgentEventFormat[M]
 	onError func(error)
 	failed  bool
 }
 
 type agentEventRecord struct {
-	Type      string `json:"type"`
 	AgentName string `json:"agent_name,omitempty"`
 	Message   any    `json:"message"`
 }
 
+// receive encodes one event through the configured format and appends it as a line.
+// An empty line skips the event — nothing is written; a non-nil error marks the file
+// unreliable and stops further writes.
 func (r *agentEventFileReceiver[M]) receive(event *adk.TypedAgentEvent[M]) {
-	if r.failed || event == nil || event.Output == nil || event.Output.MessageOutput == nil {
+	if r.failed {
 		return
 	}
 
-	msg, err := event.Output.MessageOutput.GetMessage()
+	line, err := r.format(r.ctx, event)
 	if err != nil {
-		r.fail(fmt.Errorf("materialize agent output message: %w", err))
+		r.fail(fmt.Errorf("encode agent output event: %w", err))
 		return
 	}
-	message := sanitizedMessageValue(msg)
-	data, err := sonic.Marshal(&agentEventRecord{
-		Type:      "message",
-		AgentName: event.AgentName,
-		Message:   message,
-	})
-	if err != nil {
-		r.fail(fmt.Errorf("marshal agent output event: %w", err))
-		return
+	if line == "" {
+		return // skip: no line to write for this event
 	}
-	data = append(data, '\n')
-	n, err := r.writer.Write(data)
-	if err == nil && n != len(data) {
-		err = io.ErrShortWrite
-	}
-	if err != nil {
+
+	// Write the line and its newline in one call: a single write halves per-write
+	// backend overhead (lock/RPC) and keeps the line and its terminator atomic at the
+	// write boundary; the extra newline concat is cheap. io.WriteString uses the
+	// backend's StringWriter fast path when available, avoiding a []byte copy.
+	if _, err := io.WriteString(r.writer, line+"\n"); err != nil {
 		r.fail(fmt.Errorf("write agent output: %w", err))
 	}
+}
+
+// defaultAgentEventFormat is the built-in AgentEventFormat: it emits one JSON object
+// per message-bearing event — {agent_name, message} with the event's message (root
+// Extra stripped) — and skips (returns "") events that carry no materialized message.
+// The event kind is read from the message's own role and tool calls, so no separate
+// type field is added. It does not use ctx.
+func defaultAgentEventFormat[M adk.MessageType](_ context.Context, event *adk.TypedAgentEvent[M]) (string, error) {
+	if event == nil || event.Output == nil || event.Output.MessageOutput == nil {
+		return "", nil // skip: nothing to record
+	}
+	msg, err := event.Output.MessageOutput.GetMessage()
+	if err != nil {
+		return "", fmt.Errorf("materialize agent output message: %w", err)
+	}
+	data, err := sonic.Marshal(&agentEventRecord{
+		AgentName: event.AgentName,
+		Message:   sanitizedMessageValue(msg),
+	})
+	if err != nil {
+		return "", fmt.Errorf("marshal agent output event: %w", err)
+	}
+	return string(data), nil
 }
 
 func (r *agentEventFileReceiver[M]) fail(err error) {

--- a/adk/middlewares/subagent/agent_tool.go
+++ b/adk/middlewares/subagent/agent_tool.go
@@ -18,6 +18,7 @@ package subagent
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"io"
 	"path/filepath"
@@ -35,6 +36,7 @@ import (
 	"github.com/cloudwego/eino/components/tool"
 	"github.com/cloudwego/eino/components/tool/utils"
 	"github.com/cloudwego/eino/compose"
+	"github.com/cloudwego/eino/schema"
 )
 
 const (
@@ -99,10 +101,11 @@ func newAgentTool(subAgents map[string]tool.InvokableTool, name, desc string) (t
 //
 // When store and outputDir are both set, each run is given an output file at
 // outputDir/<uuid>.output: the file is created empty up front so its advertised
-// path exists immediately, and the sub-agent's final result is appended there on
-// completion. The Manager never writes — the tool owns it. store is a
-// filesystem.AppendOpener; output files require one (no rewrite fallback).
-func newManagedAgentTool(mgr *backgroundtask.Manager, subAgents map[string]tool.InvokableTool, store filesystem.AppendOpener, outputDir, name, desc string) (tool.BaseTool, error) {
+// path exists immediately, then one append writer remains open while the
+// sub-agent runs and receives its AgentEvents in real time. The Manager never
+// writes — the tool owns the writer. store is a filesystem.AppendOpener; output
+// files require one (no rewrite fallback).
+func newManagedAgentTool[M adk.MessageType](mgr *backgroundtask.Manager, subAgents map[string]tool.InvokableTool, store filesystem.AppendOpener, outputDir, name, desc string) (tool.BaseTool, error) {
 	return utils.InferOptionableTool(name, desc,
 		func(ctx context.Context, in agentManagedInput, opts ...tool.Option) (string, error) {
 			a, params, err := resolveSubAgent(subAgents, in.SubagentType, in.Prompt, in.Description)
@@ -120,26 +123,35 @@ func newManagedAgentTool(mgr *backgroundtask.Manager, subAgents map[string]tool.
 				Metadata:        map[string]any{MetadataKeySubagentType: in.SubagentType},
 				OutputFile:      outputFile,
 			}, func(workCtx context.Context, task backgroundtask.TaskInfo) (string, error) {
-				// Bound the inner agent's forwarding to the launching turn's event
-				// stream by the task's backgrounded signal: a backgrounded run outlives
-				// the turn (which closes its event generator on turn end), so forwarding
-				// to it past that point is wrong and unsafe. The AgentTool stops
-				// forwarding when task.Backgrounded fires — for an explicit
-				// run_in_background it is already closed here, for an auto-backgrounded
-				// run it closes at the deadline. Foreground runs never fire it and
-				// forward for their whole lifetime.
-				runOpts := append(opts, agenttool.WithForwardGate(task.Backgrounded))
+				var outputReceiver agenttool.EventReceiver[*adk.TypedAgentEvent[M]]
+				if outputFile != "" {
+					writer, openErr := store.OpenAppend(workCtx, &filesystem.OpenAppendRequest{FilePath: outputFile})
+					if openErr != nil {
+						mgr.MarkOutputFileUnreliable(task.ID, openErr.Error())
+					} else {
+						fileReceiver := &agentEventFileReceiver[M]{
+							writer: writer,
+							onError: func(err error) {
+								mgr.MarkOutputFileUnreliable(task.ID, err.Error())
+							},
+						}
+						outputReceiver = fileReceiver.receive
+						defer func() {
+							if closeErr := writer.Close(); closeErr != nil {
+								fileReceiver.fail(fmt.Errorf("close agent output file: %w", closeErr))
+							}
+						}()
+					}
+				}
+
+				// Existing receivers came from the launching parent agent. Gate only
+				// those receivers when the task is backgrounded, then append the task's
+				// output-file receiver after the gate so it continues receiving events.
+				runOpts := append(opts, agenttool.WithEventReceiverTransform(
+					managedEventReceiverTransform(task.Backgrounded, outputReceiver)))
 				out, runErr := a.InvokableRun(workCtx, params, runOpts...)
 				if runErr != nil {
 					return "", runErr
-				}
-				if outputFile != "" {
-					if appendErr := appendOnce(workCtx, store, outputFile, out); appendErr != nil {
-						// The result never reached the file: mark it unreliable (by task id)
-						// so task_output reports the file's failed state instead of trusting
-						// the empty/partial file.
-						mgr.MarkOutputFileUnreliable(task.ID, appendErr.Error())
-					}
 				}
 				return out, nil
 			})
@@ -170,6 +182,116 @@ func newManagedAgentTool(mgr *backgroundtask.Manager, subAgents map[string]tool.
 				return result.Result, nil
 			}
 		})
+}
+
+// managedEventReceiverTransform gates the parent receivers configured before
+// it and then appends the task receiver. An empty current slice is valid: that
+// is the EmitInternalEvents=false path, where only task output is needed.
+func managedEventReceiverTransform[E any](backgrounded <-chan struct{}, taskReceiver agenttool.EventReceiver[E]) agenttool.EventReceiverTransform[E] {
+	return func(current []agenttool.EventReceiver[E]) []agenttool.EventReceiver[E] {
+		for i := range current {
+			receiver := current[i]
+			current[i] = func(event E) {
+				if !signalClosed(backgrounded) {
+					receiver(event)
+				}
+			}
+		}
+		if taskReceiver != nil {
+			current = append(current, taskReceiver)
+		}
+		return current
+	}
+}
+
+func signalClosed(done <-chan struct{}) bool {
+	if done == nil {
+		return false
+	}
+	select {
+	case <-done:
+		return true
+	default:
+		return false
+	}
+}
+
+type agentEventFileReceiver[M adk.MessageType] struct {
+	writer  io.Writer
+	onError func(error)
+	failed  bool
+}
+
+func (r *agentEventFileReceiver[M]) receive(event *adk.TypedAgentEvent[M]) {
+	if r.failed || event == nil || event.Output == nil || event.Output.MessageOutput == nil {
+		return
+	}
+
+	output := event.Output.MessageOutput
+	if !output.IsStreaming {
+		r.writeMessage(output.Message)
+		return
+	}
+	if output.MessageStream == nil {
+		return
+	}
+	defer output.MessageStream.Close()
+	for {
+		chunk, err := output.MessageStream.Recv()
+		if errors.Is(err, io.EOF) {
+			return
+		}
+		if err != nil {
+			r.fail(fmt.Errorf("receive agent output stream: %w", err))
+			return
+		}
+		if !r.writeMessage(chunk) {
+			return
+		}
+	}
+}
+
+func (r *agentEventFileReceiver[M]) writeMessage(msg M) bool {
+	content := agentEventText(msg)
+	if content == "" {
+		return true
+	}
+	if _, err := io.WriteString(r.writer, content); err != nil {
+		r.fail(fmt.Errorf("write agent output: %w", err))
+		return false
+	}
+	return true
+}
+
+func (r *agentEventFileReceiver[M]) fail(err error) {
+	if err == nil || r.failed {
+		return
+	}
+	r.failed = true
+	if r.onError != nil {
+		r.onError(err)
+	}
+}
+
+func agentEventText[M adk.MessageType](msg M) string {
+	switch v := any(msg).(type) {
+	case *schema.Message:
+		if v != nil {
+			return v.Content
+		}
+	case *schema.AgenticMessage:
+		if v == nil {
+			return ""
+		}
+		var texts []string
+		for _, block := range v.ContentBlocks {
+			if block != nil && block.Type == schema.ContentBlockTypeAssistantGenText && block.AssistantGenText != nil {
+				texts = append(texts, block.AssistantGenText.Text)
+			}
+		}
+		return strings.Join(texts, "\n")
+	}
+	return ""
 }
 
 // reserveAgentOutputFile reserves an output-file path under outputDir and creates

--- a/adk/middlewares/subagent/middleware.go
+++ b/adk/middlewares/subagent/middleware.go
@@ -77,10 +77,10 @@ type BackgroundConfig struct {
 	// sub-agent's final result there on completion and records the path on
 	// Task.OutputFile, so a backgrounded run's result is retrievable by path (and
 	// large results need not be inlined). The Manager itself never writes.
-	// OutputStore is a filesystem.StreamAppender (filesystem.InMemoryBackend
+	// OutputStore is a filesystem.AppendOpener (filesystem.InMemoryBackend
 	// implements it); output files require one. When either is unset, runs have no
 	// output file.
-	OutputStore filesystem.StreamAppender
+	OutputStore filesystem.AppendOpener
 	OutputDir   string
 }
 

--- a/adk/middlewares/subagent/middleware.go
+++ b/adk/middlewares/subagent/middleware.go
@@ -55,7 +55,7 @@ type TypedConfig[M adk.MessageType] struct {
 	// Background configures background-task execution for sub-agent runs. When nil,
 	// only foreground (blocking) agent execution is available and runs are NOT
 	// tracked. See BackgroundConfig.
-	Background *BackgroundConfig
+	Background *BackgroundConfig[M]
 }
 
 // BackgroundConfig enables background-task execution for the agent tool.
@@ -63,7 +63,7 @@ type TypedConfig[M adk.MessageType] struct {
 // When set, ALL agent runs (foreground and background) are managed by the Manager,
 // making them visible via Get/List, and the Agent tool gains a run_in_background
 // parameter.
-type BackgroundConfig struct {
+type BackgroundConfig[M adk.MessageType] struct {
 	// Manager is the shared background-task Manager. Required (a nil Manager is the
 	// same as no BackgroundConfig). It may be shared with other middlewares (e.g.
 	// filesystem) so a single task-ID space spans agent and shell runs. The
@@ -73,19 +73,46 @@ type BackgroundConfig struct {
 	Manager *backgroundtask.Manager
 
 	// OutputStore and OutputDir, when both set, give every managed sub-agent run an
-	// output file at OutputDir/<id>.output. The managed agent tool appends one JSONL
-	// record for each materialized AgentEvent and records the path on Task.OutputFile,
-	// so a backgrounded run's interim and final output is retrievable by path (and
-	// large results need not be inlined). The path is allocated before the run and
-	// the file is created lazily by the work callback's single append session, so a
-	// newly returned background task may briefly advertise the path before it exists.
-	// The Manager itself never writes.
+	// output file at OutputDir/<id>.output and record the path on Task.OutputFile, so
+	// a backgrounded run's output is retrievable by path (and large results need not
+	// be inlined). The path is allocated before the run and the file is created
+	// lazily by the work callback, so a newly returned background task may briefly
+	// advertise the path before it exists. The Manager itself never writes.
+	//
+	// The file is JSON Lines: one record per line, appended as each AgentEvent
+	// materializes, so a backgrounded run's interim output is visible before it
+	// completes. EventFormat encodes each event into its line (see AgentEventFormat);
+	// when nil the default encoder is used, which writes {"type","agent_name",
+	// "message"} with the event's message (root Extra stripped) and a "type" naming
+	// the event kind. A custom EventFormat may reshape or skip events — e.g. skipping
+	// everything but the final assistant answer to get a final-result-only file.
+	//
 	// OutputStore is a filesystem.AppendOpener (filesystem.InMemoryBackend
 	// implements it); output files require one. When either is unset, runs have no
 	// output file.
 	OutputStore filesystem.AppendOpener
 	OutputDir   string
+	EventFormat AgentEventFormat[M]
 }
+
+// AgentEventFormat encodes one materialized AgentEvent into the text of a single
+// output-file line (the framework appends the newline). It runs once per event, on
+// the run's Recv stack (serially, single-consumer), so it needs no synchronization.
+// ctx is the run's (detached) context; honor it for cancellation and read request
+// values from it as needed.
+//
+// Returns:
+//   - (line, nil) with line != "": the line is written, followed by a newline.
+//   - ("", nil): skip — the event contributes no line. Skipping every event but the
+//     final answer yields a final-result-only file.
+//   - (_, err): the write is abandoned and the output file is marked unreliable, so
+//     task_output reports the file's failed state instead of trusting a partial file.
+type AgentEventFormat[M adk.MessageType] func(ctx context.Context, event *adk.TypedAgentEvent[M]) (string, error)
+
+// outputFileFormatHint is the human-readable description of the default encoder's
+// output, surfaced to the launcher in the managed agent tool's background-run message
+// so the reader knows to interpret the file as JSONL.
+const outputFileFormatHint = `JSONL — one JSON object per line, each a materialized event {agent_name, message}; the message carries its own role and any tool calls/results.`
 
 // New creates a ChatModelAgentMiddleware that injects sub-agent tools into the agent context.
 //
@@ -137,7 +164,11 @@ func NewTyped[M adk.MessageType](ctx context.Context, config *TypedConfig[M]) (a
 	// Manager; without one it is a plain foreground spawn.
 	var at tool.BaseTool
 	if config.Background != nil && config.Background.Manager != nil {
-		at, err = newManagedAgentTool[M](config.Background.Manager, subAgentToolMap, config.Background.OutputStore, config.Background.OutputDir, toolName, desc)
+		at, err = newManagedAgentTool[M](config.Background.Manager, subAgentToolMap, agentOutput[M]{
+			store:     config.Background.OutputStore,
+			outputDir: config.Background.OutputDir,
+			format:    config.Background.EventFormat,
+		}, toolName, desc)
 	} else {
 		at, err = newAgentTool(subAgentToolMap, toolName, desc)
 	}

--- a/adk/middlewares/subagent/middleware.go
+++ b/adk/middlewares/subagent/middleware.go
@@ -73,10 +73,11 @@ type BackgroundConfig struct {
 	Manager *backgroundtask.Manager
 
 	// OutputStore and OutputDir, when both set, give every managed sub-agent run an
-	// output file at OutputDir/<id>.output. The managed agent tool appends the
-	// sub-agent's final result there on completion and records the path on
-	// Task.OutputFile, so a backgrounded run's result is retrievable by path (and
-	// large results need not be inlined). The Manager itself never writes.
+	// output file at OutputDir/<id>.output. The managed agent tool streams textual
+	// output from the sub-agent's AgentEvents there as they arrive and records the
+	// path on Task.OutputFile, so a backgrounded run's interim and final output is
+	// retrievable by path (and large results need not be inlined). The Manager
+	// itself never writes.
 	// OutputStore is a filesystem.AppendOpener (filesystem.InMemoryBackend
 	// implements it); output files require one. When either is unset, runs have no
 	// output file.
@@ -134,7 +135,7 @@ func NewTyped[M adk.MessageType](ctx context.Context, config *TypedConfig[M]) (a
 	// Manager; without one it is a plain foreground spawn.
 	var at tool.BaseTool
 	if config.Background != nil && config.Background.Manager != nil {
-		at, err = newManagedAgentTool(config.Background.Manager, subAgentToolMap, config.Background.OutputStore, config.Background.OutputDir, toolName, desc)
+		at, err = newManagedAgentTool[M](config.Background.Manager, subAgentToolMap, config.Background.OutputStore, config.Background.OutputDir, toolName, desc)
 	} else {
 		at, err = newAgentTool(subAgentToolMap, toolName, desc)
 	}

--- a/adk/middlewares/subagent/middleware.go
+++ b/adk/middlewares/subagent/middleware.go
@@ -73,11 +73,13 @@ type BackgroundConfig struct {
 	Manager *backgroundtask.Manager
 
 	// OutputStore and OutputDir, when both set, give every managed sub-agent run an
-	// output file at OutputDir/<id>.output. The managed agent tool streams textual
-	// output from the sub-agent's AgentEvents there as they arrive and records the
-	// path on Task.OutputFile, so a backgrounded run's interim and final output is
-	// retrievable by path (and large results need not be inlined). The Manager
-	// itself never writes.
+	// output file at OutputDir/<id>.output. The managed agent tool appends one JSONL
+	// record for each materialized AgentEvent and records the path on Task.OutputFile,
+	// so a backgrounded run's interim and final output is retrievable by path (and
+	// large results need not be inlined). The path is allocated before the run and
+	// the file is created lazily by the work callback's single append session, so a
+	// newly returned background task may briefly advertise the path before it exists.
+	// The Manager itself never writes.
 	// OutputStore is a filesystem.AppendOpener (filesystem.InMemoryBackend
 	// implements it); output files require one. When either is unset, runs have no
 	// output file.

--- a/adk/middlewares/subagent/middleware.go
+++ b/adk/middlewares/subagent/middleware.go
@@ -77,9 +77,10 @@ type BackgroundConfig struct {
 	// sub-agent's final result there on completion and records the path on
 	// Task.OutputFile, so a backgrounded run's result is retrievable by path (and
 	// large results need not be inlined). The Manager itself never writes.
-	// OutputStore is a filesystem.Appender (filesystem.InMemoryBackend implements
-	// it); output files require one. When either is unset, runs have no output file.
-	OutputStore filesystem.Appender
+	// OutputStore is a filesystem.StreamAppender (filesystem.InMemoryBackend
+	// implements it); output files require one. When either is unset, runs have no
+	// output file.
+	OutputStore filesystem.StreamAppender
 	OutputDir   string
 }
 

--- a/adk/middlewares/subagent/middleware.go
+++ b/adk/middlewares/subagent/middleware.go
@@ -55,15 +55,19 @@ type TypedConfig[M adk.MessageType] struct {
 	// Background configures background-task execution for sub-agent runs. When nil,
 	// only foreground (blocking) agent execution is available and runs are NOT
 	// tracked. See BackgroundConfig.
-	Background *BackgroundConfig[M]
+	Background *TypedBackgroundConfig[M]
 }
 
-// BackgroundConfig enables background-task execution for the agent tool.
+// BackgroundConfig enables background-task execution for the standard
+// *schema.Message agent tool.
+type BackgroundConfig = TypedBackgroundConfig[*schema.Message]
+
+// TypedBackgroundConfig enables background-task execution for the agent tool.
 //
 // When set, ALL agent runs (foreground and background) are managed by the Manager,
 // making them visible via Get/List, and the Agent tool gains a run_in_background
 // parameter.
-type BackgroundConfig[M adk.MessageType] struct {
+type TypedBackgroundConfig[M adk.MessageType] struct {
 	// Manager is the shared background-task Manager. Required (a nil Manager is the
 	// same as no BackgroundConfig). It may be shared with other middlewares (e.g.
 	// filesystem) so a single task-ID space spans agent and shell runs. The
@@ -79,13 +83,15 @@ type BackgroundConfig[M adk.MessageType] struct {
 	// lazily by the work callback, so a newly returned background task may briefly
 	// advertise the path before it exists. The Manager itself never writes.
 	//
-	// The file is JSON Lines: one record per line, appended as each AgentEvent
-	// materializes, so a backgrounded run's interim output is visible before it
-	// completes. EventFormat encodes each event into its line (see AgentEventFormat);
-	// when nil the default encoder is used, which writes {"type","agent_name",
-	// "message"} with the event's message (root Extra stripped) and a "type" naming
-	// the event kind. A custom EventFormat may reshape or skip events — e.g. skipping
-	// everything but the final assistant answer to get a final-result-only file.
+	// The output file is line-oriented: one line per materialized AgentEvent,
+	// appended as events arrive so a backgrounded run's interim output is visible
+	// before it completes. EventFormat encodes each event into its line (see
+	// AgentEventFormat) and therefore defines the file's actual format. When
+	// EventFormat is nil, the default encoder writes one JSON object per line (JSONL):
+	// {agent_name, message}, with the event's message (root Extra stripped) carrying
+	// its own role and any tool calls/results — no separate type field. A custom
+	// EventFormat may emit any per-line text and may skip events — e.g. skipping every
+	// event but the final assistant answer to get a final-result-only file.
 	//
 	// OutputStore is a filesystem.AppendOpener (filesystem.InMemoryBackend
 	// implements it); output files require one. When either is unset, runs have no

--- a/adk/middlewares/subagent/middleware_test.go
+++ b/adk/middlewares/subagent/middleware_test.go
@@ -27,6 +27,7 @@ import (
 	"github.com/cloudwego/eino/adk"
 	"github.com/cloudwego/eino/adk/backgroundtask"
 	"github.com/cloudwego/eino/adk/filesystem"
+	"github.com/cloudwego/eino/adk/internal/agenttool"
 	"github.com/cloudwego/eino/components/tool"
 	"github.com/cloudwego/eino/schema"
 )
@@ -78,6 +79,28 @@ func (m *mockAgent) Run(ctx context.Context, input *adk.AgentInput, options ...a
 
 	gen.Send(adk.EventFromMessage(schema.UserMessage(result), nil, schema.User, ""))
 	gen.Close()
+	return iter
+}
+
+type stagedAgent struct {
+	release <-chan struct{}
+}
+
+func (s *stagedAgent) Name(context.Context) string        { return "staged" }
+func (s *stagedAgent) Description(context.Context) string { return "staged agent" }
+func (s *stagedAgent) Run(context.Context, *adk.AgentInput, ...adk.AgentRunOption) *adk.AsyncIterator[*adk.AgentEvent] {
+	iter, gen := adk.NewAsyncIteratorPair[*adk.AgentEvent]()
+	stream, writer := schema.Pipe[*schema.Message](0)
+	go func() {
+		gen.Send(adk.EventFromMessage(nil, stream, schema.Assistant, ""))
+		gen.Close()
+	}()
+	go func() {
+		writer.Send(schema.AssistantMessage("first", nil), nil)
+		<-s.release
+		writer.Send(schema.AssistantMessage("second", nil), nil)
+		writer.Close()
+	}()
 	return iter
 }
 
@@ -264,7 +287,7 @@ func TestAgentTool_Background(t *testing.T) {
 	}
 
 	mw, err := New(ctx, &Config{
-		SubAgents: []adk.Agent{slowAgent},
+		SubAgents:  []adk.Agent{slowAgent},
 		Background: &BackgroundConfig{Manager: mgr},
 	})
 	require.NoError(t, err)
@@ -341,7 +364,7 @@ func TestAgentTool_ForegroundWithTaskMgr(t *testing.T) {
 	agent := &mockAgent{name: "fast", desc: "fast agent"}
 
 	mw, err := New(ctx, &Config{
-		SubAgents: []adk.Agent{agent},
+		SubAgents:  []adk.Agent{agent},
 		Background: &BackgroundConfig{Manager: mgr},
 	})
 	require.NoError(t, err)
@@ -366,7 +389,7 @@ func TestAgentTool_ForegroundWithTaskMgr(t *testing.T) {
 }
 
 // With OutputStore and OutputDir configured, a completed managed agent run writes
-// its final result to the task's output file.
+// its AgentEvent output to the task's output file.
 func TestAgentTool_WritesOutputFile(t *testing.T) {
 	ctx := context.Background()
 	backend := filesystem.NewInMemoryBackend()
@@ -405,6 +428,73 @@ func TestAgentTool_WritesOutputFile(t *testing.T) {
 	assert.Equal(t, "fast agent", got.Content)
 }
 
+func TestAgentTool_WritesInterimEventsWithoutParentReceiver(t *testing.T) {
+	ctx := context.Background()
+	backend := filesystem.NewInMemoryBackend()
+	mgr := backgroundtask.New(context.Background(), &backgroundtask.Config{})
+	defer func() {
+		closeCtx, cancel := context.WithTimeout(context.Background(), time.Second)
+		defer cancel()
+		_ = mgr.Close(closeCtx)
+	}()
+
+	release := make(chan struct{})
+	mw, err := New(ctx, &Config{
+		SubAgents: []adk.Agent{&stagedAgent{release: release}},
+		Background: &BackgroundConfig{
+			Manager:     mgr,
+			OutputStore: backend,
+			OutputDir:   "/tasks",
+		},
+	})
+	require.NoError(t, err)
+
+	runCtx := &adk.ChatModelAgentContext[*schema.Message]{}
+	_, newRunCtx, err := mw.BeforeAgent(ctx, runCtx)
+	require.NoError(t, err)
+	at := newRunCtx.Tools[0].(tool.InvokableTool)
+
+	result, err := at.InvokableRun(ctx, `{"subagent_type":"staged","prompt":"task detail","description":"task","run_in_background":true}`)
+	require.NoError(t, err)
+	assert.Contains(t, result, "running in background")
+
+	tasks := mgr.List()
+	require.Len(t, tasks, 1)
+	path := tasks[0].OutputFile
+	require.NotEmpty(t, path)
+	require.Eventually(t, func() bool {
+		got, readErr := backend.Read(ctx, &filesystem.ReadRequest{FilePath: path})
+		return readErr == nil && got.Content == "first"
+	}, time.Second, 10*time.Millisecond)
+	assert.True(t, anyRunning(mgr), "the first AgentEvent should be visible before task completion")
+
+	close(release)
+	waitAllTasks(t, mgr)
+	got, err := backend.Read(ctx, &filesystem.ReadRequest{FilePath: path})
+	require.NoError(t, err)
+	assert.Equal(t, "firstsecond", got.Content)
+}
+
+func TestManagedEventReceiverTransform_GatesOnlyParentReceivers(t *testing.T) {
+	backgrounded := make(chan struct{})
+	close(backgrounded)
+
+	var parentEvents, taskEvents int
+	transform := managedEventReceiverTransform(backgrounded, agenttool.EventReceiver[int](func(int) {
+		taskEvents++
+	}))
+	receivers := transform([]agenttool.EventReceiver[int]{func(int) {
+		parentEvents++
+	}})
+
+	require.Len(t, receivers, 2)
+	for _, receiver := range receivers {
+		receiver(1)
+	}
+	assert.Zero(t, parentEvents)
+	assert.Equal(t, 1, taskEvents)
+}
+
 // --- Auto-background ---
 
 func TestAgentTool_AutoBackground(t *testing.T) {
@@ -429,7 +519,7 @@ func TestAgentTool_AutoBackground(t *testing.T) {
 	}
 
 	mw, err := New(ctx, &Config{
-		SubAgents: []adk.Agent{slowAgent},
+		SubAgents:  []adk.Agent{slowAgent},
 		Background: &BackgroundConfig{Manager: mgr},
 	})
 	require.NoError(t, err)
@@ -469,7 +559,7 @@ func TestAgentTool_AutoBackground_FastAgent(t *testing.T) {
 	fastAgent := &mockAgent{name: "fast", desc: "fast agent"}
 
 	mw, err := New(ctx, &Config{
-		SubAgents: []adk.Agent{fastAgent},
+		SubAgents:  []adk.Agent{fastAgent},
 		Background: &BackgroundConfig{Manager: mgr},
 	})
 	require.NoError(t, err)

--- a/adk/middlewares/subagent/middleware_test.go
+++ b/adk/middlewares/subagent/middleware_test.go
@@ -119,11 +119,11 @@ type outputEventRecord struct {
 
 type countingAppendStore struct {
 	backend *filesystem.InMemoryBackend
-	opens   atomic.Int32
+	opens   int32
 }
 
 func (s *countingAppendStore) OpenAppend(ctx context.Context, req *filesystem.OpenAppendRequest) (io.WriteCloser, error) {
-	s.opens.Add(1)
+	atomic.AddInt32(&s.opens, 1)
 	return s.backend.OpenAppend(ctx, req)
 }
 
@@ -463,7 +463,7 @@ func TestAgentTool_WritesOutputFile(t *testing.T) {
 
 	got, err := backend.Read(ctx, &filesystem.ReadRequest{FilePath: path})
 	require.NoError(t, err)
-	assert.EqualValues(t, 1, store.opens.Load(), "one append session should create and write the output file")
+	assert.EqualValues(t, 1, atomic.LoadInt32(&store.opens), "one append session should create and write the output file")
 	records := decodeOutputEventRecords(t, got.Content)
 	require.Len(t, records, 1)
 	assert.Equal(t, "message", records[0].Type)

--- a/adk/middlewares/subagent/middleware_test.go
+++ b/adk/middlewares/subagent/middleware_test.go
@@ -521,26 +521,32 @@ func TestAgentTool_WritesInterimEventsWithoutParentReceiver(t *testing.T) {
 	assert.Equal(t, "firstsecond", records[0].Message["content"])
 }
 
-func TestSanitizedMessageValue_RemovesExtraFields(t *testing.T) {
+func TestSanitizedMessageValue_RemovesOnlyRootExtra(t *testing.T) {
 	t.Run("message", func(t *testing.T) {
-		value := sanitizedMessageValue(&schema.Message{
+		original := &schema.Message{
 			Role:    schema.Assistant,
 			Content: "answer",
 			Extra:   map[string]any{"not_json": func() {}},
 			UserInputMultiContent: []schema.MessageInputPart{{
 				Type:  schema.ChatMessagePartTypeText,
 				Text:  "nested",
-				Extra: map[string]any{"not_json": func() {}},
+				Extra: map[string]any{"provider": "kept"},
 			}},
-		})
+		}
+		value := sanitizedMessageValue(original).(adk.Message)
+		assert.NotSame(t, original, value)
+		assert.Nil(t, value.Extra)
+		assert.Equal(t, map[string]any{"provider": "kept"}, value.UserInputMultiContent[0].Extra)
+		assert.NotNil(t, original.Extra)
+
 		data, err := sonic.Marshal(value)
 		require.NoError(t, err)
-		assert.NotContains(t, string(data), `"extra"`)
+		assert.Contains(t, string(data), `"extra":{"provider":"kept"}`)
 		assert.Contains(t, string(data), `"answer"`)
 	})
 
 	t.Run("agentic message", func(t *testing.T) {
-		value := sanitizedMessageValue(&schema.AgenticMessage{
+		original := &schema.AgenticMessage{
 			Role:  schema.AgenticRoleTypeAssistant,
 			Extra: map[string]any{"not_json": func() {}},
 			ResponseMeta: &schema.AgenticResponseMeta{
@@ -553,12 +559,18 @@ func TestSanitizedMessageValue_RemovesExtraFields(t *testing.T) {
 			ContentBlocks: []*schema.ContentBlock{{
 				Type:             schema.ContentBlockTypeAssistantGenText,
 				AssistantGenText: &schema.AssistantGenText{Text: "answer"},
-				Extra:            map[string]any{"not_json": func() {}},
+				Extra:            map[string]any{"provider": "kept"},
 			}},
-		})
+		}
+		value := sanitizedMessageValue(original).(adk.AgenticMessage)
+		assert.NotSame(t, original, value)
+		assert.Nil(t, value.Extra)
+		assert.Equal(t, map[string]any{"provider": "kept"}, value.ContentBlocks[0].Extra)
+		assert.NotNil(t, original.Extra)
+
 		data, err := sonic.Marshal(value)
 		require.NoError(t, err)
-		assert.NotContains(t, string(data), `"extra"`)
+		assert.Contains(t, string(data), `"extra":{"provider":"kept"}`)
 		assert.Contains(t, string(data), `"openai_extension":{"id":"response-id"}`)
 		assert.Contains(t, string(data), `"extension":{"provider":"kept"}`)
 		assert.Contains(t, string(data), `"token_usage"`)

--- a/adk/middlewares/subagent/middleware_test.go
+++ b/adk/middlewares/subagent/middleware_test.go
@@ -215,7 +215,7 @@ func TestBeforeAgent_WithManager_InjectsAgentToolOnly(t *testing.T) {
 		SubAgents: []adk.Agent{
 			&mockAgent{name: "worker", desc: "does work"},
 		},
-		Background: &BackgroundConfig[*schema.Message]{Manager: mgr},
+		Background: &BackgroundConfig{Manager: mgr},
 	})
 	require.NoError(t, err)
 
@@ -324,7 +324,7 @@ func TestAgentTool_Background(t *testing.T) {
 
 	mw, err := New(ctx, &Config{
 		SubAgents:  []adk.Agent{slowAgent},
-		Background: &BackgroundConfig[*schema.Message]{Manager: mgr},
+		Background: &BackgroundConfig{Manager: mgr},
 	})
 	require.NoError(t, err)
 
@@ -401,7 +401,7 @@ func TestAgentTool_ForegroundWithTaskMgr(t *testing.T) {
 
 	mw, err := New(ctx, &Config{
 		SubAgents:  []adk.Agent{agent},
-		Background: &BackgroundConfig[*schema.Message]{Manager: mgr},
+		Background: &BackgroundConfig{Manager: mgr},
 	})
 	require.NoError(t, err)
 
@@ -439,7 +439,7 @@ func TestAgentTool_WritesOutputFile(t *testing.T) {
 
 	mw, err := New(ctx, &Config{
 		SubAgents: []adk.Agent{&mockAgent{name: "fast", desc: "fast agent"}},
-		Background: &BackgroundConfig[*schema.Message]{
+		Background: &BackgroundConfig{
 			Manager:     mgr,
 			OutputStore: store,
 			OutputDir:   "/tasks",
@@ -494,7 +494,7 @@ func TestAgentTool_CustomEventFormat(t *testing.T) {
 
 	mw, err := New(ctx, &Config{
 		SubAgents: []adk.Agent{&mockAgent{name: "fast", desc: "fast agent"}},
-		Background: &BackgroundConfig[*schema.Message]{
+		Background: &BackgroundConfig{
 			Manager:     mgr,
 			OutputStore: backend,
 			OutputDir:   "/tasks",
@@ -536,7 +536,7 @@ func TestAgentTool_EventFormatSkipsAll(t *testing.T) {
 
 	mw, err := New(ctx, &Config{
 		SubAgents: []adk.Agent{&mockAgent{name: "fast", desc: "fast agent"}},
-		Background: &BackgroundConfig[*schema.Message]{
+		Background: &BackgroundConfig{
 			Manager:     mgr,
 			OutputStore: backend,
 			OutputDir:   "/tasks",
@@ -576,7 +576,7 @@ func TestAgentTool_DefaultFormatAdvertisesHint(t *testing.T) {
 
 	mw, err := New(ctx, &Config{
 		SubAgents: []adk.Agent{&mockAgent{name: "fast", desc: "fast agent"}},
-		Background: &BackgroundConfig[*schema.Message]{
+		Background: &BackgroundConfig{
 			Manager:     mgr,
 			OutputStore: backend,
 			OutputDir:   "/tasks",
@@ -608,7 +608,7 @@ func TestAgentTool_WritesInterimEventsWithoutParentReceiver(t *testing.T) {
 	firstSent := make(chan struct{})
 	mw, err := New(ctx, &Config{
 		SubAgents: []adk.Agent{&stagedAgent{release: release, firstSent: firstSent}},
-		Background: &BackgroundConfig[*schema.Message]{
+		Background: &BackgroundConfig{
 			Manager:     mgr,
 			OutputStore: backend,
 			OutputDir:   "/tasks",
@@ -746,7 +746,7 @@ func TestAgentTool_AutoBackground(t *testing.T) {
 
 	mw, err := New(ctx, &Config{
 		SubAgents:  []adk.Agent{slowAgent},
-		Background: &BackgroundConfig[*schema.Message]{Manager: mgr},
+		Background: &BackgroundConfig{Manager: mgr},
 	})
 	require.NoError(t, err)
 
@@ -786,7 +786,7 @@ func TestAgentTool_AutoBackground_FastAgent(t *testing.T) {
 
 	mw, err := New(ctx, &Config{
 		SubAgents:  []adk.Agent{fastAgent},
-		Background: &BackgroundConfig[*schema.Message]{Manager: mgr},
+		Background: &BackgroundConfig{Manager: mgr},
 	})
 	require.NoError(t, err)
 

--- a/adk/middlewares/subagent/middleware_test.go
+++ b/adk/middlewares/subagent/middleware_test.go
@@ -18,9 +18,13 @@ package subagent
 
 import (
 	"context"
+	"io"
+	"strings"
+	"sync/atomic"
 	"testing"
 	"time"
 
+	"github.com/bytedance/sonic"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
@@ -30,6 +34,7 @@ import (
 	"github.com/cloudwego/eino/adk/internal/agenttool"
 	"github.com/cloudwego/eino/components/tool"
 	"github.com/cloudwego/eino/schema"
+	"github.com/cloudwego/eino/schema/openai"
 )
 
 // --- Mock Agent ---
@@ -83,7 +88,8 @@ func (m *mockAgent) Run(ctx context.Context, input *adk.AgentInput, options ...a
 }
 
 type stagedAgent struct {
-	release <-chan struct{}
+	release   <-chan struct{}
+	firstSent chan<- struct{}
 }
 
 func (s *stagedAgent) Name(context.Context) string        { return "staged" }
@@ -97,11 +103,42 @@ func (s *stagedAgent) Run(context.Context, *adk.AgentInput, ...adk.AgentRunOptio
 	}()
 	go func() {
 		writer.Send(schema.AssistantMessage("first", nil), nil)
+		close(s.firstSent)
 		<-s.release
 		writer.Send(schema.AssistantMessage("second", nil), nil)
 		writer.Close()
 	}()
 	return iter
+}
+
+type outputEventRecord struct {
+	Type      string         `json:"type"`
+	AgentName string         `json:"agent_name"`
+	Message   map[string]any `json:"message"`
+}
+
+type countingAppendStore struct {
+	backend *filesystem.InMemoryBackend
+	opens   atomic.Int32
+}
+
+func (s *countingAppendStore) OpenAppend(ctx context.Context, req *filesystem.OpenAppendRequest) (io.WriteCloser, error) {
+	s.opens.Add(1)
+	return s.backend.OpenAppend(ctx, req)
+}
+
+func decodeOutputEventRecords(t *testing.T, content string) []outputEventRecord {
+	t.Helper()
+	content = strings.TrimSpace(content)
+	if content == "" {
+		return nil
+	}
+	lines := strings.Split(content, "\n")
+	records := make([]outputEventRecord, len(lines))
+	for i, line := range lines {
+		require.NoError(t, sonic.UnmarshalString(line, &records[i]))
+	}
+	return records
 }
 
 // --- Config Validation Tests ---
@@ -393,6 +430,7 @@ func TestAgentTool_ForegroundWithTaskMgr(t *testing.T) {
 func TestAgentTool_WritesOutputFile(t *testing.T) {
 	ctx := context.Background()
 	backend := filesystem.NewInMemoryBackend()
+	store := &countingAppendStore{backend: backend}
 	mgr := backgroundtask.New(context.Background(), &backgroundtask.Config{})
 	defer func() {
 		closeCtx, cancel := context.WithTimeout(context.Background(), time.Second)
@@ -404,7 +442,7 @@ func TestAgentTool_WritesOutputFile(t *testing.T) {
 		SubAgents: []adk.Agent{&mockAgent{name: "fast", desc: "fast agent"}},
 		Background: &BackgroundConfig{
 			Manager:     mgr,
-			OutputStore: backend,
+			OutputStore: store,
 			OutputDir:   "/tasks",
 		},
 	})
@@ -425,7 +463,12 @@ func TestAgentTool_WritesOutputFile(t *testing.T) {
 
 	got, err := backend.Read(ctx, &filesystem.ReadRequest{FilePath: path})
 	require.NoError(t, err)
-	assert.Equal(t, "fast agent", got.Content)
+	assert.EqualValues(t, 1, store.opens.Load(), "one append session should create and write the output file")
+	records := decodeOutputEventRecords(t, got.Content)
+	require.Len(t, records, 1)
+	assert.Equal(t, "message", records[0].Type)
+	assert.Equal(t, "fast agent", records[0].Message["content"])
+	assert.Equal(t, string(schema.User), records[0].Message["role"])
 }
 
 func TestAgentTool_WritesInterimEventsWithoutParentReceiver(t *testing.T) {
@@ -439,8 +482,9 @@ func TestAgentTool_WritesInterimEventsWithoutParentReceiver(t *testing.T) {
 	}()
 
 	release := make(chan struct{})
+	firstSent := make(chan struct{})
 	mw, err := New(ctx, &Config{
-		SubAgents: []adk.Agent{&stagedAgent{release: release}},
+		SubAgents: []adk.Agent{&stagedAgent{release: release, firstSent: firstSent}},
 		Background: &BackgroundConfig{
 			Manager:     mgr,
 			OutputStore: backend,
@@ -462,17 +506,64 @@ func TestAgentTool_WritesInterimEventsWithoutParentReceiver(t *testing.T) {
 	require.Len(t, tasks, 1)
 	path := tasks[0].OutputFile
 	require.NotEmpty(t, path)
-	require.Eventually(t, func() bool {
-		got, readErr := backend.Read(ctx, &filesystem.ReadRequest{FilePath: path})
-		return readErr == nil && got.Content == "first"
-	}, time.Second, 10*time.Millisecond)
-	assert.True(t, anyRunning(mgr), "the first AgentEvent should be visible before task completion")
+	<-firstSent
+	got, err := backend.Read(ctx, &filesystem.ReadRequest{FilePath: path})
+	require.NoError(t, err)
+	assert.Empty(t, got.Content, "a streaming AgentEvent is written after GetMessage materializes it")
+	assert.True(t, anyRunning(mgr))
 
 	close(release)
 	waitAllTasks(t, mgr)
-	got, err := backend.Read(ctx, &filesystem.ReadRequest{FilePath: path})
+	got, err = backend.Read(ctx, &filesystem.ReadRequest{FilePath: path})
 	require.NoError(t, err)
-	assert.Equal(t, "firstsecond", got.Content)
+	records := decodeOutputEventRecords(t, got.Content)
+	require.Len(t, records, 1)
+	assert.Equal(t, "firstsecond", records[0].Message["content"])
+}
+
+func TestSanitizedMessageValue_RemovesExtraFields(t *testing.T) {
+	t.Run("message", func(t *testing.T) {
+		value := sanitizedMessageValue(&schema.Message{
+			Role:    schema.Assistant,
+			Content: "answer",
+			Extra:   map[string]any{"not_json": func() {}},
+			UserInputMultiContent: []schema.MessageInputPart{{
+				Type:  schema.ChatMessagePartTypeText,
+				Text:  "nested",
+				Extra: map[string]any{"not_json": func() {}},
+			}},
+		})
+		data, err := sonic.Marshal(value)
+		require.NoError(t, err)
+		assert.NotContains(t, string(data), `"extra"`)
+		assert.Contains(t, string(data), `"answer"`)
+	})
+
+	t.Run("agentic message", func(t *testing.T) {
+		value := sanitizedMessageValue(&schema.AgenticMessage{
+			Role:  schema.AgenticRoleTypeAssistant,
+			Extra: map[string]any{"not_json": func() {}},
+			ResponseMeta: &schema.AgenticResponseMeta{
+				TokenUsage: &schema.TokenUsage{TotalTokens: 1},
+				OpenAIExtension: &openai.ResponseMetaExtension{
+					ID: "response-id",
+				},
+				Extension: map[string]any{"provider": "kept"},
+			},
+			ContentBlocks: []*schema.ContentBlock{{
+				Type:             schema.ContentBlockTypeAssistantGenText,
+				AssistantGenText: &schema.AssistantGenText{Text: "answer"},
+				Extra:            map[string]any{"not_json": func() {}},
+			}},
+		})
+		data, err := sonic.Marshal(value)
+		require.NoError(t, err)
+		assert.NotContains(t, string(data), `"extra"`)
+		assert.Contains(t, string(data), `"openai_extension":{"id":"response-id"}`)
+		assert.Contains(t, string(data), `"extension":{"provider":"kept"}`)
+		assert.Contains(t, string(data), `"token_usage"`)
+		assert.Contains(t, string(data), `"answer"`)
+	})
 }
 
 func TestManagedEventReceiverTransform_GatesOnlyParentReceivers(t *testing.T) {

--- a/adk/middlewares/subagent/middleware_test.go
+++ b/adk/middlewares/subagent/middleware_test.go
@@ -112,7 +112,6 @@ func (s *stagedAgent) Run(context.Context, *adk.AgentInput, ...adk.AgentRunOptio
 }
 
 type outputEventRecord struct {
-	Type      string         `json:"type"`
 	AgentName string         `json:"agent_name"`
 	Message   map[string]any `json:"message"`
 }
@@ -216,7 +215,7 @@ func TestBeforeAgent_WithManager_InjectsAgentToolOnly(t *testing.T) {
 		SubAgents: []adk.Agent{
 			&mockAgent{name: "worker", desc: "does work"},
 		},
-		Background: &BackgroundConfig{Manager: mgr},
+		Background: &BackgroundConfig[*schema.Message]{Manager: mgr},
 	})
 	require.NoError(t, err)
 
@@ -325,7 +324,7 @@ func TestAgentTool_Background(t *testing.T) {
 
 	mw, err := New(ctx, &Config{
 		SubAgents:  []adk.Agent{slowAgent},
-		Background: &BackgroundConfig{Manager: mgr},
+		Background: &BackgroundConfig[*schema.Message]{Manager: mgr},
 	})
 	require.NoError(t, err)
 
@@ -402,7 +401,7 @@ func TestAgentTool_ForegroundWithTaskMgr(t *testing.T) {
 
 	mw, err := New(ctx, &Config{
 		SubAgents:  []adk.Agent{agent},
-		Background: &BackgroundConfig{Manager: mgr},
+		Background: &BackgroundConfig[*schema.Message]{Manager: mgr},
 	})
 	require.NoError(t, err)
 
@@ -426,7 +425,7 @@ func TestAgentTool_ForegroundWithTaskMgr(t *testing.T) {
 }
 
 // With OutputStore and OutputDir configured, a completed managed agent run writes
-// its AgentEvent output to the task's output file.
+// its events to the output file via the default encoder (one JSON record per line).
 func TestAgentTool_WritesOutputFile(t *testing.T) {
 	ctx := context.Background()
 	backend := filesystem.NewInMemoryBackend()
@@ -440,10 +439,11 @@ func TestAgentTool_WritesOutputFile(t *testing.T) {
 
 	mw, err := New(ctx, &Config{
 		SubAgents: []adk.Agent{&mockAgent{name: "fast", desc: "fast agent"}},
-		Background: &BackgroundConfig{
+		Background: &BackgroundConfig[*schema.Message]{
 			Manager:     mgr,
 			OutputStore: store,
 			OutputDir:   "/tasks",
+			// EventFormat omitted => default encoder (JSONL).
 		},
 	})
 	require.NoError(t, err)
@@ -466,9 +466,132 @@ func TestAgentTool_WritesOutputFile(t *testing.T) {
 	assert.EqualValues(t, 1, atomic.LoadInt32(&store.opens), "one append session should create and write the output file")
 	records := decodeOutputEventRecords(t, got.Content)
 	require.Len(t, records, 1)
-	assert.Equal(t, "message", records[0].Type)
+	assert.Equal(t, "fast", records[0].AgentName)
 	assert.Equal(t, "fast agent", records[0].Message["content"])
+	// The event kind is read from the message's own role, not a separate type field.
 	assert.Equal(t, string(schema.User), records[0].Message["role"])
+}
+
+// A custom EventFormat controls each line's bytes; the default format hint is not
+// advertised because the caller owns its own format.
+func TestAgentTool_CustomEventFormat(t *testing.T) {
+	ctx := context.Background()
+	backend := filesystem.NewInMemoryBackend()
+	mgr := backgroundtask.New(context.Background(), &backgroundtask.Config{})
+	defer func() {
+		closeCtx, cancel := context.WithTimeout(context.Background(), time.Second)
+		defer cancel()
+		_ = mgr.Close(closeCtx)
+	}()
+
+	format := func(_ context.Context, ev *adk.TypedAgentEvent[*schema.Message]) (string, error) {
+		msg, err := ev.Output.MessageOutput.GetMessage()
+		if err != nil {
+			return "", err
+		}
+		return "LINE:" + msg.Content, nil
+	}
+
+	mw, err := New(ctx, &Config{
+		SubAgents: []adk.Agent{&mockAgent{name: "fast", desc: "fast agent"}},
+		Background: &BackgroundConfig[*schema.Message]{
+			Manager:     mgr,
+			OutputStore: backend,
+			OutputDir:   "/tasks",
+			EventFormat: format,
+		},
+	})
+	require.NoError(t, err)
+
+	runCtx := &adk.ChatModelAgentContext[*schema.Message]{}
+	_, newRunCtx, err := mw.BeforeAgent(ctx, runCtx)
+	require.NoError(t, err)
+	at := newRunCtx.Tools[0].(tool.InvokableTool)
+
+	_, err = at.InvokableRun(ctx, `{"subagent_type":"fast","prompt":"task detail","description":"task"}`)
+	require.NoError(t, err)
+
+	tasks := mgr.List()
+	require.Len(t, tasks, 1)
+	got, err := backend.Read(ctx, &filesystem.ReadRequest{FilePath: tasks[0].OutputFile})
+	require.NoError(t, err)
+	assert.Equal(t, "LINE:fast agent\n", got.Content)
+}
+
+// An EventFormat that returns the skip signal for every event yields an empty file
+// (the FinalText-style pattern: skip all but the events you want to keep).
+func TestAgentTool_EventFormatSkipsAll(t *testing.T) {
+	ctx := context.Background()
+	backend := filesystem.NewInMemoryBackend()
+	mgr := backgroundtask.New(context.Background(), &backgroundtask.Config{})
+	defer func() {
+		closeCtx, cancel := context.WithTimeout(context.Background(), time.Second)
+		defer cancel()
+		_ = mgr.Close(closeCtx)
+	}()
+
+	skipAll := func(context.Context, *adk.TypedAgentEvent[*schema.Message]) (string, error) {
+		return "", nil
+	}
+
+	mw, err := New(ctx, &Config{
+		SubAgents: []adk.Agent{&mockAgent{name: "fast", desc: "fast agent"}},
+		Background: &BackgroundConfig[*schema.Message]{
+			Manager:     mgr,
+			OutputStore: backend,
+			OutputDir:   "/tasks",
+			EventFormat: skipAll,
+		},
+	})
+	require.NoError(t, err)
+
+	runCtx := &adk.ChatModelAgentContext[*schema.Message]{}
+	_, newRunCtx, err := mw.BeforeAgent(ctx, runCtx)
+	require.NoError(t, err)
+	at := newRunCtx.Tools[0].(tool.InvokableTool)
+
+	out, err := at.InvokableRun(ctx, `{"subagent_type":"fast","prompt":"task detail","description":"task"}`)
+	require.NoError(t, err)
+	assert.Equal(t, "fast agent", out, "skipping lines does not affect the returned result")
+
+	tasks := mgr.List()
+	require.Len(t, tasks, 1)
+	got, err := backend.Read(ctx, &filesystem.ReadRequest{FilePath: tasks[0].OutputFile})
+	require.NoError(t, err)
+	assert.Empty(t, got.Content, "every event skipped => empty file")
+}
+
+// The default encoder's format is surfaced to the launcher in the background-run
+// message (a closed loop inside the subagent middleware), so the model knows to read
+// the file as JSONL. A custom encoder gets no such description.
+func TestAgentTool_DefaultFormatAdvertisesHint(t *testing.T) {
+	ctx := context.Background()
+	backend := filesystem.NewInMemoryBackend()
+	mgr := backgroundtask.New(context.Background(), &backgroundtask.Config{})
+	defer func() {
+		closeCtx, cancel := context.WithTimeout(context.Background(), time.Second)
+		defer cancel()
+		_ = mgr.Close(closeCtx)
+	}()
+
+	mw, err := New(ctx, &Config{
+		SubAgents: []adk.Agent{&mockAgent{name: "fast", desc: "fast agent"}},
+		Background: &BackgroundConfig[*schema.Message]{
+			Manager:     mgr,
+			OutputStore: backend,
+			OutputDir:   "/tasks",
+		},
+	})
+	require.NoError(t, err)
+
+	runCtx := &adk.ChatModelAgentContext[*schema.Message]{}
+	_, newRunCtx, err := mw.BeforeAgent(ctx, runCtx)
+	require.NoError(t, err)
+	at := newRunCtx.Tools[0].(tool.InvokableTool)
+
+	msg, err := at.InvokableRun(ctx, `{"subagent_type":"fast","prompt":"task detail","description":"task","run_in_background":true}`)
+	require.NoError(t, err)
+	assert.Contains(t, msg, "JSONL", "the background-run message describes the default JSONL format")
 }
 
 func TestAgentTool_WritesInterimEventsWithoutParentReceiver(t *testing.T) {
@@ -485,7 +608,7 @@ func TestAgentTool_WritesInterimEventsWithoutParentReceiver(t *testing.T) {
 	firstSent := make(chan struct{})
 	mw, err := New(ctx, &Config{
 		SubAgents: []adk.Agent{&stagedAgent{release: release, firstSent: firstSent}},
-		Background: &BackgroundConfig{
+		Background: &BackgroundConfig[*schema.Message]{
 			Manager:     mgr,
 			OutputStore: backend,
 			OutputDir:   "/tasks",
@@ -623,7 +746,7 @@ func TestAgentTool_AutoBackground(t *testing.T) {
 
 	mw, err := New(ctx, &Config{
 		SubAgents:  []adk.Agent{slowAgent},
-		Background: &BackgroundConfig{Manager: mgr},
+		Background: &BackgroundConfig[*schema.Message]{Manager: mgr},
 	})
 	require.NoError(t, err)
 
@@ -663,7 +786,7 @@ func TestAgentTool_AutoBackground_FastAgent(t *testing.T) {
 
 	mw, err := New(ctx, &Config{
 		SubAgents:  []adk.Agent{fastAgent},
-		Background: &BackgroundConfig{Manager: mgr},
+		Background: &BackgroundConfig[*schema.Message]{Manager: mgr},
 	})
 	require.NoError(t, err)
 

--- a/adk/prebuilt/deep/deep.go
+++ b/adk/prebuilt/deep/deep.go
@@ -44,6 +44,11 @@ func init() {
 // agent. When set, shell commands and sub-agent runs can execute as managed
 // background tasks under one task-ID space, and the task_output/task_stop control
 // tools are injected once.
+//
+// It holds only configuration shared by both task kinds (shell and sub-agent). Knobs
+// that apply to only one kind — e.g. a custom sub-agent event encoder
+// (subagent.AgentEventFormat) — are intentionally not exposed here; compose the
+// subagent middleware directly when you need them.
 type BackgroundConfig struct {
 	// Manager is the shared background-task Manager. Required (a nil Manager is the
 	// same as no BackgroundConfig).
@@ -52,11 +57,11 @@ type BackgroundConfig struct {
 	// OutputDir, when set together with Config.Backend, gives every managed
 	// background task (shell command or sub-agent run) an output file under this
 	// directory. Shell runs tee their output there as it streams (interim output);
-	// sub-agent runs append materialized AgentEvents as JSONL. The path is recorded on
-	// Task.OutputFile and surfaced when the task is launched in the background, so a
-	// backgrounded task's output is retrievable by path. Sub-agent output files are
-	// created lazily, so the path may briefly be visible before the file exists. When
-	// empty, tasks have no output file.
+	// sub-agent runs write one JSON line per materialized event (the default encoder).
+	// The path is recorded on Task.OutputFile and surfaced when the task is launched
+	// in the background, so a backgrounded task's output is retrievable by path.
+	// Sub-agent output files are created lazily, so the path may briefly be visible
+	// before the file exists. When empty, tasks have no output file.
 	OutputDir string
 }
 
@@ -185,10 +190,11 @@ func NewTyped[M adk.MessageType](ctx context.Context, cfg *TypedConfig[M]) (adk.
 				ToolDescriptionGenerator: cfg.TaskToolDescriptionGenerator,
 			}
 			if cfg.Background != nil && cfg.Background.Manager != nil {
-				subCfg.Background = &subagent.BackgroundConfig{
+				subCfg.Background = &subagent.BackgroundConfig[M]{
 					Manager:     cfg.Background.Manager,
 					OutputStore: backendAppendOpener(cfg.Backend),
 					OutputDir:   cfg.Background.OutputDir,
+					// EventFormat left nil => subagent's default encoder.
 				}
 			}
 			subagentMW, err := subagent.NewTyped[M](ctx, subCfg)

--- a/adk/prebuilt/deep/deep.go
+++ b/adk/prebuilt/deep/deep.go
@@ -186,7 +186,7 @@ func NewTyped[M adk.MessageType](ctx context.Context, cfg *TypedConfig[M]) (adk.
 			if cfg.Background != nil && cfg.Background.Manager != nil {
 				subCfg.Background = &subagent.BackgroundConfig{
 					Manager:     cfg.Background.Manager,
-					OutputStore: backendAppender(cfg.Backend),
+					OutputStore: backendStreamAppender(cfg.Backend),
 					OutputDir:   cfg.Background.OutputDir,
 				}
 			}
@@ -328,7 +328,7 @@ func buildTypedBuiltinAgentMiddlewares[M adk.MessageType](ctx context.Context, c
 		if background != nil && background.Manager != nil {
 			mwCfg.Background = &filesystem2.BackgroundConfig{
 				Manager:     background.Manager,
-				OutputStore: backendAppender(cfg.Backend),
+				OutputStore: backendStreamAppender(cfg.Backend),
 				OutputDir:   background.OutputDir,
 			}
 		}
@@ -342,12 +342,12 @@ func buildTypedBuiltinAgentMiddlewares[M adk.MessageType](ctx context.Context, c
 	return ms, nil
 }
 
-// backendAppender returns b as a filesystem.Appender when it supports incremental
-// append, or nil otherwise — in which case background tasks run without output
-// files. The default InMemoryBackend implements Appender.
-func backendAppender(b filesystem.Backend) filesystem.Appender {
-	ap, _ := b.(filesystem.Appender)
-	return ap
+// backendStreamAppender returns b as a filesystem.StreamAppender when it supports
+// incremental append, or nil otherwise — in which case background tasks run without
+// output files. The default InMemoryBackend implements StreamAppender.
+func backendStreamAppender(b filesystem.Backend) filesystem.StreamAppender {
+	sa, _ := b.(filesystem.StreamAppender)
+	return sa
 }
 
 type TODO struct {

--- a/adk/prebuilt/deep/deep.go
+++ b/adk/prebuilt/deep/deep.go
@@ -52,10 +52,11 @@ type BackgroundConfig struct {
 	// OutputDir, when set together with Config.Backend, gives every managed
 	// background task (shell command or sub-agent run) an output file under this
 	// directory. Shell runs tee their output there as it streams (interim output);
-	// sub-agent runs stream their AgentEvent output there. The path is recorded on
+	// sub-agent runs append materialized AgentEvents as JSONL. The path is recorded on
 	// Task.OutputFile and surfaced when the task is launched in the background, so a
-	// backgrounded task's output is retrievable by path. When empty, tasks have no
-	// output file.
+	// backgrounded task's output is retrievable by path. Sub-agent output files are
+	// created lazily, so the path may briefly be visible before the file exists. When
+	// empty, tasks have no output file.
 	OutputDir string
 }
 

--- a/adk/prebuilt/deep/deep.go
+++ b/adk/prebuilt/deep/deep.go
@@ -186,7 +186,7 @@ func NewTyped[M adk.MessageType](ctx context.Context, cfg *TypedConfig[M]) (adk.
 			if cfg.Background != nil && cfg.Background.Manager != nil {
 				subCfg.Background = &subagent.BackgroundConfig{
 					Manager:     cfg.Background.Manager,
-					OutputStore: backendStreamAppender(cfg.Backend),
+					OutputStore: backendAppendOpener(cfg.Backend),
 					OutputDir:   cfg.Background.OutputDir,
 				}
 			}
@@ -328,7 +328,7 @@ func buildTypedBuiltinAgentMiddlewares[M adk.MessageType](ctx context.Context, c
 		if background != nil && background.Manager != nil {
 			mwCfg.Background = &filesystem2.BackgroundConfig{
 				Manager:     background.Manager,
-				OutputStore: backendStreamAppender(cfg.Backend),
+				OutputStore: backendAppendOpener(cfg.Backend),
 				OutputDir:   background.OutputDir,
 			}
 		}
@@ -342,12 +342,12 @@ func buildTypedBuiltinAgentMiddlewares[M adk.MessageType](ctx context.Context, c
 	return ms, nil
 }
 
-// backendStreamAppender returns b as a filesystem.StreamAppender when it supports
+// backendAppendOpener returns b as a filesystem.AppendOpener when it supports
 // incremental append, or nil otherwise — in which case background tasks run without
-// output files. The default InMemoryBackend implements StreamAppender.
-func backendStreamAppender(b filesystem.Backend) filesystem.StreamAppender {
-	sa, _ := b.(filesystem.StreamAppender)
-	return sa
+// output files. The default InMemoryBackend implements AppendOpener.
+func backendAppendOpener(b filesystem.Backend) filesystem.AppendOpener {
+	ao, _ := b.(filesystem.AppendOpener)
+	return ao
 }
 
 type TODO struct {

--- a/adk/prebuilt/deep/deep.go
+++ b/adk/prebuilt/deep/deep.go
@@ -190,7 +190,7 @@ func NewTyped[M adk.MessageType](ctx context.Context, cfg *TypedConfig[M]) (adk.
 				ToolDescriptionGenerator: cfg.TaskToolDescriptionGenerator,
 			}
 			if cfg.Background != nil && cfg.Background.Manager != nil {
-				subCfg.Background = &subagent.BackgroundConfig[M]{
+				subCfg.Background = &subagent.TypedBackgroundConfig[M]{
 					Manager:     cfg.Background.Manager,
 					OutputStore: backendAppendOpener(cfg.Backend),
 					OutputDir:   cfg.Background.OutputDir,

--- a/adk/prebuilt/deep/deep.go
+++ b/adk/prebuilt/deep/deep.go
@@ -52,7 +52,7 @@ type BackgroundConfig struct {
 	// OutputDir, when set together with Config.Backend, gives every managed
 	// background task (shell command or sub-agent run) an output file under this
 	// directory. Shell runs tee their output there as it streams (interim output);
-	// sub-agent runs write their final result there. The path is recorded on
+	// sub-agent runs stream their AgentEvent output there. The path is recorded on
 	// Task.OutputFile and surfaced when the task is launched in the background, so a
 	// backgrounded task's output is retrievable by path. When empty, tasks have no
 	// output file.

--- a/adk/utils.go
+++ b/adk/utils.go
@@ -231,8 +231,10 @@ func (e *agentEventWrapper) consumeStream() {
 // - safe to set fields of TypedAgentEvent
 // - safe to extend RunPath
 // - safe to receive from MessageStream
+// - safe to set fields on SessionEventVariant and its Event / MessageStreamRef
 // NOTE: even if the event is copied, it's still not recommended to modify
-// the Message itself or Chunks of the MessageStream, as they are not copied.
+// the Message itself, nested SessionEvent payloads, or Chunks of the
+// MessageStream, as they are not copied.
 // NOTE: if you have CustomizedOutput or CustomizedAction, they are NOT copied.
 func copyTypedAgentEvent[M MessageType](ae *TypedAgentEvent[M]) *TypedAgentEvent[M] {
 	rp := make([]RunStep, len(ae.RunPath))
@@ -243,6 +245,18 @@ func copyTypedAgentEvent[M MessageType](ae *TypedAgentEvent[M]) *TypedAgentEvent
 		RunPath:   rp,
 		Action:    ae.Action,
 		Err:       ae.Err,
+	}
+	if variant := ae.SessionEventVariant; variant != nil {
+		copiedVariant := *variant
+		if variant.Event != nil {
+			copiedEvent := *variant.Event
+			copiedVariant.Event = &copiedEvent
+		}
+		if variant.MessageStreamRef != nil {
+			copiedRef := *variant.MessageStreamRef
+			copiedVariant.MessageStreamRef = &copiedRef
+		}
+		copied.SessionEventVariant = &copiedVariant
 	}
 
 	if ae.Output == nil {


### PR DESCRIPTION
#### What type of PR is this?

refactor

#### Check the PR title.

- [x] This PR title match the format: \<type\>(optional scope): \<description\>
- [x] The description of this PR title is user-oriented and clear enough for others to understand.
- [ ] Attach the PR updating the user documentation if the current PR requires user awareness at the usage level.

#### (Optional) Translate the PR title into Chinese.

refactor(adk): 通过追加写入会话流式输出后台任务结果

#### (Optional) More detailed description for this PR(en: English/zh: Chinese).

en:

**Motivation**

Background task output was written through `filesystem.Appender.Append`, one
call per chunk. Every chunk paid the full backend round-trip (lock, lookup,
whole-value rewrite for some backends), which does not scale for long-running
streaming tasks. Inner AgentTool events were also forwarded to a single
generator via an on/off `ForwardGate`, leaving no room to tee the same events
to an output file.

**What this PR does**

1. **`Appender` → `AppendOpener` (open-once session).** Replaces the per-call
   `Append(content)` with `OpenAppend(req) (io.WriteCloser, error)`: callers open
   one write-only tail-append session and stream chunks into it, so per-chunk
   backend latency is amortized over the session. The `io.WriteCloser` contract is
   specified explicitly — writes MAY buffer, a broken stream returns a sticky
   error, `Close` flushes and reports the first error, and a resource-holding
   backend MUST release on ctx-cancellation (callers do not guarantee `Close` on
   abandonment). Implementations SHOULD also implement `io.StringWriter`.

2. **`ForwardGate` → `EventReceiver` / `EventReceiverTransform`.** Generalizes
   inner-AgentTool event forwarding from a single generator to an ordered list of
   best-effort receivers built by transforms. This lets a managed run feed the
   parent generator *and* the output-file sink from the same event stream; after a
   task backgrounds, only the parent receivers are gated off while the output
   receiver keeps writing.

3. **Sub-agent output is now streamed as JSONL.** The managed agent tool writes
   one JSONL record per materialized `AgentEvent` (interim + final) through a
   single append session, instead of appending only the final result string on
   completion. The path is allocated up front and the file is created lazily by
   the work callback, so a freshly returned background task may briefly advertise
   the path before the file exists.

4. **`BackgroundStartupPreviewMs` (new `RunInput` field).** An explicitly
   backgrounded `RunStream` can keep the caller stream open for a bounded startup
   window and forward launch-time chunks (e.g. an OAuth URL) before appending the
   background notice. If the work finishes inside the window, all chunks are
   forwarded and the stream closes with no notice. The bash execute tool enables a
   1s preview by default.

5. **In-memory backend uses a per-file `strings.Builder`** so appends are linear
   rather than quadratic string concatenation; reads take the builder value under
   the read lock (writes hold the write lock), keeping it race-free.

6. Renames the internal "foreground budget" terminology to "foreground timeout"
   throughout for clarity (no behavior change).

**Compatibility**

`filesystem.Appender` / `AppendRequest` are removed in favor of
`AppendOpener` / `OpenAppendRequest`. Custom backends and any code referencing
`BackgroundConfig.OutputStore` must switch to `AppendOpener`. The default
`InMemoryBackend` already implements it. Sub-agent output files change format
from a plain final-result string to JSONL event records.

zh(optional):

后台任务输出此前通过 `Appender.Append` 逐块写入，每块都要付一次完整的后端往返开销，长时间流式任务下无法扩展。本 PR 将其改为「开一次会话、持续写入」的 `AppendOpener.OpenAppend`（返回标准 `io.WriteCloser`），把逐块延迟摊薄到整个会话；同时把 AgentTool 的事件转发从单一 generator + 开关式 `ForwardGate` 泛化为一组 `EventReceiver`，使同一份事件既能转发给父 generator、又能以 JSONL 形式写入输出文件；新增 `BackgroundStartupPreviewMs` 让显式后台任务在关闭调用方流之前短暂透出启动输出（如 OAuth 链接）；内存后端改用 `strings.Builder` 实现线性追加。属重构，含少量新增能力，且对 `Appender` 接口有破坏性变更。

#### (Optional) Which issue(s) this PR fixes:

#### (optional) The PR that updates user documentation:

---

## Testing

- `go test -race ./adk/...`
- `golangci-lint run ./adk/...`
- `git diff --check`
