### PR TITLE
feat(schema): track cache creation tokens

### DIFF
--- a/components/model/callback_extra.go
+++ b/components/model/callback_extra.go
@@ -44,8 +44,10 @@ type CompletionTokensDetails struct {
 
 // PromptTokenDetails provides a breakdown of prompt token usage.
 type PromptTokenDetails struct {
-	// Cached tokens present in the prompt.
+	// CachedTokens is the number of prompt tokens read from a provider cache.
 	CachedTokens int
+	// CacheCreationTokens is the number of prompt tokens written to a provider cache.
+	CacheCreationTokens int
 }
 
 // Config is the config for the model.

--- a/schema/agentic_message.go
+++ b/schema/agentic_message.go
@@ -1126,6 +1126,9 @@ func concatTokenUsage(usages []*TokenUsage) *TokenUsage {
 		if usage.PromptTokenDetails.CachedTokens > ret.PromptTokenDetails.CachedTokens {
 			ret.PromptTokenDetails.CachedTokens = usage.PromptTokenDetails.CachedTokens
 		}
+		if usage.PromptTokenDetails.CacheCreationTokens > ret.PromptTokenDetails.CacheCreationTokens {
+			ret.PromptTokenDetails.CacheCreationTokens = usage.PromptTokenDetails.CacheCreationTokens
+		}
 		if usage.CompletionTokensDetails.ReasoningTokens > ret.CompletionTokensDetails.ReasoningTokens {
 			ret.CompletionTokensDetails.ReasoningTokens = usage.CompletionTokensDetails.ReasoningTokens
 		}

--- a/schema/agentic_message_test.go
+++ b/schema/agentic_message_test.go
@@ -811,7 +811,8 @@ func TestConcatAgenticMessages(t *testing.T) {
 						PromptTokens:     10,
 						CompletionTokens: 5,
 						PromptTokenDetails: PromptTokenDetails{
-							CachedTokens: 3,
+							CachedTokens:        3,
+							CacheCreationTokens: 7,
 						},
 						CompletionTokensDetails: CompletionTokensDetails{
 							ReasoningTokens: 2,
@@ -827,7 +828,8 @@ func TestConcatAgenticMessages(t *testing.T) {
 						PromptTokens:     8,
 						CompletionTokens: 15,
 						PromptTokenDetails: PromptTokenDetails{
-							CachedTokens: 5,
+							CachedTokens:        5,
+							CacheCreationTokens: 4,
 						},
 						CompletionTokensDetails: CompletionTokensDetails{
 							ReasoningTokens: 4,
@@ -845,6 +847,7 @@ func TestConcatAgenticMessages(t *testing.T) {
 		assert.Equal(t, 10, result.ResponseMeta.TokenUsage.PromptTokens)
 		assert.Equal(t, 23, result.ResponseMeta.TokenUsage.TotalTokens)
 		assert.Equal(t, 5, result.ResponseMeta.TokenUsage.PromptTokenDetails.CachedTokens)
+		assert.Equal(t, 7, result.ResponseMeta.TokenUsage.PromptTokenDetails.CacheCreationTokens)
 		assert.Equal(t, 4, result.ResponseMeta.TokenUsage.CompletionTokensDetails.ReasoningTokens)
 	})
 

--- a/schema/message.go
+++ b/schema/message.go
@@ -554,8 +554,10 @@ type CompletionTokensDetails struct {
 
 // PromptTokenDetails provides a breakdown of prompt token usage.
 type PromptTokenDetails struct {
-	// Cached tokens present in the prompt.
+	// CachedTokens is the number of prompt tokens read from a provider cache.
 	CachedTokens int `json:"cached_tokens"`
+	// CacheCreationTokens is the number of prompt tokens written to a provider cache.
+	CacheCreationTokens int `json:"cache_creation_tokens"`
 }
 
 var _ MessagesTemplate = &Message{}
@@ -1751,6 +1753,9 @@ func ConcatMessages(msgs []*Message) (*Message, error) {
 
 				if msg.ResponseMeta.Usage.PromptTokenDetails.CachedTokens > ret.ResponseMeta.Usage.PromptTokenDetails.CachedTokens {
 					ret.ResponseMeta.Usage.PromptTokenDetails.CachedTokens = msg.ResponseMeta.Usage.PromptTokenDetails.CachedTokens
+				}
+				if msg.ResponseMeta.Usage.PromptTokenDetails.CacheCreationTokens > ret.ResponseMeta.Usage.PromptTokenDetails.CacheCreationTokens {
+					ret.ResponseMeta.Usage.PromptTokenDetails.CacheCreationTokens = msg.ResponseMeta.Usage.PromptTokenDetails.CacheCreationTokens
 				}
 
 				if msg.ResponseMeta.Usage.CompletionTokensDetails.ReasoningTokens > ret.ResponseMeta.Usage.CompletionTokensDetails.ReasoningTokens {

--- a/schema/message_test.go
+++ b/schema/message_test.go
@@ -18,6 +18,7 @@ package schema
 
 import (
 	"context"
+	"encoding/json"
 	"reflect"
 	"sync"
 	"testing"
@@ -26,6 +27,25 @@ import (
 
 	"github.com/cloudwego/eino/internal/generic"
 )
+
+func TestPromptTokenDetailsJSON(t *testing.T) {
+	details := PromptTokenDetails{
+		CachedTokens:        3,
+		CacheCreationTokens: 5,
+	}
+
+	data, err := json.Marshal(details)
+	assert.NoError(t, err)
+	assert.JSONEq(t, `{"cached_tokens":3,"cache_creation_tokens":5}`, string(data))
+
+	var decoded PromptTokenDetails
+	assert.NoError(t, json.Unmarshal(data, &decoded))
+	assert.Equal(t, details, decoded)
+
+	var legacy PromptTokenDetails
+	assert.NoError(t, json.Unmarshal([]byte(`{"cached_tokens":3}`), &legacy))
+	assert.Equal(t, PromptTokenDetails{CachedTokens: 3}, legacy)
+}
 
 func TestMessageTemplate(t *testing.T) {
 	pyFmtMessage := UserMessage("input: {question}")
@@ -157,7 +177,8 @@ func TestConcatMessage(t *testing.T) {
 					CompletionTokens: 15,
 					PromptTokens:     30,
 					PromptTokenDetails: PromptTokenDetails{
-						CachedTokens: 15,
+						CachedTokens:        15,
+						CacheCreationTokens: 20,
 					},
 					CompletionTokensDetails: CompletionTokensDetails{
 						ReasoningTokens: 8,
@@ -179,7 +200,8 @@ func TestConcatMessage(t *testing.T) {
 						CompletionTokens: 10,
 						PromptTokens:     20,
 						PromptTokenDetails: PromptTokenDetails{
-							CachedTokens: 10,
+							CachedTokens:        10,
+							CacheCreationTokens: 20,
 						},
 						CompletionTokensDetails: CompletionTokensDetails{
 							ReasoningTokens: 5,
@@ -201,7 +223,8 @@ func TestConcatMessage(t *testing.T) {
 						CompletionTokens: 15,
 						PromptTokens:     30,
 						PromptTokenDetails: PromptTokenDetails{
-							CachedTokens: 15,
+							CachedTokens:        15,
+							CacheCreationTokens: 12,
 						},
 						CompletionTokensDetails: CompletionTokensDetails{
 							ReasoningTokens: 8,


### PR DESCRIPTION
#### What type of PR is this?

feat

#### Check the PR title.

- [x] This PR title matches the format: `<type>(optional scope): <description>`.
- [x] The description is user-oriented and clear.
- [x] A separate user-documentation PR is not required; the additive Go API field is documented inline.

#### (Optional) Translate the PR title into Chinese.

feat(schema): 追踪提示词缓存写入 token

#### (Optional) More detailed description for this PR(en: English/zh: Chinese).

en:

Providers can report and bill prompt-cache writes separately from cache reads, but Eino previously exposed only `CachedTokens`. This made cache-creation volume unavailable to provider integrations and downstream cost accounting.

This PR:

- adds provider-neutral `CacheCreationTokens` fields to `schema.PromptTokenDetails` and the model callback DTO;
- preserves cache-creation counts through both message concatenation paths using the existing cumulative-usage maximum semantics;
- adds JSON round-trip and legacy-payload compatibility coverage;
- verifies cache-read and cache-write maxima independently in standard and agentic message tests.

The change is additive. Existing payloads that omit `cache_creation_tokens` continue to decode with the Go zero value.

Validation:

- `go test ./schema ./components/model`
- `go vet ./...`
- `golangci-lint run --new-from-rev=origin/main --timeout 5m` (0 issues)
- `git diff --check`

`go test ./...` was also attempted on Windows. The changed packages pass, while unrelated existing filesystem/path and CRLF-sensitive tests fail under Windows. A WSL rerun could not start because the local WSL instance timed out before `go version`.

zh(optional):

新增独立的缓存写入 token 统计，并在普通及 Agentic 流式消息合并中保留该累计值，便于准确计算提示词缓存写入成本。

#### (Optional) Which issue(s) this PR fixes:

Fixes #1150

#### (optional) The PR that updates user documentation:

N/A
