### PR TITLE
fix(adk): return input ctx instead of nil on error in summarization middleware

### DIFF
--- a/adk/middlewares/summarization/summarization.go
+++ b/adk/middlewares/summarization/summarization.go
@@ -340,7 +340,7 @@ func (m *TypedMiddleware[M]) BeforeModelRewriteState(ctx context.Context, state 
 		Tools:    state.ToolInfos,
 	})
 	if err != nil {
-		return nil, nil, err
+		return ctx, nil, err
 	}
 	if !triggered {
 		return ctx, state, nil
@@ -348,7 +348,7 @@ func (m *TypedMiddleware[M]) BeforeModelRewriteState(ctx context.Context, state 
 
 	finalMsgs, err := m.Summarize(ctx, state)
 	if err != nil {
-		return nil, nil, err
+		return ctx, nil, err
 	}
 
 	afterState := *state


### PR DESCRIPTION
## Summary

`BeforeModelRewriteState` in the summarization middleware returned `nil` as the `context.Context` on both error paths (`shouldSummarize` failure and `Summarize` failure). Callers that inspect the returned context — even on error — would hit a nil-pointer dereference. Changed both to return the input `ctx`.

## Key Changes

1. Error branches now propagate the original context instead of `nil`, consistent with all other middleware hooks in the codebase.