### PR TITLE
feat(toolsearch): insert system reminder after conversation messages

### DIFF
--- a/adk/internal/agentic_message.go
+++ b/adk/internal/agentic_message.go
@@ -1,0 +1,55 @@
+/*
+ * Copyright 2026 CloudWeGo Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package internal
+
+import "github.com/cloudwego/eino/schema"
+
+// HasToolCall reports whether blocks contain a tool-call protocol block.
+func HasToolCall(blocks []*schema.ContentBlock) bool {
+	for _, block := range blocks {
+		if block == nil {
+			continue
+		}
+		switch block.Type {
+		case schema.ContentBlockTypeFunctionToolCall,
+			schema.ContentBlockTypeServerToolCall,
+			schema.ContentBlockTypeMCPToolCall,
+			schema.ContentBlockTypeMCPToolApprovalRequest:
+			return true
+		}
+	}
+	return false
+}
+
+// HasToolResult reports whether blocks contain a tool-result protocol block.
+func HasToolResult(blocks []*schema.ContentBlock) bool {
+	for _, block := range blocks {
+		if block == nil {
+			continue
+		}
+		switch block.Type {
+		case schema.ContentBlockTypeToolSearchResult,
+			schema.ContentBlockTypeFunctionToolResult,
+			schema.ContentBlockTypeServerToolResult,
+			schema.ContentBlockTypeMCPToolResult,
+			schema.ContentBlockTypeMCPListToolsResult,
+			schema.ContentBlockTypeMCPToolApprovalResponse:
+			return true
+		}
+	}
+	return false
+}

--- a/adk/internal/agentic_message_test.go
+++ b/adk/internal/agentic_message_test.go
@@ -1,0 +1,63 @@
+/*
+ * Copyright 2026 CloudWeGo Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package internal
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/cloudwego/eino/schema"
+)
+
+func TestHasToolCall(t *testing.T) {
+	toolCallTypes := []schema.ContentBlockType{
+		schema.ContentBlockTypeFunctionToolCall,
+		schema.ContentBlockTypeServerToolCall,
+		schema.ContentBlockTypeMCPToolCall,
+		schema.ContentBlockTypeMCPToolApprovalRequest,
+	}
+	for _, blockType := range toolCallTypes {
+		assert.True(t, HasToolCall([]*schema.ContentBlock{{Type: blockType}}))
+	}
+
+	assert.False(t, HasToolCall([]*schema.ContentBlock{
+		nil,
+		{Type: schema.ContentBlockTypeReasoning},
+		{Type: schema.ContentBlockTypeFunctionToolResult},
+	}))
+}
+
+func TestHasToolResult(t *testing.T) {
+	toolResultTypes := []schema.ContentBlockType{
+		schema.ContentBlockTypeToolSearchResult,
+		schema.ContentBlockTypeFunctionToolResult,
+		schema.ContentBlockTypeServerToolResult,
+		schema.ContentBlockTypeMCPToolResult,
+		schema.ContentBlockTypeMCPListToolsResult,
+		schema.ContentBlockTypeMCPToolApprovalResponse,
+	}
+	for _, blockType := range toolResultTypes {
+		assert.True(t, HasToolResult([]*schema.ContentBlock{{Type: blockType}}))
+	}
+
+	assert.False(t, HasToolResult([]*schema.ContentBlock{
+		nil,
+		{Type: schema.ContentBlockTypeUserInputText},
+		{Type: schema.ContentBlockTypeFunctionToolCall},
+	}))
+}

--- a/adk/middlewares/dynamictool/toolsearch/toolsearch.go
+++ b/adk/middlewares/dynamictool/toolsearch/toolsearch.go
@@ -167,42 +167,45 @@ func (m *typedMiddleware[M]) markInitialized(ctx context.Context) {
 	_ = adk.SetRunLocalValue(ctx, toolSearchInitializedKey, true)
 }
 
-func (m *typedMiddleware[M]) ensureReminder(msgs []M) (result []M, insertedMsg M, anchorMsg M, didInsert bool) {
+func (m *typedMiddleware[M]) ensureReminder(msgs []M) (result []M, insertedMsg M, beforeMessageID string, didInsert bool) {
 	for _, msg := range msgs {
 		if hasToolSearchReminderExtra(msg) {
-			return msgs, insertedMsg, anchorMsg, false
+			return msgs, insertedMsg, beforeMessageID, false
 		}
 	}
 
 	insertedMsg = makeReminderMsg[M](m.sr)
 	adk.EnsureMessageID(insertedMsg)
-	result = make([]M, 0, len(msgs)+1)
-	inserted := false
-	for _, msg := range msgs {
-		if !inserted && !isSystemRoleTS(msg) {
-			inserted = true
-			result = append(result, insertedMsg)
-			anchorMsg = msg
+
+	insertAt := len(msgs)
+	for i := len(msgs) - 1; i >= 0; i-- {
+		if isReminderAnchorTS(msgs[i]) {
+			insertAt = i + 1
+			break
 		}
-		result = append(result, msg)
 	}
-	if !inserted {
-		result = append(result, insertedMsg)
+
+	result = make([]M, 0, len(msgs)+1)
+	result = append(result, msgs[:insertAt]...)
+	result = append(result, insertedMsg)
+	result = append(result, msgs[insertAt:]...)
+	if insertAt < len(msgs) {
+		beforeMessageID = adk.GetMessageID(msgs[insertAt])
 	}
-	return result, insertedMsg, anchorMsg, true
+	return result, insertedMsg, beforeMessageID, true
 }
 
-func isNilTSMessage[M adk.MessageType](msg M) bool {
-	var zero M
-	return any(msg) == any(zero)
-}
-
-func isSystemRoleTS[M adk.MessageType](msg M) bool {
+func isReminderAnchorTS[M adk.MessageType](msg M) bool {
 	switch m := any(msg).(type) {
 	case *schema.Message:
-		return m.Role == schema.System
+		return (m.Role == schema.User) || (m.Role == schema.Assistant && len(m.ToolCalls) == 0)
 	case *schema.AgenticMessage:
-		return m.Role == schema.AgenticRoleTypeSystem
+		switch m.Role {
+		case schema.AgenticRoleTypeUser:
+			return !internal.HasToolResult(m.ContentBlocks)
+		case schema.AgenticRoleTypeAssistant:
+			return !internal.HasToolCall(m.ContentBlocks)
+		}
 	}
 	return false
 }
@@ -211,11 +214,11 @@ func makeReminderMsg[M adk.MessageType](content string) M {
 	var zero M
 	switch any(zero).(type) {
 	case *schema.Message:
-		msg := schema.UserMessage(content)
+		msg := schema.SystemMessage(content)
 		msg.Extra = map[string]any{toolSearchReminderExtraKey: true}
 		return any(msg).(M)
 	case *schema.AgenticMessage:
-		msg := schema.UserAgenticMessage(content)
+		msg := schema.SystemAgenticMessage(content)
 		msg.Extra = map[string]any{toolSearchReminderExtraKey: true}
 		return any(msg).(M)
 	}
@@ -283,21 +286,17 @@ func toolNameSet(tools []*schema.ToolInfo) map[string]bool {
 }
 
 func (m *typedMiddleware[M]) BeforeModelRewriteState(ctx context.Context, state *adk.TypedChatModelAgentState[M], _ *adk.TypedModelContext[M]) (context.Context, *adk.TypedChatModelAgentState[M], error) {
-	newMsgs, insertedMsg, anchorMsg, didInsert := m.ensureReminder(state.Messages)
+	newMsgs, insertedMsg, beforeMessageID, didInsert := m.ensureReminder(state.Messages)
 	state.Messages = newMsgs
 
 	if didInsert {
-		var beforeID string
-		if !isNilTSMessage(anchorMsg) {
-			beforeID = adk.GetMessageID(anchorMsg)
-		}
 		_ = adk.TypedSendEvent(ctx, &adk.TypedAgentEvent[M]{
 			SessionEventVariant: &adk.SessionEventVariant[M]{
 				Event: &adk.SessionEvent[M]{
 					Kind: adk.SessionEventMessageInserted,
 					MessageInserted: &adk.MessageInsertedEvent[M]{
 						Message:         insertedMsg,
-						BeforeMessageID: beforeID,
+						BeforeMessageID: beforeMessageID,
 					},
 				},
 			},

--- a/adk/middlewares/dynamictool/toolsearch/toolsearch_generic_test.go
+++ b/adk/middlewares/dynamictool/toolsearch/toolsearch_generic_test.go
@@ -95,6 +95,65 @@ func makeAssistantMsgWithToolCalls[M adk.MessageType](toolCalls []testToolCall) 
 	}
 }
 
+func makeAssistantGenMsg[M adk.MessageType](content string) M {
+	var zero M
+	switch any(zero).(type) {
+	case *schema.Message:
+		return any(schema.AssistantMessage(content, nil)).(M)
+	case *schema.AgenticMessage:
+		return any(&schema.AgenticMessage{
+			Role: schema.AgenticRoleTypeAssistant,
+			ContentBlocks: []*schema.ContentBlock{
+				schema.NewContentBlock(&schema.AssistantGenText{Text: content}),
+			},
+		}).(M)
+	default:
+		panic("unreachable")
+	}
+}
+
+func makeReasoningAssistantMsg[M adk.MessageType](reasoning, content string) M {
+	var zero M
+	switch any(zero).(type) {
+	case *schema.Message:
+		return any(&schema.Message{
+			Role:             schema.Assistant,
+			Content:          content,
+			ReasoningContent: reasoning,
+		}).(M)
+	case *schema.AgenticMessage:
+		return any(&schema.AgenticMessage{
+			Role: schema.AgenticRoleTypeAssistant,
+			ContentBlocks: []*schema.ContentBlock{
+				schema.NewContentBlock(&schema.Reasoning{Text: reasoning}),
+				schema.NewContentBlock(&schema.AssistantGenText{Text: content}),
+			},
+		}).(M)
+	default:
+		panic("unreachable")
+	}
+}
+
+func makeReasoningOnlyAssistantMsg[M adk.MessageType](reasoning string) M {
+	var zero M
+	switch any(zero).(type) {
+	case *schema.Message:
+		return any(&schema.Message{
+			Role:             schema.Assistant,
+			ReasoningContent: reasoning,
+		}).(M)
+	case *schema.AgenticMessage:
+		return any(&schema.AgenticMessage{
+			Role: schema.AgenticRoleTypeAssistant,
+			ContentBlocks: []*schema.ContentBlock{
+				schema.NewContentBlock(&schema.Reasoning{Text: reasoning}),
+			},
+		}).(M)
+	default:
+		panic("unreachable")
+	}
+}
+
 func makeToolResultMsg[M adk.MessageType](content string, callID string, toolName string) M {
 	var zero M
 	switch any(zero).(type) {
@@ -208,7 +267,7 @@ func testEnsureReminderGeneric[M adk.MessageType](t *testing.T) {
 	dynamicA := &simpleTool{name: "dynamic_tool_a", desc: "Dynamic tool A"}
 	m := newTestMiddlewareTyped[M](t, []tool.BaseTool{dynamicA})
 
-	t.Run("normal: system then user", func(t *testing.T) {
+	t.Run("after latest user message", func(t *testing.T) {
 		input := []M{
 			makeSystemMsg[M]("sys"),
 			makeUserMsg[M]("hi"),
@@ -216,11 +275,76 @@ func testEnsureReminderGeneric[M adk.MessageType](t *testing.T) {
 		got, _, _, _ := m.ensureReminder(input)
 		require.Len(t, got, 3)
 		assert.Equal(t, "system", getMsgRole(got[0]))
-		// Reminder inserted after system
+		assert.Equal(t, "user", getMsgRole(got[1]))
+		assert.Equal(t, "system", getMsgRole(got[2]))
 		extra := getMsgExtra(got[1])
+		assert.Nil(t, extra)
+		extra = getMsgExtra(got[2])
 		require.NotNil(t, extra)
 		assert.Equal(t, true, extra[toolSearchReminderExtraKey])
-		assert.Equal(t, "hi", getMsgContent(got[2]))
+	})
+
+	t.Run("after latest assistant message", func(t *testing.T) {
+		input := []M{
+			makeSystemMsg[M]("sys"),
+			makeUserMsg[M]("hi"),
+			makeAssistantGenMsg[M]("hello"),
+		}
+		got, _, _, _ := m.ensureReminder(input)
+		require.Len(t, got, 4)
+		assert.Equal(t, "assistant", getMsgRole(got[2]))
+		assert.Equal(t, "system", getMsgRole(got[3]))
+		extra := getMsgExtra(got[3])
+		require.NotNil(t, extra)
+		assert.Equal(t, true, extra[toolSearchReminderExtraKey])
+	})
+
+	t.Run("after reasoning assistant message", func(t *testing.T) {
+		input := []M{
+			makeSystemMsg[M]("sys"),
+			makeUserMsg[M]("hi"),
+			makeReasoningAssistantMsg[M]("thinking", "hello"),
+		}
+		got, _, _, _ := m.ensureReminder(input)
+		require.Len(t, got, 4)
+		assert.Equal(t, "assistant", getMsgRole(got[2]))
+		assert.Equal(t, "system", getMsgRole(got[3]))
+		extra := getMsgExtra(got[3])
+		require.NotNil(t, extra)
+		assert.Equal(t, true, extra[toolSearchReminderExtraKey])
+	})
+
+	t.Run("after reasoning-only assistant message", func(t *testing.T) {
+		input := []M{
+			makeSystemMsg[M]("sys"),
+			makeUserMsg[M]("hi"),
+			makeReasoningOnlyAssistantMsg[M]("thinking"),
+		}
+		got, _, _, _ := m.ensureReminder(input)
+		require.Len(t, got, 4)
+		assert.Equal(t, "assistant", getMsgRole(got[2]))
+		assert.Equal(t, "system", getMsgRole(got[3]))
+		extra := getMsgExtra(got[3])
+		require.NotNil(t, extra)
+		assert.Equal(t, true, extra[toolSearchReminderExtraKey])
+	})
+
+	t.Run("tool protocol messages are not anchors", func(t *testing.T) {
+		input := []M{
+			makeSystemMsg[M]("sys"),
+			makeUserMsg[M]("hi"),
+			makeAssistantMsgWithToolCalls[M]([]testToolCall{{ID: "call-1", Name: "tool", Arguments: "{}"}}),
+			makeToolResultMsg[M]("result", "call-1", "tool"),
+		}
+		adk.EnsureMessageID(input[2])
+		got, _, beforeMessageID, _ := m.ensureReminder(input)
+		require.Len(t, got, 5)
+		assert.Equal(t, "user", getMsgRole(got[1]))
+		assert.Equal(t, "system", getMsgRole(got[2]))
+		assert.Equal(t, adk.GetMessageID(input[2]), beforeMessageID)
+		extra := getMsgExtra(got[2])
+		require.NotNil(t, extra)
+		assert.Equal(t, true, extra[toolSearchReminderExtraKey])
 	})
 
 	t.Run("all system messages", func(t *testing.T) {
@@ -232,6 +356,7 @@ func testEnsureReminderGeneric[M adk.MessageType](t *testing.T) {
 		require.Len(t, got, 3)
 		assert.Equal(t, "system", getMsgRole(got[0]))
 		assert.Equal(t, "system", getMsgRole(got[1]))
+		assert.Equal(t, "system", getMsgRole(got[2]))
 		// Reminder appended at end
 		extra := getMsgExtra(got[2])
 		require.NotNil(t, extra)
@@ -241,26 +366,29 @@ func testEnsureReminderGeneric[M adk.MessageType](t *testing.T) {
 	t.Run("empty input", func(t *testing.T) {
 		got, _, _, _ := m.ensureReminder(nil)
 		require.Len(t, got, 1)
+		assert.Equal(t, "system", getMsgRole(got[0]))
 		extra := getMsgExtra(got[0])
 		require.NotNil(t, extra)
 		assert.Equal(t, true, extra[toolSearchReminderExtraKey])
 	})
 
-	t.Run("no system messages", func(t *testing.T) {
+	t.Run("user and assistant messages", func(t *testing.T) {
 		input := []M{
 			makeUserMsg[M]("hi"),
+			makeAssistantGenMsg[M]("hello"),
 		}
 		got, _, _, _ := m.ensureReminder(input)
-		require.Len(t, got, 2)
-		// Reminder inserted at position 0
-		extra := getMsgExtra(got[0])
+		require.Len(t, got, 3)
+		assert.Equal(t, "user", getMsgRole(got[0]))
+		assert.Equal(t, "assistant", getMsgRole(got[1]))
+		assert.Equal(t, "system", getMsgRole(got[2]))
+		extra := getMsgExtra(got[2])
 		require.NotNil(t, extra)
 		assert.Equal(t, true, extra[toolSearchReminderExtraKey])
-		assert.Equal(t, "hi", getMsgContent(got[1]))
 	})
 
 	t.Run("idempotent: does not insert twice", func(t *testing.T) {
-		reminder := makeUserMsg[M]("<reminder>")
+		reminder := makeSystemMsg[M]("<reminder>")
 		setMsgExtra(reminder, toolSearchReminderExtraKey, true)
 		input := []M{
 			reminder,
@@ -318,7 +446,7 @@ func testMode1ForwardSelectionGeneric[M adk.MessageType](t *testing.T) {
 	toolSearchResultJSON, _ := json.Marshal(toolSearchResult{Matches: []string{"dynamic_tool_a"}})
 
 	// Build the reminder message with the extra marker
-	reminderMsg := makeUserMsg[M]("hello")
+	reminderMsg := makeSystemMsg[M]("hello")
 	setMsgExtra(reminderMsg, toolSearchReminderExtraKey, true)
 
 	state := &adk.TypedChatModelAgentState[M]{
@@ -359,7 +487,7 @@ func testMalformedJSONGeneric[M adk.MessageType](t *testing.T) {
 	ctx := context.Background()
 
 	// Build the reminder message with the extra marker
-	reminderMsg := makeUserMsg[M]("reminder")
+	reminderMsg := makeSystemMsg[M]("reminder")
 	setMsgExtra(reminderMsg, toolSearchReminderExtraKey, true)
 
 	state := &adk.TypedChatModelAgentState[M]{

--- a/adk/middlewares/dynamictool/toolsearch/toolsearch_test.go
+++ b/adk/middlewares/dynamictool/toolsearch/toolsearch_test.go
@@ -441,7 +441,7 @@ func TestSplitCamelCase(t *testing.T) {
 func TestEnsureReminder(t *testing.T) {
 	m := &typedMiddleware[*schema.Message]{sr: "<reminder>"}
 
-	t.Run("normal: system then user", func(t *testing.T) {
+	t.Run("after latest user message", func(t *testing.T) {
 		input := []*schema.Message{
 			{Role: schema.System, Content: "sys"},
 			{Role: schema.User, Content: "hi"},
@@ -450,10 +450,23 @@ func TestEnsureReminder(t *testing.T) {
 		require.Len(t, got, 3)
 		assert.Equal(t, schema.System, got[0].Role)
 		assert.Equal(t, schema.User, got[1].Role)
-		assert.Equal(t, "<reminder>", got[1].Content)
-		assert.Equal(t, true, got[1].Extra[toolSearchReminderExtraKey])
-		assert.Equal(t, schema.User, got[2].Role)
-		assert.Equal(t, "hi", got[2].Content)
+		assert.Equal(t, schema.System, got[2].Role)
+		assert.Equal(t, "<reminder>", got[2].Content)
+		assert.Equal(t, true, got[2].Extra[toolSearchReminderExtraKey])
+	})
+
+	t.Run("after latest assistant message", func(t *testing.T) {
+		input := []*schema.Message{
+			{Role: schema.System, Content: "sys"},
+			{Role: schema.User, Content: "hi"},
+			{Role: schema.Assistant, Content: "hello"},
+		}
+		got, _, _, _ := m.ensureReminder(input)
+		require.Len(t, got, 4)
+		assert.Equal(t, schema.User, got[1].Role)
+		assert.Equal(t, schema.Assistant, got[2].Role)
+		assert.Equal(t, schema.System, got[3].Role)
+		assert.Equal(t, "<reminder>", got[3].Content)
 	})
 
 	t.Run("all system messages", func(t *testing.T) {
@@ -465,12 +478,14 @@ func TestEnsureReminder(t *testing.T) {
 		require.Len(t, got, 3)
 		assert.Equal(t, schema.System, got[0].Role)
 		assert.Equal(t, schema.System, got[1].Role)
+		assert.Equal(t, schema.System, got[2].Role)
 		assert.Equal(t, "<reminder>", got[2].Content)
 	})
 
 	t.Run("empty input", func(t *testing.T) {
 		got, _, _, _ := m.ensureReminder(nil)
 		require.Len(t, got, 1)
+		assert.Equal(t, schema.System, got[0].Role)
 		assert.Equal(t, "<reminder>", got[0].Content)
 	})
 
@@ -481,14 +496,15 @@ func TestEnsureReminder(t *testing.T) {
 		}
 		got, _, _, _ := m.ensureReminder(input)
 		require.Len(t, got, 3)
-		assert.Equal(t, "<reminder>", got[0].Content)
-		assert.Equal(t, "hi", got[1].Content)
-		assert.Equal(t, "hello", got[2].Content)
+		assert.Equal(t, "hi", got[0].Content)
+		assert.Equal(t, "hello", got[1].Content)
+		assert.Equal(t, schema.System, got[2].Role)
+		assert.Equal(t, "<reminder>", got[2].Content)
 	})
 
 	t.Run("idempotent: does not insert twice", func(t *testing.T) {
 		input := []*schema.Message{
-			{Role: schema.User, Content: "<reminder>", Extra: map[string]any{toolSearchReminderExtraKey: true}},
+			{Role: schema.System, Content: "<reminder>", Extra: map[string]any{toolSearchReminderExtraKey: true}},
 			{Role: schema.User, Content: "hi"},
 		}
 		got, _, _, _ := m.ensureReminder(input)
@@ -615,7 +631,7 @@ func TestBeforeModelRewriteState_Mode1_ForwardSelection(t *testing.T) {
 	state := &adk.ChatModelAgentState{
 		Messages: []*schema.Message{
 			{Role: schema.System, Content: "sys"},
-			{Role: schema.User, Content: "hello", Extra: map[string]any{toolSearchReminderExtraKey: true}},
+			{Role: schema.System, Content: "hello", Extra: map[string]any{toolSearchReminderExtraKey: true}},
 			schema.AssistantMessage("", []schema.ToolCall{
 				{ID: "tc1", Function: schema.FunctionCall{Name: toolSearchToolName, Arguments: `{"query":"select:dynamic_tool_a"}`}},
 			}),
@@ -773,7 +789,7 @@ func TestBeforeModelRewriteState_Mode1_MultipleToolSearchResultsAcrossTurns(t *t
 	state := &adk.ChatModelAgentState{
 		Messages: []*schema.Message{
 			{Role: schema.System, Content: "sys"},
-			{Role: schema.User, Content: "reminder", Extra: map[string]any{toolSearchReminderExtraKey: true}},
+			{Role: schema.System, Content: "reminder", Extra: map[string]any{toolSearchReminderExtraKey: true}},
 			schema.AssistantMessage("", []schema.ToolCall{
 				{ID: "tc1", Function: schema.FunctionCall{Name: toolSearchToolName, Arguments: `{"query":"select:dynamic_tool_a"}`}},
 			}),
@@ -816,7 +832,7 @@ func TestBeforeModelRewriteState_Mode1_MalformedJSONInToolSearchResult(t *testin
 	state := &adk.ChatModelAgentState{
 		Messages: []*schema.Message{
 			{Role: schema.System, Content: "sys"},
-			{Role: schema.User, Content: "reminder", Extra: map[string]any{toolSearchReminderExtraKey: true}},
+			{Role: schema.System, Content: "reminder", Extra: map[string]any{toolSearchReminderExtraKey: true}},
 			schema.AssistantMessage("", []schema.ToolCall{
 				{ID: "tc1", Function: schema.FunctionCall{Name: toolSearchToolName, Arguments: `{"query":"select:dynamic_tool_a"}`}},
 			}),
@@ -854,7 +870,7 @@ func TestBeforeModelRewriteState_Mode1_NonExistentToolInForwardSelection(t *test
 
 	state := &adk.ChatModelAgentState{
 		Messages: []*schema.Message{
-			{Role: schema.User, Content: "reminder", Extra: map[string]any{toolSearchReminderExtraKey: true}},
+			{Role: schema.System, Content: "reminder", Extra: map[string]any{toolSearchReminderExtraKey: true}},
 			schema.AssistantMessage("", []schema.ToolCall{
 				{ID: "tc1", Function: schema.FunctionCall{Name: toolSearchToolName, Arguments: `{"query":"select:nonexistent_tool,dynamic_tool_a"}`}},
 			}),
@@ -919,7 +935,7 @@ func TestBeforeModelRewriteState_Mode1_DoubleInitWithoutComposeContext(t *testin
 
 	state := &adk.ChatModelAgentState{
 		Messages: []*schema.Message{
-			{Role: schema.User, Content: "reminder", Extra: map[string]any{toolSearchReminderExtraKey: true}},
+			{Role: schema.System, Content: "reminder", Extra: map[string]any{toolSearchReminderExtraKey: true}},
 			schema.AssistantMessage("", []schema.ToolCall{
 				{ID: "tc1", Function: schema.FunctionCall{Name: toolSearchToolName, Arguments: `{"query":"select:dynamic_tool_a"}`}},
 			}),
@@ -975,7 +991,7 @@ func TestBeforeModelRewriteState_ToolInfosSliceMutation(t *testing.T) {
 
 	state := &adk.ChatModelAgentState{
 		Messages: []*schema.Message{
-			{Role: schema.User, Content: "reminder", Extra: map[string]any{toolSearchReminderExtraKey: true}},
+			{Role: schema.System, Content: "reminder", Extra: map[string]any{toolSearchReminderExtraKey: true}},
 			schema.AssistantMessage("", []schema.ToolCall{
 				{ID: "tc1", Function: schema.FunctionCall{Name: toolSearchToolName, Arguments: `{"query":"select:dynamic_tool_a"}`}},
 			}),


### PR DESCRIPTION
## Summary

Toolsearch reminders are emitted as system messages and placed after the latest completed user or assistant turn. This optimizes reminder context while preserving tool protocol handling.

## Breaking Changes

1. Toolsearch reminders now use the system role instead of the user role.
2. Reminder insertion is anchored after the latest completed conversational turn rather than after protocol-only tool-call or tool-result messages.

## Key Changes

1. Treat assistant messages without tool-call protocol blocks as completed turns and user messages without tool-result protocol blocks as turn starts, including reasoning outputs.
2. Centralize Agentic tool-call and tool-result classification in ADK-internal helpers.
3. Preserve reminder idempotency and persist the exact MessageInserted anchor ordering.
4. Add coverage for classic and Agentic messages, reasoning content, protocol-only messages, and exact BeforeMessageID behavior.