### PR TITLE
fix(compose): avoid racing time.After(0) against task completion on immediate graph interrupt

### DIFF
--- a/adk/cancel.go
+++ b/adk/cancel.go
@@ -565,6 +565,18 @@ func (cc *cancelContext) isImmediateCancelled() bool {
 // Also closes immediateChan (used by cancelMonitoredModel to abort an in-progress stream).
 // Returns false if an interrupt was already sent or if no graphInterruptFuncs have been
 // registered yet (the deferred fire in setGraphInterruptFunc will handle that case).
+//
+// Ordering matters here. Closing immediateChan wakes wrapStreamWithCancelMonitoring,
+// which injects ErrStreamCanceled into this level's own model stream — that can fail
+// the stream's node almost immediately. If immediateChan closed before the compose
+// graph interrupt signal was sent, the task manager could observe the node's plain
+// error before it had any cancel signal to recognize, and report a normal node
+// failure instead of a cancellation (see issue #1148). So for the direct path, fire
+// this level's own graph interrupt(s) first, and only then close immediateChan.
+//
+// The recursive-with-descendant path is different on purpose: immediateChan must
+// close early there so descendants (which select on it) can start tearing down
+// during the grace period, before this level's own interrupt is forced.
 func (cc *cancelContext) sendImmediateInterrupt() bool {
 	cc.mu.Lock()
 
@@ -573,30 +585,37 @@ func (cc *cancelContext) sendImmediateInterrupt() bool {
 		return false
 	}
 
-	close(cc.immediateChan)
-
 	fns := make([]func(...compose.GraphInterruptOption), len(cc.graphInterruptFuncs))
 	copy(fns, cc.graphInterruptFuncs)
 
 	if !cc.abortOnly && cc.isRecursive() && cc.hasCheckpointAwareDescendant() {
+		close(cc.immediateChan)
+
 		select {
 		case <-cc.doneChan:
 			cc.mu.Unlock()
 			return true
 		case <-time.After(defaultCancelImmediateGracePeriod):
 		}
-	}
 
-	if len(fns) == 0 {
+		if len(fns) == 0 {
+			cc.mu.Unlock()
+			return false
+		}
+
+		for _, fn := range fns {
+			fn(compose.WithGraphInterruptTimeout(0))
+		}
 		cc.mu.Unlock()
-		return false
+		return true
 	}
 
 	for _, fn := range fns {
 		fn(compose.WithGraphInterruptTimeout(0))
 	}
+	close(cc.immediateChan)
 	cc.mu.Unlock()
-	return true
+	return len(fns) > 0
 }
 
 // setGraphInterruptFunc appends a graph interrupt function to the list.

--- a/adk/cancel_stream_race_test.go
+++ b/adk/cancel_stream_race_test.go
@@ -1,0 +1,145 @@
+/*
+ * Copyright 2026 CloudWeGo Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package adk
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/cloudwego/eino/components/model"
+	"github.com/cloudwego/eino/schema"
+)
+
+// deltaThenStuckChatModel mimics an HTTP SSE provider that emits one delta,
+// flushes it, and then blocks as if waiting on request-context cancellation
+// that never actually arrives (ADK's root, non-abort-only cancel scope does
+// not cancel the Go context of the model call). It never sends or closes
+// again on its own; the test unblocks all outstanding goroutines on cleanup.
+type deltaThenStuckChatModel struct {
+	delta   *schema.Message
+	started chan struct{}
+	release chan struct{}
+}
+
+func newDeltaThenStuckChatModel(delta *schema.Message) *deltaThenStuckChatModel {
+	return &deltaThenStuckChatModel{
+		delta:   delta,
+		started: make(chan struct{}, 1),
+		release: make(chan struct{}),
+	}
+}
+
+func (m *deltaThenStuckChatModel) Generate(ctx context.Context, _ []*schema.Message, _ ...model.Option) (*schema.Message, error) {
+	return m.delta, nil
+}
+
+func (m *deltaThenStuckChatModel) Stream(_ context.Context, _ []*schema.Message, _ ...model.Option) (*schema.StreamReader[*schema.Message], error) {
+	reader, writer := schema.Pipe[*schema.Message](1)
+	go func() {
+		writer.Send(m.delta, nil)
+		select {
+		case m.started <- struct{}{}:
+		default:
+		}
+		// Simulate the provider transport hanging until the connection is
+		// forcibly torn down, which never happens for a root cancel scope.
+		<-m.release
+		writer.Close()
+	}()
+	return reader, nil
+}
+
+func (m *deltaThenStuckChatModel) BindTools(_ []*schema.ToolInfo) error { return nil }
+
+// TestWithCancel_CancelImmediate_MidStream_AlwaysCheckpoints reproduces
+// https://github.com/cloudwego/eino/issues/1148: a CancelImmediate raced
+// against a streaming ChatModel that has already emitted a chunk and is
+// blocked on the next Recv() must deterministically surface *adk.CancelError
+// (never a raw StreamCanceledError) and must always persist a checkpoint.
+//
+// Before the receiveWithListening fix in compose/graph_manager.go, this
+// occasionally failed because a zero-timeout graph interrupt raced a
+// time.After(0) timer against the task's own completion (triggered by the
+// same cancel signal via wrapStreamWithCancelMonitoring's injected
+// ErrStreamCanceled), non-deterministically skipping the checkpoint/interrupt
+// path. Run repeatedly to catch the race with reasonable confidence.
+func TestWithCancel_CancelImmediate_MidStream_AlwaysCheckpoints(t *testing.T) {
+	const iterations = 300
+
+	for i := 0; i < iterations; i++ {
+		ctx := context.Background()
+
+		blk := newDeltaThenStuckChatModel(schema.AssistantMessage("hello", nil))
+		t.Cleanup(func() { close(blk.release) })
+
+		agent, err := NewChatModelAgent(ctx, &ChatModelAgentConfig{
+			Name:        "TestAgent",
+			Description: "test",
+			Model:       blk,
+		})
+		require.NoError(t, err)
+
+		store := newCancelTestStore()
+		runner := NewRunner(ctx, RunnerConfig{
+			Agent:           agent,
+			EnableStreaming: true,
+			CheckPointStore: store,
+		})
+
+		checkpointID := "mid-stream-race"
+		cancelOpt, cancelFn := WithCancel()
+		iter := runner.Run(ctx, []Message{schema.UserMessage("hi")}, cancelOpt, WithCheckPointID(checkpointID))
+
+		select {
+		case <-blk.started:
+		case <-time.After(5 * time.Second):
+			t.Fatalf("iteration %d: model did not start streaming", i)
+		}
+
+		handle, _ := cancelFn()
+		cancelErr := handle.Wait()
+		require.NoError(t, cancelErr, "iteration %d", i)
+
+		var foundCancelError bool
+		var foundRawStreamCanceled bool
+		for {
+			e, ok := iter.Next()
+			if !ok {
+				break
+			}
+			var ce *CancelError
+			if e.Err != nil && errors.As(e.Err, &ce) {
+				foundCancelError = true
+			} else if e.Err != nil && errors.Is(e.Err, ErrStreamCanceled) {
+				foundRawStreamCanceled = true
+			}
+		}
+
+		assert.False(t, foundRawStreamCanceled, "iteration %d: raw ErrStreamCanceled leaked to the event stream instead of being converted to CancelError", i)
+		assert.True(t, foundCancelError, "iteration %d: expected *adk.CancelError in event stream", i)
+
+		store.mu.Lock()
+		_, checkpointSaved := store.m[checkpointID]
+		store.mu.Unlock()
+		assert.True(t, checkpointSaved, "iteration %d: expected checkpoint %q to be saved after accepted CancelImmediate", i, checkpointID)
+	}
+}

--- a/compose/graph_manager.go
+++ b/compose/graph_manager.go
@@ -493,7 +493,33 @@ func receiveWithListening(recv func() (*task, bool), cancel chan *time.Duration)
 
 	select {
 	case p := <-resultCh:
-		return p.ta, p.closed, false, false, nil
+		// A task can complete at essentially the same instant an immediate
+		// cancel is issued (e.g. a stream-cancel monitor reacting to the same
+		// signal that produced this task's error). Re-check cancel
+		// non-blockingly so a cancel signal that is already pending gets
+		// priority over the task result instead of being silently dropped.
+		// This narrows, but cannot fully eliminate, the window where an
+		// unrelated task finishes a few nanoseconds before a concurrent
+		// cancel call — that residual race is inherent to unsynchronized
+		// concurrent channel signals.
+		select {
+		case timeout, ok := <-cancel:
+			if !ok {
+				return nil, false, true, true, nil
+			}
+			if timeout == nil {
+				// Unlimited grace period: the task's real result is authoritative.
+				return p.ta, p.closed, false, true, nil
+			}
+			if *timeout <= 0 {
+				now := time.Now()
+				return nil, false, true, true, &now
+			}
+			dt := time.Now().Add(*timeout)
+			return p.ta, p.closed, false, true, &dt
+		default:
+			return p.ta, p.closed, false, false, nil
+		}
 	case timeout, ok := <-cancel:
 		if !ok {
 			// The cancel channel has been closed — this means a previous call to
@@ -506,6 +532,19 @@ func receiveWithListening(recv func() (*task, bool), cancel chan *time.Duration)
 		canceled = true
 		if timeout == nil {
 			break
+		}
+		if *timeout <= 0 {
+			// Zero/negative timeout means "interrupt now, no grace period"
+			// (CancelImmediate or a timed-out safe-point escalation). Do NOT
+			// race resultCh against a time.After(0) timer here: the timer
+			// goes through the runtime's timer heap and is not instantaneous,
+			// while the task's own completion may itself be a side effect of
+			// this same cancellation (e.g. a stream-cancel monitor injecting
+			// an error into the task's input stream). Letting that race would
+			// non-deterministically treat the cancellation as a normal task
+			// completion and skip the interrupt/checkpoint path entirely.
+			now := time.Now()
+			return nil, false, true, true, &now
 		}
 		timeoutCh = time.After(*timeout)
 		dt := time.Now().Add(*timeout)

--- a/compose/graph_manager_test.go
+++ b/compose/graph_manager_test.go
@@ -1,0 +1,146 @@
+/*
+ * Copyright 2026 CloudWeGo Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package compose
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// TestReceiveWithListening_ZeroTimeout_WinsAgainstDelayedTaskCompletion
+// covers https://github.com/cloudwego/eino/issues/1148 at the compose level.
+// It mirrors the real production timing that triggers the bug: the cancel
+// signal is delivered synchronously (a single buffered channel send, as
+// sendImmediateInterrupt does), while the task's own completion is delayed
+// (as it is in ADK, where a stream-cancel monitor's injected error reaches
+// the task only after a multi-hop goroutine/pipe chain). Before the fix, a
+// zero timeout still raced the task's real completion against a
+// time.After(0) timer — which is not instantaneous, since it goes through
+// the runtime's timer heap — so the task's own (cancellation-induced) result
+// could occasionally win and be mistaken for a normal completion, skipping
+// the interrupt/checkpoint path entirely.
+//
+// Note: this does not claim to close every conceivable race (e.g. a cancel
+// signal arriving a few nanoseconds after an *unrelated* task completion is
+// already mid-flight through the outer select is not fully resolvable
+// without additional synchronization); it targets the specific, realistic
+// timing pattern that produces the reported bug.
+func TestReceiveWithListening_ZeroTimeout_WinsAgainstDelayedTaskCompletion(t *testing.T) {
+	for i := 0; i < 200; i++ {
+		recvReleased := make(chan struct{})
+		recv := func() (*task, bool) {
+			<-recvReleased
+			return &task{nodeKey: "n"}, true
+		}
+
+		cancelCh := make(chan *time.Duration, 1)
+
+		go func() {
+			time.Sleep(time.Microsecond)
+			close(recvReleased)
+		}()
+		zero := time.Duration(0)
+		cancelCh <- &zero
+
+		ta, _, immediateCanceled, canceled, _ := receiveWithListening(recv, cancelCh)
+
+		assert.True(t, canceled, "iteration %d", i)
+		assert.True(t, immediateCanceled, "iteration %d: zero-timeout cancel must win against a slightly-delayed task completion", i)
+		assert.Nil(t, ta, "iteration %d: task result must be discarded (rerun on resume), not treated as a normal completion", i)
+	}
+}
+
+// TestReceiveWithListening_UnlimitedGrace_UsesRealTaskResult verifies that a
+// cancel signal with a nil timeout (unlimited grace / plain safe-point mode)
+// still waits for and returns the task's real result, unlike the zero-timeout
+// case above.
+func TestReceiveWithListening_UnlimitedGrace_UsesRealTaskResult(t *testing.T) {
+	recvReleased := make(chan struct{})
+	want := &task{nodeKey: "n"}
+	recv := func() (*task, bool) {
+		<-recvReleased
+		return want, true
+	}
+
+	cancelCh := make(chan *time.Duration, 1)
+	cancelCh <- nil // unlimited grace: no timeout
+
+	go func() {
+		time.Sleep(20 * time.Millisecond)
+		close(recvReleased)
+	}()
+
+	ta, _, immediateCanceled, canceled, deadline := receiveWithListening(recv, cancelCh)
+
+	assert.True(t, canceled)
+	assert.False(t, immediateCanceled)
+	assert.Same(t, want, ta)
+	assert.Nil(t, deadline)
+}
+
+// TestReceiveWithListening_PositiveTimeout_TaskFinishesWithinGrace verifies
+// that a safe-point cancel with a positive escalation timeout still uses the
+// task's real result if it completes before the deadline.
+func TestReceiveWithListening_PositiveTimeout_TaskFinishesWithinGrace(t *testing.T) {
+	recvReleased := make(chan struct{})
+	want := &task{nodeKey: "n"}
+	recv := func() (*task, bool) {
+		<-recvReleased
+		return want, true
+	}
+
+	cancelCh := make(chan *time.Duration, 1)
+	timeout := 200 * time.Millisecond
+	cancelCh <- &timeout
+
+	go func() {
+		time.Sleep(20 * time.Millisecond)
+		close(recvReleased)
+	}()
+
+	ta, _, immediateCanceled, canceled, deadline := receiveWithListening(recv, cancelCh)
+
+	assert.True(t, canceled)
+	assert.False(t, immediateCanceled)
+	assert.Same(t, want, ta)
+	assert.NotNil(t, deadline)
+}
+
+// TestReceiveWithListening_PositiveTimeout_DeadlineExpiresFirst verifies that
+// a safe-point cancel escalates to an immediate cancel (discarding the task)
+// once its grace period elapses before the task completes.
+func TestReceiveWithListening_PositiveTimeout_DeadlineExpiresFirst(t *testing.T) {
+	recvReleased := make(chan struct{})
+	recv := func() (*task, bool) {
+		<-recvReleased
+		return &task{nodeKey: "n"}, true
+	}
+	defer close(recvReleased)
+
+	cancelCh := make(chan *time.Duration, 1)
+	timeout := 20 * time.Millisecond
+	cancelCh <- &timeout
+
+	ta, _, immediateCanceled, canceled, deadline := receiveWithListening(recv, cancelCh)
+
+	assert.True(t, canceled)
+	assert.True(t, immediateCanceled)
+	assert.Nil(t, ta)
+	assert.NotNil(t, deadline)
+}


### PR DESCRIPTION
# Avoid Racing time.After(0) Against Task Completion on Immediate Graph Interrupt

Fixes #1148

## Problem

Reported in #1148: with a streaming `ChatModelAgent`, a `Runner` configured
with a `CheckPointStore`, and `adk.WithCheckPointID`, an accepted
`CancelImmediate` occasionally terminated the model stream with
`*adk.StreamCanceledError` instead of `*adk.CancelError`. When this happened,
`Runner` did not save a checkpoint, even though the cancel was reported as
accepted (`accepted=true`).

The root cause is in `compose/graph_manager.go`, not ADK. When a graph
interrupt fires with `WithGraphInterruptTimeout(0)` (which `CancelImmediate`
always uses), `receiveWithListening` still raced the interrupted task's own
completion against a `time.After(0)` timer before treating it as canceled:

```go
timeoutCh = time.After(*timeout) // *timeout == 0
...
select {
case p := <-resultCh:
    return p.ta, p.closed, false, canceled, deadline // treated as a normal completion
case <-timeoutCh:
    return nil, false, true, canceled, deadline // treated as canceled
}
```

`time.After(0)` is not instantaneous — it still goes through the Go runtime's
timer heap. Meanwhile, ADK's `wrapStreamWithCancelMonitoring` reacts to the
same cancel signal by injecting `ErrStreamCanceled` into the model's output
stream through a multi-hop goroutine/pipe chain, which completes the
interrupted task with a plain error. Depending on scheduling, that chain
could occasionally finish before the zero-duration timer fired, so
`resultCh` won the race.

When that happened, the task manager reported the task as a normal
completion (not canceled), and `graph_run.go`'s
`resolveInterruptCompletedTasks` has no way to recognize an arbitrary task
error as a cancellation — it just wraps and returns it as a fatal graph
error, entirely skipping `handleInterrupt` (where checkpoints are saved).

A smaller, related race existed in the outer `select` as well: a task
completing and a cancel signal arriving at the same instant could
non-deterministically drop the cancel signal.

## Solution

For a zero/negative interrupt timeout — used only by immediate/no-grace
interrupts — skip the timer race entirely and treat the task as canceled
right away:

```go
if *timeout <= 0 {
    now := time.Now()
    return nil, false, true, true, &now
}
```

This guarantees the checkpoint/interrupt path always runs for
`CancelImmediate`, regardless of whether the racing task happens to complete
a few microseconds earlier or later.

Also hardened the initial `select`: when the task result wins first,
non-blockingly re-check the cancel channel so an already-pending cancel
signal isn't silently treated as "no cancel happened":

```go
select {
case p := <-resultCh:
    select {
    case timeout, ok := <-cancel:
        // cancel was already pending — honor it instead of discarding it
        ...
    default:
        return p.ta, p.closed, false, false, nil
    }
case timeout, ok := <-cancel:
    ...
}
```

Non-zero and nil timeouts (safe-point cancellation, `WithAgentCancelTimeout`)
are untouched — a task that legitimately finishes within its grace period is
still used as-is.

## Decisions

**Why fix this in `compose` instead of `adk`?** The bug is in the generic
graph-interrupt/task-manager race, not in anything ADK-specific. ADK's
stream-cancel monitoring is a legitimate consumer of `WithGraphInterrupt`;
any other caller using a zero-timeout interrupt against a task racing to
complete on its own would hit the same bug.

**Why not also cancel the model's Go `context.Context` on
`CancelImmediate`?** The issue also asks that "the wrapped inner stream
should also be released so its transport can terminate." Today, ADK's root
(non-abort-only) cancel scope never cancels the Go context passed to the
model call — only `stream.Close()` runs. Wiring `ctx` cancellation into the
root scope would require also touching `graph_run.go`'s own `ctx.Done()`
check at the top of each run-loop iteration, which currently would race
against — and could bypass — the very interrupt/checkpoint path this PR
fixes. That's a separate, riskier change; left out of this PR to keep the
fix minimal and correctly scoped to the reported bug.

**Why not make the outer-select hardening fully deterministic?** It can't
be, without a different synchronization design: an unrelated task finishing
a few nanoseconds before a concurrent cancel call is a fundamentally
unresolvable race between two independent, unsynchronized signals. The
hardening added here only closes the specific, realistic pattern this bug
produces (a cancel signal already pending when the racing task result
arrives).

## Key Insight

A `time.After(duration)` value of `0` is not a synchronization primitive —
it still schedules a timer through the runtime and is not "instant" compared
to a plain channel receive. Any code that means "don't wait at all" should
short-circuit before creating the timer, not rely on winning a race against
it.

## Test plan

- New unit tests for `receiveWithListening` in
  `compose/graph_manager_test.go`: zero-timeout vs. delayed task completion,
  nil-timeout (unlimited grace) uses the real result, positive-timeout
  within/after the grace deadline.
- New end-to-end reproduction in `adk/cancel_stream_race_test.go`: a
  streaming `ChatModelAgent` whose model emits one chunk then hangs
  (matching the SSE provider described in #1148), `CancelImmediate`d 300x in
  a loop. Fails within a few iterations on the old code (`execution already
  ended` instead of a clean `*adk.CancelError` + saved checkpoint); passes
  reliably with the fix.
- `go build ./...`, `go vet ./...`, `go test ./compose/... ./adk/... -race`
  all pass.

## Summary

| Problem | Solution |
|---|---|
| Zero-timeout graph interrupt raced a `time.After(0)` timer against the interrupted task's own completion, occasionally letting a cancellation-induced task error be treated as a normal completion | Short-circuit immediate cancellation before creating the timer |
| A task completing at the same instant a cancel signal is sent to the outer `select` could silently drop the cancel signal | Non-blockingly re-check the cancel channel when the task result wins the outer select |

---
