### PR TITLE
perf(schema): assemble streamed string fields with pre-sized builders

### DIFF
--- a/schema/agentic_message.go
+++ b/schema/agentic_message.go
@@ -1312,6 +1312,33 @@ func genericGetTFromContentBlocks[T any](blocks []*ContentBlock, checkAndGetter 
 	return ret, nil
 }
 
+// concatStringField assembles a streamed string field from a list of chunks using a
+// single, pre-sized allocation. It first sums the fragment lengths, then grows a
+// strings.Builder once and writes every fragment in order. This keeps the total work
+// and bytes copied at O(total bytes), avoiding the quadratic intermediate strings that
+// repeated `+=` concatenation produces as the number of chunks grows. nil chunks are
+// skipped, matching the surrounding concat logic.
+func concatStringField[T any](items []*T, get func(*T) string) string {
+	total := 0
+	for _, it := range items {
+		if it != nil {
+			total += len(get(it))
+		}
+	}
+	if total == 0 {
+		return ""
+	}
+
+	var sb strings.Builder
+	sb.Grow(total)
+	for _, it := range items {
+		if it != nil {
+			sb.WriteString(get(it))
+		}
+	}
+	return sb.String()
+}
+
 func concatReasoning(reasons []*Reasoning) (ret *Reasoning, err error) {
 	if len(reasons) == 0 {
 		return nil, fmt.Errorf("no reasoning found")
@@ -1319,17 +1346,15 @@ func concatReasoning(reasons []*Reasoning) (ret *Reasoning, err error) {
 
 	ret = &Reasoning{}
 
+	// Assemble the streamed string fields with a single pre-sized allocation each.
+	ret.Text = concatStringField(reasons, func(r *Reasoning) string { return r.Text })
+	ret.Signature = concatStringField(reasons, func(r *Reasoning) string { return r.Signature })
+
 	openaiExtensions := make([]*openai.ReasoningExtension, 0, len(reasons))
 
 	for _, r := range reasons {
 		if r == nil {
 			continue
-		}
-		if r.Text != "" {
-			ret.Text += r.Text
-		}
-		if r.Signature != "" {
-			ret.Signature += r.Signature
 		}
 		if r.OpenAIExtension != nil {
 			openaiExtensions = append(openaiExtensions, r.OpenAIExtension)
@@ -1416,6 +1441,9 @@ func concatAssistantGenTexts(texts []*AssistantGenText) (ret *AssistantGenText, 
 
 	ret = &AssistantGenText{}
 
+	// Assemble the streamed text with a single pre-sized allocation.
+	ret.Text = concatStringField(texts, func(t *AssistantGenText) string { return t.Text })
+
 	openaiExtensions := make([]*openai.AssistantGenTextExtension, 0, len(texts))
 	claudeExtensions := make([]*claude.AssistantGenTextExtension, 0, len(texts))
 
@@ -1428,8 +1456,6 @@ func concatAssistantGenTexts(texts []*AssistantGenText) (ret *AssistantGenText, 
 		if t == nil {
 			continue
 		}
-
-		ret.Text += t.Text
 
 		var isConsistent bool
 
@@ -1498,12 +1524,13 @@ func concatAssistantGenImages(images []*AssistantGenImage) (*AssistantGenImage, 
 
 	ret := &AssistantGenImage{}
 
+	// Assemble the streamed Base64 data with a single pre-sized allocation.
+	ret.Base64Data = concatStringField(images, func(i *AssistantGenImage) string { return i.Base64Data })
+
 	for _, img := range images {
 		if img == nil {
 			continue
 		}
-
-		ret.Base64Data += img.Base64Data
 
 		if ret.URL == "" {
 			ret.URL = img.URL
@@ -1531,12 +1558,13 @@ func concatAssistantGenAudios(audios []*AssistantGenAudio) (*AssistantGenAudio, 
 
 	ret := &AssistantGenAudio{}
 
+	// Assemble the streamed Base64 data with a single pre-sized allocation.
+	ret.Base64Data = concatStringField(audios, func(a *AssistantGenAudio) string { return a.Base64Data })
+
 	for _, audio := range audios {
 		if audio == nil {
 			continue
 		}
-
-		ret.Base64Data += audio.Base64Data
 
 		if ret.URL == "" {
 			ret.URL = audio.URL
@@ -1564,12 +1592,13 @@ func concatAssistantGenVideos(videos []*AssistantGenVideo) (*AssistantGenVideo, 
 
 	ret := &AssistantGenVideo{}
 
+	// Assemble the streamed Base64 data with a single pre-sized allocation.
+	ret.Base64Data = concatStringField(videos, func(v *AssistantGenVideo) string { return v.Base64Data })
+
 	for _, video := range videos {
 		if video == nil {
 			continue
 		}
-
-		ret.Base64Data += video.Base64Data
 
 		if ret.URL == "" {
 			ret.URL = video.URL
@@ -1597,6 +1626,9 @@ func concatFunctionToolCalls(calls []*FunctionToolCall) (*FunctionToolCall, erro
 
 	ret := &FunctionToolCall{}
 
+	// Assemble the streamed JSON arguments with a single pre-sized allocation.
+	ret.Arguments = concatStringField(calls, func(c *FunctionToolCall) string { return c.Arguments })
+
 	for _, c := range calls {
 		if c == nil {
 			continue
@@ -1613,8 +1645,6 @@ func concatFunctionToolCalls(calls []*FunctionToolCall) (*FunctionToolCall, erro
 		} else if c.Name != "" && c.Name != ret.Name {
 			return nil, fmt.Errorf("expected tool name '%s' for function tool call, but got '%s'", ret.Name, c.Name)
 		}
-
-		ret.Arguments += c.Arguments
 	}
 
 	return ret, nil
@@ -1629,6 +1659,12 @@ func concatFunctionToolResults(results []*FunctionToolResult) (*FunctionToolResu
 	}
 
 	ret := &FunctionToolResult{}
+
+	// Gather every content block from all chunks in one pass, then merge adjacent
+	// text runs a single time. This avoids the previous per-chunk `append(nil, left...)`
+	// copy and the pairwise `+` text growth, both of which were O(n^2) in the number
+	// of streamed result chunks.
+	var allContent []*FunctionToolResultContentBlock
 
 	for _, r := range results {
 		if r == nil {
@@ -1647,8 +1683,12 @@ func concatFunctionToolResults(results []*FunctionToolResult) (*FunctionToolResu
 			return nil, fmt.Errorf("expected tool name '%s' for function tool result, but got '%s'", ret.Name, r.Name)
 		}
 
+		allContent = append(allContent, r.Content...)
+	}
+
+	if len(allContent) > 0 {
 		var err error
-		ret.Content, err = concatFunctionToolResultContent(ret.Content, r.Content)
+		ret.Content, err = mergeFunctionToolResultContent(allContent)
 		if err != nil {
 			return nil, err
 		}
@@ -1725,50 +1765,84 @@ func concatFunctionToolResultBlocks(a, b *ContentBlock) (*ContentBlock, error) {
 	return block, nil
 }
 
-func concatFunctionToolResultContent(
-	left, right []*FunctionToolResultContentBlock,
+// mergeFunctionToolResultContent merges a flat list of content blocks, collapsing runs
+// of consecutive text blocks (each with non-nil Text) into a single text block. It runs
+// in a single pass and builds each merged run with a pre-sized strings.Builder, keeping
+// the work proportional to the total number of blocks and bytes.
+func mergeFunctionToolResultContent(
+	blocks []*FunctionToolResultContentBlock,
 ) ([]*FunctionToolResultContentBlock, error) {
-	ret := append([]*FunctionToolResultContentBlock(nil), left...)
-	for _, block := range right {
+	ret := make([]*FunctionToolResultContentBlock, 0, len(blocks))
+
+	// run accumulates consecutive mergeable text blocks; it is flushed into a single
+	// block whenever a non-mergeable block is reached or the input ends.
+	var run []*FunctionToolResultContentBlock
+	flush := func() error {
+		switch len(run) {
+		case 0:
+			return nil
+		case 1:
+			// A lone text block is kept as-is to preserve pointer identity and extras.
+			ret = append(ret, run[0])
+		default:
+			merged, err := mergeFunctionToolResultTextRun(run)
+			if err != nil {
+				return err
+			}
+			ret = append(ret, merged)
+		}
+		run = run[:0]
+		return nil
+	}
+
+	for _, block := range blocks {
 		if block == nil {
 			continue
 		}
-		if len(ret) > 0 && canConcatFunctionToolResultTextBlocks(ret[len(ret)-1], block) {
-			merged, err := concatFunctionToolResultTextBlocks(ret[len(ret)-1], block)
-			if err != nil {
-				return nil, err
-			}
-			ret[len(ret)-1] = merged
+		if block.Type == FunctionToolResultContentBlockTypeText && block.Text != nil {
+			run = append(run, block)
 			continue
+		}
+		if err := flush(); err != nil {
+			return nil, err
 		}
 		ret = append(ret, block)
 	}
+	if err := flush(); err != nil {
+		return nil, err
+	}
 
+	if len(ret) == 0 {
+		return nil, nil
+	}
 	return ret, nil
 }
 
-func canConcatFunctionToolResultTextBlocks(a, b *FunctionToolResultContentBlock) bool {
-	return a != nil && b != nil &&
-		a.Type == FunctionToolResultContentBlockTypeText &&
-		b.Type == FunctionToolResultContentBlockTypeText &&
-		a.Text != nil && b.Text != nil
-}
-
-func concatFunctionToolResultTextBlocks(
-	a, b *FunctionToolResultContentBlock,
+// mergeFunctionToolResultTextRun concatenates a run of two or more text blocks into one,
+// joining their Text with a single pre-sized allocation and merging their Extra maps.
+func mergeFunctionToolResultTextRun(
+	run []*FunctionToolResultContentBlock,
 ) (*FunctionToolResultContentBlock, error) {
+	total := 0
+	for _, b := range run {
+		total += len(b.Text.Text)
+	}
+
+	var sb strings.Builder
+	sb.Grow(total)
+	extras := make([]map[string]any, 0, len(run))
+	for _, b := range run {
+		sb.WriteString(b.Text.Text)
+		if len(b.Extra) > 0 {
+			extras = append(extras, b.Extra)
+		}
+	}
+
 	ret := &FunctionToolResultContentBlock{
 		Type: FunctionToolResultContentBlockTypeText,
-		Text: &UserInputText{Text: a.Text.Text + b.Text.Text},
+		Text: &UserInputText{Text: sb.String()},
 	}
 
-	var extras []map[string]any
-	if len(a.Extra) > 0 {
-		extras = append(extras, a.Extra)
-	}
-	if len(b.Extra) > 0 {
-		extras = append(extras, b.Extra)
-	}
 	if len(extras) > 0 {
 		extra, err := concatExtra(extras)
 		if err != nil {
@@ -1900,12 +1974,13 @@ func concatMCPToolCalls(calls []*MCPToolCall) (*MCPToolCall, error) {
 
 	ret := &MCPToolCall{}
 
+	// Assemble the streamed JSON arguments with a single pre-sized allocation.
+	ret.Arguments = concatStringField(calls, func(c *MCPToolCall) string { return c.Arguments })
+
 	for _, c := range calls {
 		if c == nil {
 			continue
 		}
-
-		ret.Arguments += c.Arguments
 
 		if ret.ServerLabel == "" {
 			ret.ServerLabel = c.ServerLabel
@@ -2015,12 +2090,13 @@ func concatMCPToolApprovalRequests(requests []*MCPToolApprovalRequest) (*MCPTool
 
 	ret := &MCPToolApprovalRequest{}
 
+	// Assemble the streamed JSON arguments with a single pre-sized allocation.
+	ret.Arguments = concatStringField(requests, func(r *MCPToolApprovalRequest) string { return r.Arguments })
+
 	for _, r := range requests {
 		if r == nil {
 			continue
 		}
-
-		ret.Arguments += r.Arguments
 
 		if ret.ID == "" {
 			ret.ID = r.ID

--- a/schema/agentic_message_concat_test.go
+++ b/schema/agentic_message_concat_test.go
@@ -238,10 +238,10 @@ func TestConcatFunctionToolResults_Optimized(t *testing.T) {
 	t.Run("adjacent text chunks merged, non-text preserved", func(t *testing.T) {
 		results := []*FunctionToolResult{
 			{CallID: "c1", Name: "tool1", Content: []*FunctionToolResultContentBlock{
-				{Type: FunctionToolResultContentBlockTypeText, Text: &UserInputText{Text: "hel"}},
+				{Type: FunctionToolResultContentBlockTypeText, Text: &UserInputText{Text: "he"}},
 			}},
 			{CallID: "c1", Name: "tool1", Content: []*FunctionToolResultContentBlock{
-				{Type: FunctionToolResultContentBlockTypeText, Text: &UserInputText{Text: "lo "}},
+				{Type: FunctionToolResultContentBlockTypeText, Text: &UserInputText{Text: "llo "}},
 			}},
 			{CallID: "c1", Name: "tool1", Content: []*FunctionToolResultContentBlock{
 				{Type: FunctionToolResultContentBlockTypeText, Text: &UserInputText{Text: "world"}},

--- a/schema/agentic_message_concat_test.go
+++ b/schema/agentic_message_concat_test.go
@@ -1,0 +1,397 @@
+/*
+ * Copyright 2025 CloudWeGo Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package schema
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestConcatStringField covers the shared pre-sized string concatenation helper.
+func TestConcatStringField(t *testing.T) {
+	get := func(s *string) string { return *s }
+	str := func(s string) *string { return &s }
+
+	tests := []struct {
+		name  string
+		items []*string
+		want  string
+	}{
+		{name: "nil slice", items: nil, want: ""},
+		{name: "empty fragments", items: []*string{str(""), str("")}, want: ""},
+		{name: "nil elements skipped", items: []*string{str("a"), nil, str("b")}, want: "ab"},
+		{name: "ordered join", items: []*string{str("a"), str("b"), str("c")}, want: "abc"},
+		{name: "mixed empty and value", items: []*string{str(""), str("x"), str(""), str("y")}, want: "xy"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, concatStringField(tt.items, get))
+		})
+	}
+}
+
+func TestConcatReasoning_Optimized(t *testing.T) {
+	t.Run("text and signature together, in order", func(t *testing.T) {
+		reasons := []*Reasoning{
+			{Text: "he", Signature: "sig-"},
+			nil,
+			{Text: "llo", Signature: ""},
+			{Text: " world", Signature: "123"},
+		}
+		got, err := concatReasoning(reasons)
+		require.NoError(t, err)
+		assert.Equal(t, "hello world", got.Text)
+		assert.Equal(t, "sig-123", got.Signature)
+	})
+
+	t.Run("does not mutate input", func(t *testing.T) {
+		reasons := []*Reasoning{
+			{Text: "a", Signature: "s1"},
+			{Text: "b", Signature: "s2"},
+		}
+		_, err := concatReasoning(reasons)
+		require.NoError(t, err)
+		assert.Equal(t, "a", reasons[0].Text)
+		assert.Equal(t, "s1", reasons[0].Signature)
+		assert.Equal(t, "b", reasons[1].Text)
+		assert.Equal(t, "s2", reasons[1].Signature)
+	})
+
+	t.Run("empty", func(t *testing.T) {
+		_, err := concatReasoning(nil)
+		require.Error(t, err)
+	})
+}
+
+func TestConcatAssistantGenTexts_Optimized(t *testing.T) {
+	t.Run("multiple chunks in order", func(t *testing.T) {
+		texts := []*AssistantGenText{
+			{Text: "foo"},
+			nil,
+			{Text: "bar"},
+			{Text: "baz"},
+		}
+		got, err := concatAssistantGenTexts(texts)
+		require.NoError(t, err)
+		assert.Equal(t, "foobarbaz", got.Text)
+	})
+
+	t.Run("single element fast path returns input pointer", func(t *testing.T) {
+		in := &AssistantGenText{Text: "only"}
+		got, err := concatAssistantGenTexts([]*AssistantGenText{in})
+		require.NoError(t, err)
+		assert.Same(t, in, got)
+	})
+
+	t.Run("does not mutate input", func(t *testing.T) {
+		texts := []*AssistantGenText{{Text: "x"}, {Text: "y"}}
+		_, err := concatAssistantGenTexts(texts)
+		require.NoError(t, err)
+		assert.Equal(t, "x", texts[0].Text)
+		assert.Equal(t, "y", texts[1].Text)
+	})
+}
+
+func TestConcatAssistantGenMedia_Optimized(t *testing.T) {
+	t.Run("image base64 concatenated, metadata consistent", func(t *testing.T) {
+		imgs := []*AssistantGenImage{
+			{Base64Data: "AA", MIMEType: "image/png"},
+			{Base64Data: "BB", URL: "http://x"},
+			{Base64Data: "CC", MIMEType: "image/png", URL: "http://x"},
+		}
+		got, err := concatAssistantGenImages(imgs)
+		require.NoError(t, err)
+		assert.Equal(t, "AABBCC", got.Base64Data)
+		assert.Equal(t, "image/png", got.MIMEType)
+		assert.Equal(t, "http://x", got.URL)
+	})
+
+	t.Run("image conflicting mime type errors", func(t *testing.T) {
+		imgs := []*AssistantGenImage{
+			{Base64Data: "AA", MIMEType: "image/png"},
+			{Base64Data: "BB", MIMEType: "image/jpeg"},
+		}
+		_, err := concatAssistantGenImages(imgs)
+		require.Error(t, err)
+	})
+
+	t.Run("audio base64 concatenated", func(t *testing.T) {
+		got, err := concatAssistantGenAudios([]*AssistantGenAudio{
+			{Base64Data: "12"}, {Base64Data: "34"},
+		})
+		require.NoError(t, err)
+		assert.Equal(t, "1234", got.Base64Data)
+	})
+
+	t.Run("video base64 concatenated", func(t *testing.T) {
+		got, err := concatAssistantGenVideos([]*AssistantGenVideo{
+			{Base64Data: "ab"}, {Base64Data: "cd"},
+		})
+		require.NoError(t, err)
+		assert.Equal(t, "abcd", got.Base64Data)
+	})
+
+	t.Run("image does not mutate input", func(t *testing.T) {
+		imgs := []*AssistantGenImage{{Base64Data: "AA"}, {Base64Data: "BB"}}
+		_, err := concatAssistantGenImages(imgs)
+		require.NoError(t, err)
+		assert.Equal(t, "AA", imgs[0].Base64Data)
+	})
+}
+
+func TestConcatFunctionToolCalls_Optimized(t *testing.T) {
+	t.Run("sharded json arguments joined byte-exact", func(t *testing.T) {
+		calls := []*FunctionToolCall{
+			{CallID: "c1", Name: "fn", Arguments: `{"a":`},
+			{Arguments: `1,"b":`},
+			{Arguments: `"two"}`},
+		}
+		got, err := concatFunctionToolCalls(calls)
+		require.NoError(t, err)
+		assert.Equal(t, `{"a":1,"b":"two"}`, got.Arguments)
+		assert.Equal(t, "c1", got.CallID)
+		assert.Equal(t, "fn", got.Name)
+	})
+
+	t.Run("conflicting call id errors", func(t *testing.T) {
+		_, err := concatFunctionToolCalls([]*FunctionToolCall{
+			{CallID: "c1", Arguments: "a"},
+			{CallID: "c2", Arguments: "b"},
+		})
+		require.Error(t, err)
+	})
+
+	t.Run("does not mutate input", func(t *testing.T) {
+		calls := []*FunctionToolCall{{Arguments: "x"}, {Arguments: "y"}}
+		_, err := concatFunctionToolCalls(calls)
+		require.NoError(t, err)
+		assert.Equal(t, "x", calls[0].Arguments)
+	})
+}
+
+func TestConcatMCPToolCalls_Optimized(t *testing.T) {
+	t.Run("sharded arguments joined", func(t *testing.T) {
+		calls := []*MCPToolCall{
+			{ServerLabel: "s", CallID: "c", Name: "n", Arguments: `{"x`},
+			{Arguments: `":1}`},
+		}
+		got, err := concatMCPToolCalls(calls)
+		require.NoError(t, err)
+		assert.Equal(t, `{"x":1}`, got.Arguments)
+		assert.Equal(t, "s", got.ServerLabel)
+		assert.Equal(t, "c", got.CallID)
+		assert.Equal(t, "n", got.Name)
+	})
+
+	t.Run("conflicting server label errors", func(t *testing.T) {
+		_, err := concatMCPToolCalls([]*MCPToolCall{
+			{ServerLabel: "s1", Arguments: "a"},
+			{ServerLabel: "s2", Arguments: "b"},
+		})
+		require.Error(t, err)
+	})
+}
+
+func TestConcatMCPToolApprovalRequests_Optimized(t *testing.T) {
+	t.Run("sharded arguments joined", func(t *testing.T) {
+		reqs := []*MCPToolApprovalRequest{
+			{ID: "id", Name: "n", ServerLabel: "s", Arguments: `{"k":`},
+			{Arguments: `true}`},
+		}
+		got, err := concatMCPToolApprovalRequests(reqs)
+		require.NoError(t, err)
+		assert.Equal(t, `{"k":true}`, got.Arguments)
+		assert.Equal(t, "id", got.ID)
+		assert.Equal(t, "n", got.Name)
+		assert.Equal(t, "s", got.ServerLabel)
+	})
+
+	t.Run("conflicting id errors", func(t *testing.T) {
+		_, err := concatMCPToolApprovalRequests([]*MCPToolApprovalRequest{
+			{ID: "a", Arguments: "x"},
+			{ID: "b", Arguments: "y"},
+		})
+		require.Error(t, err)
+	})
+}
+
+func TestConcatFunctionToolResults_Optimized(t *testing.T) {
+	t.Run("adjacent text chunks merged, non-text preserved", func(t *testing.T) {
+		results := []*FunctionToolResult{
+			{CallID: "c1", Name: "tool1", Content: []*FunctionToolResultContentBlock{
+				{Type: FunctionToolResultContentBlockTypeText, Text: &UserInputText{Text: "hel"}},
+			}},
+			{CallID: "c1", Name: "tool1", Content: []*FunctionToolResultContentBlock{
+				{Type: FunctionToolResultContentBlockTypeText, Text: &UserInputText{Text: "lo "}},
+			}},
+			{CallID: "c1", Name: "tool1", Content: []*FunctionToolResultContentBlock{
+				{Type: FunctionToolResultContentBlockTypeText, Text: &UserInputText{Text: "world"}},
+			}},
+			{CallID: "c1", Name: "tool1", Content: []*FunctionToolResultContentBlock{
+				{Type: FunctionToolResultContentBlockTypeImage, Image: &UserInputImage{URL: "http://img.png"}},
+			}},
+		}
+		got, err := concatFunctionToolResults(results)
+		require.NoError(t, err)
+		require.Len(t, got.Content, 2)
+		assert.Equal(t, "hello world", got.Content[0].Text.Text)
+		assert.Equal(t, "http://img.png", got.Content[1].Image.URL)
+	})
+
+	t.Run("text run split by intervening image", func(t *testing.T) {
+		results := []*FunctionToolResult{
+			{CallID: "c1", Content: []*FunctionToolResultContentBlock{
+				{Type: FunctionToolResultContentBlockTypeText, Text: &UserInputText{Text: "a"}},
+				{Type: FunctionToolResultContentBlockTypeImage, Image: &UserInputImage{URL: "u"}},
+				{Type: FunctionToolResultContentBlockTypeText, Text: &UserInputText{Text: "b"}},
+			}},
+			{CallID: "c1", Content: []*FunctionToolResultContentBlock{
+				{Type: FunctionToolResultContentBlockTypeText, Text: &UserInputText{Text: "c"}},
+			}},
+		}
+		got, err := concatFunctionToolResults(results)
+		require.NoError(t, err)
+		require.Len(t, got.Content, 3)
+		assert.Equal(t, "a", got.Content[0].Text.Text)
+		assert.Equal(t, "u", got.Content[1].Image.URL)
+		assert.Equal(t, "bc", got.Content[2].Text.Text)
+	})
+
+	t.Run("extras on merged text run are concatenated", func(t *testing.T) {
+		results := []*FunctionToolResult{
+			{CallID: "c1", Content: []*FunctionToolResultContentBlock{
+				{Type: FunctionToolResultContentBlockTypeText, Text: &UserInputText{Text: "a"}, Extra: map[string]any{"k": "1"}},
+			}},
+			{CallID: "c1", Content: []*FunctionToolResultContentBlock{
+				{Type: FunctionToolResultContentBlockTypeText, Text: &UserInputText{Text: "b"}, Extra: map[string]any{"k": "2"}},
+			}},
+		}
+		got, err := concatFunctionToolResults(results)
+		require.NoError(t, err)
+		require.Len(t, got.Content, 1)
+		assert.Equal(t, "ab", got.Content[0].Text.Text)
+		assert.Equal(t, "12", got.Content[0].Extra["k"])
+	})
+
+	t.Run("empty content stays nil", func(t *testing.T) {
+		results := []*FunctionToolResult{
+			{CallID: "c1", Name: "t"},
+			{CallID: "c1", Name: "t"},
+		}
+		got, err := concatFunctionToolResults(results)
+		require.NoError(t, err)
+		assert.Nil(t, got.Content)
+	})
+}
+
+// ------------------------- Benchmarks -------------------------
+
+var concatChunkCounts = []int{16, 64, 256, 1024}
+var concatPayloadSizes = []int{8, 128}
+
+func makePayload(n int) string {
+	return strings.Repeat("a", n)
+}
+
+func BenchmarkConcatReasoning(b *testing.B) {
+	for _, chunks := range concatChunkCounts {
+		for _, size := range concatPayloadSizes {
+			b.Run(fmt.Sprintf("chunks=%d/payload=%d", chunks, size), func(b *testing.B) {
+				payload := makePayload(size)
+				in := make([]*Reasoning, chunks)
+				for i := range in {
+					in[i] = &Reasoning{Text: payload, Signature: payload}
+				}
+				b.ReportAllocs()
+				b.ResetTimer()
+				for i := 0; i < b.N; i++ {
+					if _, err := concatReasoning(in); err != nil {
+						b.Fatal(err)
+					}
+				}
+			})
+		}
+	}
+}
+
+func BenchmarkConcatAssistantGenTexts(b *testing.B) {
+	for _, chunks := range concatChunkCounts {
+		for _, size := range concatPayloadSizes {
+			b.Run(fmt.Sprintf("chunks=%d/payload=%d", chunks, size), func(b *testing.B) {
+				payload := makePayload(size)
+				in := make([]*AssistantGenText, chunks)
+				for i := range in {
+					in[i] = &AssistantGenText{Text: payload}
+				}
+				b.ReportAllocs()
+				b.ResetTimer()
+				for i := 0; i < b.N; i++ {
+					if _, err := concatAssistantGenTexts(in); err != nil {
+						b.Fatal(err)
+					}
+				}
+			})
+		}
+	}
+}
+
+func BenchmarkConcatFunctionToolCalls(b *testing.B) {
+	for _, chunks := range concatChunkCounts {
+		for _, size := range concatPayloadSizes {
+			b.Run(fmt.Sprintf("chunks=%d/payload=%d", chunks, size), func(b *testing.B) {
+				payload := makePayload(size)
+				in := make([]*FunctionToolCall, chunks)
+				for i := range in {
+					in[i] = &FunctionToolCall{CallID: "c", Name: "fn", Arguments: payload}
+				}
+				b.ReportAllocs()
+				b.ResetTimer()
+				for i := 0; i < b.N; i++ {
+					if _, err := concatFunctionToolCalls(in); err != nil {
+						b.Fatal(err)
+					}
+				}
+			})
+		}
+	}
+}
+
+func BenchmarkConcatMCPToolCalls(b *testing.B) {
+	for _, chunks := range concatChunkCounts {
+		for _, size := range concatPayloadSizes {
+			b.Run(fmt.Sprintf("chunks=%d/payload=%d", chunks, size), func(b *testing.B) {
+				payload := makePayload(size)
+				in := make([]*MCPToolCall, chunks)
+				for i := range in {
+					in[i] = &MCPToolCall{ServerLabel: "s", CallID: "c", Name: "fn", Arguments: payload}
+				}
+				b.ReportAllocs()
+				b.ResetTimer()
+				for i := 0; i < b.N; i++ {
+					if _, err := concatMCPToolCalls(in); err != nil {
+						b.Fatal(err)
+					}
+				}
+			})
+		}
+	}
+}

--- a/schema/openai/extension.go
+++ b/schema/openai/extension.go
@@ -19,6 +19,7 @@ package openai
 import (
 	"fmt"
 	"sort"
+	"strings"
 )
 
 type ResponseMetaExtension struct {
@@ -168,15 +169,26 @@ func ConcatAssistantGenTextExtensions(chunks []*AssistantGenTextExtension) (*Ass
 		ret.Annotations = append(ret.Annotations, &an)
 	}
 
+	// Assemble the refusal reason from all chunks with a single pre-sized allocation,
+	// building a fresh OutputRefusal so the input chunks are never mutated.
+	var (
+		refusalParts []string
+		refusalLen   int
+	)
 	for _, ext := range chunks {
 		if ext.Refusal == nil {
 			continue
 		}
-		if ret.Refusal == nil {
-			ret.Refusal = ext.Refusal
-		} else {
-			ret.Refusal.Reason += ext.Refusal.Reason
+		refusalParts = append(refusalParts, ext.Refusal.Reason)
+		refusalLen += len(ext.Refusal.Reason)
+	}
+	if len(refusalParts) > 0 {
+		var sb strings.Builder
+		sb.Grow(refusalLen)
+		for _, p := range refusalParts {
+			sb.WriteString(p)
 		}
+		ret.Refusal = &OutputRefusal{Reason: sb.String()}
 	}
 
 	return ret, nil
@@ -191,10 +203,11 @@ func ConcatReasoningExtensions(chunks []*ReasoningExtension) (*ReasoningExtensio
 	ret := &ReasoningExtension{}
 
 	var (
-		indices        []int
-		indexToContent = map[int]*ReasoningContent{}
-		hasIndexed     bool
-		hasUnindexed   bool
+		indices      []int
+		indexToParts = map[int][]string{}
+		indexToLen   = map[int]int{}
+		hasIndexed   bool
+		hasUnindexed bool
 	)
 
 	for _, ext := range chunks {
@@ -214,12 +227,13 @@ func ConcatReasoningExtensions(chunks []*ReasoningExtension) (*ReasoningExtensio
 
 			hasIndexed = true
 			idx := *c.Index
-			if existing, ok := indexToContent[idx]; ok {
-				existing.Text += c.Text
-			} else {
-				indexToContent[idx] = &ReasoningContent{Text: c.Text}
+			// Accumulate fragments per index; the string is built once below so a
+			// long stream sharing one index stays O(total bytes) instead of O(n^2).
+			if _, ok := indexToParts[idx]; !ok {
 				indices = append(indices, idx)
 			}
+			indexToParts[idx] = append(indexToParts[idx], c.Text)
+			indexToLen[idx] += len(c.Text)
 		}
 	}
 
@@ -231,7 +245,12 @@ func ConcatReasoningExtensions(chunks []*ReasoningExtension) (*ReasoningExtensio
 		sort.Ints(indices)
 		ret.Content = make([]*ReasoningContent, 0, len(indices))
 		for _, idx := range indices {
-			ret.Content = append(ret.Content, indexToContent[idx])
+			var sb strings.Builder
+			sb.Grow(indexToLen[idx])
+			for _, p := range indexToParts[idx] {
+				sb.WriteString(p)
+			}
+			ret.Content = append(ret.Content, &ReasoningContent{Text: sb.String()})
 		}
 	}
 

--- a/schema/openai/extension.go
+++ b/schema/openai/extension.go
@@ -205,7 +205,6 @@ func ConcatReasoningExtensions(chunks []*ReasoningExtension) (*ReasoningExtensio
 	var (
 		indices      []int
 		indexToParts = map[int][]string{}
-		indexToLen   = map[int]int{}
 		hasIndexed   bool
 		hasUnindexed bool
 	)
@@ -233,7 +232,6 @@ func ConcatReasoningExtensions(chunks []*ReasoningExtension) (*ReasoningExtensio
 				indices = append(indices, idx)
 			}
 			indexToParts[idx] = append(indexToParts[idx], c.Text)
-			indexToLen[idx] += len(c.Text)
 		}
 	}
 
@@ -245,9 +243,14 @@ func ConcatReasoningExtensions(chunks []*ReasoningExtension) (*ReasoningExtensio
 		sort.Ints(indices)
 		ret.Content = make([]*ReasoningContent, 0, len(indices))
 		for _, idx := range indices {
+			parts := indexToParts[idx]
+			total := 0
+			for _, p := range parts {
+				total += len(p)
+			}
 			var sb strings.Builder
-			sb.Grow(indexToLen[idx])
-			for _, p := range indexToParts[idx] {
+			sb.Grow(total)
+			for _, p := range parts {
 				sb.WriteString(p)
 			}
 			ret.Content = append(ret.Content, &ReasoningContent{Text: sb.String()})

--- a/schema/openai/extension_concat_test.go
+++ b/schema/openai/extension_concat_test.go
@@ -1,0 +1,121 @@
+/*
+ * Copyright 2025 CloudWeGo Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package openai
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestConcatAssistantGenTextExtensions_Refusal(t *testing.T) {
+	t.Run("refusal reason concatenated in order", func(t *testing.T) {
+		chunks := []*AssistantGenTextExtension{
+			{Refusal: &OutputRefusal{Reason: "I "}},
+			{},
+			{Refusal: &OutputRefusal{Reason: "can't "}},
+			{Refusal: &OutputRefusal{Reason: "help"}},
+		}
+		got, err := ConcatAssistantGenTextExtensions(chunks)
+		require.NoError(t, err)
+		require.NotNil(t, got.Refusal)
+		assert.Equal(t, "I can't help", got.Refusal.Reason)
+	})
+
+	t.Run("does not mutate input refusal chunks", func(t *testing.T) {
+		chunks := []*AssistantGenTextExtension{
+			{Refusal: &OutputRefusal{Reason: "a"}},
+			{Refusal: &OutputRefusal{Reason: "b"}},
+		}
+		_, err := ConcatAssistantGenTextExtensions(chunks)
+		require.NoError(t, err)
+		assert.Equal(t, "a", chunks[0].Refusal.Reason)
+		assert.Equal(t, "b", chunks[1].Refusal.Reason)
+	})
+
+	t.Run("no refusal yields nil", func(t *testing.T) {
+		chunks := []*AssistantGenTextExtension{{}, {}}
+		got, err := ConcatAssistantGenTextExtensions(chunks)
+		require.NoError(t, err)
+		assert.Nil(t, got.Refusal)
+	})
+}
+
+func TestConcatReasoningExtensions_IndexedText(t *testing.T) {
+	idx := func(i int) *int { return &i }
+
+	t.Run("same index merged in stream order", func(t *testing.T) {
+		chunks := []*ReasoningExtension{
+			{Content: []*ReasoningContent{{Index: idx(0), Text: "he"}}},
+			{Content: []*ReasoningContent{{Index: idx(1), Text: "AA"}}},
+			{Content: []*ReasoningContent{{Index: idx(0), Text: "llo"}}},
+			{Content: []*ReasoningContent{{Index: idx(1), Text: "BB"}}},
+		}
+		got, err := ConcatReasoningExtensions(chunks)
+		require.NoError(t, err)
+		require.Len(t, got.Content, 2)
+		assert.Equal(t, "hello", got.Content[0].Text)
+		assert.Equal(t, "AABB", got.Content[1].Text)
+	})
+
+	t.Run("indices sorted ascending", func(t *testing.T) {
+		chunks := []*ReasoningExtension{
+			{Content: []*ReasoningContent{{Index: idx(2), Text: "c"}}},
+			{Content: []*ReasoningContent{{Index: idx(0), Text: "a"}}},
+			{Content: []*ReasoningContent{{Index: idx(1), Text: "b"}}},
+		}
+		got, err := ConcatReasoningExtensions(chunks)
+		require.NoError(t, err)
+		require.Len(t, got.Content, 3)
+		assert.Equal(t, "a", got.Content[0].Text)
+		assert.Equal(t, "b", got.Content[1].Text)
+		assert.Equal(t, "c", got.Content[2].Text)
+	})
+
+	t.Run("unindexed content kept in order", func(t *testing.T) {
+		chunks := []*ReasoningExtension{
+			{Content: []*ReasoningContent{{Text: "x"}}},
+			{Content: []*ReasoningContent{{Text: "y"}}},
+		}
+		got, err := ConcatReasoningExtensions(chunks)
+		require.NoError(t, err)
+		require.Len(t, got.Content, 2)
+		assert.Equal(t, "x", got.Content[0].Text)
+		assert.Equal(t, "y", got.Content[1].Text)
+	})
+
+	t.Run("mixing indexed and unindexed errors", func(t *testing.T) {
+		chunks := []*ReasoningExtension{
+			{Content: []*ReasoningContent{{Index: idx(0), Text: "a"}}},
+			{Content: []*ReasoningContent{{Text: "b"}}},
+		}
+		_, err := ConcatReasoningExtensions(chunks)
+		require.Error(t, err)
+	})
+
+	t.Run("does not mutate input content", func(t *testing.T) {
+		chunks := []*ReasoningExtension{
+			{Content: []*ReasoningContent{{Index: idx(0), Text: "a"}}},
+			{Content: []*ReasoningContent{{Index: idx(0), Text: "b"}}},
+		}
+		_, err := ConcatReasoningExtensions(chunks)
+		require.NoError(t, err)
+		assert.Equal(t, "a", chunks[0].Content[0].Text)
+		assert.Equal(t, "b", chunks[1].Content[0].Text)
+	})
+}


### PR DESCRIPTION
## Background

Production CPU profiles showed `schema.ConcatAgenticMessages` dominating CPU time. Its downstream concat helpers assembled streamed string fields with in-loop `+=` concatenation, producing a fresh full-history intermediate string per chunk. A single concat pass was therefore **O(n²)** in the number of chunks, generating heavy allocation and GC churn.

## What changed

Every pure-string streaming accumulation path now uses a **single pre-sized allocation**: sum the fragment lengths, then `strings.Builder.Grow` once and `WriteString` each fragment (no reflection, no `unsafe`), mirroring the existing `ConcatMessages` implementation.

Audited & optimized paths:

| Location | Field(s) |
|---|---|
| `concatReasoning` | `Reasoning.Text`, `Signature` |
| `concatAssistantGenTexts` | `AssistantGenText.Text` |
| `concatAssistantGenImages/Audios/Videos` | `Base64Data` (string join only, no decode) |
| `concatFunctionToolCalls` | `Arguments` |
| `concatMCPToolCalls` | `Arguments` |
| `concatMCPToolApprovalRequests` | `Arguments` |
| `concatFunctionToolResults` content | text-run merge — flatten once + single-pass run collapse (removes O(n²) slice copy + pairwise `+`) |
| `openai.ConcatAssistantGenTextExtensions` | `Refusal.Reason` (also fixes input-chunk mutation) |
| `openai.ConcatReasoningExtensions` | indexed content `Text` |

claude/gemini extensions and `internal.concatStrings` were audited and needed no change.

A shared internal helper `concatStringField[T]` is added for the main file; the openai package uses a local `strings.Builder`.

## Compatibility

Public APIs (`ConcatAgenticMessages`, `ConcatAgenticMessagesArray`), output content, chunk ordering, single-element fast paths, metadata consistency checks (CallID/Name/URL/MIMEType/ServerLabel), and extension/Extra merge semantics are all unchanged. No internal caller re-concatenates accumulating prefixes, so no new accumulator API was introduced.

## Benchmarks

`ReportAllocs`, chunks ∈ {16,64,256,1024} × payload ∈ {8,128} bytes. Allocs/op is now **constant (~2)** regardless of chunk count. Representative `chunks=1024/payload=128`:

| Benchmark | ns/op | B/op | allocs/op |
|---|---|---|---|
| ConcatReasoning | 10713µs → **24.2µs** (-99.77%) | 137MB → **265KB** | 4106 → **6** |
| ConcatAssistantGenTexts | 5293µs → **15.3µs** (-99.71%) | 68MB → **146KB** | — |
| ConcatFunctionToolCalls | 4693µs → **15.0µs** (-99.68%) | 68MB → **128KB** | 1027 → **2** |
| ConcatMCPToolCalls | 4918µs → **19.8µs** (-99.60%) | 68MB → **128KB** | 1027 → **2** |

geomean: **-95.9% time, -98.1% bytes**.

## Verification

- `go test ./schema/...` ✅
- `go test -race ./schema/...` ✅
- `go test ./...` (52 packages) ✅
- `gofmt -l` clean, `golangci-lint run ./schema/...` → 0 issues

New table-driven tests cover multi-chunk order, empty/nil elements, single-element fast path, reasoning Text+Signature, sharded JSON args, media Base64, metadata consistency/conflict, tool-result text-run merge (incl. split by non-text), extra merge, OpenAI refusal & indexed reasoning content, and input non-mutation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)