### PR TITLE
fix(adk): bound summarization model input

### DIFF
--- a/adk/middlewares/summarization/summarization.go
+++ b/adk/middlewares/summarization/summarization.go
@@ -75,6 +75,11 @@ type TypedConfig[M adk.MessageType] struct {
 
 	// Trigger specifies the conditions that activate summarization.
 	// Optional. Defaults to triggering when total tokens exceed 160k.
+	//
+	// ContextTokens also bounds the default summarization model input. When
+	// history exceeds that limit, the default input builder keeps the newest
+	// contiguous messages that fit and evicts older messages. A custom
+	// GenModelInput retains full control and is not windowed.
 	Trigger *TriggerCondition
 
 	// EmitInternalEvents indicates whether internal events should be emitted during summarization,
@@ -372,7 +377,7 @@ func (m *TypedMiddleware[M]) shouldSummarize(ctx context.Context, input *TypedTo
 
 func (m *TypedMiddleware[M]) getTriggerContextTokens() int {
 	const defaultTriggerContextTokens = 160000
-	if m.cfg.Trigger != nil {
+	if m.cfg.Trigger != nil && m.cfg.Trigger.ContextTokens > 0 {
 		return m.cfg.Trigger.ContextTokens
 	}
 	return defaultTriggerContextTokens
@@ -433,12 +438,7 @@ func defaultTypedTokenCounter[M adk.MessageType](_ context.Context, input *Typed
 
 	var incrementTokens int
 	for _, msg := range input.Messages[incrementStart:] {
-		switch m := any(msg).(type) {
-		case *schema.Message:
-			incrementTokens += estimateMessageTokens(m)
-		case *schema.AgenticMessage:
-			incrementTokens += estimateAgenticMessageTokens(m)
-		}
+		incrementTokens += estimateTypedMessageTokens(msg)
 	}
 
 	for _, tl := range input.Tools {
@@ -479,6 +479,17 @@ func estimateTokenCount(charLen int) int {
 
 func estimateTokenBytes(tokens int) int {
 	return tokens * 4
+}
+
+func estimateTypedMessageTokens[M adk.MessageType](msg M) int {
+	switch m := any(msg).(type) {
+	case *schema.Message:
+		return estimateMessageTokens(m)
+	case *schema.AgenticMessage:
+		return estimateAgenticMessageTokens(m)
+	default:
+		return 0
+	}
 }
 
 func (m *TypedMiddleware[M]) summarize(ctx context.Context, originalMsgs []M) (M, []M, error) {
@@ -614,12 +625,38 @@ func (m *TypedMiddleware[M]) buildSummarizationModelInput(ctx context.Context, o
 		return input, nil
 	}
 
+	contextMsgs = windowMessagesByTokenLimit(contextMsgs, m.getTriggerContextTokens()-
+		estimateTypedMessageTokens(sysInstruction)-estimateTypedMessageTokens(userInstruction))
+
 	input := make([]M, 0, len(contextMsgs)+2)
 	input = append(input, sysInstruction)
 	input = append(input, contextMsgs...)
 	input = append(input, userInstruction)
 
 	return input, nil
+}
+
+// windowMessagesByTokenLimit returns the newest contiguous message window that
+// fits within tokenLimit. Keeping a suffix preserves the latest user intent and
+// tool-call/result ordering while preventing an already-over-limit history from
+// being sent unchanged to the summarization model.
+func windowMessagesByTokenLimit[M adk.MessageType](messages []M, tokenLimit int) []M {
+	if tokenLimit <= 0 || len(messages) == 0 {
+		return nil
+	}
+
+	total := 0
+	start := len(messages)
+	for i := len(messages) - 1; i >= 0; i-- {
+		tokens := estimateTypedMessageTokens(messages[i])
+		if total+tokens > tokenLimit {
+			break
+		}
+		total += tokens
+		start = i
+	}
+
+	return messages[start:]
 }
 
 func (m *TypedMiddleware[M]) getModelInstructions() (M, M) {

--- a/adk/middlewares/summarization/summarization.go
+++ b/adk/middlewares/summarization/summarization.go
@@ -655,8 +655,31 @@ func windowMessagesByTokenLimit[M adk.MessageType](messages []M, tokenLimit int)
 		total += tokens
 		start = i
 	}
+	// A token boundary can land between an assistant tool call and its result.
+	// Do not send an orphaned leading result to the summarization model: providers
+	// generally require every tool result to follow its corresponding tool call.
+	for start < len(messages) && isToolResultMessage(messages[start]) {
+		start++
+	}
 
 	return messages[start:]
+}
+
+func isToolResultMessage[M adk.MessageType](msg M) bool {
+	switch m := any(msg).(type) {
+	case *schema.Message:
+		return m != nil && m.Role == schema.Tool
+	case *schema.AgenticMessage:
+		if m == nil || m.Role != schema.AgenticRoleTypeUser {
+			return false
+		}
+		for _, block := range m.ContentBlocks {
+			if block != nil && block.Type == schema.ContentBlockTypeFunctionToolResult {
+				return true
+			}
+		}
+	}
+	return false
 }
 
 func (m *TypedMiddleware[M]) getModelInstructions() (M, M) {

--- a/adk/middlewares/summarization/summarization_test.go
+++ b/adk/middlewares/summarization/summarization_test.go
@@ -575,6 +575,23 @@ func TestMiddlewareShouldSummarize(t *testing.T) {
 		assert.False(t, triggered)
 	})
 
+	t.Run("message-only trigger does not enable zero token threshold", func(t *testing.T) {
+		mw := &TypedMiddleware[*schema.Message]{
+			cfg: &Config{
+				Trigger: &TriggerCondition{ContextMessages: 3},
+			},
+		}
+
+		triggered, err := mw.shouldSummarize(ctx, &TokenCounterInput{
+			Messages: []adk.Message{
+				schema.UserMessage("msg1"),
+				schema.UserMessage("msg2"),
+			},
+		})
+		assert.NoError(t, err)
+		assert.False(t, triggered)
+	})
+
 	t.Run("returns true when over threshold", func(t *testing.T) {
 		mw := &TypedMiddleware[*schema.Message]{
 			cfg: &Config{
@@ -1022,6 +1039,27 @@ func TestMiddlewareBuildSummarizationModelInput(t *testing.T) {
 		assert.True(t, found, "should contain context message")
 	})
 
+	t.Run("windows default input to context token threshold", func(t *testing.T) {
+		mw := &TypedMiddleware[*schema.Message]{
+			cfg: &Config{
+				Trigger: &TriggerCondition{},
+			},
+		}
+		systemInstruction, userInstruction := mw.getModelInstructions()
+		mw.cfg.Trigger.ContextTokens = estimateTypedMessageTokens(systemInstruction) +
+			estimateTypedMessageTokens(userInstruction) + 3
+
+		oldMessage := schema.UserMessage(strings.Repeat("old", 20))
+		recentMessage := schema.UserMessage("recent")
+		contextMsgs := []adk.Message{oldMessage, recentMessage}
+
+		input, err := mw.buildSummarizationModelInput(ctx, contextMsgs, contextMsgs)
+		require.NoError(t, err)
+		require.Len(t, input, 3)
+		assert.Same(t, recentMessage, input[1])
+		assert.NotContains(t, input, oldMessage)
+	})
+
 	t.Run("uses GenModelInput", func(t *testing.T) {
 		expectedInput := []adk.Message{
 			schema.UserMessage("custom input"),
@@ -1072,6 +1110,18 @@ func TestMiddlewareBuildSummarizationModelInput(t *testing.T) {
 		assert.Equal(t, schema.User, lastMsg.Role)
 		assert.Contains(t, lastMsg.Content, "custom instruction")
 	})
+}
+
+func TestWindowMessagesByTokenLimit(t *testing.T) {
+	oldMessage := schema.UserMessage(strings.Repeat("o", 80))
+	recentMessage := schema.UserMessage("recent")
+	messages := []adk.Message{oldMessage, recentMessage}
+
+	window := windowMessagesByTokenLimit(messages, estimateTypedMessageTokens(recentMessage))
+	require.Len(t, window, 1)
+	assert.Same(t, recentMessage, window[0])
+
+	assert.Nil(t, windowMessagesByTokenLimit(messages, 0))
 }
 
 func TestMiddlewareSummarize(t *testing.T) {

--- a/adk/middlewares/summarization/summarization_test.go
+++ b/adk/middlewares/summarization/summarization_test.go
@@ -1122,6 +1122,44 @@ func TestWindowMessagesByTokenLimit(t *testing.T) {
 	assert.Same(t, recentMessage, window[0])
 
 	assert.Nil(t, windowMessagesByTokenLimit(messages, 0))
+
+	t.Run("drops an orphaned message tool result at the boundary", func(t *testing.T) {
+		toolCall := schema.AssistantMessage("", []schema.ToolCall{{
+			ID: "call_1",
+			Function: schema.FunctionCall{
+				Name: "lookup",
+			},
+		}})
+		toolResult := schema.ToolMessage("result", "call_1")
+		messages := []adk.Message{toolCall, toolResult, recentMessage}
+		limit := estimateTypedMessageTokens(toolResult) + estimateTypedMessageTokens(recentMessage)
+
+		window := windowMessagesByTokenLimit(messages, limit)
+		require.Len(t, window, 1)
+		assert.Same(t, recentMessage, window[0])
+	})
+
+	t.Run("drops an orphaned agentic tool result at the boundary", func(t *testing.T) {
+		toolCall := &schema.AgenticMessage{
+			Role: schema.AgenticRoleTypeAssistant,
+			ContentBlocks: []*schema.ContentBlock{
+				schema.NewContentBlock(&schema.FunctionToolCall{CallID: "call_1", Name: "lookup"}),
+			},
+		}
+		toolResult := &schema.AgenticMessage{
+			Role: schema.AgenticRoleTypeUser,
+			ContentBlocks: []*schema.ContentBlock{
+				schema.NewContentBlock(&schema.FunctionToolResult{CallID: "call_1", Name: "lookup"}),
+			},
+		}
+		recentMessage := schema.UserAgenticMessage("recent")
+		messages := []*schema.AgenticMessage{toolCall, toolResult, recentMessage}
+		limit := estimateTypedMessageTokens(toolResult) + estimateTypedMessageTokens(recentMessage)
+
+		window := windowMessagesByTokenLimit(messages, limit)
+		require.Len(t, window, 1)
+		assert.Same(t, recentMessage, window[0])
+	})
 }
 
 func TestMiddlewareSummarize(t *testing.T) {


### PR DESCRIPTION
#### What type of PR is this?

fix

#### Check the PR title.

- [x] This PR title matches the required format.
- [x] The description is user-oriented and clear.
- [x] No separate documentation PR is required; the behavior is documented on the existing config field.

#### (Optional) Translate the PR title into Chinese.

fix(adk): 限制摘要模型的输入长度

#### (Optional) More detailed description for this PR(en: English/zh: Chinese).

en:

When conversation history crosses the summarization threshold, the default input builder currently forwards the complete over-limit history to the summarization model. If that model has the same or a smaller context window, the recovery mechanism fails with another context-length error.

This change uses `Trigger.ContextTokens` as the input budget for the default summary request. After reserving space for the system and user summary instructions, it keeps the newest contiguous message window that fits and evicts older messages. Keeping a suffix preserves current user intent and tool-call/result ordering. Custom `GenModelInput` callbacks remain untouched and retain full control.

It also fixes a related trigger edge case: configuring only `ContextMessages` previously left `ContextTokens` at zero, causing any non-empty history below the message threshold to trigger anyway. A disabled token condition now falls back to the documented default 160k threshold.

User impact: default summarization no longer retries an already oversized history unchanged, and message-only trigger configurations behave as documented.

Compatibility/risk: no new API. The window applies only to the default model-input builder; users needing different retention semantics can continue using `GenModelInput`.

Validation:

- `go test ./adk/middlewares/summarization -run "TestMiddlewareShouldSummarize|TestMiddlewareBuildSummarizationModelInput|TestWindowMessagesByTokenLimit" -count=10`
- `go test -race ./adk/middlewares/summarization -run "TestMiddlewareShouldSummarize|TestMiddlewareBuildSummarizationModelInput|TestWindowMessagesByTokenLimit" -count=1`
- `go test ./adk/middlewares/summarization`
- `go test ./adk`
- `go test ./...`
- `go vet ./...`

`golangci-lint` could not be completed locally because the pinned runner repeatedly stalled while downloading `github.com/MirrexOne/unqueryvet v1.5.4`.

#### (Optional) Which issue(s) this PR fixes:

Fixes #940