### PR TITLE
fix(adk): isolate direct nested agent cancel scope

### DIFF
--- a/adk/cancel_recursive_test.go
+++ b/adk/cancel_recursive_test.go
@@ -645,3 +645,27 @@ func TestResolveRunCancelContext_CheckpointAwareInheritedScope(t *testing.T) {
 		t.Fatal("checkpoint-aware inherited scope should not be owned by the child run")
 	}
 }
+
+func TestAttack_DirectNestedAgentUnderCheckpointAwareParentGetsAbortOnlyScope(t *testing.T) {
+	parent := newCancelContext()
+	baseCtx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	checkpointAware := parent.deriveCheckpointAwareCancelContext(baseCtx)
+	t.Cleanup(checkpointAware.markDone)
+	ctx := withCancelContext(baseCtx, checkpointAware)
+	ctx = withTypedChatModelAgentExecCtx(ctx, &chatModelAgentExecCtx{
+		cancelCtx: checkpointAware,
+	})
+
+	got, owned := resolveRunCancelContext(ctx, &options{})
+	if got == checkpointAware {
+		t.Fatal("direct nested agent reused the checkpoint-aware parent scope")
+	}
+	if got == nil || !got.abortOnly || got.parent != checkpointAware {
+		t.Fatalf("direct nested agent should derive an abort-only child scope, got %#v", got)
+	}
+	if !owned {
+		t.Fatal("direct nested agent should own the derived abort-only scope")
+	}
+}

--- a/adk/chatmodel.go
+++ b/adk/chatmodel.go
@@ -476,6 +476,11 @@ func isCheckpointAwareCancelScope(cc *cancelContext) bool {
 	return cc != nil && cc.parent != nil && !cc.abortOnly
 }
 
+func hasActiveChatModelAgentExecCtx(ctx context.Context) bool {
+	return getTypedChatModelAgentExecCtx[*schema.Message](ctx) != nil ||
+		getTypedChatModelAgentExecCtx[*schema.AgenticMessage](ctx) != nil
+}
+
 func resolveRunCancelContext(ctx context.Context, o *options) (*cancelContext, bool) {
 	inherited := getCancelContext(ctx)
 	if o.cancelCtx != nil {
@@ -484,7 +489,7 @@ func resolveRunCancelContext(ctx context.Context, o *options) (*cancelContext, b
 	if inherited != nil {
 		// ADK-managed child boundaries pass explicit checkpoint-aware scopes.
 		// Such scopes may reach ChatModelAgent through transparent wrappers.
-		if isCheckpointAwareCancelScope(inherited) {
+		if isCheckpointAwareCancelScope(inherited) && !hasActiveChatModelAgentExecCtx(ctx) {
 			return inherited, false
 		}
 		// Other inherited scopes are direct non-boundary nesting: only immediate


### PR DESCRIPTION
# Direct Nested Agent Cancel Scope Isolation

## Problem
PR #1143 made ADK-managed sub-agent boundaries checkpoint-aware, while direct nested `ChatModelAgent.Run` calls from user code should remain abort-only resume barriers.

One edge case still reused the parent checkpoint-aware scope: a direct nested `ChatModelAgent.Run` invoked while another `ChatModelAgent` execution was already active. That allowed the direct child to participate in recursive checkpoint cancellation instead of receiving only cooperative teardown.

Expected: direct nested agent under an active parent derives an abort-only child scope.
Actual: if the inherited scope was checkpoint-aware, it could be reused.

## Solution
`resolveRunCancelContext` now distinguishes transparent wrapper forwarding from direct nested agent execution:

```go
if isCheckpointAwareCancelScope(inherited) && !hasActiveChatModelAgentExecCtx(ctx) {
    return inherited, false
}
```

Transparent wrappers outside an active `ChatModelAgent` execution can still forward a checkpoint-aware scope. Direct nested calls made inside an active execution derive an abort-only scope, preserving the resume barrier.

## Key Insight
A checkpoint-aware inherited scope is safe to reuse only before entering a `ChatModelAgent` execution. Once an active agent execution context exists, a nested `Run` is no longer an ADK-managed boundary; it is user/model/tool code and must not expose its internal checkpoints to the root.

## Summary

| Problem | Solution |
| --- | --- |
| Direct nested `ChatModelAgent.Run` could reuse a checkpoint-aware parent scope inside active execution | Detect active `ChatModelAgent` execution and derive an abort-only child scope |
| The active-execution branch lacked focused regression coverage | Add an attack test for checkpoint-aware parent plus direct nested child |

---

# 直接嵌套 Agent 的取消作用域隔离

## 问题
PR #1143 将 ADK 管理的 sub-agent 边界统一为 checkpoint-aware，但用户代码中直接嵌套调用的 `ChatModelAgent.Run` 仍然应该是 abort-only resume barrier。

仍有一个边界场景会复用父级 checkpoint-aware scope：当一个 `ChatModelAgent` execution 已经处于 active 状态时，再直接调用嵌套的 `ChatModelAgent.Run`。这样 direct child 可能参与 recursive checkpoint cancellation，而不是只接收 cooperative teardown。

期望：active parent 下的 direct nested agent 派生 abort-only child scope。
实际：如果 inherited scope 是 checkpoint-aware，它可能被直接复用。

## 解决方案
`resolveRunCancelContext` 现在区分 transparent wrapper 转发和 direct nested agent execution：

```go
if isCheckpointAwareCancelScope(inherited) && !hasActiveChatModelAgentExecCtx(ctx) {
    return inherited, false
}
```

active `ChatModelAgent` execution 之外的 transparent wrapper 仍然可以转发 checkpoint-aware scope。active execution 内部的 direct nested call 会派生 abort-only scope，从而保留 resume barrier。

## 关键洞察
只有在进入 `ChatModelAgent` execution 之前，复用 inherited checkpoint-aware scope 才是安全的。一旦存在 active agent execution context，嵌套 `Run` 就不再是 ADK 管理的边界，而是 user/model/tool code，不能把内部 checkpoint 暴露给 root。

## 总结

| 问题 | 解决方案 |
| --- | --- |
| active execution 内部的 direct nested `ChatModelAgent.Run` 可能复用 checkpoint-aware parent scope | 检测 active `ChatModelAgent` execution，并派生 abort-only child scope |
| active-execution 分支缺少聚焦的回归覆盖 | 增加 checkpoint-aware parent 加 direct nested child 的 attack test |