### PR TITLE
fix(adk): unify checkpoint-aware child cancel scopes

### DIFF
--- a/adk/agent_tool.go
+++ b/adk/agent_tool.go
@@ -155,7 +155,7 @@ func (at *typedAgentTool[M]) InvokableRun(ctx context.Context, argumentsInJSON s
 	if cancelCtx := getCancelContext(ctx); cancelCtx != nil {
 		cancelCtx.markAgentToolDescendant()
 	}
-	ctx = context.WithValue(ctx, chatModelAgentExecutionKey{}, false)
+	ctx = clearChatModelAgentExecCtx(ctx)
 
 	gen, enableStreaming := getEmitGeneratorAndEnableStreaming[M](opts)
 	var ms *bridgeStore

--- a/adk/agent_tool.go
+++ b/adk/agent_tool.go
@@ -155,6 +155,7 @@ func (at *typedAgentTool[M]) InvokableRun(ctx context.Context, argumentsInJSON s
 	if cancelCtx := getCancelContext(ctx); cancelCtx != nil {
 		cancelCtx.markAgentToolDescendant()
 	}
+	ctx = context.WithValue(ctx, chatModelAgentExecutionKey{}, false)
 
 	gen, enableStreaming := getEmitGeneratorAndEnableStreaming[M](opts)
 	var ms *bridgeStore

--- a/adk/agent_tool.go
+++ b/adk/agent_tool.go
@@ -153,9 +153,8 @@ func (at *typedAgentTool[M]) Info(ctx context.Context) (*schema.ToolInfo, error)
 
 func (at *typedAgentTool[M]) InvokableRun(ctx context.Context, argumentsInJSON string, opts ...tool.Option) (string, error) {
 	if cancelCtx := getCancelContext(ctx); cancelCtx != nil {
-		cancelCtx.markAgentToolDescendant()
+		cancelCtx.markCheckpointAwareDescendant()
 	}
-	ctx = clearChatModelAgentExecCtx(ctx)
 
 	gen, enableStreaming := getEmitGeneratorAndEnableStreaming[M](opts)
 	var ms *bridgeStore
@@ -325,19 +324,8 @@ func getOptionsByAgentName(agentName string, opts []tool.Option) []AgentRunOptio
 
 func extractAndDeriveAgentToolCancelCtx(ctx context.Context, agentName string, opts []tool.Option) []AgentRunOption {
 	agentOpts := getOptionsByAgentName(agentName, opts)
-	baseOpts := getCommonOptions(nil, agentOpts...)
-	parentCtx := baseOpts.cancelCtx
-	if parentCtx == nil {
-		parentCtx = getCancelContext(ctx)
-	}
-	if parentCtx != nil {
-		parentCtx.markAgentToolDescendant()
-		childCtx := parentCtx.deriveAgentToolCancelContext(ctx)
-		agentOpts = append(agentOpts, WrapImplSpecificOptFn(func(o *options) {
-			o.cancelCtx = childCtx
-		}))
-	}
-	return agentOpts
+	childCancelCtx := deriveCheckpointAwareSubAgentCancelContext(ctx, agentOpts)
+	return appendCancelContextOption(agentOpts, childCancelCtx)
 }
 
 func getEmitGeneratorAndEnableStreaming[M MessageType](opts []tool.Option) (*AsyncGenerator[*TypedAgentEvent[M]], bool) {

--- a/adk/cancel.go
+++ b/adk/cancel.go
@@ -434,6 +434,11 @@ func (cc *cancelContext) deriveCheckpointAwareCancelContext(ctx context.Context)
 	return child
 }
 
+// deriveAbortOnlyCancelContext creates a child cancelContext for direct
+// non-boundary nested runs, such as a ChatModelAgent called from user
+// middleware. The child only receives recursive immediate teardown from the
+// parent; safe-point modes do not propagate because this scope is a resume
+// barrier and cannot contribute checkpoint state to the parent.
 func deriveAbortOnlyCancelContext(ctx context.Context, parent *cancelContext) *cancelContext {
 	if parent == nil {
 		return nil
@@ -466,6 +471,10 @@ func deriveAbortOnlyCancelContext(ctx context.Context, parent *cancelContext) *c
 	return child
 }
 
+// withAbortOnlyCancelContext bridges an abort-only cancelContext into the Go
+// context seen by user/model/tool code. When the cancelContext receives
+// immediate teardown or finishes, ctx.Done() is closed so ordinary cooperative
+// cancellation checks can stop promptly.
 func withAbortOnlyCancelContext(ctx context.Context, cc *cancelContext) (context.Context, context.CancelFunc) {
 	ctx = withCancelContext(ctx, cc)
 	ctx, cancel := context.WithCancel(ctx)
@@ -707,6 +716,11 @@ func isAbortOnlyCancelled(cc *cancelContext) bool {
 	return cc != nil && cc.abortOnly && cc.isImmediateCancelled()
 }
 
+// checkPreExecCancel handles cancellation that is already visible before a
+// ChatModelAgent enters its compose graph. This closes the window before graph
+// interrupt functions are registered: checkpoint-aware scopes emit a CancelError
+// for immediate cancellation, while abort-only scopes silently terminate because
+// they are teardown-only resume barriers.
 func checkPreExecCancel[M MessageType](cc *cancelContext, gen *AsyncGenerator[*TypedAgentEvent[M]]) (terminated bool) {
 	if cc == nil {
 		return false

--- a/adk/cancel.go
+++ b/adk/cancel.go
@@ -45,10 +45,12 @@ type CancelMode int
 const (
 	// CancelImmediate cancels the agent as soon as the signal is received,
 	// without waiting for a ChatModel or ToolCalls safe-point.
-	// By default, only the root agent is interrupted; descendant agents inside
-	// AgentTools are torn down via context cancellation as a side effect.
+	// By default, only the root agent is interrupted.
 	// Use WithRecursive to propagate explicit immediate-cancel signals to
-	// descendants for clean teardown with grace period.
+	// checkpoint-aware AgentTool boundaries and direct synchronous middleware
+	// agents. AgentTool descendants may contribute nested checkpoints; direct
+	// middleware agents only receive cooperative teardown through Go context
+	// cancellation, stream termination, and local graph interruption.
 	CancelImmediate CancelMode = 0
 	// CancelAfterChatModel cancels after the root agent's next chat model call
 	// completes. By default, only the root agent checks this safe-point;
@@ -120,16 +122,26 @@ func WithAgentCancelTimeout(timeout time.Duration) AgentCancelOption {
 }
 
 // WithRecursive opts into recursive cancel propagation. By default, cancel
-// modes only affect the root agent; descendant agents inside AgentTools are
-// not notified. WithRecursive makes the cancel propagate to all descendants:
-//   - CancelAfterChatModel / CancelAfterToolCalls: descendants check their own safe-points.
-//   - CancelImmediate: descendants receive explicit immediate-cancel signals for
+// modes only affect the root agent. WithRecursive makes the cancel propagate
+// through checkpoint-aware AgentTool boundaries:
+//   - CancelAfterChatModel / CancelAfterToolCalls: AgentTool descendants check their own safe-points.
+//   - CancelImmediate: AgentTool descendants receive explicit immediate-cancel signals for
 //     clean teardown; the root uses a grace period to collect child interrupts.
 //
-// With recursive cancellation, each descendant agent also triggers cancellation
-// and cascades its interrupt information upward. The root agent ultimately
-// produces a complete checkpoint that includes descendant checkpoints, enabling
-// resumption from the exact point where each descendant was interrupted.
+// Direct synchronous ChatModelAgent calls made from middleware do not establish
+// the checkpoint bridge required for targeted resumption. WithRecursive still
+// propagates CancelImmediate to them as abort-only teardown, but their local
+// interrupts are not attached to the root checkpoint.
+//
+// Immediate termination is cooperative: user code that ignores context
+// cancellation, stream termination, and graph interruption cannot be forcibly
+// killed by the framework.
+//
+// With recursive cancellation, each AgentTool descendant also triggers
+// cancellation and cascades its interrupt information upward. The root agent
+// ultimately produces a complete checkpoint that includes descendant
+// checkpoints, enabling resumption from the exact point where each descendant
+// was interrupted.
 //
 // Once any cancel call includes WithRecursive, the flag stays set for the
 // entire cancel lifecycle (monotonic escalation).
@@ -316,8 +328,9 @@ type cancelContext struct {
 	recursive     int32         // atomic; 1 if cancel should propagate into AgentTool internal agents
 	recursiveChan chan struct{} // closed when recursive transitions from 0 to 1
 
-	root   bool           // true for the original cancelContext created by WithCancel(); false for AgentTool internal agents
-	parent *cancelContext // non-nil for AgentTool internal agents; used to propagate AgentTool boundary markers upward
+	root      bool           // true for the original cancelContext created by WithCancel(); false for derived scopes
+	abortOnly bool           // true for direct middleware children that receive teardown but do not contribute checkpoints
+	parent    *cancelContext // non-nil for AgentTool internal agents; used to propagate AgentTool boundary markers upward
 
 	agentToolDescendant int32 // atomic; 1 once an AgentTool runs under this cancel context
 
@@ -420,6 +433,52 @@ func (cc *cancelContext) deriveAgentToolCancelContext(ctx context.Context) *canc
 	return child
 }
 
+func deriveAbortOnlyCancelContext(ctx context.Context, parent *cancelContext) *cancelContext {
+	if parent == nil {
+		return nil
+	}
+	child := newCancelContext()
+	child.root = false
+	child.abortOnly = true
+
+	go func() {
+		select {
+		case <-parent.immediateChan:
+			if parent.isRecursive() {
+				child.setRecursive(true)
+				child.triggerImmediateCancel()
+				return
+			}
+			select {
+			case <-parent.recursiveChan:
+				child.setRecursive(true)
+				child.triggerImmediateCancel()
+			case <-child.doneChan:
+			case <-ctx.Done():
+			}
+		case <-child.doneChan:
+		case <-ctx.Done():
+		}
+	}()
+
+	return child
+}
+
+func withAbortOnlyCancelContext(ctx context.Context, cc *cancelContext) (context.Context, context.CancelFunc) {
+	ctx = withCancelContext(ctx, cc)
+	ctx, cancel := context.WithCancel(ctx)
+	go func() {
+		select {
+		case <-cc.immediateChan:
+			cancel()
+		case <-cc.doneChan:
+			cancel()
+		case <-ctx.Done():
+		}
+	}()
+	return ctx, cancel
+}
+
 func (cc *cancelContext) triggerCancel(mode CancelMode) {
 	cc.setMode(mode)
 	if atomic.CompareAndSwapInt32(&cc.state, stateRunning, stateCancelling) {
@@ -508,7 +567,7 @@ func (cc *cancelContext) sendImmediateInterrupt() bool {
 	fns := make([]func(...compose.GraphInterruptOption), len(cc.graphInterruptFuncs))
 	copy(fns, cc.graphInterruptFuncs)
 
-	if cc.isRecursive() && cc.hasAgentToolDescendant() {
+	if !cc.abortOnly && cc.isRecursive() && cc.hasAgentToolDescendant() {
 		select {
 		case <-cc.doneChan:
 			cc.mu.Unlock()
@@ -569,6 +628,9 @@ func (cc *cancelContext) hasAgentToolDescendant() bool {
 func (cc *cancelContext) markAgentToolDescendant() {
 	for cur := cc; cur != nil; cur = cur.parent {
 		atomic.StoreInt32(&cur.agentToolDescendant, 1)
+		if cur.abortOnly {
+			break
+		}
 	}
 }
 
@@ -608,6 +670,34 @@ func (cc *cancelContext) createAndMarkCancelHandled() (*CancelError, bool) {
 	cancelErr := cc.createCancelError()
 	ok := cc.markCancelHandled()
 	return cancelErr, ok
+}
+
+func isAbortOnlyCancelled(cc *cancelContext) bool {
+	return cc != nil && cc.abortOnly && cc.isImmediateCancelled()
+}
+
+func checkPreExecCancel[M MessageType](cc *cancelContext, gen *AsyncGenerator[*TypedAgentEvent[M]]) (terminated bool) {
+	if cc == nil {
+		return false
+	}
+	if cc.abortOnly {
+		if cc.isImmediateCancelled() {
+			cc.markDone()
+			return true
+		}
+		return false
+	}
+	if cc.shouldCancel() {
+		if cc.getMode() == CancelImmediate || atomic.LoadInt32(&cc.escalated) == 1 {
+			cancelErr, ok := cc.createAndMarkCancelHandled()
+			if !ok {
+				return true
+			}
+			gen.Send(&TypedAgentEvent[M]{Err: cancelErr})
+			return true
+		}
+	}
+	return false
 }
 
 // buildCancelFunc builds the AgentCancelFunc for external use.

--- a/adk/cancel.go
+++ b/adk/cancel.go
@@ -47,14 +47,15 @@ const (
 	// without waiting for a ChatModel or ToolCalls safe-point.
 	// By default, only the root agent is interrupted.
 	// Use WithRecursive to propagate explicit immediate-cancel signals to
-	// checkpoint-aware AgentTool boundaries and direct synchronous middleware
-	// agents. AgentTool descendants may contribute nested checkpoints; direct
+	// checkpoint-aware ADK-managed sub-agent boundaries and direct synchronous middleware
+	// agents. Checkpoint descendants may contribute nested checkpoints; direct
 	// middleware agents only receive cooperative teardown through Go context
 	// cancellation, stream termination, and local graph interruption.
 	CancelImmediate CancelMode = 0
 	// CancelAfterChatModel cancels after the root agent's next chat model call
 	// completes. By default, only the root agent checks this safe-point;
-	// nested sub-agents inside AgentTools are unaware of the cancel.
+	// nested sub-agents inside explicit checkpoint-aware boundaries are unaware
+	// of the cancel.
 	// Use WithRecursive to propagate the cancel to all descendants — whichever
 	// ChatModel finishes first triggers the cancel.
 	CancelAfterChatModel CancelMode = 1 << iota
@@ -123,9 +124,9 @@ func WithAgentCancelTimeout(timeout time.Duration) AgentCancelOption {
 
 // WithRecursive opts into recursive cancel propagation. By default, cancel
 // modes only affect the root agent. WithRecursive makes the cancel propagate
-// through checkpoint-aware AgentTool boundaries:
-//   - CancelAfterChatModel / CancelAfterToolCalls: AgentTool descendants check their own safe-points.
-//   - CancelImmediate: AgentTool descendants receive explicit immediate-cancel signals for
+// through checkpoint-aware ADK-managed sub-agent boundaries:
+//   - CancelAfterChatModel / CancelAfterToolCalls: checkpoint descendants check their own safe-points.
+//   - CancelImmediate: checkpoint descendants receive explicit immediate-cancel signals for
 //     clean teardown; the root uses a grace period to collect child interrupts.
 //
 // Direct synchronous ChatModelAgent calls made from middleware do not establish
@@ -137,7 +138,7 @@ func WithAgentCancelTimeout(timeout time.Duration) AgentCancelOption {
 // cancellation, stream termination, and graph interruption cannot be forcibly
 // killed by the framework.
 //
-// With recursive cancellation, each AgentTool descendant also triggers
+// With recursive cancellation, each checkpoint descendant also triggers
 // cancellation and cascades its interrupt information upward. The root agent
 // ultimately produces a complete checkpoint that includes descendant
 // checkpoints, enabling resumption from the exact point where each descendant
@@ -284,9 +285,9 @@ const (
 	interruptImmediate int32 = 1
 )
 
-// defaultCancelImmediateGracePeriod is the bounded time a recursive
-// AgentTool cancel waits before forcing the current level's graph interrupt.
-// This gives deeper AgentTool/internal-agent interrupts a chance to bubble up
+// defaultCancelImmediateGracePeriod is the bounded time a recursive cancel
+// waits before forcing the current level's graph interrupt. This gives deeper
+// checkpoint-aware sub-agent boundary interrupts a chance to bubble up
 // as CompositeInterrupts. If this proves insufficient for deeply nested
 // structures or too slow for latency-sensitive use cases, consider making it
 // configurable via an AgentCancelOption.
@@ -325,14 +326,14 @@ type cancelContext struct {
 	startedMode      int32 // atomic, mode when state transitioned to cancelling
 	deadlineUnixNano int64 // atomic, 0 means no deadline
 
-	recursive     int32         // atomic; 1 if cancel should propagate into AgentTool internal agents
+	recursive     int32         // atomic; 1 if cancel should propagate into checkpoint-aware sub-agent scopes
 	recursiveChan chan struct{} // closed when recursive transitions from 0 to 1
 
 	root      bool           // true for the original cancelContext created by WithCancel(); false for derived scopes
 	abortOnly bool           // true for direct middleware children that receive teardown but do not contribute checkpoints
-	parent    *cancelContext // non-nil for AgentTool internal agents; used to propagate AgentTool boundary markers upward
+	parent    *cancelContext // non-nil for derived scopes; used to propagate checkpoint boundary markers upward
 
-	agentToolDescendant int32 // atomic; 1 once an AgentTool runs under this cancel context
+	checkpointAwareDescendant int32 // atomic; 1 once a checkpoint-aware sub-agent boundary runs under this cancel context
 
 	cancelMu      sync.Mutex
 	timeoutOnce   sync.Once
@@ -369,12 +370,12 @@ func (cc *cancelContext) setRecursive(v bool) {
 	}
 }
 
-// deriveAgentToolCancelContext creates the cancelContext used by an AgentTool's
-// internal agent. It receives recursive cancel propagation from the parent
-// AgentTool call. The caller MUST ensure the child's markDone() is eventually
+// deriveCheckpointAwareCancelContext creates a checkpoint-aware sub-agent cancelContext
+// for an explicit ADK-managed sub-agent execution boundary. It receives recursive
+// cancel propagation from the parent scope. The caller MUST ensure the child's markDone() is eventually
 // called (e.g., via wrapIterWithCancelCtx's defer) or that ctx is canceled;
 // otherwise the two propagation goroutines will leak.
-func (cc *cancelContext) deriveAgentToolCancelContext(ctx context.Context) *cancelContext {
+func (cc *cancelContext) deriveCheckpointAwareCancelContext(ctx context.Context) *cancelContext {
 	if cc == nil {
 		return nil
 	}
@@ -440,6 +441,7 @@ func deriveAbortOnlyCancelContext(ctx context.Context, parent *cancelContext) *c
 	child := newCancelContext()
 	child.root = false
 	child.abortOnly = true
+	child.parent = parent
 
 	go func() {
 		select {
@@ -567,7 +569,7 @@ func (cc *cancelContext) sendImmediateInterrupt() bool {
 	fns := make([]func(...compose.GraphInterruptOption), len(cc.graphInterruptFuncs))
 	copy(fns, cc.graphInterruptFuncs)
 
-	if !cc.abortOnly && cc.isRecursive() && cc.hasAgentToolDescendant() {
+	if !cc.abortOnly && cc.isRecursive() && cc.hasCheckpointAwareDescendant() {
 		select {
 		case <-cc.doneChan:
 			cc.mu.Unlock()
@@ -621,17 +623,46 @@ func (cc *cancelContext) markDone() {
 	}
 }
 
-func (cc *cancelContext) hasAgentToolDescendant() bool {
-	return cc != nil && atomic.LoadInt32(&cc.agentToolDescendant) == 1
+func (cc *cancelContext) hasCheckpointAwareDescendant() bool {
+	return cc != nil && atomic.LoadInt32(&cc.checkpointAwareDescendant) == 1
 }
 
-func (cc *cancelContext) markAgentToolDescendant() {
+func (cc *cancelContext) markCheckpointAwareDescendant() {
 	for cur := cc; cur != nil; cur = cur.parent {
-		atomic.StoreInt32(&cur.agentToolDescendant, 1)
 		if cur.abortOnly {
 			break
 		}
+		atomic.StoreInt32(&cur.checkpointAwareDescendant, 1)
 	}
+}
+
+// deriveCheckpointAwareSubAgentCancelContext derives a checkpoint-aware cancelContext
+// for an ADK-managed sub-agent boundary that should participate in recursive
+// checkpoint cancellation.
+func deriveCheckpointAwareSubAgentCancelContext(ctx context.Context, opts []AgentRunOption) *cancelContext {
+	parentCtx := getCommonOptions(nil, opts...).cancelCtx
+	if parentCtx == nil {
+		parentCtx = getCancelContext(ctx)
+	}
+	if parentCtx == nil || parentCtx.abortOnly {
+		return nil
+	}
+
+	parentCtx.markCheckpointAwareDescendant()
+	return parentCtx.deriveCheckpointAwareCancelContext(ctx)
+}
+
+// appendCancelContextOption copies opts before appending the internal cancel
+// option so parallel sub-agent derivation cannot share the caller's slice
+// backing array.
+func appendCancelContextOption(opts []AgentRunOption, cancelCtx *cancelContext) []AgentRunOption {
+	childOpts := append([]AgentRunOption(nil), opts...)
+	if cancelCtx == nil {
+		return childOpts
+	}
+	return append(childOpts, WrapImplSpecificOptFn(func(o *options) {
+		o.cancelCtx = cancelCtx
+	}))
 }
 
 // markCancelHandled signals that the cancel path in the runFunc has created
@@ -875,7 +906,7 @@ func (cc *cancelContext) buildCancelFunc() AgentCancelFunc {
 // It calls markDone when the inner iterator is fully drained, ensuring the
 // cancelContext's doneChan is closed and propagation goroutines can exit.
 //
-// For root cancelContexts (created by WithCancel, not deriveAgentToolCancelContext), it also
+// For root cancelContexts (created by WithCancel, not deriveCheckpointAwareCancelContext), it also
 // converts interrupt ACTION events to CancelError when cancel is active.
 // This is the single point of interrupt-to-CancelError conversion in the
 // system — Runner.handleIter only enriches the resulting CancelError with

--- a/adk/cancel_edge_test.go
+++ b/adk/cancel_edge_test.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"strings"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -320,10 +321,10 @@ func TestWithCancel_AfterCompletion(t *testing.T) {
 	assert.ErrorIs(t, cancelErr, ErrExecutionEnded)
 }
 
-// TestWithCancel_DerivedAgentToolCancelContextMarkedDoneAfterRun verifies that
-// an explicitly derived AgentTool child cancel context is owned by the child run,
+// TestWithCancel_DerivedCheckpointContextMarkedDoneAfterRun verifies that
+// an explicitly derived checkpoint-aware cancel context is owned by the sub-agent run,
 // even when the Go context also carries the parent cancel context.
-func TestWithCancel_DerivedAgentToolCancelContextMarkedDoneAfterRun(t *testing.T) {
+func TestWithCancel_DerivedCheckpointCancelContextMarkedDoneAfterRun(t *testing.T) {
 	ctx := context.Background()
 
 	agent, err := NewChatModelAgent(ctx, &ChatModelAgentConfig{
@@ -335,7 +336,7 @@ func TestWithCancel_DerivedAgentToolCancelContextMarkedDoneAfterRun(t *testing.T
 
 	parent := newCancelContext()
 	parentCtx := withCancelContext(ctx, parent)
-	child := parent.deriveAgentToolCancelContext(parentCtx)
+	child := parent.deriveCheckpointAwareCancelContext(parentCtx)
 
 	childOpt := WrapImplSpecificOptFn(func(o *options) {
 		o.cancelCtx = child
@@ -351,7 +352,7 @@ func TestWithCancel_DerivedAgentToolCancelContextMarkedDoneAfterRun(t *testing.T
 	select {
 	case <-child.doneChan:
 	case <-time.After(time.Second):
-		t.Fatal("derived AgentTool cancel context was not marked done after child run completion")
+		t.Fatal("derived checkpoint cancel context was not marked done after child run completion")
 	}
 }
 
@@ -1290,16 +1291,11 @@ func TestWithCancel_Resume_CancelAfterChatModel_MessagePreserved(t *testing.T) {
 
 }
 
-// TestHandleRunFuncError_AlreadyHandled_NoDuplicate verifies that when
-// markCancelHandled() was already claimed by a sub-agent's handleRunFuncError,
-// the sequential workflow's checkCancel does not emit a second CancelError.
-//
-// Setup: sequential[cma1, cma2] with CancelAfterToolCalls. cma1 has tools,
-// cancel fires while tool is running. After tool completes, the safe-point
-// fires in cma1's handleRunFuncError (claiming markCancelHandled). The
-// sequential workflow's checkCancel at the transition point should find
-// markCancelHandled returns false and skip — producing exactly 1 CancelError.
-func TestHandleRunFuncError_AlreadyHandled_NoDuplicate(t *testing.T) {
+// TestWithCancel_SafePoint_DirectWorkflowChildAbortOnly verifies that a
+// ChatModelAgent invoked as a direct workflow child does not participate in
+// safe-point checkpointing. Safe-point cancel remains local to checkpoint-aware
+// scopes; direct children only receive recursive immediate abort.
+func TestWithCancel_SafePoint_DirectWorkflowChildAbortOnly(t *testing.T) {
 	ctx := context.Background()
 
 	bt := newBlockingTool("bt")
@@ -1343,8 +1339,9 @@ func TestHandleRunFuncError_AlreadyHandled_NoDuplicate(t *testing.T) {
 		t.Fatal("Tool did not start")
 	}
 
-	// Cancel while tool is still running (in goroutine because cancelFn blocks
-	// until execution finishes), then unblock tool so safe-point fires
+	// Cancel while the direct child tool is still running. This should not
+	// produce a sub-agent checkpoint: direct non-boundary nested runs ignore safe-point
+	// cancel and continue until they finish normally.
 	go func() {
 		handle, _ := cancelFn(WithAgentCancelMode(CancelAfterToolCalls))
 		_ = handle.Wait()
@@ -1366,24 +1363,20 @@ func TestHandleRunFuncError_AlreadyHandled_NoDuplicate(t *testing.T) {
 		}
 	}
 
-	assert.Equal(t, 1, cancelCount, "Should have exactly one CancelError, no duplicate from handleRunFuncError + checkCancel")
+	assert.Equal(t, 0, cancelCount, "direct workflow child should not emit a safe-point CancelError")
 }
 
-func TestWithCancel_CancelAfterChatModel_NestedAgentTool(t *testing.T) {
+func TestWithCancel_RecursiveImmediate_TransferChildCheckpoint(t *testing.T) {
 	ctx := context.Background()
 
-	subAgentModel := newBlockingChatModel(toolCallMsg(toolCall("c1", "sub_tool", `{"input":"x"}`)))
+	subAgentModel := newContextAwareBlockingChatModel(schema.AssistantMessage("sub-agent done", nil))
 	subAgentModelStarted := subAgentModel.started
-	subTool := newBlockingTool("sub_tool")
 
 	subAgent, err := NewChatModelAgent(ctx, &ChatModelAgentConfig{
 		Name:        "sub_agent",
 		Description: "test sub agent",
 		Instruction: "you are a sub agent",
 		Model:       subAgentModel,
-		ToolsConfig: ToolsConfig{
-			ToolsNodeConfig: compose.ToolsNodeConfig{Tools: []tool.BaseTool{subTool}},
-		},
 	})
 	require.NoError(t, err)
 
@@ -1411,13 +1404,16 @@ func TestWithCancel_CancelAfterChatModel_NestedAgentTool(t *testing.T) {
 	agentWithSubAgents, err := SetSubAgents(ctx, supervisorAgent, []Agent{subAgent})
 	require.NoError(t, err)
 
+	store := newCancelTestStore()
+	checkpointID := "recursive-immediate-transfer-child-checkpoint"
 	runner := NewRunner(ctx, RunnerConfig{
 		Agent:           agentWithSubAgents,
 		EnableStreaming: false,
+		CheckPointStore: store,
 	})
 
 	cancelOpt, cancelFn := WithCancel()
-	iter := runner.Run(ctx, []Message{schema.UserMessage("test")}, cancelOpt)
+	iter := runner.Run(ctx, []Message{schema.UserMessage("test")}, cancelOpt, WithCheckPointID(checkpointID))
 
 	select {
 	case <-subAgentModelStarted:
@@ -1429,29 +1425,195 @@ func TestWithCancel_CancelAfterChatModel_NestedAgentTool(t *testing.T) {
 
 	cancelDone := make(chan error, 1)
 	go func() {
-		handle, _ := cancelFn(WithAgentCancelMode(CancelAfterChatModel), WithRecursive())
+		handle, _ := cancelFn(WithRecursive())
 		cancelDone <- handle.Wait()
 	}()
 
-	time.Sleep(100 * time.Millisecond)
-	close(subAgentModel.unblockCh)
-
 	cancelErr := <-cancelDone
-	assert.NoError(t, cancelErr)
+	require.NoError(t, cancelErr)
 
-	hasCancelError := false
-	for {
-		event, ok := iter.Next()
-		if !ok {
+	_, cancelErrors := drainCancelErrors(iter)
+	require.Len(t, cancelErrors, 1, "transfer child should emit a checkpoint CancelError")
+	assert.Equal(t, CancelImmediate, cancelErrors[0].Info.Mode)
+
+	var hasSubAgentCheckpoint bool
+	for _, intCtx := range cancelErrors[0].InterruptContexts {
+		if strings.Contains(fmt.Sprint(intCtx.Address), "sub_agent") {
+			hasSubAgentCheckpoint = true
 			break
 		}
-		var ce *CancelError
-		if event.Err != nil && errors.As(event.Err, &ce) {
-			hasCancelError = true
-		}
+	}
+	assert.True(t, hasSubAgentCheckpoint, "transfer target should participate in checkpoint interrupt contexts")
+
+	resumeSubAgentCalls := int32(0)
+	resumeSubAgent, err := NewChatModelAgent(ctx, &ChatModelAgentConfig{
+		Name:        "sub_agent",
+		Description: "test sub agent",
+		Instruction: "you are a sub agent",
+		Model: &countingChatModel{
+			callCount: &resumeSubAgentCalls,
+			responses: []*schema.Message{
+				schema.AssistantMessage("sub-agent resumed", nil),
+			},
+		},
+	})
+	require.NoError(t, err)
+
+	resumeSupervisor, err := NewChatModelAgent(ctx, &ChatModelAgentConfig{
+		Name:        "supervisor",
+		Description: "supervisor agent (equivalent to DeepAgent)",
+		Instruction: "you are a supervisor",
+		Model:       supervisorModel,
+	})
+	require.NoError(t, err)
+
+	resumeAgentWithSubAgents, err := SetSubAgents(ctx, resumeSupervisor, []Agent{resumeSubAgent})
+	require.NoError(t, err)
+	resumeRunner := NewRunner(ctx, RunnerConfig{
+		Agent:           resumeAgentWithSubAgents,
+		EnableStreaming: false,
+		CheckPointStore: store,
+	})
+	resumeIter, err := resumeRunner.Resume(ctx, checkpointID)
+	require.NoError(t, err)
+	resumeEvents, resumeCancelErrors := drainCancelErrors(resumeIter)
+	require.Empty(t, resumeCancelErrors)
+	require.NotEmpty(t, resumeEvents)
+	assert.Equal(t, int32(1), atomic.LoadInt32(&resumeSubAgentCalls), "transfer target should resume from its own checkpoint")
+}
+
+func TestWithCancel_RecursiveSafePoint_TransferChildCheckpoint(t *testing.T) {
+	ctx := context.Background()
+
+	subTool := &slowTool{
+		name:   "sub_tool",
+		delay:  10 * time.Millisecond,
+		result: "sub tool result",
+	}
+	subAgentModel := newContextAwareBlockingChatModel(&schema.Message{
+		Role: schema.Assistant,
+		ToolCalls: []schema.ToolCall{{
+			ID: "sub_call_1", Type: "function",
+			Function: schema.FunctionCall{
+				Name:      "sub_tool",
+				Arguments: `{"input":"x"}`,
+			},
+		}},
+	})
+	subAgent, err := NewChatModelAgent(ctx, &ChatModelAgentConfig{
+		Name:        "sub_agent",
+		Description: "test sub agent",
+		Instruction: "you are a sub agent",
+		Model:       subAgentModel,
+		ToolsConfig: ToolsConfig{
+			ToolsNodeConfig: compose.ToolsNodeConfig{
+				Tools: []tool.BaseTool{subTool},
+			},
+		},
+	})
+	require.NoError(t, err)
+
+	supervisorModel := &simpleChatModel{
+		response: &schema.Message{
+			Role: schema.Assistant,
+			ToolCalls: []schema.ToolCall{{
+				ID: "call_1", Type: "function",
+				Function: schema.FunctionCall{
+					Name:      TransferToAgentToolName,
+					Arguments: `{"agent_name": "sub_agent"}`,
+				},
+			}},
+		},
+	}
+	supervisorAgent, err := NewChatModelAgent(ctx, &ChatModelAgentConfig{
+		Name:        "supervisor",
+		Description: "supervisor agent",
+		Instruction: "you are a supervisor",
+		Model:       supervisorModel,
+	})
+	require.NoError(t, err)
+
+	agentWithSubAgents, err := SetSubAgents(ctx, supervisorAgent, []Agent{subAgent})
+	require.NoError(t, err)
+
+	store := newCancelTestStore()
+	checkpointID := "recursive-safe-point-transfer-child-checkpoint"
+	runner := NewRunner(ctx, RunnerConfig{
+		Agent:           agentWithSubAgents,
+		EnableStreaming: false,
+		CheckPointStore: store,
+	})
+
+	cancelOpt, cancelFn := WithCancel()
+	iter := runner.Run(ctx, []Message{schema.UserMessage("test")}, cancelOpt, WithCheckPointID(checkpointID))
+
+	select {
+	case <-subAgentModel.started:
+	case <-time.After(10 * time.Second):
+		t.Fatal("Sub-agent model did not start")
 	}
 
-	assert.True(t, hasCancelError, "CancelError expected from nested agent tool with tools")
+	handle, contributed := cancelFn(WithAgentCancelMode(CancelAfterChatModel), WithRecursive())
+	require.True(t, contributed)
+	cancelDone := make(chan error, 1)
+	go func() {
+		cancelDone <- handle.Wait()
+	}()
+	time.Sleep(50 * time.Millisecond)
+	close(subAgentModel.release)
+
+	_, cancelErrors := drainCancelErrors(iter)
+	require.NoError(t, <-cancelDone)
+	require.Len(t, cancelErrors, 1, "transfer child should emit a safe-point checkpoint CancelError")
+	assert.Equal(t, CancelAfterChatModel, cancelErrors[0].Info.Mode)
+
+	var hasSubAgentCheckpoint bool
+	for _, intCtx := range cancelErrors[0].InterruptContexts {
+		if strings.Contains(fmt.Sprint(intCtx.Address), "sub_agent") {
+			hasSubAgentCheckpoint = true
+			break
+		}
+	}
+	assert.True(t, hasSubAgentCheckpoint, "transfer target should participate in safe-point checkpoint interrupt contexts")
+
+	resumeSubAgentCalls := int32(0)
+	resumeSubAgent, err := NewChatModelAgent(ctx, &ChatModelAgentConfig{
+		Name:        "sub_agent",
+		Description: "test sub agent",
+		Instruction: "you are a sub agent",
+		Model: &countingChatModel{
+			callCount: &resumeSubAgentCalls,
+			responses: []*schema.Message{
+				schema.AssistantMessage("sub-agent resumed", nil),
+			},
+		},
+		ToolsConfig: ToolsConfig{
+			ToolsNodeConfig: compose.ToolsNodeConfig{
+				Tools: []tool.BaseTool{subTool},
+			},
+		},
+	})
+	require.NoError(t, err)
+	resumeSupervisor, err := NewChatModelAgent(ctx, &ChatModelAgentConfig{
+		Name:        "supervisor",
+		Description: "supervisor agent",
+		Instruction: "you are a supervisor",
+		Model:       supervisorModel,
+	})
+	require.NoError(t, err)
+	resumeAgentWithSubAgents, err := SetSubAgents(ctx, resumeSupervisor, []Agent{resumeSubAgent})
+	require.NoError(t, err)
+	resumeRunner := NewRunner(ctx, RunnerConfig{
+		Agent:           resumeAgentWithSubAgents,
+		EnableStreaming: false,
+		CheckPointStore: store,
+	})
+	resumeIter, err := resumeRunner.Resume(ctx, checkpointID)
+	require.NoError(t, err)
+	resumeEvents, resumeCancelErrors := drainCancelErrors(resumeIter)
+	require.Empty(t, resumeCancelErrors)
+	require.NotEmpty(t, resumeEvents)
+	assert.Equal(t, int32(1), atomic.LoadInt32(&resumeSubAgentCalls), "transfer target should resume from its safe-point checkpoint")
 }
 
 func TestWithCancel_RecursiveImmediate_MiddlewareChildAbortOnly(t *testing.T) {
@@ -1560,6 +1722,161 @@ func TestWithCancel_RecursiveImmediate_MiddlewareChildAbortOnly(t *testing.T) {
 	require.Empty(t, resumeCancelErrors)
 	require.NotEmpty(t, resumeEvents)
 	assert.Equal(t, int32(1), atomic.LoadInt32(&resumeChildCalls), "middleware child should be invoked as a fresh Run on root resume")
+}
+
+func TestWithCancel_RecursiveImmediate_MiddlewareChildAgentToolCheckpointResumeBarrier(t *testing.T) {
+	ctx := context.Background()
+
+	leafModel := newBlockingChatModel(schema.AssistantMessage("leaf done", nil))
+	t.Cleanup(func() {
+		close(leafModel.unblockCh)
+	})
+	leafAgent, err := NewChatModelAgent(ctx, &ChatModelAgentConfig{
+		Name:        "MiddlewareLeafAgent",
+		Description: "leaf agent wrapped as a tool under a direct middleware child",
+		Instruction: "leaf",
+		Model:       leafModel,
+	})
+	require.NoError(t, err)
+
+	childModelCallCount := int32(0)
+	childModel := &countingChatModel{
+		callCount: &childModelCallCount,
+		responses: []*schema.Message{
+			toolCallMsg(toolCall("child-leaf", "MiddlewareLeafAgent", `{"request":"leaf work"}`)),
+			schema.AssistantMessage("child done", nil),
+		},
+	}
+	childAgent, err := NewChatModelAgent(ctx, &ChatModelAgentConfig{
+		Name:        "MiddlewareChildWithAgentTool",
+		Description: "direct middleware child with an agent tool",
+		Instruction: "child",
+		Model:       childModel,
+		ToolsConfig: ToolsConfig{
+			ToolsNodeConfig: compose.ToolsNodeConfig{
+				Tools: []tool.BaseTool{NewAgentTool(ctx, leafAgent)},
+			},
+		},
+	})
+	require.NoError(t, err)
+
+	childInterruptSeen := int32(0)
+	resumeChildCalls := int32(0)
+	resumeLeafCalls := int32(0)
+	outerAgent, err := NewChatModelAgent(ctx, &ChatModelAgentConfig{
+		Name:        "OuterMiddlewareAgent",
+		Description: "outer",
+		Instruction: "outer",
+		Model:       &plainResponseModel{text: "outer done"},
+		Middlewares: []AgentMiddleware{{
+			BeforeChatModel: func(ctx context.Context, _ *ChatModelAgentState) error {
+				iter := childAgent.Run(ctx, &AgentInput{Messages: []Message{schema.UserMessage("child work")}})
+				for {
+					event, ok := iter.Next()
+					if !ok {
+						return nil
+					}
+					if event.Action != nil && event.Action.Interrupted != nil {
+						atomic.StoreInt32(&childInterruptSeen, 1)
+					}
+					if event.Err != nil {
+						return event.Err
+					}
+				}
+			},
+		}},
+	})
+	require.NoError(t, err)
+
+	store := newCancelTestStore()
+	checkpointID := "recursive-immediate-middleware-agent-tool-resume-barrier"
+	runner := NewRunner(ctx, RunnerConfig{Agent: outerAgent, CheckPointStore: store})
+
+	cancelOpt, cancelFn := WithCancel()
+	iter := runner.Run(ctx, []Message{schema.UserMessage("go")}, cancelOpt, WithCheckPointID(checkpointID))
+
+	select {
+	case <-leafModel.started:
+	case <-time.After(5 * time.Second):
+		t.Fatal("leaf agent model did not start")
+	}
+
+	handle, _ := cancelFn(WithRecursive())
+	assert.NoError(t, handle.Wait(),
+		"the root may handle its own immediate interrupt, but not a checkpoint hidden behind a direct middleware Run")
+	_, cancelErrors := drainCancelErrors(iter)
+	require.Len(t, cancelErrors, 1, "root stream should expose only the root immediate cancel")
+	for _, intCtx := range cancelErrors[0].InterruptContexts {
+		assert.NotContains(t, fmt.Sprint(intCtx.Address), "MiddlewareLeafAgent",
+			"root cancel must not expose the nested AgentTool checkpoint from behind the direct middleware Run")
+	}
+	assert.Equal(t, int32(0), atomic.LoadInt32(&childInterruptSeen),
+		"the abort-only middleware child must swallow the nested AgentTool interrupt action instead of surfacing it as a resumable boundary")
+
+	resumeLeafModel := &countingChatModel{
+		callCount: &resumeLeafCalls,
+		responses: []*schema.Message{
+			schema.AssistantMessage("leaf done after resume", nil),
+		},
+	}
+	resumeLeafAgent, err := NewChatModelAgent(ctx, &ChatModelAgentConfig{
+		Name:        "MiddlewareLeafAgent",
+		Description: "leaf agent wrapped as a tool under a direct middleware child",
+		Instruction: "leaf",
+		Model:       resumeLeafModel,
+	})
+	require.NoError(t, err)
+
+	resumeChildModel := &countingChatModel{
+		callCount: &resumeChildCalls,
+		responses: []*schema.Message{
+			toolCallMsg(toolCall("child-leaf", "MiddlewareLeafAgent", `{"request":"leaf work"}`)),
+			schema.AssistantMessage("child done after resume", nil),
+		},
+	}
+	resumeChildAgent, err := NewChatModelAgent(ctx, &ChatModelAgentConfig{
+		Name:        "MiddlewareChildWithAgentTool",
+		Description: "direct middleware child with an agent tool",
+		Instruction: "child",
+		Model:       resumeChildModel,
+		ToolsConfig: ToolsConfig{
+			ToolsNodeConfig: compose.ToolsNodeConfig{
+				Tools: []tool.BaseTool{NewAgentTool(ctx, resumeLeafAgent)},
+			},
+		},
+	})
+	require.NoError(t, err)
+
+	resumeOuterAgent, err := NewChatModelAgent(ctx, &ChatModelAgentConfig{
+		Name:        "OuterMiddlewareAgent",
+		Description: "outer",
+		Instruction: "outer",
+		Model:       &plainResponseModel{text: "outer done after resume"},
+		Middlewares: []AgentMiddleware{{
+			BeforeChatModel: func(ctx context.Context, _ *ChatModelAgentState) error {
+				iter := resumeChildAgent.Run(ctx, &AgentInput{Messages: []Message{schema.UserMessage("child work")}})
+				for {
+					event, ok := iter.Next()
+					if !ok {
+						return nil
+					}
+					if event.Err != nil {
+						return event.Err
+					}
+				}
+			},
+		}},
+	})
+	require.NoError(t, err)
+
+	resumeRunner := NewRunner(ctx, RunnerConfig{Agent: resumeOuterAgent, CheckPointStore: store})
+	resumeIter, err := resumeRunner.Resume(ctx, checkpointID)
+	require.NoError(t, err)
+	resumeEvents, resumeCancelErrors := drainCancelErrors(resumeIter)
+	require.Empty(t, resumeCancelErrors)
+	require.NotEmpty(t, resumeEvents)
+	assert.GreaterOrEqual(t, atomic.LoadInt32(&resumeChildCalls), int32(1), "middleware child should be invoked as a fresh Run on root resume")
+	assert.Equal(t, int32(1), atomic.LoadInt32(&resumeLeafCalls), "nested AgentTool should run fresh, not resume from the hidden checkpoint")
 }
 
 func TestWithCancel_RecursiveImmediate_BeforeAgentChildAbortOnly(t *testing.T) {

--- a/adk/cancel_edge_test.go
+++ b/adk/cancel_edge_test.go
@@ -234,6 +234,57 @@ func drainCancelErrors(iter *AsyncIterator[*AgentEvent]) ([]*AgentEvent, []*Canc
 	return events, cancelErrors
 }
 
+func runChildAgentToEnd(ctx context.Context, child Agent, msg string) error {
+	iter := child.Run(ctx, &AgentInput{Messages: []Message{schema.UserMessage(msg)}})
+	for {
+		event, ok := iter.Next()
+		if !ok {
+			return nil
+		}
+		if event.Err != nil {
+			return event.Err
+		}
+	}
+}
+
+func newTransferSupervisorWithSubAgent(t *testing.T, ctx context.Context, mdl model.BaseChatModel, subAgent Agent) Agent {
+	t.Helper()
+
+	supervisorAgent, err := NewChatModelAgent(ctx, &ChatModelAgentConfig{
+		Name:        "supervisor",
+		Description: "supervisor agent",
+		Instruction: "you are a supervisor",
+		Model:       mdl,
+	})
+	require.NoError(t, err)
+
+	agentWithSubAgents, err := SetSubAgents(ctx, supervisorAgent, []Agent{subAgent})
+	require.NoError(t, err)
+	return agentWithSubAgents
+}
+
+func assertCancelErrorExcludesAddresses(t *testing.T, cancelErr *CancelError, names ...string) {
+	t.Helper()
+
+	for _, intCtx := range cancelErr.InterruptContexts {
+		addr := fmt.Sprint(intCtx.Address)
+		for _, name := range names {
+			assert.NotContains(t, addr, name)
+		}
+	}
+}
+
+func assertCancelErrorIncludesAddress(t *testing.T, cancelErr *CancelError, name string) {
+	t.Helper()
+
+	for _, intCtx := range cancelErr.InterruptContexts {
+		if strings.Contains(fmt.Sprint(intCtx.Address), name) {
+			return
+		}
+	}
+	t.Fatalf("cancel interrupt contexts do not include %q", name)
+}
+
 // --- tests ---
 
 // TestWithCancel_BeforeExecutionStarts verifies that a cancel issued before
@@ -394,17 +445,7 @@ func TestWithCancel_RecursiveDoesNotTargetAgentEmbeddedInMiddleware(t *testing.T
 				state *ChatModelAgentState,
 				_ *ModelContext,
 			) (context.Context, *ChatModelAgentState, error) {
-				iter := innerAgent.Run(ctx, &AgentInput{Messages: []Message{schema.UserMessage("run")}})
-				for {
-					event, ok := iter.Next()
-					if !ok {
-						break
-					}
-					if event.Err != nil {
-						return ctx, state, event.Err
-					}
-				}
-				return ctx, state, nil
+				return ctx, state, runChildAgentToEnd(ctx, innerAgent, "run")
 			}},
 		},
 	})
@@ -1393,21 +1434,10 @@ func TestWithCancel_RecursiveImmediate_TransferChildCheckpoint(t *testing.T) {
 		},
 	}
 
-	supervisorAgent, err := NewChatModelAgent(ctx, &ChatModelAgentConfig{
-		Name:        "supervisor",
-		Description: "supervisor agent (equivalent to DeepAgent)",
-		Instruction: "you are a supervisor",
-		Model:       supervisorModel,
-	})
-	require.NoError(t, err)
-
-	agentWithSubAgents, err := SetSubAgents(ctx, supervisorAgent, []Agent{subAgent})
-	require.NoError(t, err)
-
 	store := newCancelTestStore()
 	checkpointID := "recursive-immediate-transfer-child-checkpoint"
 	runner := NewRunner(ctx, RunnerConfig{
-		Agent:           agentWithSubAgents,
+		Agent:           newTransferSupervisorWithSubAgent(t, ctx, supervisorModel, subAgent),
 		EnableStreaming: false,
 		CheckPointStore: store,
 	})
@@ -1436,14 +1466,7 @@ func TestWithCancel_RecursiveImmediate_TransferChildCheckpoint(t *testing.T) {
 	require.Len(t, cancelErrors, 1, "transfer child should emit a checkpoint CancelError")
 	assert.Equal(t, CancelImmediate, cancelErrors[0].Info.Mode)
 
-	var hasSubAgentCheckpoint bool
-	for _, intCtx := range cancelErrors[0].InterruptContexts {
-		if strings.Contains(fmt.Sprint(intCtx.Address), "sub_agent") {
-			hasSubAgentCheckpoint = true
-			break
-		}
-	}
-	assert.True(t, hasSubAgentCheckpoint, "transfer target should participate in checkpoint interrupt contexts")
+	assertCancelErrorIncludesAddress(t, cancelErrors[0], "sub_agent")
 
 	resumeSubAgentCalls := int32(0)
 	resumeSubAgent, err := NewChatModelAgent(ctx, &ChatModelAgentConfig{
@@ -1459,18 +1482,8 @@ func TestWithCancel_RecursiveImmediate_TransferChildCheckpoint(t *testing.T) {
 	})
 	require.NoError(t, err)
 
-	resumeSupervisor, err := NewChatModelAgent(ctx, &ChatModelAgentConfig{
-		Name:        "supervisor",
-		Description: "supervisor agent (equivalent to DeepAgent)",
-		Instruction: "you are a supervisor",
-		Model:       supervisorModel,
-	})
-	require.NoError(t, err)
-
-	resumeAgentWithSubAgents, err := SetSubAgents(ctx, resumeSupervisor, []Agent{resumeSubAgent})
-	require.NoError(t, err)
 	resumeRunner := NewRunner(ctx, RunnerConfig{
-		Agent:           resumeAgentWithSubAgents,
+		Agent:           newTransferSupervisorWithSubAgent(t, ctx, supervisorModel, resumeSubAgent),
 		EnableStreaming: false,
 		CheckPointStore: store,
 	})
@@ -1525,21 +1538,10 @@ func TestWithCancel_RecursiveSafePoint_TransferChildCheckpoint(t *testing.T) {
 			}},
 		},
 	}
-	supervisorAgent, err := NewChatModelAgent(ctx, &ChatModelAgentConfig{
-		Name:        "supervisor",
-		Description: "supervisor agent",
-		Instruction: "you are a supervisor",
-		Model:       supervisorModel,
-	})
-	require.NoError(t, err)
-
-	agentWithSubAgents, err := SetSubAgents(ctx, supervisorAgent, []Agent{subAgent})
-	require.NoError(t, err)
-
 	store := newCancelTestStore()
 	checkpointID := "recursive-safe-point-transfer-child-checkpoint"
 	runner := NewRunner(ctx, RunnerConfig{
-		Agent:           agentWithSubAgents,
+		Agent:           newTransferSupervisorWithSubAgent(t, ctx, supervisorModel, subAgent),
 		EnableStreaming: false,
 		CheckPointStore: store,
 	})
@@ -1567,14 +1569,7 @@ func TestWithCancel_RecursiveSafePoint_TransferChildCheckpoint(t *testing.T) {
 	require.Len(t, cancelErrors, 1, "transfer child should emit a safe-point checkpoint CancelError")
 	assert.Equal(t, CancelAfterChatModel, cancelErrors[0].Info.Mode)
 
-	var hasSubAgentCheckpoint bool
-	for _, intCtx := range cancelErrors[0].InterruptContexts {
-		if strings.Contains(fmt.Sprint(intCtx.Address), "sub_agent") {
-			hasSubAgentCheckpoint = true
-			break
-		}
-	}
-	assert.True(t, hasSubAgentCheckpoint, "transfer target should participate in safe-point checkpoint interrupt contexts")
+	assertCancelErrorIncludesAddress(t, cancelErrors[0], "sub_agent")
 
 	resumeSubAgentCalls := int32(0)
 	resumeSubAgent, err := NewChatModelAgent(ctx, &ChatModelAgentConfig{
@@ -1594,17 +1589,8 @@ func TestWithCancel_RecursiveSafePoint_TransferChildCheckpoint(t *testing.T) {
 		},
 	})
 	require.NoError(t, err)
-	resumeSupervisor, err := NewChatModelAgent(ctx, &ChatModelAgentConfig{
-		Name:        "supervisor",
-		Description: "supervisor agent",
-		Instruction: "you are a supervisor",
-		Model:       supervisorModel,
-	})
-	require.NoError(t, err)
-	resumeAgentWithSubAgents, err := SetSubAgents(ctx, resumeSupervisor, []Agent{resumeSubAgent})
-	require.NoError(t, err)
 	resumeRunner := NewRunner(ctx, RunnerConfig{
-		Agent:           resumeAgentWithSubAgents,
+		Agent:           newTransferSupervisorWithSubAgent(t, ctx, supervisorModel, resumeSubAgent),
 		EnableStreaming: false,
 		CheckPointStore: store,
 	})
@@ -1635,16 +1621,7 @@ func TestWithCancel_RecursiveImmediate_MiddlewareChildAbortOnly(t *testing.T) {
 		Model:       &plainResponseModel{text: "outer done"},
 		Middlewares: []AgentMiddleware{{
 			BeforeChatModel: func(ctx context.Context, _ *ChatModelAgentState) error {
-				iter := childAgent.Run(ctx, &AgentInput{Messages: []Message{schema.UserMessage("child work")}})
-				for {
-					event, ok := iter.Next()
-					if !ok {
-						return nil
-					}
-					if event.Err != nil {
-						return event.Err
-					}
-				}
+				return runChildAgentToEnd(ctx, childAgent, "child work")
 			},
 		}},
 	})
@@ -1674,9 +1651,7 @@ func TestWithCancel_RecursiveImmediate_MiddlewareChildAbortOnly(t *testing.T) {
 	require.NoError(t, handle.Wait())
 	_, cancelErrors := drainCancelErrors(iter)
 	require.Len(t, cancelErrors, 1, "outer stream should emit exactly one root CancelError")
-	for _, intCtx := range cancelErrors[0].InterruptContexts {
-		assert.NotContains(t, fmt.Sprint(intCtx.Address), "MiddlewareChild")
-	}
+	assertCancelErrorExcludesAddresses(t, cancelErrors[0], "MiddlewareChild")
 
 	resumeChildCalls := int32(0)
 	resumeChildModel := &countingChatModel{
@@ -1700,16 +1675,7 @@ func TestWithCancel_RecursiveImmediate_MiddlewareChildAbortOnly(t *testing.T) {
 		Model:       &plainResponseModel{text: "outer done after resume"},
 		Middlewares: []AgentMiddleware{{
 			BeforeChatModel: func(ctx context.Context, _ *ChatModelAgentState) error {
-				iter := resumeChildAgent.Run(ctx, &AgentInput{Messages: []Message{schema.UserMessage("child work")}})
-				for {
-					event, ok := iter.Next()
-					if !ok {
-						return nil
-					}
-					if event.Err != nil {
-						return event.Err
-					}
-				}
+				return runChildAgentToEnd(ctx, resumeChildAgent, "child work")
 			},
 		}},
 	})
@@ -1806,10 +1772,7 @@ func TestWithCancel_RecursiveImmediate_MiddlewareChildAgentToolCheckpointResumeB
 		"the root may handle its own immediate interrupt, but not a checkpoint hidden behind a direct middleware Run")
 	_, cancelErrors := drainCancelErrors(iter)
 	require.Len(t, cancelErrors, 1, "root stream should expose only the root immediate cancel")
-	for _, intCtx := range cancelErrors[0].InterruptContexts {
-		assert.NotContains(t, fmt.Sprint(intCtx.Address), "MiddlewareLeafAgent",
-			"root cancel must not expose the nested AgentTool checkpoint from behind the direct middleware Run")
-	}
+	assertCancelErrorExcludesAddresses(t, cancelErrors[0], "MiddlewareLeafAgent")
 	assert.Equal(t, int32(0), atomic.LoadInt32(&childInterruptSeen),
 		"the abort-only middleware child must swallow the nested AgentTool interrupt action instead of surfacing it as a resumable boundary")
 
@@ -1854,16 +1817,7 @@ func TestWithCancel_RecursiveImmediate_MiddlewareChildAgentToolCheckpointResumeB
 		Model:       &plainResponseModel{text: "outer done after resume"},
 		Middlewares: []AgentMiddleware{{
 			BeforeChatModel: func(ctx context.Context, _ *ChatModelAgentState) error {
-				iter := resumeChildAgent.Run(ctx, &AgentInput{Messages: []Message{schema.UserMessage("child work")}})
-				for {
-					event, ok := iter.Next()
-					if !ok {
-						return nil
-					}
-					if event.Err != nil {
-						return event.Err
-					}
-				}
+				return runChildAgentToEnd(ctx, resumeChildAgent, "child work")
 			},
 		}},
 	})
@@ -1942,9 +1896,7 @@ func TestWithCancel_RecursiveImmediate_BeforeAgentChildAbortOnly(t *testing.T) {
 	}
 	_, cancelErrors := drainCancelErrors(iter)
 	require.Len(t, cancelErrors, 1, "outer stream should emit exactly one root CancelError")
-	for _, intCtx := range cancelErrors[0].InterruptContexts {
-		assert.NotContains(t, fmt.Sprint(intCtx.Address), "BeforeAgentMiddlewareChild")
-	}
+	assertCancelErrorExcludesAddresses(t, cancelErrors[0], "BeforeAgentMiddlewareChild")
 }
 
 func TestWithCancel_RecursiveImmediate_MultiLevelMiddlewareChildrenAbortOnly(t *testing.T) {
@@ -1974,16 +1926,7 @@ func TestWithCancel_RecursiveImmediate_MultiLevelMiddlewareChildrenAbortOnly(t *
 					default:
 					}
 				}()
-				iter := agentC.Run(ctx, &AgentInput{Messages: []Message{schema.UserMessage("c work")}})
-				for {
-					event, ok := iter.Next()
-					if !ok {
-						return nil
-					}
-					if event.Err != nil {
-						return event.Err
-					}
-				}
+				return runChildAgentToEnd(ctx, agentC, "c work")
 			},
 		}},
 	})
@@ -1996,16 +1939,7 @@ func TestWithCancel_RecursiveImmediate_MultiLevelMiddlewareChildrenAbortOnly(t *
 		Model:       &plainResponseModel{text: "outer done"},
 		Middlewares: []AgentMiddleware{{
 			BeforeChatModel: func(ctx context.Context, _ *ChatModelAgentState) error {
-				iter := agentB.Run(ctx, &AgentInput{Messages: []Message{schema.UserMessage("b work")}})
-				for {
-					event, ok := iter.Next()
-					if !ok {
-						return nil
-					}
-					if event.Err != nil {
-						return event.Err
-					}
-				}
+				return runChildAgentToEnd(ctx, agentB, "b work")
 			},
 		}},
 	})
@@ -2036,11 +1970,7 @@ func TestWithCancel_RecursiveImmediate_MultiLevelMiddlewareChildrenAbortOnly(t *
 	require.NoError(t, handle.Wait())
 	_, cancelErrors := drainCancelErrors(iter)
 	require.Len(t, cancelErrors, 1, "outer stream should emit exactly one root CancelError")
-	for _, intCtx := range cancelErrors[0].InterruptContexts {
-		addr := fmt.Sprint(intCtx.Address)
-		assert.NotContains(t, addr, "MiddlewareChildB")
-		assert.NotContains(t, addr, "MiddlewareChildC")
-	}
+	assertCancelErrorExcludesAddresses(t, cancelErrors[0], "MiddlewareChildB", "MiddlewareChildC")
 }
 
 func TestWithCancel_NonRecursiveImmediate_DoesNotAbortMiddlewareChild(t *testing.T) {
@@ -2068,16 +1998,7 @@ func TestWithCancel_NonRecursiveImmediate_DoesNotAbortMiddlewareChild(t *testing
 		Model:       &plainResponseModel{text: "outer done"},
 		Middlewares: []AgentMiddleware{{
 			BeforeChatModel: func(ctx context.Context, _ *ChatModelAgentState) error {
-				iter := childAgent.Run(ctx, &AgentInput{Messages: []Message{schema.UserMessage("child work")}})
-				for {
-					event, ok := iter.Next()
-					if !ok {
-						return nil
-					}
-					if event.Err != nil {
-						return event.Err
-					}
-				}
+				return runChildAgentToEnd(ctx, childAgent, "child work")
 			},
 		}},
 	})

--- a/adk/cancel_edge_test.go
+++ b/adk/cancel_edge_test.go
@@ -73,6 +73,51 @@ func (m *blockingChatModel) Stream(ctx context.Context, _ []*schema.Message, _ .
 
 func (m *blockingChatModel) BindTools(_ []*schema.ToolInfo) error { return nil }
 
+type contextAwareBlockingChatModel struct {
+	release        chan struct{}
+	response       *schema.Message
+	started        chan struct{}
+	cancelObserved chan struct{}
+	callCount      int32
+}
+
+func newContextAwareBlockingChatModel(response *schema.Message) *contextAwareBlockingChatModel {
+	return &contextAwareBlockingChatModel{
+		release:        make(chan struct{}),
+		response:       response,
+		started:        make(chan struct{}, 4),
+		cancelObserved: make(chan struct{}, 4),
+	}
+}
+
+func (m *contextAwareBlockingChatModel) Generate(ctx context.Context, _ []*schema.Message, _ ...model.Option) (*schema.Message, error) {
+	atomic.AddInt32(&m.callCount, 1)
+	select {
+	case m.started <- struct{}{}:
+	default:
+	}
+	select {
+	case <-ctx.Done():
+		select {
+		case m.cancelObserved <- struct{}{}:
+		default:
+		}
+		return nil, ctx.Err()
+	case <-m.release:
+		return m.response, nil
+	}
+}
+
+func (m *contextAwareBlockingChatModel) Stream(ctx context.Context, input []*schema.Message, opts ...model.Option) (*schema.StreamReader[*schema.Message], error) {
+	msg, err := m.Generate(ctx, input, opts...)
+	if err != nil {
+		return nil, err
+	}
+	return schema.StreamReaderFromArray([]*schema.Message{msg}), nil
+}
+
+func (m *contextAwareBlockingChatModel) BindTools(_ []*schema.ToolInfo) error { return nil }
+
 // errorChatModel returns an error from Generate/Stream.
 type errorChatModel struct {
 	err     error
@@ -169,6 +214,23 @@ func drainEvents(iter *AsyncIterator[*AgentEvent]) ([]*AgentEvent, bool) {
 		}
 	}
 	return events, hasCancelError
+}
+
+func drainCancelErrors(iter *AsyncIterator[*AgentEvent]) ([]*AgentEvent, []*CancelError) {
+	var events []*AgentEvent
+	var cancelErrors []*CancelError
+	for {
+		e, ok := iter.Next()
+		if !ok {
+			break
+		}
+		events = append(events, e)
+		var ce *CancelError
+		if e.Err != nil && errors.As(e.Err, &ce) {
+			cancelErrors = append(cancelErrors, ce)
+		}
+	}
+	return events, cancelErrors
 }
 
 // --- tests ---
@@ -291,6 +353,95 @@ func TestWithCancel_DerivedAgentToolCancelContextMarkedDoneAfterRun(t *testing.T
 	case <-time.After(time.Second):
 		t.Fatal("derived AgentTool cancel context was not marked done after child run completion")
 	}
+}
+
+func TestWithCancel_RecursiveDoesNotTargetAgentEmbeddedInMiddleware(t *testing.T) {
+	ctx := context.Background()
+
+	innerModel := newBlockingChatModel(toolCallMsg(toolCall("inner-call", "inner-tool", `{"input":"x"}`)))
+	innerToolCalled := make(chan struct{}, 1)
+	innerTool := &callbackTool{
+		name: "inner-tool",
+		onCall: func() {
+			innerToolCalled <- struct{}{}
+		},
+	}
+	innerAgent, err := NewChatModelAgent(ctx, &ChatModelAgentConfig{
+		Name:        "InnerMiddlewareAgent",
+		Description: "agent invoked as middleware implementation detail",
+		Model:       innerModel,
+		ToolsConfig: ToolsConfig{
+			ToolsNodeConfig: compose.ToolsNodeConfig{Tools: []tool.BaseTool{innerTool}},
+			ReturnDirectly:  map[string]bool{"inner-tool": true},
+		},
+	})
+	require.NoError(t, err)
+
+	outerTool := newBlockingTool("outer-tool")
+	outerAgent, err := NewChatModelAgent(ctx, &ChatModelAgentConfig{
+		Name:        "OuterAgent",
+		Description: "outer agent",
+		Model: &simpleChatModel{
+			response: toolCallMsg(toolCall("outer-call", "outer-tool", `{"input":"x"}`)),
+		},
+		ToolsConfig: ToolsConfig{
+			ToolsNodeConfig: compose.ToolsNodeConfig{Tools: []tool.BaseTool{outerTool}},
+		},
+		Handlers: []ChatModelAgentMiddleware{
+			&testAfterModelRewriteStateHandler{fn: func(
+				ctx context.Context,
+				state *ChatModelAgentState,
+				_ *ModelContext,
+			) (context.Context, *ChatModelAgentState, error) {
+				iter := innerAgent.Run(ctx, &AgentInput{Messages: []Message{schema.UserMessage("run")}})
+				for {
+					event, ok := iter.Next()
+					if !ok {
+						break
+					}
+					if event.Err != nil {
+						return ctx, state, event.Err
+					}
+				}
+				return ctx, state, nil
+			}},
+		},
+	})
+	require.NoError(t, err)
+
+	cancelOpt, cancelFn := WithCancel()
+	iter := outerAgent.Run(ctx, &AgentInput{Messages: []Message{schema.UserMessage("run")}}, cancelOpt)
+
+	select {
+	case <-innerModel.started:
+	case <-time.After(5 * time.Second):
+		t.Fatal("middleware's embedded agent did not start")
+	}
+
+	cancelDone := make(chan error, 1)
+	go func() {
+		handle, _ := cancelFn(WithAgentCancelMode(CancelAfterChatModel), WithRecursive())
+		cancelDone <- handle.Wait()
+	}()
+
+	close(innerModel.unblockCh)
+
+	select {
+	case <-innerToolCalled:
+	case <-time.After(5 * time.Second):
+		t.Fatal("recursive cancel incorrectly targeted the middleware's embedded agent")
+	}
+
+	select {
+	case err := <-cancelDone:
+		require.NoError(t, err)
+	case <-time.After(5 * time.Second):
+		t.Fatal("outer cancel did not complete")
+	}
+
+	_, hasCancelError := drainEvents(iter)
+	assert.True(t, hasCancelError, "outer agent should cancel at its own safe-point")
+	assert.Equal(t, int32(0), atomic.LoadInt32(&outerTool.callCount), "outer tool must not run after cancellation")
 }
 
 // TestWithCancel_AfterBusinessInterrupt verifies cancelFn returns ErrExecutionEnded
@@ -1301,6 +1452,270 @@ func TestWithCancel_CancelAfterChatModel_NestedAgentTool(t *testing.T) {
 	}
 
 	assert.True(t, hasCancelError, "CancelError expected from nested agent tool with tools")
+}
+
+func TestWithCancel_RecursiveImmediate_MiddlewareChildAbortOnly(t *testing.T) {
+	ctx := context.Background()
+
+	childModel := newContextAwareBlockingChatModel(schema.AssistantMessage("child done", nil))
+	childAgent, err := NewChatModelAgent(ctx, &ChatModelAgentConfig{
+		Name:        "MiddlewareChild",
+		Description: "direct middleware child",
+		Instruction: "child",
+		Model:       childModel,
+	})
+	require.NoError(t, err)
+
+	outerAgent, err := NewChatModelAgent(ctx, &ChatModelAgentConfig{
+		Name:        "OuterMiddlewareAgent",
+		Description: "outer",
+		Instruction: "outer",
+		Model:       &plainResponseModel{text: "outer done"},
+		Middlewares: []AgentMiddleware{{
+			BeforeChatModel: func(ctx context.Context, _ *ChatModelAgentState) error {
+				iter := childAgent.Run(ctx, &AgentInput{Messages: []Message{schema.UserMessage("child work")}})
+				for {
+					event, ok := iter.Next()
+					if !ok {
+						return nil
+					}
+					if event.Err != nil {
+						return event.Err
+					}
+				}
+			},
+		}},
+	})
+	require.NoError(t, err)
+
+	store := newCancelTestStore()
+	checkpointID := "recursive-immediate-middleware-child-abort-only"
+	runner := NewRunner(ctx, RunnerConfig{Agent: outerAgent, CheckPointStore: store})
+
+	cancelOpt, cancelFn := WithCancel()
+	iter := runner.Run(ctx, []Message{schema.UserMessage("go")}, cancelOpt, WithCheckPointID(checkpointID))
+
+	select {
+	case <-childModel.started:
+	case <-time.After(5 * time.Second):
+		t.Fatal("middleware child model did not start")
+	}
+
+	handle, _ := cancelFn(WithRecursive())
+
+	select {
+	case <-childModel.cancelObserved:
+	case <-time.After(time.Second):
+		t.Fatal("middleware child did not observe recursive immediate context cancellation")
+	}
+
+	require.NoError(t, handle.Wait())
+	_, cancelErrors := drainCancelErrors(iter)
+	require.Len(t, cancelErrors, 1, "outer stream should emit exactly one root CancelError")
+	for _, intCtx := range cancelErrors[0].InterruptContexts {
+		assert.NotContains(t, fmt.Sprint(intCtx.Address), "MiddlewareChild")
+	}
+
+	resumeChildCalls := int32(0)
+	resumeChildModel := &countingChatModel{
+		callCount: &resumeChildCalls,
+		responses: []*schema.Message{
+			schema.AssistantMessage("fresh child run after resume", nil),
+		},
+	}
+	resumeChildAgent, err := NewChatModelAgent(ctx, &ChatModelAgentConfig{
+		Name:        "MiddlewareChild",
+		Description: "direct middleware child",
+		Instruction: "child",
+		Model:       resumeChildModel,
+	})
+	require.NoError(t, err)
+
+	resumeOuterAgent, err := NewChatModelAgent(ctx, &ChatModelAgentConfig{
+		Name:        "OuterMiddlewareAgent",
+		Description: "outer",
+		Instruction: "outer",
+		Model:       &plainResponseModel{text: "outer done after resume"},
+		Middlewares: []AgentMiddleware{{
+			BeforeChatModel: func(ctx context.Context, _ *ChatModelAgentState) error {
+				iter := resumeChildAgent.Run(ctx, &AgentInput{Messages: []Message{schema.UserMessage("child work")}})
+				for {
+					event, ok := iter.Next()
+					if !ok {
+						return nil
+					}
+					if event.Err != nil {
+						return event.Err
+					}
+				}
+			},
+		}},
+	})
+	require.NoError(t, err)
+
+	resumeRunner := NewRunner(ctx, RunnerConfig{Agent: resumeOuterAgent, CheckPointStore: store})
+	resumeIter, err := resumeRunner.Resume(ctx, checkpointID)
+	require.NoError(t, err)
+	resumeEvents, resumeCancelErrors := drainCancelErrors(resumeIter)
+	require.Empty(t, resumeCancelErrors)
+	require.NotEmpty(t, resumeEvents)
+	assert.Equal(t, int32(1), atomic.LoadInt32(&resumeChildCalls), "middleware child should be invoked as a fresh Run on root resume")
+}
+
+func TestWithCancel_RecursiveImmediate_MultiLevelMiddlewareChildrenAbortOnly(t *testing.T) {
+	ctx := context.Background()
+
+	cModel := newContextAwareBlockingChatModel(schema.AssistantMessage("c done", nil))
+	agentC, err := NewChatModelAgent(ctx, &ChatModelAgentConfig{
+		Name:        "MiddlewareChildC",
+		Description: "direct middleware child C",
+		Instruction: "child C",
+		Model:       cModel,
+	})
+	require.NoError(t, err)
+
+	bCancelObserved := make(chan struct{}, 1)
+	agentB, err := NewChatModelAgent(ctx, &ChatModelAgentConfig{
+		Name:        "MiddlewareChildB",
+		Description: "direct middleware child B",
+		Instruction: "child B",
+		Model:       &plainResponseModel{text: "b done"},
+		Middlewares: []AgentMiddleware{{
+			BeforeChatModel: func(ctx context.Context, _ *ChatModelAgentState) error {
+				go func() {
+					<-ctx.Done()
+					select {
+					case bCancelObserved <- struct{}{}:
+					default:
+					}
+				}()
+				iter := agentC.Run(ctx, &AgentInput{Messages: []Message{schema.UserMessage("c work")}})
+				for {
+					event, ok := iter.Next()
+					if !ok {
+						return nil
+					}
+					if event.Err != nil {
+						return event.Err
+					}
+				}
+			},
+		}},
+	})
+	require.NoError(t, err)
+
+	outerAgent, err := NewChatModelAgent(ctx, &ChatModelAgentConfig{
+		Name:        "OuterMultiLevelMiddlewareAgent",
+		Description: "outer",
+		Instruction: "outer",
+		Model:       &plainResponseModel{text: "outer done"},
+		Middlewares: []AgentMiddleware{{
+			BeforeChatModel: func(ctx context.Context, _ *ChatModelAgentState) error {
+				iter := agentB.Run(ctx, &AgentInput{Messages: []Message{schema.UserMessage("b work")}})
+				for {
+					event, ok := iter.Next()
+					if !ok {
+						return nil
+					}
+					if event.Err != nil {
+						return event.Err
+					}
+				}
+			},
+		}},
+	})
+	require.NoError(t, err)
+
+	cancelOpt, cancelFn := WithCancel()
+	iter := NewRunner(ctx, RunnerConfig{Agent: outerAgent}).Run(ctx, []Message{schema.UserMessage("go")}, cancelOpt)
+
+	select {
+	case <-cModel.started:
+	case <-time.After(5 * time.Second):
+		t.Fatal("middleware child C model did not start")
+	}
+
+	handle, _ := cancelFn(WithRecursive())
+
+	select {
+	case <-bCancelObserved:
+	case <-time.After(time.Second):
+		t.Fatal("middleware child B did not observe recursive immediate context cancellation")
+	}
+	select {
+	case <-cModel.cancelObserved:
+	case <-time.After(time.Second):
+		t.Fatal("middleware child C did not observe recursive immediate context cancellation")
+	}
+
+	require.NoError(t, handle.Wait())
+	_, cancelErrors := drainCancelErrors(iter)
+	require.Len(t, cancelErrors, 1, "outer stream should emit exactly one root CancelError")
+	for _, intCtx := range cancelErrors[0].InterruptContexts {
+		addr := fmt.Sprint(intCtx.Address)
+		assert.NotContains(t, addr, "MiddlewareChildB")
+		assert.NotContains(t, addr, "MiddlewareChildC")
+	}
+}
+
+func TestWithCancel_NonRecursiveImmediate_DoesNotAbortMiddlewareChild(t *testing.T) {
+	ctx := context.Background()
+
+	childModel := newContextAwareBlockingChatModel(schema.AssistantMessage("child done", nil))
+	released := false
+	t.Cleanup(func() {
+		if !released {
+			close(childModel.release)
+		}
+	})
+	childAgent, err := NewChatModelAgent(ctx, &ChatModelAgentConfig{
+		Name:        "MiddlewareChild",
+		Description: "direct middleware child",
+		Instruction: "child",
+		Model:       childModel,
+	})
+	require.NoError(t, err)
+
+	outerAgent, err := NewChatModelAgent(ctx, &ChatModelAgentConfig{
+		Name:        "OuterMiddlewareAgent",
+		Description: "outer",
+		Instruction: "outer",
+		Model:       &plainResponseModel{text: "outer done"},
+		Middlewares: []AgentMiddleware{{
+			BeforeChatModel: func(ctx context.Context, _ *ChatModelAgentState) error {
+				iter := childAgent.Run(ctx, &AgentInput{Messages: []Message{schema.UserMessage("child work")}})
+				for {
+					event, ok := iter.Next()
+					if !ok {
+						return nil
+					}
+					if event.Err != nil {
+						return event.Err
+					}
+				}
+			},
+		}},
+	})
+	require.NoError(t, err)
+
+	cancelOpt, cancelFn := WithCancel()
+	iter := NewRunner(ctx, RunnerConfig{Agent: outerAgent}).Run(ctx, []Message{schema.UserMessage("go")}, cancelOpt)
+
+	select {
+	case <-childModel.started:
+	case <-time.After(5 * time.Second):
+		t.Fatal("middleware child model did not start")
+	}
+
+	handle, _ := cancelFn()
+	assertNotClosedWithin(t, childModel.cancelObserved, 100*time.Millisecond)
+
+	close(childModel.release)
+	released = true
+
+	require.NoError(t, handle.Wait())
+	_, cancelErrors := drainCancelErrors(iter)
+	require.Len(t, cancelErrors, 1)
 }
 
 // slowStreamingTool implements StreamableTool (but NOT InvokableTool), streaming

--- a/adk/cancel_edge_test.go
+++ b/adk/cancel_edge_test.go
@@ -1562,6 +1562,74 @@ func TestWithCancel_RecursiveImmediate_MiddlewareChildAbortOnly(t *testing.T) {
 	assert.Equal(t, int32(1), atomic.LoadInt32(&resumeChildCalls), "middleware child should be invoked as a fresh Run on root resume")
 }
 
+func TestWithCancel_RecursiveImmediate_BeforeAgentChildAbortOnly(t *testing.T) {
+	ctx := context.Background()
+
+	childModel := newContextAwareBlockingChatModel(schema.AssistantMessage("child done", nil))
+	childAgent, err := NewChatModelAgent(ctx, &ChatModelAgentConfig{
+		Name:        "BeforeAgentMiddlewareChild",
+		Description: "direct BeforeAgent child",
+		Instruction: "child",
+		Model:       childModel,
+	})
+	require.NoError(t, err)
+
+	outerAgent, err := NewChatModelAgent(ctx, &ChatModelAgentConfig{
+		Name:        "OuterBeforeAgentMiddlewareAgent",
+		Description: "outer",
+		Instruction: "outer",
+		Model:       &plainResponseModel{text: "outer done"},
+		Handlers: []ChatModelAgentMiddleware{
+			&testBeforeAgentHandler{fn: func(ctx context.Context, runCtx *ChatModelAgentContext) (context.Context, *ChatModelAgentContext, error) {
+				iter := childAgent.Run(ctx, &AgentInput{Messages: []Message{schema.UserMessage("child work")}})
+				for {
+					event, ok := iter.Next()
+					if !ok {
+						return ctx, runCtx, nil
+					}
+					if event.Err != nil {
+						return ctx, runCtx, event.Err
+					}
+				}
+			}},
+		},
+	})
+	require.NoError(t, err)
+
+	cancelOpt, cancelFn := WithCancel()
+	iterCh := make(chan *AsyncIterator[*AgentEvent], 1)
+	go func() {
+		iterCh <- NewRunner(ctx, RunnerConfig{Agent: outerAgent}).Run(ctx, []Message{schema.UserMessage("go")}, cancelOpt)
+	}()
+
+	select {
+	case <-childModel.started:
+	case <-time.After(5 * time.Second):
+		t.Fatal("BeforeAgent middleware child model did not start")
+	}
+
+	handle, _ := cancelFn(WithRecursive())
+
+	select {
+	case <-childModel.cancelObserved:
+	case <-time.After(time.Second):
+		t.Fatal("BeforeAgent middleware child did not observe recursive immediate context cancellation")
+	}
+
+	require.NoError(t, handle.Wait())
+	var iter *AsyncIterator[*AgentEvent]
+	select {
+	case iter = <-iterCh:
+	case <-time.After(5 * time.Second):
+		t.Fatal("outer Run did not return after BeforeAgent child cancellation")
+	}
+	_, cancelErrors := drainCancelErrors(iter)
+	require.Len(t, cancelErrors, 1, "outer stream should emit exactly one root CancelError")
+	for _, intCtx := range cancelErrors[0].InterruptContexts {
+		assert.NotContains(t, fmt.Sprint(intCtx.Address), "BeforeAgentMiddlewareChild")
+	}
+}
+
 func TestWithCancel_RecursiveImmediate_MultiLevelMiddlewareChildrenAbortOnly(t *testing.T) {
 	ctx := context.Background()
 

--- a/adk/cancel_recursive_test.go
+++ b/adk/cancel_recursive_test.go
@@ -257,6 +257,10 @@ func TestDeriveCheckpointAwareCancelContext(t *testing.T) {
 }
 
 func TestDeriveAbortOnlyCancelContext(t *testing.T) {
+	t.Run("NilParentReturnsNil", func(t *testing.T) {
+		assert.Nil(t, deriveAbortOnlyCancelContext(context.Background(), nil))
+	})
+
 	t.Run("SafePointDoesNotPropagate", func(t *testing.T) {
 		parent, child, _ := setupAbortOnlyChild(t)
 
@@ -622,4 +626,22 @@ func TestDeriveCheckpointAwareSubAgentCancelContext(t *testing.T) {
 			t.Fatal("root checkpoint-aware ancestor was marked through an abort-only barrier")
 		}
 	})
+}
+
+func TestResolveRunCancelContext_CheckpointAwareInheritedScope(t *testing.T) {
+	parent := newCancelContext()
+	baseCtx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	child := parent.deriveCheckpointAwareCancelContext(baseCtx)
+	t.Cleanup(child.markDone)
+	ctx := withCancelContext(baseCtx, child)
+
+	got, owned := resolveRunCancelContext(ctx, &options{})
+	if got != child {
+		t.Fatal("checkpoint-aware inherited scope was not reused")
+	}
+	if owned {
+		t.Fatal("checkpoint-aware inherited scope should not be owned by the child run")
+	}
 }

--- a/adk/cancel_recursive_test.go
+++ b/adk/cancel_recursive_test.go
@@ -40,7 +40,7 @@ func assertNotClosedWithin(t *testing.T, ch <-chan struct{}, d time.Duration) {
 func setupParentChild(t *testing.T) (parent, child *cancelContext, cleanup func()) {
 	parent = newCancelContext()
 	ctx, cancel := context.WithCancel(context.Background())
-	child = parent.deriveAgentToolCancelContext(ctx)
+	child = parent.deriveCheckpointAwareCancelContext(ctx)
 	cleanup = func() {
 		child.markDone()
 		cancel()
@@ -61,7 +61,7 @@ func setupAbortOnlyChild(t *testing.T) (parent, child *cancelContext, cleanup fu
 	return parent, child, cleanup
 }
 
-func TestDeriveAgentToolCancelContext(t *testing.T) {
+func TestDeriveCheckpointAwareCancelContext(t *testing.T) {
 	t.Run("Shallow", func(t *testing.T) {
 		t.Run("DoesNotPropagateSafePoint", func(t *testing.T) {
 			parent, child, _ := setupParentChild(t)
@@ -83,8 +83,8 @@ func TestDeriveAgentToolCancelContext(t *testing.T) {
 			a := newCancelContext()
 			ctx, cancel := context.WithCancel(context.Background())
 
-			b := a.deriveAgentToolCancelContext(ctx)
-			c := b.deriveAgentToolCancelContext(ctx)
+			b := a.deriveCheckpointAwareCancelContext(ctx)
+			c := b.deriveCheckpointAwareCancelContext(ctx)
 			t.Cleanup(func() {
 				c.markDone()
 				b.markDone()
@@ -105,7 +105,7 @@ func TestDeriveAgentToolCancelContext(t *testing.T) {
 			parent := newCancelContext()
 			ctx, cancel := context.WithCancel(context.Background())
 
-			child := parent.deriveAgentToolCancelContext(ctx)
+			child := parent.deriveCheckpointAwareCancelContext(ctx)
 
 			parent.triggerCancel(CancelAfterChatModel)
 			time.Sleep(100 * time.Millisecond)
@@ -155,8 +155,8 @@ func TestDeriveAgentToolCancelContext(t *testing.T) {
 			a := newCancelContext()
 			ctx, cancel := context.WithCancel(context.Background())
 
-			b := a.deriveAgentToolCancelContext(ctx)
-			c := b.deriveAgentToolCancelContext(ctx)
+			b := a.deriveCheckpointAwareCancelContext(ctx)
+			c := b.deriveCheckpointAwareCancelContext(ctx)
 			t.Cleanup(func() {
 				c.markDone()
 				b.markDone()
@@ -204,7 +204,7 @@ func TestDeriveAgentToolCancelContext(t *testing.T) {
 			parent.setRecursive(true)
 			parent.triggerCancel(CancelAfterChatModel)
 
-			child := parent.deriveAgentToolCancelContext(ctx)
+			child := parent.deriveCheckpointAwareCancelContext(ctx)
 			t.Cleanup(func() {
 				child.markDone()
 				cancel()
@@ -323,23 +323,23 @@ func TestDeriveAbortOnlyCancelContext(t *testing.T) {
 		assertNotClosedWithin(t, child.immediateChan, 50*time.Millisecond)
 	})
 
-	t.Run("AgentToolDescendantStopsAtAbortOnlyBoundary", func(t *testing.T) {
+	t.Run("CheckpointAwareDescendantStopsAtAbortOnlyBoundary", func(t *testing.T) {
 		root := newCancelContext()
 		ctx, cancel := context.WithCancel(context.Background())
 		defer cancel()
 
 		abortOnly := deriveAbortOnlyCancelContext(ctx, root)
-		agentToolChild := abortOnly.deriveAgentToolCancelContext(ctx)
+		checkpointAwareScope := abortOnly.deriveCheckpointAwareCancelContext(ctx)
 		t.Cleanup(func() {
-			agentToolChild.markDone()
+			checkpointAwareScope.markDone()
 			abortOnly.markDone()
 		})
 
-		agentToolChild.markAgentToolDescendant()
+		checkpointAwareScope.markCheckpointAwareDescendant()
 
-		assert.True(t, agentToolChild.hasAgentToolDescendant())
-		assert.True(t, abortOnly.hasAgentToolDescendant())
-		assert.False(t, root.hasAgentToolDescendant())
+		assert.True(t, checkpointAwareScope.hasCheckpointAwareDescendant())
+		assert.False(t, abortOnly.hasCheckpointAwareDescendant())
+		assert.False(t, root.hasCheckpointAwareDescendant())
 	})
 }
 
@@ -394,13 +394,13 @@ func TestCheckPreExecCancel(t *testing.T) {
 	})
 }
 
-func TestDeriveAgentToolCancelContext_Race(t *testing.T) {
+func TestDeriveCheckpointAwareCancelContext_Race(t *testing.T) {
 	t.Run("SetRecursiveConcurrentWithCancelChan", func(t *testing.T) {
 		for i := 0; i < 100; i++ {
 			parent := newCancelContext()
 			ctx, cancel := context.WithCancel(context.Background())
 
-			child := parent.deriveAgentToolCancelContext(ctx)
+			child := parent.deriveCheckpointAwareCancelContext(ctx)
 
 			var wg sync.WaitGroup
 			wg.Add(2)
@@ -434,7 +434,7 @@ func TestDeriveAgentToolCancelContext_Race(t *testing.T) {
 		ctx, cancel := context.WithCancel(context.Background())
 		defer cancel()
 
-		child := parent.deriveAgentToolCancelContext(ctx)
+		child := parent.deriveCheckpointAwareCancelContext(ctx)
 
 		parent.triggerCancel(CancelAfterChatModel)
 		time.Sleep(50 * time.Millisecond)
@@ -452,8 +452,8 @@ func TestDeriveAgentToolCancelContext_Race(t *testing.T) {
 		ctx, cancel := context.WithCancel(context.Background())
 		defer cancel()
 
-		child1 := parent.deriveAgentToolCancelContext(ctx)
-		child2 := parent.deriveAgentToolCancelContext(ctx)
+		child1 := parent.deriveCheckpointAwareCancelContext(ctx)
+		child2 := parent.deriveCheckpointAwareCancelContext(ctx)
 
 		parent.triggerCancel(CancelAfterChatModel)
 		time.Sleep(50 * time.Millisecond)
@@ -482,7 +482,7 @@ func TestDeriveAgentToolCancelContext_Race(t *testing.T) {
 			parent := newCancelContext()
 			ctx, cancel := context.WithCancel(context.Background())
 
-			child := parent.deriveAgentToolCancelContext(ctx)
+			child := parent.deriveCheckpointAwareCancelContext(ctx)
 
 			parent.triggerCancel(CancelAfterChatModel)
 
@@ -535,5 +535,91 @@ func TestDeriveAgentToolCancelContext_Race(t *testing.T) {
 		}
 
 		assert.True(t, parent.isRecursive())
+	})
+}
+
+func TestAppendCancelContextOption_CopiesInputSlice(t *testing.T) {
+	parent := newCancelContext()
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	child := parent.deriveCheckpointAwareCancelContext(ctx)
+	t.Cleanup(child.markDone)
+
+	raw := make([]AgentRunOption, 1, 2)
+	raw[0] = WrapImplSpecificOptFn(func(o *options) {
+		o.skipTransferMessages = true
+	})
+	opts := raw[:1]
+
+	childOpts := appendCancelContextOption(opts, child)
+
+	requireLen := func(name string, got, want int) {
+		t.Helper()
+		if got != want {
+			t.Fatalf("%s length = %d, want %d", name, got, want)
+		}
+	}
+	requireLen("opts", len(opts), 1)
+	requireLen("childOpts", len(childOpts), 2)
+
+	originalCommon := getCommonOptions(nil, raw[:2]...)
+	if originalCommon.cancelCtx != nil {
+		t.Fatal("appendCancelContextOption reused the caller's backing array")
+	}
+
+	childCommon := getCommonOptions(nil, childOpts...)
+	if childCommon.cancelCtx != child {
+		t.Fatal("sub-agent opts did not receive the requested cancel context")
+	}
+}
+
+func TestDeriveCheckpointAwareSubAgentCancelContext(t *testing.T) {
+	t.Run("CheckpointAwareParent", func(t *testing.T) {
+		parent := newCancelContext()
+		baseCtx, cancel := context.WithCancel(context.Background())
+		defer cancel()
+		ctx := withCancelContext(baseCtx, parent)
+
+		child := deriveCheckpointAwareSubAgentCancelContext(ctx, nil)
+		if child != nil {
+			t.Cleanup(child.markDone)
+		}
+
+		if child == nil {
+			t.Fatal("sub-agent cancel context was not derived")
+		}
+		if child == parent {
+			t.Fatal("sub-agent cancel context reused the parent cancel context")
+		}
+		if child.parent != parent || child.abortOnly {
+			t.Fatal("sub-agent cancel context is not checkpoint-aware")
+		}
+		if !parent.hasCheckpointAwareDescendant() {
+			t.Fatal("parent was not marked as having a checkpoint-aware descendant")
+		}
+	})
+
+	t.Run("AbortOnlyParentIsResumeBarrier", func(t *testing.T) {
+		root := newCancelContext()
+		baseCtx, cancel := context.WithCancel(context.Background())
+		defer cancel()
+		abortOnly := deriveAbortOnlyCancelContext(baseCtx, root)
+		t.Cleanup(abortOnly.markDone)
+		ctx := withCancelContext(baseCtx, abortOnly)
+
+		child := deriveCheckpointAwareSubAgentCancelContext(ctx, nil)
+		if child != nil {
+			t.Cleanup(child.markDone)
+		}
+
+		if child != nil {
+			t.Fatal("sub-agent cancel context crossed an abort-only resume barrier")
+		}
+		if abortOnly.hasCheckpointAwareDescendant() {
+			t.Fatal("abort-only scope was marked as having a checkpoint-aware descendant")
+		}
+		if root.hasCheckpointAwareDescendant() {
+			t.Fatal("root checkpoint-aware ancestor was marked through an abort-only barrier")
+		}
 	})
 }

--- a/adk/cancel_recursive_test.go
+++ b/adk/cancel_recursive_test.go
@@ -24,6 +24,8 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/assert"
+
+	"github.com/cloudwego/eino/schema"
 )
 
 func assertNotClosedWithin(t *testing.T, ch <-chan struct{}, d time.Duration) {
@@ -39,6 +41,18 @@ func setupParentChild(t *testing.T) (parent, child *cancelContext, cleanup func(
 	parent = newCancelContext()
 	ctx, cancel := context.WithCancel(context.Background())
 	child = parent.deriveAgentToolCancelContext(ctx)
+	cleanup = func() {
+		child.markDone()
+		cancel()
+	}
+	t.Cleanup(cleanup)
+	return parent, child, cleanup
+}
+
+func setupAbortOnlyChild(t *testing.T) (parent, child *cancelContext, cleanup func()) {
+	parent = newCancelContext()
+	ctx, cancel := context.WithCancel(context.Background())
+	child = deriveAbortOnlyCancelContext(ctx, parent)
 	cleanup = func() {
 		child.markDone()
 		cancel()
@@ -239,6 +253,144 @@ func TestDeriveAgentToolCancelContext(t *testing.T) {
 			}
 			assert.True(t, child.isImmediateCancelled())
 		})
+	})
+}
+
+func TestDeriveAbortOnlyCancelContext(t *testing.T) {
+	t.Run("SafePointDoesNotPropagate", func(t *testing.T) {
+		parent, child, _ := setupAbortOnlyChild(t)
+
+		parent.setRecursive(true)
+		parent.triggerCancel(CancelAfterChatModel)
+
+		assertNotClosedWithin(t, child.cancelChan, 50*time.Millisecond)
+		assertNotClosedWithin(t, child.immediateChan, 50*time.Millisecond)
+	})
+
+	t.Run("RecursiveImmediatePropagates", func(t *testing.T) {
+		parent, child, _ := setupAbortOnlyChild(t)
+
+		parent.setRecursive(true)
+		parent.triggerImmediateCancel()
+
+		select {
+		case <-child.immediateChan:
+		case <-time.After(time.Second):
+			t.Fatal("abort-only child did not receive immediate cancel")
+		}
+		assert.True(t, child.isImmediateCancelled())
+	})
+
+	t.Run("LateRecursiveImmediateEscalationPropagates", func(t *testing.T) {
+		parent, child, _ := setupAbortOnlyChild(t)
+
+		parent.triggerImmediateCancel()
+		assertNotClosedWithin(t, child.immediateChan, 50*time.Millisecond)
+
+		parent.setRecursive(true)
+
+		select {
+		case <-child.immediateChan:
+		case <-time.After(time.Second):
+			t.Fatal("abort-only child did not receive late recursive immediate cancel")
+		}
+	})
+
+	t.Run("ChildCompletionPreventsLaterPropagation", func(t *testing.T) {
+		parent, child, _ := setupAbortOnlyChild(t)
+
+		parent.triggerImmediateCancel()
+		time.Sleep(50 * time.Millisecond)
+		child.markDone()
+		parent.setRecursive(true)
+
+		assertNotClosedWithin(t, child.immediateChan, 50*time.Millisecond)
+	})
+
+	t.Run("ParentImmediateThenContextDoneExits", func(t *testing.T) {
+		parent := newCancelContext()
+		ctx, cancel := context.WithCancel(context.Background())
+		child := deriveAbortOnlyCancelContext(ctx, parent)
+		t.Cleanup(func() {
+			child.markDone()
+			cancel()
+		})
+
+		parent.triggerImmediateCancel()
+		assertNotClosedWithin(t, child.immediateChan, 50*time.Millisecond)
+
+		cancel()
+		assertNotClosedWithin(t, child.immediateChan, 50*time.Millisecond)
+	})
+
+	t.Run("AgentToolDescendantStopsAtAbortOnlyBoundary", func(t *testing.T) {
+		root := newCancelContext()
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
+
+		abortOnly := deriveAbortOnlyCancelContext(ctx, root)
+		agentToolChild := abortOnly.deriveAgentToolCancelContext(ctx)
+		t.Cleanup(func() {
+			agentToolChild.markDone()
+			abortOnly.markDone()
+		})
+
+		agentToolChild.markAgentToolDescendant()
+
+		assert.True(t, agentToolChild.hasAgentToolDescendant())
+		assert.True(t, abortOnly.hasAgentToolDescendant())
+		assert.False(t, root.hasAgentToolDescendant())
+	})
+}
+
+func TestWithAbortOnlyCancelContext(t *testing.T) {
+	cc := newCancelContext()
+	cc.abortOnly = true
+
+	ctx, cancel := withAbortOnlyCancelContext(context.Background(), cc)
+	defer cancel()
+
+	cc.markDone()
+
+	select {
+	case <-ctx.Done():
+	case <-time.After(time.Second):
+		t.Fatal("abort-only context was not canceled when cancel context completed")
+	}
+}
+
+func TestCheckPreExecCancel(t *testing.T) {
+	t.Run("AbortOnlyImmediateTerminatesWithoutEvent", func(t *testing.T) {
+		cc := newCancelContext()
+		cc.abortOnly = true
+		cc.triggerImmediateCancel()
+
+		iter, gen := NewAsyncIteratorPair[*TypedAgentEvent[*schema.Message]]()
+
+		assert.True(t, checkPreExecCancel(cc, gen))
+		select {
+		case <-cc.doneChan:
+		case <-time.After(time.Second):
+			t.Fatal("abort-only pre-exec cancel did not mark context done")
+		}
+
+		gen.Close()
+		_, ok := iter.Next()
+		assert.False(t, ok)
+	})
+
+	t.Run("AlreadyHandledCancelTerminatesWithoutDuplicateEvent", func(t *testing.T) {
+		cc := newCancelContext()
+		cc.triggerImmediateCancel()
+		assert.True(t, cc.markCancelHandled())
+
+		iter, gen := NewAsyncIteratorPair[*TypedAgentEvent[*schema.Message]]()
+
+		assert.True(t, checkPreExecCancel(cc, gen))
+
+		gen.Close()
+		_, ok := iter.Next()
+		assert.False(t, ok)
 	})
 }
 

--- a/adk/cancel_test.go
+++ b/adk/cancel_test.go
@@ -187,6 +187,23 @@ func drainEventsAndAssertCancelError(t *testing.T, iter *AsyncIterator[*AgentEve
 	return events
 }
 
+func drainEventsAndAssertNoCancelError(t *testing.T, iter *AsyncIterator[*AgentEvent]) []*AgentEvent {
+	t.Helper()
+	var events []*AgentEvent
+	for {
+		event, ok := iter.Next()
+		if !ok {
+			break
+		}
+		var ce *CancelError
+		if event.Err != nil && errors.As(event.Err, &ce) {
+			t.Fatalf("unexpected CancelError in event stream: %v", ce)
+		}
+		events = append(events, event)
+	}
+	return events
+}
+
 func TestCancelContext(t *testing.T) {
 	t.Run("BasicCancelContext", func(t *testing.T) {
 		cc := newCancelContext()
@@ -435,7 +452,7 @@ func TestWithCancel_WithTools(t *testing.T) {
 		ctx, cancel := context.WithCancel(context.Background())
 		defer cancel()
 
-		child := cc.deriveAgentToolCancelContext(ctx)
+		child := cc.deriveCheckpointAwareCancelContext(ctx)
 		assert.NotNil(t, child)
 
 		cc.setRecursive(true)
@@ -1511,12 +1528,11 @@ func TestWithCancel_SequentialAgent(t *testing.T) {
 
 		time.Sleep(50 * time.Millisecond)
 
-		// Cancel should NOT return ErrExecutionEnded (the bug before the fix)
 		handle, _ := cancelFn()
 		err = handle.Wait()
-		assert.NoError(t, err, "Cancel during second agent should succeed, not return ErrExecutionEnded")
+		assert.ErrorIs(t, err, ErrExecutionEnded, "direct workflow child immediate cancel should not create a checkpoint")
 
-		drainEventsAndAssertCancelError(t, iter)
+		drainEventsAndAssertNoCancelError(t, iter)
 	})
 }
 
@@ -1617,16 +1633,11 @@ func TestWithCancel_ParallelAgent(t *testing.T) {
 
 		time.Sleep(50 * time.Millisecond)
 
-		start := time.Now()
 		handle, _ := cancelFn()
 		err = handle.Wait()
-		assert.NoError(t, err, "Cancel during parallel agents should succeed")
+		assert.ErrorIs(t, err, ErrExecutionEnded, "direct parallel children should not create checkpoints")
 
-		events := drainEventsAndAssertCancelError(t, iter)
-		elapsed := time.Since(start)
-
-		_ = events
-		assert.True(t, elapsed < 3*time.Second, "Should complete quickly after cancel, elapsed: %v", elapsed)
+		drainEventsAndAssertNoCancelError(t, iter)
 	})
 }
 
@@ -1689,15 +1700,11 @@ func TestWithCancel_SupervisorAgent(t *testing.T) {
 
 		time.Sleep(50 * time.Millisecond)
 
-		start := time.Now()
 		handle, _ := cancelFn()
 		err = handle.Wait()
-		assert.NoError(t, err, "Cancel during sub-agent should succeed")
+		assert.ErrorIs(t, err, ErrExecutionEnded, "direct supervisor child should not create a checkpoint")
 
-		drainAndAssertCancelError(t, iter)
-		elapsed := time.Since(start)
-
-		assert.True(t, elapsed < 3*time.Second, "Should complete quickly after cancel, elapsed: %v", elapsed)
+		drainEventsAndAssertNoCancelError(t, iter)
 	})
 }
 
@@ -2196,8 +2203,8 @@ func TestCheckCancel_AlreadyHandled_NoDuplicate(t *testing.T) {
 }
 
 // Tests for CancelAfterChatModel/CancelAfterToolCalls in nested workflow structures.
-// These verify that safe-point cancel modes propagate through the entire agent hierarchy
-// and fire at whichever nested level reaches the safe-point first.
+// ADK-managed workflow children participate in safe-point checkpointing when
+// recursive cancel propagation is requested.
 
 func TestCancel_SequentialWorkflow_CancelAfterChatModel(t *testing.T) {
 	ctx := context.Background()
@@ -2228,56 +2235,14 @@ func TestCancel_SequentialWorkflow_CancelAfterChatModel(t *testing.T) {
 		t.Fatal("First agent did not start")
 	}
 
-	handle, contributed := cancelFn(WithAgentCancelMode(CancelAfterChatModel))
+	handle, contributed := cancelFn(WithAgentCancelMode(CancelAfterChatModel), WithRecursive())
 	assert.True(t, contributed, "Cancel should contribute")
 	err = handle.Wait()
 	assert.NoError(t, err)
 
-	hasCancelError := false
-	var cancelErr *CancelError
-	for {
-		event, ok := iter.Next()
-		if !ok {
-			break
-		}
-		if event.Err != nil && errors.As(event.Err, &cancelErr) {
-			hasCancelError = true
-		}
-	}
-
-	assert.True(t, hasCancelError, "Should have CancelError")
+	cancelErr := drainCancelError(t, iter)
+	assert.NotNil(t, cancelErr, "Should have CancelError from sequential workflow child")
 	assert.Equal(t, CancelAfterChatModel, cancelErr.Info.Mode)
-	assert.NotNil(t, cancelErr.interruptSignal, "CancelError should have interrupt signal for checkpoint")
-
-	resumeAgent1 := newCancelTestAgentWithToolsFinalAnswer(t, "seq_slow")
-	resumeAgent2 := newCancelTestAgentWithToolsFinalAnswer(t, "seq_fast")
-
-	resumeSeq, err := NewSequentialAgent(ctx, &SequentialAgentConfig{
-		Name:        "seq_agent",
-		Description: "Sequential workflow",
-		SubAgents:   []Agent{resumeAgent1, resumeAgent2},
-	})
-	assert.NoError(t, err)
-
-	runner2 := NewRunner(ctx, RunnerConfig{
-		Agent:           resumeSeq,
-		CheckPointStore: store,
-	})
-
-	resumeIter, err := runner2.Resume(ctx, "seq-cancel-1")
-	assert.NoError(t, err)
-	assert.NotNil(t, resumeIter)
-
-	var resumeEvents []*AgentEvent
-	for {
-		event, ok := resumeIter.Next()
-		if !ok {
-			break
-		}
-		assert.Nil(t, event.Err, "Should not have error during resume")
-		resumeEvents = append(resumeEvents, event)
-	}
-	assert.NotEmpty(t, resumeEvents, "Resume should produce events")
 }
 
 func TestCancelImmediate_OrphanedToolGoroutine_NoPanic(t *testing.T) {
@@ -2659,7 +2624,7 @@ func TestCancelImmediate_ParallelWorkflow_WithAgentTool(t *testing.T) {
 	waitForChan(t, simpleStarted, "Simple agent did not start")
 
 	start := time.Now()
-	handle, _ := cancelFn()
+	handle, _ := cancelFn(WithRecursive())
 	assert.NoError(t, handle.Wait())
 
 	cancelErr := drainCancelError(t, iter)
@@ -3167,24 +3132,24 @@ func TestCancelAfterToolCalls_LoopTransitionBoundary(t *testing.T) {
 }
 
 func TestCancelContext_RecursiveGraceBoundary(t *testing.T) {
-	t.Run("AgentToolDescendantMarker_PropagatesToParents", func(t *testing.T) {
+	t.Run("CheckpointAwareDescendantMarker_PropagatesToParents", func(t *testing.T) {
 		parent := newCancelContext()
 		ctx := context.Background()
-		child := parent.deriveAgentToolCancelContext(ctx)
-		grandchild := child.deriveAgentToolCancelContext(ctx)
+		child := parent.deriveCheckpointAwareCancelContext(ctx)
+		grandchild := child.deriveCheckpointAwareCancelContext(ctx)
 		t.Cleanup(func() {
 			grandchild.markDone()
 			child.markDone()
 		})
 
-		assert.False(t, parent.hasAgentToolDescendant())
-		assert.False(t, child.hasAgentToolDescendant())
+		assert.False(t, parent.hasCheckpointAwareDescendant())
+		assert.False(t, child.hasCheckpointAwareDescendant())
 
-		grandchild.markAgentToolDescendant()
+		grandchild.markCheckpointAwareDescendant()
 
-		assert.True(t, grandchild.hasAgentToolDescendant())
-		assert.True(t, child.hasAgentToolDescendant())
-		assert.True(t, parent.hasAgentToolDescendant())
+		assert.True(t, grandchild.hasCheckpointAwareDescendant())
+		assert.True(t, child.hasCheckpointAwareDescendant())
+		assert.True(t, parent.hasCheckpointAwareDescendant())
 	})
 }
 
@@ -3217,56 +3182,14 @@ func TestCancel_ParallelWorkflow_CancelAfterChatModel(t *testing.T) {
 		t.Fatal("Slow agent did not start")
 	}
 
-	handle, contributed := cancelFn(WithAgentCancelMode(CancelAfterChatModel))
+	handle, contributed := cancelFn(WithAgentCancelMode(CancelAfterChatModel), WithRecursive())
 	assert.True(t, contributed, "Cancel should contribute")
 	err = handle.Wait()
 	assert.NoError(t, err)
 
-	hasCancelError := false
-	var cancelErr *CancelError
-	for {
-		event, ok := iter.Next()
-		if !ok {
-			break
-		}
-		if event.Err != nil && errors.As(event.Err, &cancelErr) {
-			hasCancelError = true
-		}
-	}
-
-	assert.True(t, hasCancelError, "Should have CancelError from parallel workflow")
+	cancelErr := drainCancelError(t, iter)
+	assert.NotNil(t, cancelErr, "Should have CancelError from parallel workflow child")
 	assert.Equal(t, CancelAfterChatModel, cancelErr.Info.Mode)
-
-	resumeSlow := newCancelTestAgentWithToolsFinalAnswer(t, "par_slow")
-	resumeFast := newCancelTestAgentWithToolsFinalAnswer(t, "par_fast")
-
-	resumePar, err := NewParallelAgent(ctx, &ParallelAgentConfig{
-		Name:        "par_agent",
-		Description: "Parallel workflow",
-		SubAgents:   []Agent{resumeSlow, resumeFast},
-	})
-	assert.NoError(t, err)
-
-	runner2 := NewRunner(ctx, RunnerConfig{
-		Agent:           resumePar,
-		CheckPointStore: store,
-	})
-
-	resumeIter, err := runner2.Resume(ctx, "par-cancel-1")
-	assert.NoError(t, err)
-	assert.NotNil(t, resumeIter)
-
-	var resumeErrors []error
-	for {
-		event, ok := resumeIter.Next()
-		if !ok {
-			break
-		}
-		if event.Err != nil {
-			resumeErrors = append(resumeErrors, event.Err)
-		}
-	}
-	assert.Empty(t, resumeErrors, "Resume should complete without errors")
 }
 
 func TestCancel_LoopWorkflow_CancelAfterChatModel(t *testing.T) {
@@ -3298,55 +3221,14 @@ func TestCancel_LoopWorkflow_CancelAfterChatModel(t *testing.T) {
 		t.Fatal("Model did not start")
 	}
 
-	handle, contributed := cancelFn(WithAgentCancelMode(CancelAfterChatModel))
+	handle, contributed := cancelFn(WithAgentCancelMode(CancelAfterChatModel), WithRecursive())
 	assert.True(t, contributed, "Cancel should contribute")
 	err = handle.Wait()
 	assert.NoError(t, err)
 
-	hasCancelError := false
-	var cancelErr *CancelError
-	for {
-		event, ok := iter.Next()
-		if !ok {
-			break
-		}
-		if event.Err != nil && errors.As(event.Err, &cancelErr) {
-			hasCancelError = true
-		}
-	}
-
-	assert.True(t, hasCancelError, "Should have CancelError from loop workflow")
+	cancelErr := drainCancelError(t, iter)
+	assert.NotNil(t, cancelErr, "Should have CancelError from loop workflow child")
 	assert.Equal(t, CancelAfterChatModel, cancelErr.Info.Mode)
-
-	resumeAgent := newCancelTestAgentWithToolsFinalAnswer(t, "loop_inner")
-
-	resumeLoop, err := NewLoopAgent(ctx, &LoopAgentConfig{
-		Name:          "loop_agent",
-		Description:   "Loop workflow",
-		SubAgents:     []Agent{resumeAgent},
-		MaxIterations: 10,
-	})
-	assert.NoError(t, err)
-
-	runner2 := NewRunner(ctx, RunnerConfig{
-		Agent:           resumeLoop,
-		CheckPointStore: store,
-	})
-
-	resumeIter, err := runner2.Resume(ctx, "loop-cancel-1")
-	assert.NoError(t, err)
-	assert.NotNil(t, resumeIter)
-
-	var resumeEvents []*AgentEvent
-	for {
-		event, ok := resumeIter.Next()
-		if !ok {
-			break
-		}
-		assert.Nil(t, event.Err, "Should not have error during resume")
-		resumeEvents = append(resumeEvents, event)
-	}
-	assert.NotEmpty(t, resumeEvents, "Resume should produce events")
 }
 
 func TestCancel_NestedWorkflow_AgentTool_CancelAfterChatModel(t *testing.T) {
@@ -3571,80 +3453,14 @@ func TestCancel_CancelAfterToolCalls_InSequentialWorkflow(t *testing.T) {
 		t.Fatal("Tool did not start")
 	}
 
-	// Cancel after tool calls — should wait for the tool to finish, then cancel
-	handle, contributed := cancelFn(WithAgentCancelMode(CancelAfterToolCalls))
+	handle, contributed := cancelFn(WithAgentCancelMode(CancelAfterToolCalls), WithRecursive())
 	assert.True(t, contributed, "Cancel should contribute")
 	err = handle.Wait()
 	assert.NoError(t, err)
 
-	hasCancelError := false
-	var cancelErr *CancelError
-	for {
-		event, ok := iter.Next()
-		if !ok {
-			break
-		}
-		if event.Err != nil && errors.As(event.Err, &cancelErr) {
-			hasCancelError = true
-		}
-	}
-
-	assert.True(t, hasCancelError, "Should have CancelError after tool calls complete")
+	cancelErr := drainCancelError(t, iter)
+	assert.NotNil(t, cancelErr, "Should have CancelError from sequential workflow tool calls")
 	assert.Equal(t, CancelAfterToolCalls, cancelErr.Info.Mode)
-
-	// Phase 2: Resume from checkpoint — new instances
-	resumeTool := &slowTool{
-		name:        "slow_tool",
-		delay:       50 * time.Millisecond,
-		result:      "resumed tool done",
-		startedChan: make(chan struct{}, 1),
-	}
-
-	resumeModel := &simpleChatModel{
-		response: &schema.Message{
-			Role:    schema.Assistant,
-			Content: "resumed response after tool",
-		},
-	}
-
-	resumeAgentWithTools, err := NewChatModelAgent(ctx, &ChatModelAgentConfig{
-		Name:        "agent_with_tools",
-		Description: "Agent with slow tool",
-		Model:       resumeModel,
-		ToolsConfig: ToolsConfig{
-			ToolsNodeConfig: compose.ToolsNodeConfig{
-				Tools: []tool.BaseTool{resumeTool},
-			},
-		},
-	})
-	assert.NoError(t, err)
-
-	resumeSeq, err := NewSequentialAgent(ctx, &SequentialAgentConfig{
-		Name:        "seq_agent",
-		Description: "Sequential workflow with tool agent",
-		SubAgents:   []Agent{resumeAgentWithTools},
-	})
-	assert.NoError(t, err)
-
-	runner2 := NewRunner(ctx, RunnerConfig{
-		Agent:           resumeSeq,
-		CheckPointStore: store,
-	})
-
-	resumeIter, err := runner2.Resume(ctx, "tool-cancel-1")
-	assert.NoError(t, err)
-	assert.NotNil(t, resumeIter)
-
-	var resumeEvents []*AgentEvent
-	for {
-		event, ok := resumeIter.Next()
-		if !ok {
-			break
-		}
-		assert.Nil(t, event.Err, "Should not have error during resume")
-		resumeEvents = append(resumeEvents, event)
-	}
-	assert.NotEmpty(t, resumeEvents, "Resume should produce events")
 }
 
 // TestCancel_SafePointNeverFires_ErrExecutionEnded verifies the waitForCompletion

--- a/adk/chatmodel.go
+++ b/adk/chatmodel.go
@@ -83,14 +83,6 @@ func getTypedChatModelAgentExecCtx[M MessageType](ctx context.Context) *typedCha
 	return nil
 }
 
-// AgentTool is a checkpoint boundary: its internal agents must not be classified
-// as direct middleware children of the ChatModelAgent that called the tool.
-func clearChatModelAgentExecCtx(ctx context.Context) context.Context {
-	ctx = context.WithValue(ctx, typedChatModelAgentExecCtxKey[*schema.Message]{}, nil)
-	ctx = context.WithValue(ctx, typedChatModelAgentExecCtxKey[*schema.AgenticMessage]{}, nil)
-	return ctx
-}
-
 type chatModelAgentRunOptions struct {
 	chatModelOptions []model.Option
 	toolOptions      []tool.Option
@@ -480,24 +472,8 @@ type typedRunParams[M MessageType] struct {
 
 type typedRunFunc[M MessageType] func(ctx context.Context, p *typedRunParams[M])
 
-func hasChatModelAgentExecCtx(ctx context.Context) bool {
-	return getTypedChatModelAgentExecCtx[*schema.Message](ctx) != nil ||
-		getTypedChatModelAgentExecCtx[*schema.AgenticMessage](ctx) != nil
-}
-
-// The current Address is read before this ChatModelAgent installs its own
-// compose graph, so the nearest ADK segment describes the caller-side boundary.
-func isUnderADKToolBoundary(ctx context.Context) bool {
-	addr := compose.GetCurrentAddress(ctx)
-	for i := len(addr) - 1; i >= 0; i-- {
-		switch addr[i].Type {
-		case AddressSegmentTool:
-			return true
-		case AddressSegmentAgent:
-			return false
-		}
-	}
-	return false
+func isCheckpointAwareCancelScope(cc *cancelContext) bool {
+	return cc != nil && cc.parent != nil && !cc.abortOnly
 }
 
 func resolveRunCancelContext(ctx context.Context, o *options) (*cancelContext, bool) {
@@ -505,10 +481,17 @@ func resolveRunCancelContext(ctx context.Context, o *options) (*cancelContext, b
 	if o.cancelCtx != nil {
 		return o.cancelCtx, o.cancelCtx != inherited
 	}
-	if hasChatModelAgentExecCtx(ctx) && !isUnderADKToolBoundary(ctx) {
-		return deriveAbortOnlyCancelContext(ctx, inherited), inherited != nil
+	if inherited != nil {
+		// ADK-managed child boundaries pass explicit checkpoint-aware scopes.
+		// Such scopes may reach ChatModelAgent through transparent wrappers.
+		if isCheckpointAwareCancelScope(inherited) {
+			return inherited, false
+		}
+		// Other inherited scopes are direct non-boundary nesting: only immediate
+		// recursive abort should propagate, without safe-point checkpointing.
+		return deriveAbortOnlyCancelContext(ctx, inherited), true
 	}
-	return inherited, false
+	return nil, false
 }
 
 // NewChatModelAgent creates a new ChatModelAgent with the given config.

--- a/adk/chatmodel.go
+++ b/adk/chatmodel.go
@@ -71,7 +71,6 @@ func (e *typedChatModelAgentExecCtx[M]) send(event *TypedAgentEvent[M]) {
 type chatModelAgentExecCtx = typedChatModelAgentExecCtx[*schema.Message]
 
 type typedChatModelAgentExecCtxKey[M MessageType] struct{}
-type chatModelAgentExecutionKey struct{}
 
 func withTypedChatModelAgentExecCtx[M MessageType](ctx context.Context, execCtx *typedChatModelAgentExecCtx[M]) context.Context {
 	return context.WithValue(ctx, typedChatModelAgentExecCtxKey[M]{}, execCtx)
@@ -82,6 +81,14 @@ func getTypedChatModelAgentExecCtx[M MessageType](ctx context.Context) *typedCha
 		return v.(*typedChatModelAgentExecCtx[M])
 	}
 	return nil
+}
+
+// AgentTool is a checkpoint boundary: its internal agents must not be classified
+// as direct middleware children of the ChatModelAgent that called the tool.
+func clearChatModelAgentExecCtx(ctx context.Context) context.Context {
+	ctx = context.WithValue(ctx, typedChatModelAgentExecCtxKey[*schema.Message]{}, nil)
+	ctx = context.WithValue(ctx, typedChatModelAgentExecCtxKey[*schema.AgenticMessage]{}, nil)
+	return ctx
 }
 
 type chatModelAgentRunOptions struct {
@@ -473,12 +480,32 @@ type typedRunParams[M MessageType] struct {
 
 type typedRunFunc[M MessageType] func(ctx context.Context, p *typedRunParams[M])
 
+func hasChatModelAgentExecCtx(ctx context.Context) bool {
+	return getTypedChatModelAgentExecCtx[*schema.Message](ctx) != nil ||
+		getTypedChatModelAgentExecCtx[*schema.AgenticMessage](ctx) != nil
+}
+
+// The current Address is read before this ChatModelAgent installs its own
+// compose graph, so the nearest ADK segment describes the caller-side boundary.
+func isUnderADKToolBoundary(ctx context.Context) bool {
+	addr := compose.GetCurrentAddress(ctx)
+	for i := len(addr) - 1; i >= 0; i-- {
+		switch addr[i].Type {
+		case AddressSegmentTool:
+			return true
+		case AddressSegmentAgent:
+			return false
+		}
+	}
+	return false
+}
+
 func resolveRunCancelContext(ctx context.Context, o *options) (*cancelContext, bool) {
 	inherited := getCancelContext(ctx)
 	if o.cancelCtx != nil {
 		return o.cancelCtx, o.cancelCtx != inherited
 	}
-	if _, ok := ctx.Value(chatModelAgentExecutionKey{}).(struct{}); ok {
+	if hasChatModelAgentExecCtx(ctx) && !isUnderADKToolBoundary(ctx) {
 		return deriveAbortOnlyCancelContext(ctx, inherited), inherited != nil
 	}
 	return inherited, false
@@ -1437,7 +1464,11 @@ func (a *TypedChatModelAgent[M]) Run(ctx context.Context, input *TypedAgentInput
 	if cancelCtxOwned && cancelCtx != nil && cancelCtx.abortOnly {
 		ctx, abortOnlyCancel = withAbortOnlyCancelContext(ctx, cancelCtx)
 	}
-	ctx = context.WithValue(ctx, chatModelAgentExecutionKey{}, struct{}{})
+	ctx = withTypedChatModelAgentExecCtx(ctx, &typedChatModelAgentExecCtx[M]{
+		generator:                generator,
+		cancelCtx:                cancelCtx,
+		failoverLastSuccessModel: a.model,
+	})
 
 	ctx, run, bc, err := a.getRunFunc(ctx)
 	if err != nil {
@@ -1522,7 +1553,11 @@ func (a *TypedChatModelAgent[M]) Resume(ctx context.Context, info *ResumeInfo, o
 	if cancelCtxOwned && cancelCtx != nil && cancelCtx.abortOnly {
 		ctx, abortOnlyCancel = withAbortOnlyCancelContext(ctx, cancelCtx)
 	}
-	ctx = context.WithValue(ctx, chatModelAgentExecutionKey{}, struct{}{})
+	ctx = withTypedChatModelAgentExecCtx(ctx, &typedChatModelAgentExecCtx[M]{
+		generator:                generator,
+		cancelCtx:                cancelCtx,
+		failoverLastSuccessModel: a.model,
+	})
 
 	ctx, run, bc, err := a.getRunFunc(ctx)
 	if err != nil {

--- a/adk/chatmodel.go
+++ b/adk/chatmodel.go
@@ -71,6 +71,7 @@ func (e *typedChatModelAgentExecCtx[M]) send(event *TypedAgentEvent[M]) {
 type chatModelAgentExecCtx = typedChatModelAgentExecCtx[*schema.Message]
 
 type typedChatModelAgentExecCtxKey[M MessageType] struct{}
+type chatModelAgentExecutionKey struct{}
 
 func withTypedChatModelAgentExecCtx[M MessageType](ctx context.Context, execCtx *typedChatModelAgentExecCtx[M]) context.Context {
 	return context.WithValue(ctx, typedChatModelAgentExecCtxKey[M]{}, execCtx)
@@ -476,6 +477,9 @@ func resolveRunCancelContext(ctx context.Context, o *options) (*cancelContext, b
 	inherited := getCancelContext(ctx)
 	if o.cancelCtx != nil {
 		return o.cancelCtx, o.cancelCtx != inherited
+	}
+	if _, ok := ctx.Value(chatModelAgentExecutionKey{}).(struct{}); ok {
+		return deriveAbortOnlyCancelContext(ctx, inherited), inherited != nil
 	}
 	return inherited, false
 }
@@ -918,6 +922,13 @@ func (a *TypedChatModelAgent[M]) handleRunFuncError(
 	store *bridgeStore,
 	generator *AsyncGenerator[*TypedAgentEvent[M]],
 ) {
+	if isAbortOnlyCancelled(cancelCtx) {
+		if cancelCtxOwned {
+			cancelCtx.markDone()
+		}
+		return
+	}
+
 	info, ok := compose.ExtractInterruptInfo(err)
 	if ok {
 		if cancelCtx != nil {
@@ -1038,16 +1049,8 @@ func (a *TypedChatModelAgent[M]) buildNoToolsRunFunc(_ context.Context) (typedRu
 			failoverLastSuccessModel: a.model,
 		})
 
-		// Pre-execution cancel check
-		if cancelCtx != nil && cancelCtx.shouldCancel() {
-			if cancelCtx.getMode() == CancelImmediate || atomic.LoadInt32(&cancelCtx.escalated) == 1 {
-				cancelErr, ok := cancelCtx.createAndMarkCancelHandled()
-				if !ok {
-					return
-				}
-				p.generator.Send(&TypedAgentEvent[M]{Err: cancelErr})
-				return
-			}
+		if checkPreExecCancel(cancelCtx, p.generator) {
+			return
 		}
 
 		in := typedNoToolsInput[M]{input: p.input, instruction: p.instruction}
@@ -1177,16 +1180,8 @@ func (a *TypedChatModelAgent[M]) buildMessageReActRunFunc(_ context.Context, bc 
 			afterToolCallsHook:       mp.afterToolCallsHook,
 		})
 
-		// Pre-execution cancel check
-		if cancelCtx != nil && cancelCtx.shouldCancel() {
-			if cancelCtx.getMode() == CancelImmediate || atomic.LoadInt32(&cancelCtx.escalated) == 1 {
-				cancelErr, ok := cancelCtx.createAndMarkCancelHandled()
-				if !ok {
-					return
-				}
-				mp.generator.Send(&AgentEvent{Err: cancelErr})
-				return
-			}
+		if checkPreExecCancel(cancelCtx, mp.generator) {
+			return
 		}
 
 		in := reactRunInput{
@@ -1315,16 +1310,8 @@ func (a *TypedChatModelAgent[M]) buildAgenticReActRunFunc(_ context.Context, bc 
 			afterToolCallsHook:       ap.afterToolCallsHook,
 		})
 
-		// Pre-execution cancel check
-		if cancelCtx != nil && cancelCtx.shouldCancel() {
-			if cancelCtx.getMode() == CancelImmediate || atomic.LoadInt32(&cancelCtx.escalated) == 1 {
-				cancelErr, ok := cancelCtx.createAndMarkCancelHandled()
-				if !ok {
-					return
-				}
-				ap.generator.Send(&TypedAgentEvent[*schema.AgenticMessage]{Err: cancelErr})
-				return
-			}
+		if checkPreExecCancel(cancelCtx, ap.generator) {
+			return
 		}
 
 		in := agenticReactRunInput{input: ap.input, instruction: ap.instruction}
@@ -1446,10 +1433,18 @@ func (a *TypedChatModelAgent[M]) Run(ctx context.Context, input *TypedAgentInput
 
 	o := getCommonOptions(nil, opts...)
 	cancelCtx, cancelCtxOwned := resolveRunCancelContext(ctx, o)
+	var abortOnlyCancel context.CancelFunc
+	if cancelCtxOwned && cancelCtx != nil && cancelCtx.abortOnly {
+		ctx, abortOnlyCancel = withAbortOnlyCancelContext(ctx, cancelCtx)
+	}
+	ctx = context.WithValue(ctx, chatModelAgentExecutionKey{}, struct{}{})
 
 	ctx, run, bc, err := a.getRunFunc(ctx)
 	if err != nil {
 		go func() {
+			if abortOnlyCancel != nil {
+				defer abortOnlyCancel()
+			}
 			if cancelCtxOwned && cancelCtx != nil {
 				defer cancelCtx.markDone()
 			}
@@ -1476,6 +1471,9 @@ func (a *TypedChatModelAgent[M]) Run(ctx context.Context, input *TypedAgentInput
 	}
 
 	go func() {
+		if abortOnlyCancel != nil {
+			defer abortOnlyCancel()
+		}
 		defer func() {
 			panicErr := recover()
 			if panicErr != nil {
@@ -1520,10 +1518,18 @@ func (a *TypedChatModelAgent[M]) Resume(ctx context.Context, info *ResumeInfo, o
 
 	o := getCommonOptions(nil, opts...)
 	cancelCtx, cancelCtxOwned := resolveRunCancelContext(ctx, o)
+	var abortOnlyCancel context.CancelFunc
+	if cancelCtxOwned && cancelCtx != nil && cancelCtx.abortOnly {
+		ctx, abortOnlyCancel = withAbortOnlyCancelContext(ctx, cancelCtx)
+	}
+	ctx = context.WithValue(ctx, chatModelAgentExecutionKey{}, struct{}{})
 
 	ctx, run, bc, err := a.getRunFunc(ctx)
 	if err != nil {
 		go func() {
+			if abortOnlyCancel != nil {
+				defer abortOnlyCancel()
+			}
 			if cancelCtxOwned && cancelCtx != nil {
 				defer cancelCtx.markDone()
 			}
@@ -1600,6 +1606,9 @@ func (a *TypedChatModelAgent[M]) Resume(ctx context.Context, info *ResumeInfo, o
 	}
 
 	go func() {
+		if abortOnlyCancel != nil {
+			defer abortOnlyCancel()
+		}
 		defer func() {
 			panicErr := recover()
 			if panicErr != nil {

--- a/adk/flow.go
+++ b/adk/flow.go
@@ -461,7 +461,10 @@ func (a *flowAgent) Resume(ctx context.Context, info *ResumeInfo, opts ...AgentR
 	}
 
 	ctxForSubAgents = withCancelContext(ctxForSubAgents, cancelCtx)
-	innerIter := subAgent.Resume(ctxForSubAgents, info, filterCancelOption(opts)...)
+	filteredOpts := filterCancelOption(opts)
+	childCancelCtx := deriveCheckpointAwareSubAgentCancelContext(ctxForSubAgents, filteredOpts)
+	childOpts := appendCancelContextOption(filteredOpts, childCancelCtx)
+	innerIter := subAgent.Resume(ctxForSubAgents, info, childOpts...)
 	return wrapIterWithCancelCtx(wrapIterWithOnEnd(ctx, innerIter), cancelCtx)
 }
 
@@ -563,7 +566,9 @@ func (a *flowAgent) run(
 			return
 		}
 
-		subAIter := agentToRun.Run(ctxForSubAgents, nil /*subagents get input from runCtx*/, opts...)
+		childCancelCtx := deriveCheckpointAwareSubAgentCancelContext(ctxForSubAgents, opts)
+		childOpts := appendCancelContextOption(opts, childCancelCtx)
+		subAIter := agentToRun.Run(ctxForSubAgents, nil /*subagents get input from runCtx*/, childOpts...)
 		for {
 			subEvent, ok_ := subAIter.Next()
 			if !ok_ {

--- a/adk/prebuilt/planexecute/plan_execute_test.go
+++ b/adk/prebuilt/planexecute/plan_execute_test.go
@@ -1008,8 +1008,9 @@ func (m *slowChatModel) WithTools(tools []*schema.ToolInfo) (model.ToolCallingCh
 	return m, nil
 }
 
-// TestWithCancel_PlanExecute_DuringExecution verifies that cancel works
-// during the executor (ChatModelAgent) phase of the PlanExecute agent.
+// TestWithCancel_PlanExecute_DuringExecution verifies that recursive immediate
+// cancel aborts the executor (ChatModelAgent) phase promptly while the outer
+// workflow handles the cancellation.
 func TestWithCancel_PlanExecute_DuringExecution(t *testing.T) {
 	ctx := context.Background()
 
@@ -1078,10 +1079,10 @@ func TestWithCancel_PlanExecute_DuringExecution(t *testing.T) {
 
 	time.Sleep(50 * time.Millisecond)
 
-	// Cancel should NOT return ErrExecutionEnded
-	handle, _ := cancelFn()
+	start := time.Now()
+	handle, _ := cancelFn(adk.WithRecursive())
 	err = handle.Wait()
-	assert.NoError(t, err, "Cancel during executor should succeed")
+	assert.NoError(t, err, "PlanExecute workflow should handle recursive cancel")
 
 	hasCancelError := false
 	for {
@@ -1094,12 +1095,15 @@ func TestWithCancel_PlanExecute_DuringExecution(t *testing.T) {
 			hasCancelError = true
 		}
 	}
+	elapsed := time.Since(start)
 
-	assert.True(t, hasCancelError, "Should have CancelError event")
+	assert.True(t, hasCancelError, "Should have CancelError event from PlanExecute workflow")
+	assert.True(t, elapsed < 3*time.Second, "Should complete quickly after recursive cancel, elapsed: %v", elapsed)
 }
 
-// TestWithCancel_PlanExecute_BetweenTransitions verifies that cancel works
-// when fired between agent transitions (e.g., after planner, before executor starts).
+// TestWithCancel_PlanExecute_BetweenTransitions verifies that recursive immediate
+// cancel aborts a direct executor child after the planner phase promptly while
+// the outer workflow handles the cancellation.
 func TestWithCancel_PlanExecute_BetweenTransitions(t *testing.T) {
 	ctx := context.Background()
 
@@ -1179,9 +1183,9 @@ func TestWithCancel_PlanExecute_BetweenTransitions(t *testing.T) {
 	}
 
 	start := time.Now()
-	handle, _ := cancelFn()
+	handle, _ := cancelFn(adk.WithRecursive())
 	err = handle.Wait()
-	assert.NoError(t, err, "Cancel between transitions should succeed")
+	assert.NoError(t, err, "PlanExecute workflow should handle recursive cancel")
 
 	hasCancelError := false
 	for {
@@ -1196,6 +1200,90 @@ func TestWithCancel_PlanExecute_BetweenTransitions(t *testing.T) {
 	}
 	elapsed := time.Since(start)
 
-	assert.True(t, hasCancelError, "Should have CancelError event")
-	assert.True(t, elapsed < 3*time.Second, "Should complete quickly after cancel, elapsed: %v", elapsed)
+	assert.True(t, hasCancelError, "Should have CancelError event from PlanExecute workflow")
+	assert.True(t, elapsed < 3*time.Second, "Should complete quickly after recursive cancel, elapsed: %v", elapsed)
+}
+
+func TestWithCancel_PlanExecute_DuringExecution_CancelAfterChatModel(t *testing.T) {
+	ctx := context.Background()
+
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	mockPlanner := mockAdk.NewMockAgent(ctrl)
+	mockPlanner.EXPECT().Name(gomock.Any()).Return("planner").AnyTimes()
+	mockPlanner.EXPECT().Description(gomock.Any()).Return("a planner agent").AnyTimes()
+
+	plan := &defaultPlan{Steps: []string{"Step 1"}}
+	userInput := []adk.Message{schema.UserMessage("test task")}
+
+	mockPlanner.EXPECT().Run(gomock.Any(), gomock.Any(), gomock.Any()).DoAndReturn(
+		func(ctx context.Context, input *adk.AgentInput, opts ...adk.AgentRunOption) *adk.AsyncIterator[*adk.AgentEvent] {
+			iterator, generator := adk.NewAsyncIteratorPair[*adk.AgentEvent]()
+			adk.AddSessionValue(ctx, PlanSessionKey, plan)
+			adk.AddSessionValue(ctx, UserInputSessionKey, userInput)
+			planJSON, _ := sonic.MarshalString(plan)
+			generator.Send(adk.EventFromMessage(schema.AssistantMessage(planJSON, nil), nil, schema.Assistant, ""))
+			generator.Close()
+			return iterator
+		},
+	).Times(1)
+
+	executorStarted := make(chan struct{})
+	executor, err := NewExecutor(ctx, &ExecutorConfig{
+		Model: &slowChatModel{
+			delay:       100 * time.Millisecond,
+			response:    schema.AssistantMessage("step result", nil),
+			startedChan: executorStarted,
+		},
+		MaxIterations: 5,
+	})
+	assert.NoError(t, err)
+
+	mockReplanner := mockAdk.NewMockAgent(ctrl)
+	mockReplanner.EXPECT().Name(gomock.Any()).Return("replanner").AnyTimes()
+	mockReplanner.EXPECT().Description(gomock.Any()).Return("a replanner agent").AnyTimes()
+
+	agent, err := New(ctx, &Config{
+		Planner:       mockPlanner,
+		Executor:      executor,
+		Replanner:     mockReplanner,
+		MaxIterations: 5,
+	})
+	assert.NoError(t, err)
+
+	store := newCheckpointStore()
+	runner := adk.NewRunner(ctx, adk.RunnerConfig{
+		Agent:           agent,
+		CheckPointStore: store,
+	})
+
+	cancelOpt, cancelFn := adk.WithCancel()
+	iter := runner.Run(ctx, userInput, cancelOpt, adk.WithCheckPointID("planexecute-safe-point-cancel"))
+
+	select {
+	case <-executorStarted:
+	case <-time.After(10 * time.Second):
+		t.Fatal("Executor model did not start")
+	}
+
+	handle, _ := cancelFn(adk.WithAgentCancelMode(adk.CancelAfterChatModel), adk.WithRecursive())
+	err = handle.Wait()
+	assert.NoError(t, err, "PlanExecute workflow should handle recursive safe-point cancel")
+
+	var cancelErr *adk.CancelError
+	for {
+		event, ok := iter.Next()
+		if !ok {
+			break
+		}
+		if event.Err != nil {
+			errors.As(event.Err, &cancelErr)
+		}
+	}
+
+	if assert.NotNil(t, cancelErr, "Should have CancelError event from PlanExecute workflow safe-point") {
+		assert.Equal(t, adk.CancelAfterChatModel, cancelErr.Info.Mode)
+		assert.NotEmpty(t, cancelErr.InterruptContexts)
+	}
 }

--- a/adk/turn_loop_test.go
+++ b/adk/turn_loop_test.go
@@ -4843,9 +4843,9 @@ func TestNewTurnLoop_NilPrepareAgent_Panics(t *testing.T) {
 	})
 }
 
-func TestDeriveAgentToolCancelContext_NilParent_ReturnsNil(t *testing.T) {
+func TestDeriveCheckpointAwareCancelContext_NilParent_ReturnsNil(t *testing.T) {
 	var cc *cancelContext
-	assert.Nil(t, cc.deriveAgentToolCancelContext(context.Background()))
+	assert.Nil(t, cc.deriveCheckpointAwareCancelContext(context.Background()))
 }
 
 func TestUntilIdleFor(t *testing.T) {
@@ -5774,7 +5774,7 @@ func TestAttack_SkipCheckpoint_Sticky(t *testing.T) {
 //
 // IMPORTANT: child.markDone() is NOT called by the probe. The test MUST
 // call it (e.g. via t.Cleanup) after verifying propagation to avoid a
-// race between markDone closing child.doneChan and the deriveAgentToolCancelContext
+// race between markDone closing child.doneChan and the deriveCheckpointAwareCancelContext
 // goroutines propagating the cancel signal.
 type turnLoopNestedProbeAgent struct {
 	parentCCCh chan *cancelContext
@@ -5788,7 +5788,7 @@ func (a *turnLoopNestedProbeAgent) Run(ctx context.Context, _ *AgentInput, opts 
 	o := getCommonOptions(nil, opts...)
 	cc := o.cancelCtx
 
-	child := cc.deriveAgentToolCancelContext(ctx)
+	child := cc.deriveCheckpointAwareCancelContext(ctx)
 	a.parentCCCh <- cc
 	a.childCCCh <- child
 

--- a/adk/turn_loop_test.go
+++ b/adk/turn_loop_test.go
@@ -981,16 +981,19 @@ func TestTurnLoop_GetAgentError_RecoverConsumed(t *testing.T) {
 func TestTurnLoop_GenInputError_RecoverItems(t *testing.T) {
 	genErr := errors.New("gen input error")
 
-	loop := newAndRunTurnLoop(context.Background(), TurnLoopConfig[string, *schema.Message]{
+	loop := NewTurnLoop(TurnLoopConfig[string, *schema.Message]{
 		GenInput: func(ctx context.Context, _ *TurnLoop[string, *schema.Message], items []string) (*GenInputResult[string, *schema.Message], error) {
 			return nil, genErr
 		},
 		PrepareAgent: prepareTestAgent,
 	})
 
-	loop.Push("msg1")
-	loop.Push("msg2")
+	ok, _ := loop.Push("msg1")
+	require.True(t, ok)
+	ok, _ = loop.Push("msg2")
+	require.True(t, ok)
 
+	loop.Run(context.Background())
 	result := loop.Wait()
 	assert.ErrorIs(t, result.ExitReason, genErr)
 	assert.Len(t, result.UnhandledItems, 2, "should recover all items when GenInput fails")

--- a/adk/workflow.go
+++ b/adk/workflow.go
@@ -208,6 +208,8 @@ func (a *workflowAgent) runSequential(ctx context.Context,
 		}
 
 		var subIterator *AsyncIterator[*AgentEvent]
+		childCancelCtx := deriveCheckpointAwareSubAgentCancelContext(seqCtx, opts)
+		childOpts := appendCancelContextOption(opts, childCancelCtx)
 		if seqState != nil {
 			wfInfo, _ := info.Data.(*WorkflowInterruptInfo)
 			if wfInfo != nil && wfInfo.SequentialInterruptInfo != nil {
@@ -215,13 +217,13 @@ func (a *workflowAgent) runSequential(ctx context.Context,
 				subIterator = subAgent.Resume(seqCtx, &ResumeInfo{
 					EnableStreaming: info.EnableStreaming,
 					InterruptInfo:   wfInfo.SequentialInterruptInfo,
-				}, opts...)
+				}, childOpts...)
 			} else {
-				subIterator = subAgent.Run(seqCtx, nil, opts...)
+				subIterator = subAgent.Run(seqCtx, nil, childOpts...)
 			}
 			seqState = nil
 		} else {
-			subIterator = subAgent.Run(seqCtx, nil, opts...)
+			subIterator = subAgent.Run(seqCtx, nil, childOpts...)
 		}
 
 		seqCtx = updateRunPathOnly(seqCtx, subAgent.Name(seqCtx))
@@ -360,6 +362,8 @@ func (a *workflowAgent) runLoop(ctx context.Context, generator *AsyncGenerator[*
 			}
 
 			var subIterator *AsyncIterator[*AgentEvent]
+			childCancelCtx := deriveCheckpointAwareSubAgentCancelContext(loopCtx, opts)
+			childOpts := appendCancelContextOption(opts, childCancelCtx)
 			if loopState != nil {
 				wfInfo, _ := resumeInfo.Data.(*WorkflowInterruptInfo)
 				if wfInfo != nil && wfInfo.SequentialInterruptInfo != nil {
@@ -367,13 +371,13 @@ func (a *workflowAgent) runLoop(ctx context.Context, generator *AsyncGenerator[*
 					subIterator = subAgent.Resume(loopCtx, &ResumeInfo{
 						EnableStreaming: resumeInfo.EnableStreaming,
 						InterruptInfo:   wfInfo.SequentialInterruptInfo,
-					}, opts...)
+					}, childOpts...)
 				} else {
-					subIterator = subAgent.Run(loopCtx, nil, opts...)
+					subIterator = subAgent.Run(loopCtx, nil, childOpts...)
 				}
 				loopState = nil // Only resume the first time.
 			} else {
-				subIterator = subAgent.Run(loopCtx, nil, opts...)
+				subIterator = subAgent.Run(loopCtx, nil, childOpts...)
 			}
 
 			loopCtx = updateRunPathOnly(loopCtx, subAgent.Name(loopCtx))
@@ -533,13 +537,17 @@ func (a *workflowAgent) runParallel(ctx context.Context, generator *AsyncGenerat
 				if wfInfo, ok := resumeInfo.Data.(*WorkflowInterruptInfo); ok && wfInfo != nil {
 					childResumeInfo.InterruptInfo = wfInfo.ParallelInterruptInfo[idx]
 				}
-				iterator = agent.Resume(childContexts[idx], childResumeInfo, opts...)
+				childCancelCtx := deriveCheckpointAwareSubAgentCancelContext(childContexts[idx], opts)
+				childOpts := appendCancelContextOption(opts, childCancelCtx)
+				iterator = agent.Resume(childContexts[idx], childResumeInfo, childOpts...)
 			} else if parState != nil {
 				// We are resuming, but this child is not in the next points map.
 				// This means it finished successfully, so we don't run it.
 				return
 			} else {
-				iterator = agent.Run(childContexts[idx], nil, opts...)
+				childCancelCtx := deriveCheckpointAwareSubAgentCancelContext(childContexts[idx], opts)
+				childOpts := appendCancelContextOption(opts, childCancelCtx)
+				iterator = agent.Run(childContexts[idx], nil, childOpts...)
 			}
 
 			for {


### PR DESCRIPTION
# Unify Checkpoint-Aware Child Cancel Scopes

## Problem

ADK recursive cancellation needs to distinguish two kinds of nested execution:

- ADK-managed child boundaries that can be checkpointed and resumed, such as `AgentTool`, workflow sub-agents, transfer targets, and prebuilt agents built on workflow.
- Direct `ChatModelAgent` calls made inside user middleware. These inherit context and should be torn down on recursive immediate cancel, but they do not have a resume path through the root checkpoint.

The previous implementation was migrating toward this distinction, but it still had gaps around abort-only resume barriers. A checkpoint-aware descendant marker could cross an abort-only scope, and helper logic could still model `AgentTool` as a special cancel concept instead of one case of an explicit ADK child boundary.

Concrete expected behavior:

```text
WithRecursive + CancelAfterChatModel / CancelAfterToolCalls
  ADK-managed child boundary: may checkpoint and resume
  Direct middleware child: does not produce a child checkpoint

WithRecursive + CancelImmediate
  ADK-managed child boundary: receives immediate cancel and may contribute checkpoint state
  Direct middleware child: receives abort-only teardown and cannot expose nested checkpoints to root
```

## Solution

Model the distinction directly in `cancelContext` participation mode.

A checkpoint-aware child scope is explicitly derived and injected by ADK-owned child execution boundaries. `AgentTool`, workflow sub-agents, and transfer targets now use the same helper to derive that scope and pass it through internal `AgentRunOption` values.

A plain inherited cancel scope remains abort-only. It can receive recursive immediate teardown, but it is a resume barrier: checkpoint-aware derivation and descendant optimization markers stop at that boundary, and abort-only immediate errors are swallowed at that child level.

The root `ChatModelAgent` cancel resolution stays intentionally small:

```go
if o.cancelCtx != nil { return o.cancelCtx, o.cancelCtx != inherited }
if inherited is checkpoint-aware { return inherited, false }
if inherited exists { return deriveAbortOnlyCancelContext(ctx, inherited), true }
return nil, false
```

This avoids `Address`-based or exec-context-based inference. The boundary is not guessed from runtime traces; it is expressed by the ADK call site that owns the child execution.

## Decisions

Do not make `AgentTool` a special cancel concept. It is one example of an explicit ADK child boundary, sharing the same semantics as workflow and transfer children.

Do not let abort-only scopes leak internal checkpoints. A middleware child can contain its own `AgentTool` or workflow, but the direct middleware `Run` is not resumable from the root. That scope must remain a resume barrier.

Do not expand the public API. The change is internal: `cancelContext` mode plus internal option injection.

## Key Insight

For ADK cancellation, inheriting context is not the same as being resumable.

The resumable boundary is the place where ADK knows how to re-enter the child during `Runner.Resume`. `AgentTool`, workflow children, and transfer targets have that re-entry path. A direct middleware child only shares the parent Go context, so it can be aborted but cannot safely contribute root checkpoint state.

## Summary

| Problem | Solution |
|---------|----------|
| Workflow and transfer children lost recursive safe-point checkpoint behavior | Derive checkpoint-aware sub-agent cancel scopes at explicit ADK child call sites |
| `AgentTool`-specific cancel naming obscured the shared semantics | Replace `AgentTool`-specific helpers with checkpoint-aware sub-agent helpers |
| Abort-only middleware children could leak internal checkpoint signals | Stop derived checkpoint scopes and descendant markers at abort-only barriers |
| Abort-only immediate child errors could surface as root resumable interrupts | Handle abort-only immediate cancellation before interrupt extraction |

---

# 统一 checkpoint-aware 子执行 cancel scope

## 问题

ADK recursive cancellation 需要区分两类嵌套执行：

- ADK 托管的子执行边界，可以 checkpoint 和 resume，例如 `AgentTool`、workflow sub-agent、transfer target，以及基于 workflow 的 prebuilt agent。
- 用户 middleware 内直接调用的 `ChatModelAgent`。它们继承 context，recursive immediate cancel 时应该被 teardown，但没有通过 root checkpoint resume 的路径。

之前实现已经在迁移到这个方向，但 abort-only resume barrier 仍有缺口。checkpoint-aware descendant marker 可能跨过 abort-only scope，helper 命名也仍把 `AgentTool` 建模成特殊 cancel 概念，而不是“显式 ADK 子执行边界”的一种。

具体预期行为：

```text
WithRecursive + CancelAfterChatModel / CancelAfterToolCalls
  ADK-managed child boundary: 可以 checkpoint 和 resume
  Direct middleware child: 不生成 child checkpoint

WithRecursive + CancelImmediate
  ADK-managed child boundary: 接收 immediate cancel，并可贡献 checkpoint state
  Direct middleware child: 只接收 abort-only teardown，不能把内部 checkpoint 暴露给 root
```

## 解决方案

把差异直接表达为 `cancelContext` participation mode。

checkpoint-aware child scope 只由 ADK 拥有的子执行边界显式派生并注入。`AgentTool`、workflow sub-agent、transfer target 现在使用同一个 helper 派生该 scope，并通过内部 `AgentRunOption` 传入子 Agent。

普通继承来的 cancel scope 仍是 abort-only。它可以接收 recursive immediate teardown，但它是 resume barrier：checkpoint-aware 派生和 descendant optimization marker 都会在这里停止，abort-only immediate 错误也会在 child 层被吞掉。

root `ChatModelAgent` 的 cancel resolution 保持极简：

```go
if o.cancelCtx != nil { return o.cancelCtx, o.cancelCtx != inherited }
if inherited is checkpoint-aware { return inherited, false }
if inherited exists { return deriveAbortOnlyCancelContext(ctx, inherited), true }
return nil, false
```

这避免了基于 `Address`、exec ctx 或 runtime trace 的调用来源推断。边界不是运行时猜出来的，而是由拥有子执行语义的 ADK call site 显式表达。

## 决策记录

不把 `AgentTool` 建模成特殊 cancel 概念。它只是显式 ADK 子执行边界的一种，和 workflow、transfer 子执行共享同一套语义。

不允许 abort-only scope 泄漏内部 checkpoint。middleware child 内部可以再包含 `AgentTool` 或 workflow，但直接 middleware `Run` 本身不能从 root resume，因此必须是 resume barrier。

不扩大 public API。变化只在内部：`cancelContext` mode 和 internal option injection。

## 关键洞察

对 ADK cancellation 来说，继承 context 不等于可 resume。

可 resume 的边界是 ADK 知道如何在 `Runner.Resume` 时重新进入 child 的位置。`AgentTool`、workflow child、transfer target 都有这条 re-entry path。直接 middleware child 只是共享父级 Go context，所以可以被 abort，但不能安全地贡献 root checkpoint state。

## 总结

| 问题 | 解决方案 |
|------|----------|
| workflow 和 transfer child 丢失 recursive safe-point checkpoint 行为 | 在显式 ADK child call site 派生 checkpoint-aware sub-agent cancel scope |
| `AgentTool` 专属 cancel 命名掩盖了共享语义 | 用 checkpoint-aware sub-agent helper 替换 `AgentTool` 专属 helper |
| abort-only middleware child 可能泄漏内部 checkpoint 信号 | 在 abort-only barrier 停止 checkpoint scope 派生和 descendant marker 回传 |
| abort-only immediate child error 可能冒泡成 root 可恢复 interrupt | 在 interrupt extraction 前先处理 abort-only immediate cancellation |
