### PR TITLE
feat(adk): add session event turn id

### DIFF
--- a/adk/agent_tool_test.go
+++ b/adk/agent_tool_test.go
@@ -1339,6 +1339,64 @@ func TestAgentToolEventReceiver_PreservesChildSessionEnvelope(t *testing.T) {
 	assert.Equal(t, SessionEventMessage, got.SessionEventVariant.Event.Kind)
 }
 
+func TestAttack_AgentToolForeignSessionEventsDoNotInheritParentTurnID(t *testing.T) {
+	tests := []struct {
+		name            string
+		enableStreaming bool
+		wantRef         bool
+	}{
+		{name: "materialized event"},
+		{name: "stream ref", enableStreaming: true, wantRef: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctx := context.Background()
+			inner, err := NewChatModelAgent(ctx, &ChatModelAgentConfig{
+				Name:        "turn-id-child-" + strings.ReplaceAll(tt.name, " ", "-"),
+				Description: "child",
+				Model:       &emitOnceModel{},
+			})
+			require.NoError(t, err)
+			at := NewAgentTool(ctx, inner).(tool.InvokableTool)
+
+			ctx = contextWithSessionEventContext[*schema.Message](ctx, nil, "parent-turn-id")
+			var got *AgentEvent
+			opts := []tool.Option{
+				withAgentToolOptions(inner.Name(ctx), []AgentRunOption{withEnableSessionEvents()}),
+				agenttool.WithEventReceiverTransform(func(current []agenttool.EventReceiver[*AgentEvent]) []agenttool.EventReceiver[*AgentEvent] {
+					return append(current, func(event *AgentEvent) {
+						if event.SessionEventVariant == nil {
+							return
+						}
+						if !tt.wantRef && event.SessionEventVariant.Event != nil {
+							got = event
+						}
+						if tt.wantRef && event.SessionEventVariant.MessageStreamRef != nil {
+							got = event
+						}
+					})
+				}),
+			}
+			if tt.enableStreaming {
+				opts = append([]tool.Option{withAgentToolEnableStreaming(true)}, opts...)
+			}
+			_, err = at.InvokableRun(ctx, `{"request":"q"}`, opts...)
+			require.NoError(t, err)
+			require.NotNil(t, got)
+			require.NotNil(t, got.SessionEventVariant)
+			require.Contains(t, got.SessionEventVariant.SessionID, "agent_tool:")
+			if tt.wantRef {
+				require.NotNil(t, got.SessionEventVariant.MessageStreamRef)
+				assert.Empty(t, got.SessionEventVariant.MessageStreamRef.TurnID)
+				return
+			}
+			require.NotNil(t, got.SessionEventVariant.Event)
+			assert.Empty(t, got.SessionEventVariant.Event.TurnID)
+		})
+	}
+}
+
 func TestAgentToolEventReceiver_LaterTransformCanSuppressParent(t *testing.T) {
 	ctx := context.Background()
 	sub := &emitEventsAgent{events: []*AgentEvent{

--- a/adk/cancel_edge_test.go
+++ b/adk/cancel_edge_test.go
@@ -1684,9 +1684,8 @@ func TestWithCancel_RecursiveImmediate_MiddlewareChildAbortOnly(t *testing.T) {
 	resumeRunner := NewRunner(ctx, RunnerConfig{Agent: resumeOuterAgent, CheckPointStore: store})
 	resumeIter, err := resumeRunner.Resume(ctx, checkpointID)
 	require.NoError(t, err)
-	resumeEvents, resumeCancelErrors := drainCancelErrors(resumeIter)
+	_, resumeCancelErrors := drainCancelErrors(resumeIter)
 	require.Empty(t, resumeCancelErrors)
-	require.NotEmpty(t, resumeEvents)
 	assert.Equal(t, int32(1), atomic.LoadInt32(&resumeChildCalls), "middleware child should be invoked as a fresh Run on root resume")
 }
 
@@ -1826,9 +1825,8 @@ func TestWithCancel_RecursiveImmediate_MiddlewareChildAgentToolCheckpointResumeB
 	resumeRunner := NewRunner(ctx, RunnerConfig{Agent: resumeOuterAgent, CheckPointStore: store})
 	resumeIter, err := resumeRunner.Resume(ctx, checkpointID)
 	require.NoError(t, err)
-	resumeEvents, resumeCancelErrors := drainCancelErrors(resumeIter)
+	_, resumeCancelErrors := drainCancelErrors(resumeIter)
 	require.Empty(t, resumeCancelErrors)
-	require.NotEmpty(t, resumeEvents)
 	assert.GreaterOrEqual(t, atomic.LoadInt32(&resumeChildCalls), int32(1), "middleware child should be invoked as a fresh Run on root resume")
 	assert.Equal(t, int32(1), atomic.LoadInt32(&resumeLeafCalls), "nested AgentTool should run fresh, not resume from the hidden checkpoint")
 }

--- a/adk/chatmodel.go
+++ b/adk/chatmodel.go
@@ -76,6 +76,7 @@ func (e *typedChatModelAgentExecCtx[M]) send(ctx context.Context, event *TypedAg
 	}
 	ensureTypedAgentEventMessageIDs(event)
 	if event.SessionEventVariant != nil && event.SessionEventVariant.Event != nil {
+		stampSessionEventTurnID(event.SessionEventVariant.Event, sessionEventTurnIDFromContext[M](ctx))
 		gen := sessionEventIDGeneratorFromContext[M](ctx)
 		if gen == nil {
 			gen = DefaultSessionEventIDGenerator[M]

--- a/adk/chatmodel.go
+++ b/adk/chatmodel.go
@@ -87,6 +87,12 @@ func (e *typedChatModelAgentExecCtx[M]) send(ctx context.Context, event *TypedAg
 			event.Err = err
 		}
 	}
+	if event.SessionEventVariant != nil && event.SessionEventVariant.MessageStreamRef != nil {
+		turnID := sessionEventTurnIDFromContext[M](ctx)
+		if turnID != "" {
+			event.SessionEventVariant.MessageStreamRef.TurnID = turnID
+		}
+	}
 	e.generator.trySend(event)
 }
 

--- a/adk/chatmodel.go
+++ b/adk/chatmodel.go
@@ -200,7 +200,7 @@ func newTypedChatModelAgentExecCtx[M MessageType](
 	}
 }
 
-func configureTypedChatModelAgentExecCtx[M MessageType](
+func initTypedChatModelAgentExecCtx[M MessageType](
 	ctx context.Context,
 	generator *AsyncGenerator[*TypedAgentEvent[M]],
 	cancelCtx *cancelContext,
@@ -208,16 +208,8 @@ func configureTypedChatModelAgentExecCtx[M MessageType](
 	timelineEvents bool,
 	internalTimelineEvents bool,
 ) (context.Context, *typedChatModelAgentExecCtx[M]) {
-	execCtx := getTypedChatModelAgentExecCtx[M](ctx)
-	if execCtx == nil {
-		execCtx = &typedChatModelAgentExecCtx[M]{}
-		ctx = withTypedChatModelAgentExecCtx(ctx, execCtx)
-	}
-	execCtx.generator = generator
-	execCtx.cancelCtx = cancelCtx
-	execCtx.sessionEvents = sessionEvents
-	execCtx.timelineEvents = timelineEvents
-	execCtx.internalTimelineEvents = internalTimelineEvents
+	execCtx := newTypedChatModelAgentExecCtx(generator, cancelCtx, sessionEvents, timelineEvents, internalTimelineEvents)
+	ctx = withTypedChatModelAgentExecCtx(ctx, execCtx)
 	return ctx, execCtx
 }
 
@@ -1325,8 +1317,7 @@ func (a *TypedChatModelAgent[M]) buildNoToolsRunFunc(_ context.Context) (typedRu
 			return
 		}
 
-		var execCtx *typedChatModelAgentExecCtx[M]
-		ctx, execCtx = configureTypedChatModelAgentExecCtx(ctx, p.generator, cancelCtx, p.sessionEvents, p.timelineEvents, p.internalTimelineEvents)
+		execCtx := getTypedChatModelAgentExecCtx[M](ctx)
 		execCtx.failoverLastSuccessModel = a.model
 
 		if checkPreExecCancel(cancelCtx, p.generator) {
@@ -1461,7 +1452,7 @@ func (a *TypedChatModelAgent[M]) buildMessageReActRunFunc(_ context.Context, bc 
 			return
 		}
 
-		ctx, execCtx := configureTypedChatModelAgentExecCtx(ctx, mp.generator, cancelCtx, mp.sessionEvents, mp.timelineEvents, mp.internalTimelineEvents)
+		execCtx := getTypedChatModelAgentExecCtx[*schema.Message](ctx)
 		execCtx.runtimeReturnDirectly = mp.returnDirectly
 		execCtx.failoverLastSuccessModel = msgModel
 		execCtx.afterToolCallsHook = mp.afterToolCallsHook
@@ -1597,7 +1588,7 @@ func (a *TypedChatModelAgent[M]) buildAgenticReActRunFunc(_ context.Context, bc 
 			return
 		}
 
-		ctx, execCtx := configureTypedChatModelAgentExecCtx(ctx, ap.generator, cancelCtx, ap.sessionEvents, ap.timelineEvents, ap.internalTimelineEvents)
+		execCtx := getTypedChatModelAgentExecCtx[*schema.AgenticMessage](ctx)
 		execCtx.runtimeReturnDirectly = ap.returnDirectly
 		execCtx.failoverLastSuccessModel = agenticModel
 		execCtx.afterToolCallsHook = ap.afterToolCallsHook
@@ -1730,7 +1721,7 @@ func (a *TypedChatModelAgent[M]) Run(ctx context.Context, input *TypedAgentInput
 	if cancelCtxOwned && cancelCtx != nil && cancelCtx.abortOnly {
 		ctx, abortOnlyCancel = withAbortOnlyCancelContext(ctx, cancelCtx)
 	}
-	ctx, execCtx := configureTypedChatModelAgentExecCtx(ctx, generator, cancelCtx, o.enableSessionEvents, o.enableTimelineEvents, o.enableInternalTimelineEvents)
+	ctx, execCtx := initTypedChatModelAgentExecCtx(ctx, generator, cancelCtx, o.enableSessionEvents, o.enableTimelineEvents, o.enableInternalTimelineEvents)
 	execCtx.failoverLastSuccessModel = a.model
 
 	ctx, run, bc, input, err := a.getRunFunc(ctx, input)
@@ -1823,7 +1814,7 @@ func (a *TypedChatModelAgent[M]) Resume(ctx context.Context, info *ResumeInfo, o
 	if cancelCtxOwned && cancelCtx != nil && cancelCtx.abortOnly {
 		ctx, abortOnlyCancel = withAbortOnlyCancelContext(ctx, cancelCtx)
 	}
-	ctx, execCtx := configureTypedChatModelAgentExecCtx(ctx, generator, cancelCtx, o.enableSessionEvents, o.enableTimelineEvents, o.enableInternalTimelineEvents)
+	ctx, execCtx := initTypedChatModelAgentExecCtx(ctx, generator, cancelCtx, o.enableSessionEvents, o.enableTimelineEvents, o.enableInternalTimelineEvents)
 	execCtx.failoverLastSuccessModel = a.model
 
 	ctx, run, bc, _, err := a.getRunFunc(ctx, nil)

--- a/adk/chatmodel.go
+++ b/adk/chatmodel.go
@@ -75,9 +75,10 @@ func (e *typedChatModelAgentExecCtx[M]) send(ctx context.Context, event *TypedAg
 		return
 	}
 	ensureTypedAgentEventMessageIDs(event)
+	sc := sessionEventContextFromContext[M](ctx)
 	if event.SessionEventVariant != nil && event.SessionEventVariant.Event != nil {
-		stampSessionEventTurnID(event.SessionEventVariant.Event, sessionEventTurnIDFromContext[M](ctx))
-		gen := sessionEventIDGeneratorFromContext[M](ctx)
+		stampSessionEventTurnID(event.SessionEventVariant.Event, sc.turnID)
+		gen := sc.generator
 		if gen == nil {
 			gen = DefaultSessionEventIDGenerator[M]
 		}
@@ -88,9 +89,8 @@ func (e *typedChatModelAgentExecCtx[M]) send(ctx context.Context, event *TypedAg
 		}
 	}
 	if event.SessionEventVariant != nil && event.SessionEventVariant.MessageStreamRef != nil {
-		turnID := sessionEventTurnIDFromContext[M](ctx)
-		if turnID != "" {
-			event.SessionEventVariant.MessageStreamRef.TurnID = turnID
+		if sc.turnID != "" {
+			event.SessionEventVariant.MessageStreamRef.TurnID = sc.turnID
 		}
 	}
 	e.generator.trySend(event)

--- a/adk/runner.go
+++ b/adk/runner.go
@@ -776,13 +776,13 @@ func typedRunnerHandleIterImpl[M MessageType](enableStreaming bool, store CheckP
 			}
 		}
 	}
-	stampParentSessionEvent := func(se *SessionEvent[M]) {
+	stampOwnTurnID := func(se *SessionEvent[M]) {
 		if sessionState == nil || !sessionState.enabled {
 			return
 		}
 		stampSessionEventTurnID(se, sessionState.turnID)
 	}
-	stampParentStreamRef := func(ref *MessageStreamRef) {
+	stampOwnStreamRefTurnID := func(ref *MessageStreamRef) {
 		if ref == nil || sessionState == nil || !sessionState.enabled || sessionState.turnID == "" {
 			return
 		}
@@ -817,7 +817,7 @@ func typedRunnerHandleIterImpl[M MessageType](enableStreaming bool, store CheckP
 		if persister == nil || se == nil {
 			return nil
 		}
-		stampParentSessionEvent(se)
+		stampOwnTurnID(se)
 		if err := ValidateEmittedSessionEventKind(se); err != nil {
 			setPersistErr(err)
 			return err
@@ -831,7 +831,7 @@ func typedRunnerHandleIterImpl[M MessageType](enableStreaming bool, store CheckP
 		if se == nil {
 			return false
 		}
-		stampParentSessionEvent(se)
+		stampOwnTurnID(se)
 		if se.EventID == "" {
 			if err := assignSessionEventIDFromContext(ctx, se); err != nil {
 				setPersistErr(err)
@@ -856,14 +856,14 @@ func typedRunnerHandleIterImpl[M MessageType](enableStreaming bool, store CheckP
 			if ref.Timestamp.IsZero() {
 				ref.Timestamp = newEventTimestamp()
 			}
-			stampParentStreamRef(ref)
+			stampOwnStreamRefTurnID(ref)
 			ref.Kind = SessionEventMessage
 			if ref.EventID == "" {
 				draft := &SessionEvent[M]{
 					Timestamp: ref.Timestamp,
 					Kind:      SessionEventMessage,
 				}
-				stampParentSessionEvent(draft)
+				stampOwnTurnID(draft)
 				if err := assignSessionEventID(ctx, draft, sessionState.sessionConfig.EventIDGenerator); err != nil {
 					setPersistErr(err)
 					return nil, err
@@ -878,7 +878,7 @@ func typedRunnerHandleIterImpl[M MessageType](enableStreaming bool, store CheckP
 			Timestamp: newEventTimestamp(),
 			Kind:      SessionEventMessage,
 		}
-		stampParentSessionEvent(draft)
+		stampOwnTurnID(draft)
 		if err := assignSessionEventID(ctx, draft, sessionState.sessionConfig.EventIDGenerator); err != nil {
 			setPersistErr(err)
 			return nil, err
@@ -902,7 +902,7 @@ func typedRunnerHandleIterImpl[M MessageType](enableStreaming bool, store CheckP
 			Kind:      SessionEventMessage,
 			Message:   event.Output.MessageOutput.Message,
 		}
-		stampParentSessionEvent(draft)
+		stampOwnTurnID(draft)
 		if idErr := assignSessionEventID(ctx, draft, sessionState.sessionConfig.EventIDGenerator); idErr != nil {
 			return nil, idErr
 		}
@@ -940,7 +940,7 @@ func typedRunnerHandleIterImpl[M MessageType](enableStreaming bool, store CheckP
 			event.SessionEventVariant.SessionID != "" &&
 			event.SessionEventVariant.SessionID != sessionState.sessionID
 		if !fromOtherSession && event.SessionEventVariant != nil && event.SessionEventVariant.Event != nil {
-			stampParentSessionEvent(event.SessionEventVariant.Event)
+			stampOwnTurnID(event.SessionEventVariant.Event)
 			gen := DefaultSessionEventIDGenerator[M]
 			if sessionState != nil && sessionState.enabled {
 				gen = sessionState.sessionConfig.EventIDGenerator
@@ -956,7 +956,7 @@ func typedRunnerHandleIterImpl[M MessageType](enableStreaming bool, store CheckP
 			}
 		}
 		if !fromOtherSession && event.SessionEventVariant != nil && event.SessionEventVariant.MessageStreamRef != nil {
-			stampParentStreamRef(event.SessionEventVariant.MessageStreamRef)
+			stampOwnStreamRefTurnID(event.SessionEventVariant.MessageStreamRef)
 		}
 		if err := validateAgentSessionEventIdentity(event); err != nil {
 			setPersistErr(err)

--- a/adk/runner.go
+++ b/adk/runner.go
@@ -399,7 +399,7 @@ func prepareRunnerSessionResume[M MessageType]( //nolint:revive // argument-limi
 		Kind:      SessionEventKind(SessionEventExtensionPrefix + "resume.request_started"),
 		Extension: &SessionExtensionEvent{},
 	}
-	if cp != nil && cp.TurnID != "" {
+	if cp.TurnID != "" {
 		state.turnID = cp.TurnID
 		resumeEvent.TurnID = state.turnID
 	}
@@ -409,7 +409,7 @@ func prepareRunnerSessionResume[M MessageType]( //nolint:revive // argument-limi
 	}
 	if state.turnID == "" {
 		state.turnID = resumeEvent.EventID
-		resumeEvent.TurnID = state.turnID
+		resumeEvent.TurnID = resumeEvent.EventID
 	}
 	if err := appendRunnerSessionControlEvent(ctx, state, resumeEvent); err != nil {
 		_ = state.sessionHandle.close(ctx)

--- a/adk/runner.go
+++ b/adk/runner.go
@@ -176,6 +176,7 @@ type runnerSessionRunState[M MessageType] struct {
 	sessionStore    SessionEventStore[M]
 	sessionHandle   sessionHandle[M]
 	checkPointStore CheckPointStore
+	turnID          string
 	initialTimeline []*SessionEvent[M]
 	// inputMessages are the caller-provided messages for this turn (before history prepend).
 	// Captured so the Runner can persist them as session events at turn start.
@@ -295,6 +296,8 @@ func prepareRunnerSessionRun[M MessageType]( //nolint:revive // argument-limit
 		_ = state.sessionHandle.close(ctx)
 		return nil, err
 	}
+	state.turnID = runningEvent.EventID
+	runningEvent.TurnID = state.turnID
 	err = appendRunnerSessionControlEvent(ctx, state, runningEvent)
 	if err != nil {
 		_ = state.sessionHandle.close(ctx)
@@ -379,7 +382,7 @@ func prepareRunnerSessionResume[M MessageType]( //nolint:revive // argument-limi
 	// passing an explicit checkpoint ID has asserted the checkpoint should exist
 	// and any error will surface from the subsequent load. For implicit resume,
 	// the absence of a pending checkpoint is fatal and reported here.
-	_, existed, err := loadRunnerSessionCheckpoint(ctx, checkPointStore, effectiveCheckPointID)
+	cp, existed, err := loadRunnerSessionCheckpoint(ctx, checkPointStore, effectiveCheckPointID)
 	if err != nil {
 		_ = state.sessionHandle.close(ctx)
 		return nil, "", err
@@ -396,9 +399,17 @@ func prepareRunnerSessionResume[M MessageType]( //nolint:revive // argument-limi
 		Kind:      SessionEventKind(SessionEventExtensionPrefix + "resume.request_started"),
 		Extension: &SessionExtensionEvent{},
 	}
+	if cp != nil && cp.TurnID != "" {
+		state.turnID = cp.TurnID
+		resumeEvent.TurnID = state.turnID
+	}
 	if err := assignSessionEventID(ctx, resumeEvent, state.sessionConfig.EventIDGenerator); err != nil {
 		_ = state.sessionHandle.close(ctx)
 		return nil, "", err
+	}
+	if state.turnID == "" {
+		state.turnID = resumeEvent.EventID
+		resumeEvent.TurnID = state.turnID
 	}
 	if err := appendRunnerSessionControlEvent(ctx, state, resumeEvent); err != nil {
 		_ = state.sessionHandle.close(ctx)
@@ -433,6 +444,7 @@ func appendRunnerSessionInputEvents[M MessageType](
 	}
 	for _, msg := range messages {
 		se := makeInputSessionEvent[M](msg)
+		stampSessionEventTurnID(se, state.turnID)
 		if err := assignSessionEventID(ctx, se, state.sessionConfig.EventIDGenerator); err != nil {
 			return err
 		}
@@ -529,6 +541,7 @@ func saveRunnerCheckpoint[M MessageType]( //nolint:revive // argument-limit
 	data, err := encodeRunnerSessionCheckpoint(&runnerSessionCheckpoint{
 		SessionID:    sessionState.sessionID,
 		CheckPointID: checkPointID,
+		TurnID:       sessionState.turnID,
 		Payload:      payload,
 	})
 	if err != nil {
@@ -575,6 +588,7 @@ func typedRunnerRunImpl[M MessageType](a TypedAgent[M], enableStreaming bool, st
 
 	if sessionState.enabled {
 		ctx = contextWithSessionEventIDGenerator[M](ctx, sessionState.sessionConfig.EventIDGenerator)
+		ctx = contextWithSessionEventTurnID[M](ctx, sessionState.turnID)
 	}
 
 	var zero M
@@ -687,6 +701,7 @@ func typedRunnerResumeInternalImpl[M MessageType](a TypedAgent[M], store CheckPo
 
 	if sessionState.enabled {
 		ctx = contextWithSessionEventIDGenerator[M](ctx, sessionState.sessionConfig.EventIDGenerator)
+		ctx = contextWithSessionEventTurnID[M](ctx, sessionState.turnID)
 	}
 
 	if len(resumeData) > 0 {
@@ -763,6 +778,18 @@ func typedRunnerHandleIterImpl[M MessageType](enableStreaming bool, store CheckP
 			}
 		}
 	}
+	stampParentSessionEvent := func(se *SessionEvent[M]) {
+		if sessionState == nil || !sessionState.enabled {
+			return
+		}
+		stampSessionEventTurnID(se, sessionState.turnID)
+	}
+	stampParentStreamRef := func(ref *MessageStreamRef) {
+		if ref == nil || sessionState == nil || !sessionState.enabled || sessionState.turnID == "" {
+			return
+		}
+		ref.TurnID = sessionState.turnID
+	}
 	setPersistErr := func(err error) {
 		if err != nil && persistErr == nil {
 			persistErr = err
@@ -792,6 +819,7 @@ func typedRunnerHandleIterImpl[M MessageType](enableStreaming bool, store CheckP
 		if persister == nil || se == nil {
 			return nil
 		}
+		stampParentSessionEvent(se)
 		if err := ValidateEmittedSessionEventKind(se); err != nil {
 			setPersistErr(err)
 			return err
@@ -805,6 +833,7 @@ func typedRunnerHandleIterImpl[M MessageType](enableStreaming bool, store CheckP
 		if se == nil {
 			return false
 		}
+		stampParentSessionEvent(se)
 		if se.EventID == "" {
 			if err := assignSessionEventIDFromContext(ctx, se); err != nil {
 				setPersistErr(err)
@@ -829,17 +858,20 @@ func typedRunnerHandleIterImpl[M MessageType](enableStreaming bool, store CheckP
 			if ref.Timestamp.IsZero() {
 				ref.Timestamp = newEventTimestamp()
 			}
+			stampParentStreamRef(ref)
 			ref.Kind = SessionEventMessage
 			if ref.EventID == "" {
 				draft := &SessionEvent[M]{
 					Timestamp: ref.Timestamp,
 					Kind:      SessionEventMessage,
 				}
+				stampParentSessionEvent(draft)
 				if err := assignSessionEventID(ctx, draft, sessionState.sessionConfig.EventIDGenerator); err != nil {
 					setPersistErr(err)
 					return nil, err
 				}
 				ref.EventID = draft.EventID
+				ref.TurnID = draft.TurnID
 				ref.Timestamp = draft.Timestamp
 			}
 			return ref, nil
@@ -848,12 +880,14 @@ func typedRunnerHandleIterImpl[M MessageType](enableStreaming bool, store CheckP
 			Timestamp: newEventTimestamp(),
 			Kind:      SessionEventMessage,
 		}
+		stampParentSessionEvent(draft)
 		if err := assignSessionEventID(ctx, draft, sessionState.sessionConfig.EventIDGenerator); err != nil {
 			setPersistErr(err)
 			return nil, err
 		}
 		return &MessageStreamRef{
 			EventID:   draft.EventID,
+			TurnID:    draft.TurnID,
 			Timestamp: draft.Timestamp,
 			Kind:      SessionEventMessage,
 		}, nil
@@ -870,6 +904,7 @@ func typedRunnerHandleIterImpl[M MessageType](enableStreaming bool, store CheckP
 			Kind:      SessionEventMessage,
 			Message:   event.Output.MessageOutput.Message,
 		}
+		stampParentSessionEvent(draft)
 		if idErr := assignSessionEventID(ctx, draft, sessionState.sessionConfig.EventIDGenerator); idErr != nil {
 			return nil, idErr
 		}
@@ -907,6 +942,7 @@ func typedRunnerHandleIterImpl[M MessageType](enableStreaming bool, store CheckP
 			event.SessionEventVariant.SessionID != "" &&
 			event.SessionEventVariant.SessionID != sessionState.sessionID
 		if !fromOtherSession && event.SessionEventVariant != nil && event.SessionEventVariant.Event != nil {
+			stampParentSessionEvent(event.SessionEventVariant.Event)
 			gen := DefaultSessionEventIDGenerator[M]
 			if sessionState != nil && sessionState.enabled {
 				gen = sessionState.sessionConfig.EventIDGenerator
@@ -1024,6 +1060,7 @@ func typedRunnerHandleIterImpl[M MessageType](enableStreaming bool, store CheckP
 						if hasChunks {
 							_ = persistSessionEvent(&SessionEvent[M]{
 								EventID:   ref.EventID,
+								TurnID:    ref.TurnID,
 								Timestamp: ref.Timestamp,
 								Kind:      SessionEventMessageStreamIncomplete,
 								MessageStreamIncomplete: &MessageStreamIncompleteEvent[M]{
@@ -1040,6 +1077,7 @@ func typedRunnerHandleIterImpl[M MessageType](enableStreaming bool, store CheckP
 
 					_ = persistSessionEvent(&SessionEvent[M]{
 						EventID:   ref.EventID,
+						TurnID:    ref.TurnID,
 						Timestamp: ref.Timestamp,
 						Kind:      SessionEventMessage,
 						Message:   persistedMsg,

--- a/adk/runner.go
+++ b/adk/runner.go
@@ -587,8 +587,7 @@ func typedRunnerRunImpl[M MessageType](a TypedAgent[M], enableStreaming bool, st
 	}
 
 	if sessionState.enabled {
-		ctx = contextWithSessionEventIDGenerator[M](ctx, sessionState.sessionConfig.EventIDGenerator)
-		ctx = contextWithSessionEventTurnID[M](ctx, sessionState.turnID)
+		ctx = contextWithSessionEventContext[M](ctx, sessionState.sessionConfig.EventIDGenerator, sessionState.turnID)
 	}
 
 	var zero M
@@ -700,8 +699,7 @@ func typedRunnerResumeInternalImpl[M MessageType](a TypedAgent[M], store CheckPo
 	AddSessionValues(ctx, o.sessionValues)
 
 	if sessionState.enabled {
-		ctx = contextWithSessionEventIDGenerator[M](ctx, sessionState.sessionConfig.EventIDGenerator)
-		ctx = contextWithSessionEventTurnID[M](ctx, sessionState.turnID)
+		ctx = contextWithSessionEventContext[M](ctx, sessionState.sessionConfig.EventIDGenerator, sessionState.turnID)
 	}
 
 	if len(resumeData) > 0 {

--- a/adk/runner.go
+++ b/adk/runner.go
@@ -957,6 +957,9 @@ func typedRunnerHandleIterImpl[M MessageType](enableStreaming bool, store CheckP
 				event.Err = err
 			}
 		}
+		if !fromOtherSession && event.SessionEventVariant != nil && event.SessionEventVariant.MessageStreamRef != nil {
+			stampParentStreamRef(event.SessionEventVariant.MessageStreamRef)
+		}
 		if err := validateAgentSessionEventIdentity(event); err != nil {
 			setPersistErr(err)
 			event.Err = err

--- a/adk/runner.go
+++ b/adk/runner.go
@@ -935,11 +935,11 @@ func typedRunnerHandleIterImpl[M MessageType](enableStreaming bool, store CheckP
 		if !ok {
 			break
 		}
-		fromOtherSession := event.SessionEventVariant != nil &&
+		foreignEvent := event.SessionEventVariant != nil &&
 			sessionState != nil && sessionState.enabled &&
 			event.SessionEventVariant.SessionID != "" &&
 			event.SessionEventVariant.SessionID != sessionState.sessionID
-		if !fromOtherSession && event.SessionEventVariant != nil && event.SessionEventVariant.Event != nil {
+		if !foreignEvent && event.SessionEventVariant != nil && event.SessionEventVariant.Event != nil {
 			stampOwnTurnID(event.SessionEventVariant.Event)
 			gen := DefaultSessionEventIDGenerator[M]
 			if sessionState != nil && sessionState.enabled {
@@ -955,7 +955,7 @@ func typedRunnerHandleIterImpl[M MessageType](enableStreaming bool, store CheckP
 				event.Err = err
 			}
 		}
-		if !fromOtherSession && event.SessionEventVariant != nil && event.SessionEventVariant.MessageStreamRef != nil {
+		if !foreignEvent && event.SessionEventVariant != nil && event.SessionEventVariant.MessageStreamRef != nil {
 			stampOwnStreamRefTurnID(event.SessionEventVariant.MessageStreamRef)
 		}
 		if err := validateAgentSessionEventIdentity(event); err != nil {
@@ -1021,9 +1021,9 @@ func typedRunnerHandleIterImpl[M MessageType](enableStreaming bool, store CheckP
 
 		liveDelivered := false
 		if persister != nil {
-			// Skip persistence (but not live delivery) for events owned by a
-			// different session (inner agent events forwarded via AgentTool).
-			if !fromOtherSession {
+			// Skip persistence (but not live delivery) for events tagged with a
+			// foreign SessionID (inner agent events forwarded via AgentTool).
+			if !foreignEvent {
 				if event.Output != nil && event.Output.MessageOutput != nil &&
 					event.Output.MessageOutput.IsStreaming && event.Output.MessageOutput.MessageStream != nil {
 					ref, err := reserveMessageStreamRef(event)

--- a/adk/session.go
+++ b/adk/session.go
@@ -136,6 +136,14 @@ type SessionEvent[M MessageType] struct {
 	// the session message array.
 	EventID string `json:"event_id"`
 
+	// TurnID is runner-owned, session-local correlation metadata. For a fresh
+	// runner-managed Run or Query, it equals the opening
+	// session.status_running EventID. Every event produced by that logical turn
+	// carries the same value, and Resume preserves the value from the runner
+	// checkpoint. Empty TurnID is valid for legacy records and events created
+	// outside a runner-managed turn.
+	TurnID string `json:"turn_id,omitempty"`
+
 	// Timestamp is inherited from the source AgentEvent and represents the event
 	// occurrence time, not the SessionEventStore persistence time.
 	Timestamp time.Time `json:"timestamp,omitempty"`
@@ -182,6 +190,7 @@ type SessionEventVariant[M MessageType] struct {
 // resulting message as a SessionEvent.
 type MessageStreamRef struct {
 	EventID   string
+	TurnID    string
 	Timestamp time.Time
 	Kind      SessionEventKind
 }
@@ -519,6 +528,7 @@ type reconstructedSessionState[M MessageType] struct {
 type runnerSessionCheckpoint struct {
 	SessionID    string
 	CheckPointID string
+	TurnID       string
 	Payload      []byte
 }
 
@@ -986,6 +996,7 @@ func assignSessionEventID[M MessageType](
 }
 
 type sessionEventIDGeneratorKey[M MessageType] struct{}
+type sessionEventTurnIDKey[M MessageType] struct{}
 
 // contextWithSessionEventIDGenerator stores the typed SessionEventIDGenerator[M]
 // in ctx so that deeply-nested wrappers (model / tool / middleware) can route
@@ -1012,6 +1023,29 @@ func sessionEventIDGeneratorFromContext[M MessageType](ctx context.Context) Sess
 	return nil
 }
 
+func contextWithSessionEventTurnID[M MessageType](ctx context.Context, turnID string) context.Context {
+	if turnID == "" {
+		return ctx
+	}
+	return context.WithValue(ctx, sessionEventTurnIDKey[M]{}, turnID)
+}
+
+func sessionEventTurnIDFromContext[M MessageType](ctx context.Context) string {
+	if v := ctx.Value(sessionEventTurnIDKey[M]{}); v != nil {
+		if turnID, ok := v.(string); ok {
+			return turnID
+		}
+	}
+	return ""
+}
+
+func stampSessionEventTurnID[M MessageType](event *SessionEvent[M], turnID string) {
+	if event == nil || turnID == "" {
+		return
+	}
+	event.TurnID = turnID
+}
+
 // assignSessionEventIDFromContext assigns the EventID of a draft
 // SessionEvent[M] using the SessionEventIDGenerator[M] stored in ctx (falling
 // back to DefaultSessionEventIDGenerator[M] when none is set). Wrappers and
@@ -1020,6 +1054,7 @@ func assignSessionEventIDFromContext[M MessageType](ctx context.Context, event *
 	if event == nil {
 		return nil
 	}
+	stampSessionEventTurnID(event, sessionEventTurnIDFromContext[M](ctx))
 	return assignSessionEventID(ctx, event, sessionEventIDGeneratorFromContext[M](ctx))
 }
 

--- a/adk/session.go
+++ b/adk/session.go
@@ -995,48 +995,37 @@ func assignSessionEventID[M MessageType](
 	return nil
 }
 
-type sessionEventIDGeneratorKey[M MessageType] struct{}
-type sessionEventTurnIDKey[M MessageType] struct{}
+type sessionEventContextKey[M MessageType] struct{}
 
-// contextWithSessionEventIDGenerator stores the typed SessionEventIDGenerator[M]
-// in ctx so that deeply-nested wrappers (model / tool / middleware) can route
-// SessionEvent[M] draft ID allocation through the runner's configured
-// generator without explicit parameter threading.
-//
-// This is an internal plumbing escape hatch; the only payload allowed in ctx
-// under this key is the generator function itself. Storing business IDs,
-// per-event state, or anything else under this key is forbidden — see the
-// "scoped exception" note in the design plan.
-func contextWithSessionEventIDGenerator[M MessageType](ctx context.Context, gen SessionEventIDGenerator[M]) context.Context {
+type sessionEventContext[M MessageType] struct {
+	generator SessionEventIDGenerator[M]
+	turnID    string
+}
+
+func contextWithSessionEventContext[M MessageType](ctx context.Context, gen SessionEventIDGenerator[M], turnID string) context.Context {
+	if gen == nil && turnID == "" {
+		return ctx
+	}
+	existing := sessionEventContextFromContext[M](ctx)
 	if gen == nil {
-		return ctx
+		gen = existing.generator
 	}
-	return context.WithValue(ctx, sessionEventIDGeneratorKey[M]{}, gen)
-}
-
-func sessionEventIDGeneratorFromContext[M MessageType](ctx context.Context) SessionEventIDGenerator[M] {
-	if v := ctx.Value(sessionEventIDGeneratorKey[M]{}); v != nil {
-		if gen, ok := v.(SessionEventIDGenerator[M]); ok {
-			return gen
-		}
-	}
-	return nil
-}
-
-func contextWithSessionEventTurnID[M MessageType](ctx context.Context, turnID string) context.Context {
 	if turnID == "" {
-		return ctx
+		turnID = existing.turnID
 	}
-	return context.WithValue(ctx, sessionEventTurnIDKey[M]{}, turnID)
+	return context.WithValue(ctx, sessionEventContextKey[M]{}, &sessionEventContext[M]{
+		generator: gen,
+		turnID:    turnID,
+	})
 }
 
-func sessionEventTurnIDFromContext[M MessageType](ctx context.Context) string {
-	if v := ctx.Value(sessionEventTurnIDKey[M]{}); v != nil {
-		if turnID, ok := v.(string); ok {
-			return turnID
+func sessionEventContextFromContext[M MessageType](ctx context.Context) sessionEventContext[M] {
+	if v := ctx.Value(sessionEventContextKey[M]{}); v != nil {
+		if sc, ok := v.(*sessionEventContext[M]); ok && sc != nil {
+			return *sc
 		}
 	}
-	return ""
+	return sessionEventContext[M]{}
 }
 
 func stampSessionEventTurnID[M MessageType](event *SessionEvent[M], turnID string) {
@@ -1054,8 +1043,9 @@ func assignSessionEventIDFromContext[M MessageType](ctx context.Context, event *
 	if event == nil {
 		return nil
 	}
-	stampSessionEventTurnID(event, sessionEventTurnIDFromContext[M](ctx))
-	return assignSessionEventID(ctx, event, sessionEventIDGeneratorFromContext[M](ctx))
+	sc := sessionEventContextFromContext[M](ctx)
+	stampSessionEventTurnID(event, sc.turnID)
+	return assignSessionEventID(ctx, event, sc.generator)
 }
 
 type sessionEventPersister[M MessageType] struct {

--- a/adk/session/conformance.go
+++ b/adk/session/conformance.go
@@ -354,6 +354,7 @@ func testEventBodyRoundTrip[M adk.MessageType](t *testing.T, factory func(testin
 	ctx := context.Background()
 
 	event := messageEvent("body-test-1", makeMessage("body"))
+	event.TurnID = "turn-body-test-1"
 	appendEvents(t, ctx, store, "s", event)
 
 	res, err := store.LoadEvents(ctx, "s", &adk.LoadSessionEventsRequest{})

--- a/adk/session_test.go
+++ b/adk/session_test.go
@@ -696,6 +696,75 @@ func TestAttack_SessionEventIDGeneratorCoversRunnerEvents(t *testing.T) {
 	}
 }
 
+func TestRunnerSessionTurnIDFreshRuns(t *testing.T) {
+	ctx := context.Background()
+	store := newSessionHelperStore()
+	sessionID := "turn-id-fresh"
+	runner := NewRunner(ctx, RunnerConfig{
+		Agent:        &runnerSessionAgent{name: "turn-id-agent"},
+		SessionID:    sessionID,
+		SessionStore: store,
+	})
+
+	drainSessionEvents(t, runner.Query(ctx, "first"))
+	first := decodeStoredSessionEvents(t, store.events)
+	require.NotEmpty(t, first)
+	require.Equal(t, SessionEventSessionStatusRunning, first[0].Kind)
+	firstTurnID := first[0].EventID
+	require.NotEmpty(t, firstTurnID)
+	for _, event := range first {
+		assert.Equal(t, firstTurnID, event.TurnID, "kind=%s event_id=%s", event.Kind, event.EventID)
+	}
+
+	beforeSecond := len(store.events)
+	drainSessionEvents(t, runner.Query(ctx, "second"))
+	second := decodeStoredSessionEvents(t, store.events[beforeSecond:])
+	require.NotEmpty(t, second)
+	require.Equal(t, SessionEventSessionStatusRunning, second[0].Kind)
+	secondTurnID := second[0].EventID
+	require.NotEmpty(t, secondTurnID)
+	assert.NotEqual(t, firstTurnID, secondTurnID)
+	for _, event := range second {
+		assert.Equal(t, secondTurnID, event.TurnID, "kind=%s event_id=%s", event.Kind, event.EventID)
+	}
+}
+
+func TestRunnerSessionTurnIDCustomGeneratorObservesDraft(t *testing.T) {
+	ctx := context.Background()
+	store := newSessionHelperStore()
+	const openingID = "business-opening-turn"
+	var observedAfterOpening []string
+	var sawOpening bool
+	gen := func(ctx context.Context, e *SessionEvent[*schema.Message]) (string, error) {
+		if e.Kind == SessionEventSessionStatusRunning {
+			sawOpening = true
+			assert.Empty(t, e.TurnID)
+			return openingID, nil
+		}
+		observedAfterOpening = append(observedAfterOpening, e.TurnID)
+		return DefaultSessionEventIDGenerator[*schema.Message](ctx, e)
+	}
+	runner := NewRunner(ctx, RunnerConfig{
+		Agent:        &runnerSessionAgent{name: "turn-id-generator-agent"},
+		SessionID:    "turn-id-generator",
+		SessionStore: store,
+		SessionConfig: &SessionConfig[*schema.Message]{
+			EventIDGenerator: gen,
+		},
+	})
+
+	drainSessionEvents(t, runner.Query(ctx, "hello"))
+
+	require.True(t, sawOpening)
+	require.NotEmpty(t, observedAfterOpening)
+	for _, turnID := range observedAfterOpening {
+		assert.Equal(t, openingID, turnID)
+	}
+	for _, event := range decodeStoredSessionEvents(t, store.events) {
+		assert.Equal(t, openingID, event.TurnID)
+	}
+}
+
 func TestAttack_RunnerHandlesSessionEventWithoutSessionStore(t *testing.T) {
 	ctx := context.Background()
 	runner := NewRunner(ctx, RunnerConfig{
@@ -959,6 +1028,36 @@ func TestRunnerSessionModeRejectsPendingCheckpoint(t *testing.T) {
 	assert.Equal(t, "new input", agent.inputs[0][0].Content)
 }
 
+func TestRunnerSessionCheckpointTurnIDRoundTrip(t *testing.T) {
+	data, err := encodeRunnerSessionCheckpoint(&runnerSessionCheckpoint{
+		SessionID:    "s",
+		CheckPointID: "cp",
+		TurnID:       "turn-1",
+		Payload:      []byte("opaque"),
+	})
+	require.NoError(t, err)
+
+	decoded, err := decodeRunnerSessionCheckpoint(data)
+	require.NoError(t, err)
+	assert.Equal(t, "turn-1", decoded.TurnID)
+
+	type oldRunnerSessionCheckpoint struct {
+		SessionID    string
+		CheckPointID string
+		Payload      []byte
+	}
+	legacyPayload, err := encodeGob(&oldRunnerSessionCheckpoint{
+		SessionID:    "s",
+		CheckPointID: "cp",
+		Payload:      []byte("legacy"),
+	})
+	require.NoError(t, err)
+	legacy, err := decodeRunnerSessionCheckpoint(legacyPayload)
+	require.NoError(t, err)
+	assert.Empty(t, legacy.TurnID)
+	assert.Equal(t, []byte("legacy"), legacy.Payload)
+}
+
 func TestAttack_RunClosesSessionHandleWhenCheckpointDecodeFails(t *testing.T) {
 	ctx := context.Background()
 	store := &publicSessionHelperStore{sessionHelperStore: newSessionHelperStore()}
@@ -1160,6 +1259,7 @@ func TestRunnerSessionStreamingRefAllocatesMissingEventID(t *testing.T) {
 	ref := event.SessionEventVariant.MessageStreamRef
 	require.NotNil(t, ref)
 	assert.Equal(t, businessID, ref.EventID)
+	assert.NotEmpty(t, ref.TurnID)
 	assert.Equal(t, SessionEventMessage, ref.Kind)
 	assert.False(t, ref.Timestamp.IsZero())
 
@@ -1175,6 +1275,7 @@ func TestRunnerSessionStreamingRefAllocatesMissingEventID(t *testing.T) {
 	})
 	require.Len(t, messages, 1)
 	assert.Equal(t, businessID, messages[0].EventID)
+	assert.Equal(t, ref.TurnID, messages[0].TurnID)
 	assert.Equal(t, ref.Timestamp, messages[0].Timestamp)
 }
 
@@ -1769,6 +1870,7 @@ func TestSessionEvent_HumanReadableSerializerDirectRoundTrip(t *testing.T) {
 	serializer := &schema.HumanReadableSerializer{}
 	se := &SessionEvent[*schema.Message]{
 		EventID: "serializer-direct",
+		TurnID:  "serializer-turn",
 		Kind:    SessionEventSessionStatusIdle,
 		Lifecycle: &LifecycleEvent{
 			State: SessionRunStateIdle,
@@ -1782,7 +1884,22 @@ func TestSessionEvent_HumanReadableSerializerDirectRoundTrip(t *testing.T) {
 	require.NoError(t, serializer.Unmarshal(data, &decoded))
 	require.NoError(t, NormalizeSessionEventKind(&decoded))
 	assert.Equal(t, se.EventID, decoded.EventID)
+	assert.Equal(t, se.TurnID, decoded.TurnID)
 	assert.Equal(t, se.Kind, decoded.Kind)
+}
+
+func TestSessionEvent_OldPayloadWithoutTurnIDDecodesEmpty(t *testing.T) {
+	rawJSON := []byte(`{
+		"event_id": "evt-no-turn",
+		"kind": "message",
+		"message": {"role": "user", "content": "legacy"}
+	}`)
+
+	event, err := decodeSessionEventWithSerializer[*schema.Message](rawJSON, nil)
+	require.NoError(t, err)
+	require.NotNil(t, event)
+	assert.Equal(t, "evt-no-turn", event.EventID)
+	assert.Empty(t, event.TurnID)
 }
 
 // --- New tests covering the design doc ---
@@ -1791,11 +1908,12 @@ func TestSessionEvent_HumanReadableRoundTrip(t *testing.T) {
 	t.Run("Message", func(t *testing.T) {
 		msg := schema.UserMessage("hello")
 		EnsureMessageID(msg)
-		se := &SessionEvent[*schema.Message]{Message: msg}
+		se := &SessionEvent[*schema.Message]{TurnID: "turn-message", Message: msg}
 		data, err := encodeSessionEvent(se)
 		require.NoError(t, err)
 		decoded, err := decodeSessionEvent[*schema.Message](data)
 		require.NoError(t, err)
+		assert.Equal(t, "turn-message", decoded.TurnID)
 		require.NotNil(t, decoded.Message)
 		assert.Equal(t, "hello", decoded.Message.Content)
 		assert.Equal(t, GetMessageID(msg), GetMessageID(decoded.Message))
@@ -3131,6 +3249,22 @@ func TestAttack_ResumeAfterInterruptedRunWritesSessionEvents(t *testing.T) {
 		}
 	}
 
+	interruptedEvents := decodeStoredSessionEvents(t, store.events)
+	require.NotEmpty(t, interruptedEvents)
+	var interruptedTurnID string
+	for i := len(interruptedEvents) - 1; i >= 0; i-- {
+		if interruptedEvents[i].Kind == SessionEventSessionStatusRunning {
+			interruptedTurnID = interruptedEvents[i].TurnID
+			assert.Equal(t, interruptedEvents[i].EventID, interruptedTurnID)
+			break
+		}
+	}
+	require.NotEmpty(t, interruptedTurnID)
+	cp, existed, err := loadRunnerSessionCheckpoint(ctx, store, sessionRunnerCheckpointID(sessionID))
+	require.NoError(t, err)
+	require.True(t, existed)
+	require.Equal(t, interruptedTurnID, cp.TurnID)
+
 	eventsBeforeResume := len(store.events)
 
 	resumeIter, err := runner.Resume(ctx, "")
@@ -3148,6 +3282,9 @@ func TestAttack_ResumeAfterInterruptedRunWritesSessionEvents(t *testing.T) {
 			se.Kind == SessionEventSessionStatusIdle
 	})
 	require.NotEmpty(t, resumeEvents)
+	for _, event := range resumeEvents {
+		assert.Equal(t, interruptedTurnID, event.TurnID, "kind=%s", event.Kind)
+	}
 }
 
 func TestAttack_FreshRunIgnoresInterruptedSuffixMetadata(t *testing.T) {
@@ -4507,6 +4644,29 @@ func TestExplicitCheckpointResume_WithSessionMode(t *testing.T) {
 		"caller-supplied checkpoint ID must be preserved")
 }
 
+func TestPrepareRunnerSessionResume_LegacyCheckpointUsesResumeEventTurnID(t *testing.T) {
+	ctx := context.Background()
+	store := newSessionHelperStore()
+	sid := "legacy-turn-id-resume"
+	cpID := "legacy-turn-id-cp"
+	cpBytes, err := encodeRunnerSessionCheckpoint(&runnerSessionCheckpoint{
+		Payload: []byte("opaque"),
+	})
+	require.NoError(t, err)
+	require.NoError(t, store.Set(ctx, cpID, cpBytes))
+
+	state, effective, err := prepareRunnerSessionResume[*schema.Message](ctx, store, sid, store, nil, cpID)
+	require.NoError(t, err)
+	require.True(t, state.enabled)
+	require.Equal(t, cpID, effective)
+	require.Len(t, state.initialTimeline, 1)
+	resumeEvent := state.initialTimeline[0]
+	require.Equal(t, SessionEventKind(SessionEventExtensionPrefix+"resume.request_started"), resumeEvent.Kind)
+	require.NotEmpty(t, resumeEvent.EventID)
+	assert.Equal(t, resumeEvent.EventID, state.turnID)
+	assert.Equal(t, resumeEvent.EventID, resumeEvent.TurnID)
+}
+
 // TestResumePath_TailReplay verifies that the resume path also performs tail
 // replay (uses the same fast path as the run path).
 func TestResumePath_TailReplay(t *testing.T) {
@@ -5335,6 +5495,58 @@ func TestAgentTool_ChildSessionID_FiltersFromParentLog(t *testing.T) {
 	}
 	assert.False(t, sawChild, "events tagged with a different SessionEvent.SessionID must NOT enter the parent session log")
 	assert.True(t, sawParent, "parent's own events must be persisted")
+}
+
+func TestRunnerSessionTurnIDOverwritesProducerEventsAndSkipsChildSession(t *testing.T) {
+	ctx := context.Background()
+	store := newSessionHelperStore()
+	sid := "turn-id-producer"
+	extensionKind := SessionEventKind(SessionEventExtensionPrefix + "producer")
+	agent := &mutationAgent{
+		events: []*AgentEvent{
+			{
+				SessionEventVariant: &SessionEventVariant[*schema.Message]{
+					Event: &SessionEvent[*schema.Message]{
+						TurnID:    "producer-selected-turn",
+						Kind:      extensionKind,
+						Extension: &SessionExtensionEvent{},
+					},
+				},
+			},
+			{
+				SessionEventVariant: &SessionEventVariant[*schema.Message]{
+					SessionID: "agent_tool:child",
+					Event: &SessionEvent[*schema.Message]{
+						TurnID:    "child-turn",
+						Kind:      extensionKind,
+						Extension: &SessionExtensionEvent{},
+					},
+				},
+			},
+		},
+	}
+	runner := NewRunner(ctx, RunnerConfig{
+		Agent:        agent,
+		SessionID:    sid,
+		SessionStore: store,
+	})
+
+	drainSessionEvents(t, runner.Query(ctx, "go", WithTimelineEvents()))
+
+	events := decodeStoredSessionEvents(t, store.events)
+	require.NotEmpty(t, events)
+	parentTurnID := events[0].TurnID
+	require.NotEmpty(t, parentTurnID)
+	var sawExtension bool
+	for _, event := range events {
+		assert.Equal(t, parentTurnID, event.TurnID, "kind=%s", event.Kind)
+		if event.Kind == extensionKind {
+			sawExtension = true
+			assert.NotEqual(t, "producer-selected-turn", event.TurnID)
+		}
+		assert.NotEqual(t, "child-turn", event.TurnID)
+	}
+	assert.True(t, sawExtension)
 }
 
 // TestAgentToolInterruptState_RoundTrip verifies the wrapper struct round-trips

--- a/adk/session_timeline_test.go
+++ b/adk/session_timeline_test.go
@@ -552,10 +552,20 @@ func TestRunner_ExtensionEventSentWithTypedSendEventIsLiveAndPersisted(t *testin
 
 	t.Run("visible when timeline requested", func(t *testing.T) {
 		store := newSessionHelperStore()
+		var extensionDraftTurnID string
+		gen := func(ctx context.Context, e *SessionEvent[*schema.Message]) (string, error) {
+			if e.Kind == extensionKind {
+				extensionDraftTurnID = e.TurnID
+			}
+			return DefaultSessionEventIDGenerator[*schema.Message](ctx, e)
+		}
 		runner := NewRunner(ctx, RunnerConfig{
 			Agent:        agent,
 			SessionID:    "extension-event-session-visible",
 			SessionStore: store,
+			SessionConfig: &SessionConfig[*schema.Message]{
+				EventIDGenerator: gen,
+			},
 		})
 
 		var liveExtension *SessionEvent[*schema.Message]
@@ -573,6 +583,8 @@ func TestRunner_ExtensionEventSentWithTypedSendEventIsLiveAndPersisted(t *testin
 
 		require.NotNil(t, liveExtension)
 		require.NotEmpty(t, liveExtension.EventID)
+		require.NotEmpty(t, liveExtension.TurnID)
+		assert.Equal(t, liveExtension.TurnID, extensionDraftTurnID)
 		require.NotNil(t, liveExtension.Extension)
 		livePayload, ok := liveExtension.Extension.Data.(*sessionTimelineExtensionPayload)
 		require.True(t, ok)
@@ -584,6 +596,7 @@ func TestRunner_ExtensionEventSentWithTypedSendEventIsLiveAndPersisted(t *testin
 		})
 		require.Len(t, stored, 1)
 		assert.Equal(t, liveExtension.EventID, stored[0].EventID)
+		assert.Equal(t, liveExtension.TurnID, stored[0].TurnID)
 		require.NotNil(t, stored[0].Extension)
 		storedPayload, ok := stored[0].Extension.Data.(*sessionTimelineExtensionPayload)
 		require.True(t, ok)

--- a/adk/wrappers.go
+++ b/adk/wrappers.go
@@ -306,7 +306,7 @@ func sendSessionTimelineEvent[M MessageType](ctx context.Context, se *SessionEve
 	if !execCtx.timelineEvents && !execCtx.internalTimelineEvents {
 		return
 	}
-	stampSessionEventTurnID(se, sessionEventTurnIDFromContext[M](ctx))
+	stampSessionEventTurnID(se, sessionEventContextFromContext[M](ctx).turnID)
 	if se.Timestamp.IsZero() {
 		se.Timestamp = newEventTimestamp()
 	}

--- a/adk/wrappers.go
+++ b/adk/wrappers.go
@@ -306,6 +306,7 @@ func sendSessionTimelineEvent[M MessageType](ctx context.Context, se *SessionEve
 	if !execCtx.timelineEvents && !execCtx.internalTimelineEvents {
 		return
 	}
+	stampSessionEventTurnID(se, sessionEventTurnIDFromContext[M](ctx))
 	if se.Timestamp.IsZero() {
 		se.Timestamp = newEventTimestamp()
 	}
@@ -674,6 +675,7 @@ func (m *typedEventSenderModel[M]) Stream(ctx context.Context, input []M, opts .
 	event.SessionEventVariant = &SessionEventVariant[M]{
 		MessageStreamRef: &MessageStreamRef{
 			EventID:   assistantMsgEventID,
+			TurnID:    assistantDraft.TurnID,
 			Timestamp: timestamp,
 			Kind:      SessionEventMessage,
 		},
@@ -1465,6 +1467,7 @@ func (w *typedEventSenderToolWrapper[M]) WrapStreamableToolCall(_ context.Contex
 		event.SessionEventVariant = &SessionEventVariant[M]{
 			MessageStreamRef: &MessageStreamRef{
 				EventID:   resultEventID,
+				TurnID:    toolResultDraft.TurnID,
 				Timestamp: timestamp,
 				Kind:      SessionEventMessage,
 			},
@@ -1676,6 +1679,7 @@ func (w *typedEventSenderToolWrapper[M]) WrapEnhancedStreamableToolCall(_ contex
 		event.SessionEventVariant = &SessionEventVariant[M]{
 			MessageStreamRef: &MessageStreamRef{
 				EventID:   resultEventID,
+				TurnID:    toolResultDraft.TurnID,
 				Timestamp: timestamp,
 				Kind:      SessionEventMessage,
 			},


### PR DESCRIPTION
# SessionEvent TurnID Correlation

## Problem

Session consumers could see individual `SessionEvent` records, but they had no durable grouping identity for one logical runner turn.

That made common workflows harder than they should be:

- grouping all events produced by one `Run` or `Query`;
- identifying the resumed suffix of an interrupted turn without treating it as a new interaction;
- correlating live streaming refs with the final persisted stream message.

Inferring turn boundaries from message roles or lifecycle markers is brittle, especially when middleware, retry/failover spans, tool events, streaming output, and resume events all share the same session log.

## Solution

Add `TurnID` as runner-owned, session-local correlation metadata.

For a fresh `Run` or `Query`, the `TurnID` is the `EventID` of the opening `session.status_running` event. The runner stamps that value onto every parent-session event in the same logical turn. On `Resume`, the runner restores the checkpointed `TurnID`; old checkpoints without this field fall back to using `x.resume.request_started.EventID` for the post-upgrade resumed suffix.

The important ordering is:

```go
runningEvent.EventID = generatedID
state.turnID = runningEvent.EventID
runningEvent.TurnID = state.turnID
```

Deep event producers also receive the current `TurnID` through the session-event context, so model/tool spans, streaming refs, and middleware events emitted through `TypedSendEvent` or `SendEvent` are stamped before custom `SessionEventIDGenerator` implementations inspect the draft.

## Decisions

`TurnID` is correlation metadata only. It does not affect rollback targets, rollback CAS, session loading filters, or input provenance.

The runner overwrites producer-supplied `TurnID` for parent-session events. Producers can create event payloads, but they do not choose turn ownership.

Child-session events forwarded from `AgentTool` retain their child `SessionID` and are not relabeled with the parent turn.

## Key Insight

A logical runner turn is not the same thing as a single execution attempt. `Resume` continues the interrupted turn, so the turn identity must live in the runner checkpoint and must be available before event ID allocation in wrapper and middleware paths.

## Summary

| Problem | Solution |
|---------|----------|
| Consumers could not reliably group all events from one logical turn | Add `SessionEvent.TurnID` and `MessageStreamRef.TurnID` |
| Fresh runs needed a stable turn identity without another generator | Reuse opening `session.status_running.EventID` |
| Resume could look like a new turn | Persist `TurnID` in runner checkpoints and restore it on resume |
| Middleware events could be generated before the outer runner loop saw them | Stamp `TurnID` in session-event context before generator invocation |
| Child agent events could be confused with parent session events | Preserve child `SessionID` and skip parent TurnID relabeling |

---

# SessionEvent TurnID 关联标识

## 问题

session 消费者可以读取单个 `SessionEvent`，但缺少一个持久化的分组标识来表示一次逻辑 runner turn。

这会让常见场景变得脆弱：

- 分组一次 `Run` 或 `Query` 产生的全部 events；
- 在 interrupted turn 被 resumed 后，识别它仍属于同一次交互；
- 将 live streaming ref 和最终持久化的 stream message 对齐。

依赖 message role 或 lifecycle marker 推断 turn 边界并不可靠，因为 middleware、retry/failover spans、tool events、streaming output 和 resume events 都会进入同一个 session log。

## 方案

新增 `TurnID`，作为 runner 管理的 session-local correlation metadata。

对于 fresh `Run` 或 `Query`，`TurnID` 等于 opening `session.status_running` event 的 `EventID`。Runner 会把该值写入同一逻辑 turn 内所有 parent-session events。对于 `Resume`，Runner 从 checkpoint 恢复 `TurnID`；旧 checkpoint 没有该字段时，使用 `x.resume.request_started.EventID` 作为升级后 resumed suffix 的 `TurnID`。

关键顺序是：

```go
runningEvent.EventID = generatedID
state.turnID = runningEvent.EventID
runningEvent.TurnID = state.turnID
```

深层 event producer 也会通过 session-event context 获得当前 `TurnID`，所以 model/tool spans、streaming refs，以及通过 `TypedSendEvent` 或 `SendEvent` 发出的 middleware events，都会在自定义 `SessionEventIDGenerator` 观察 draft 之前完成 stamping。

## 决策

`TurnID` 只用于 correlation。它不参与 rollback target、rollback CAS、session loading filter，也不表达输入来源。

对于 parent-session events，Runner 会覆盖 producer 提供的 `TurnID`。Producer 可以构造 event payload，但不能选择 turn ownership。

通过 `AgentTool` 转发的 child-session events 保留 child `SessionID`，不会被改写成 parent turn。

## Key Insight

一次逻辑 runner turn 不等于一次 execution attempt。`Resume` 是继续 interrupted turn，因此 turn identity 必须保存在 runner checkpoint 中，并且必须在 wrapper 和 middleware 路径分配 event ID 之前可见。

## Summary

| Problem | Solution |
|---------|----------|
| 消费者无法可靠分组一次逻辑 turn 的全部 events | 新增 `SessionEvent.TurnID` 和 `MessageStreamRef.TurnID` |
| Fresh run 需要稳定 turn identity，但不应新增 generator | 复用 opening `session.status_running.EventID` |
| Resume 容易被误认为新 turn | 在 runner checkpoint 中保存并恢复 `TurnID` |
| Middleware events 可能在外层 runner loop 看到前就已生成 | 通过 session-event context 在 generator 调用前写入 `TurnID` |
| Child agent events 可能和 parent session events 混淆 | 保留 child `SessionID`，跳过 parent TurnID relabel |
