### PR TITLE
feat(adk): reduction add ClearPreCommit hook for pre-commit message p…

### DIFF
--- a/adk/middlewares/reduction/reduction.go
+++ b/adk/middlewares/reduction/reduction.go
@@ -135,6 +135,26 @@ type TypedConfig[M adk.MessageType] struct {
 	// Optional. Default is nil, which means no rewrite.
 	ClearMessageRewriter func(ctx context.Context, toolCallMsg M, toolResponseMsgs []M) (messagesAfterRewrite []M, err error)
 
+	// ClearPreCommit is called after all clear modifications (ClearMessageRewriter + ClearHandlers)
+	// have been applied to the message copies, but before the framework applies the result.
+	//
+	// The input's ModifiedMessages contains only the messages within the clear range (i.e. those
+	// that were subject to clearing), not the full message list. Messages outside the clear range
+	// (system/user prefix and the retention suffix) are excluded.
+	// Mutations to ModifiedMessages are reflected in subsequent processing
+	// (TokenCounter threshold check when ClearAtLeastTokens > 0, ClearPostProcess, and the final committed state).
+	//
+	// Use cases:
+	//   - Invalidate per-message cached token counts so TokenCounter reflects updated content.
+	//   - Perform pre-commit validation or transformations on the modified messages.
+	//   - Collect metrics about what was modified before the commit/rollback decision.
+	//
+	// Returning a non-nil error aborts the entire clear operation; original state is preserved.
+	//
+	// Not called when clear is skipped (e.g. estimatedTokens < MaxTokensForClear, or SkipClear is true).
+	// Optional. Default is nil, which means no processing.
+	ClearPreCommit func(ctx context.Context, input *ClearPreCommitInput[M]) error
+
 	// ClearPostProcess is clear post process handler.
 	// Optional.
 	ClearPostProcess func(ctx context.Context, state *adk.TypedChatModelAgentState[M]) context.Context
@@ -235,6 +255,15 @@ type ClearResult struct {
 	OffloadContent string
 }
 
+// ClearPreCommitInput is the input for ClearPreCommit.
+type ClearPreCommitInput[M adk.MessageType] struct {
+	// ModifiedMessages contains the messages within the clear range after all modifications
+	// (ClearMessageRewriter + ClearHandlers) have been applied.
+	// This does NOT include messages outside the clear range that are unaffected.
+	// Mutations to these messages are reflected in subsequent processing.
+	ModifiedMessages []M
+}
+
 func (t *TypedConfig[M]) copyAndFillDefaults() (*TypedConfig[M], error) {
 	cfg := &TypedConfig[M]{
 		Backend:                   t.Backend,
@@ -252,6 +281,7 @@ func (t *TypedConfig[M]) copyAndFillDefaults() (*TypedConfig[M], error) {
 		ClearAtLeastTokens:        t.ClearAtLeastTokens,
 		ClearExcludeTools:         t.ClearExcludeTools,
 		ClearMessageRewriter:      t.ClearMessageRewriter,
+		ClearPreCommit:            t.ClearPreCommit,
 		ClearPostProcess:          t.ClearPostProcess,
 	}
 	if cfg.TokenCounter == nil {
@@ -1084,20 +1114,10 @@ func (t *typedToolReductionMiddleware[M]) beforeModelRewriteStateGeneric(ctx con
 					if cfg.Backend == nil {
 						return ctx, state, fmt.Errorf("clear: no backend for offload")
 					}
-					if clearAtLeastTokens > 0 { // delay clear offloading
-						offloadStash = append(offloadStash, &offloadStashItem{
-							config:      cfg,
-							offloadInfo: offloadInfo,
-						})
-					} else { // instant clear offloading
-						writeErr := cfg.Backend.Write(ctx, &filesystem.WriteRequest{
-							FilePath: offloadInfo.OffloadFilePath,
-							Content:  offloadInfo.OffloadContent,
-						})
-						if writeErr != nil {
-							return ctx, state, writeErr
-						}
-					}
+					offloadStash = append(offloadStash, &offloadStashItem{
+						config:      cfg,
+						offloadInfo: offloadInfo,
+					})
 				}
 
 				setToolCallArguments(toolCallMsg, tc.BlockIndex, offloadInfo.ToolArgument.Text)
@@ -1110,6 +1130,13 @@ func (t *typedToolReductionMiddleware[M]) beforeModelRewriteStateGeneric(ctx con
 		toolCallMsgIndex++
 	}
 
+	// ClearPreCommit: let consumer process modified messages before commit decision
+	if t.config.ClearPreCommit != nil {
+		if err = t.config.ClearPreCommit(ctx, &ClearPreCommitInput[M]{ModifiedMessages: editTarget[start:end]}); err != nil {
+			return ctx, state, err
+		}
+	}
+
 	if clearAtLeastTokens > 0 {
 		estimatedTokensAfterClear, err := t.config.TokenCounter(ctx, editTarget, state.ToolInfos)
 		if err != nil {
@@ -1120,14 +1147,16 @@ func (t *typedToolReductionMiddleware[M]) beforeModelRewriteStateGeneric(ctx con
 			// clear not applied, post process won't apply as well.
 			return ctx, state, nil
 		}
-		for _, item := range offloadStash {
-			writeErr := item.config.Backend.Write(ctx, &filesystem.WriteRequest{
-				FilePath: item.offloadInfo.OffloadFilePath,
-				Content:  item.offloadInfo.OffloadContent,
-			})
-			if writeErr != nil {
-				return ctx, state, writeErr
-			}
+	}
+
+	// commit offloads
+	for _, item := range offloadStash {
+		writeErr := item.config.Backend.Write(ctx, &filesystem.WriteRequest{
+			FilePath: item.offloadInfo.OffloadFilePath,
+			Content:  item.offloadInfo.OffloadContent,
+		})
+		if writeErr != nil {
+			return ctx, state, writeErr
 		}
 	}
 
@@ -1149,11 +1178,7 @@ func (t *typedToolReductionMiddleware[M]) applyClearRewriteGeneric(ctx context.C
 
 	editTarget = append(editTarget, state.Messages[:start]...)
 
-	if clearAtLeastTokens > 0 {
-		needProcessPart = copyMessagesGeneric(state.Messages[start:end])
-	} else {
-		needProcessPart = state.Messages[start:end]
-	}
+	needProcessPart = copyMessagesGeneric(state.Messages[start:end])
 
 	if t.config.ClearMessageRewriter != nil {
 		var (

--- a/adk/middlewares/reduction/reduction_test.go
+++ b/adk/middlewares/reduction/reduction_test.go
@@ -1387,7 +1387,7 @@ func TestReductionMiddlewareClear(t *testing.T) {
 				Function: schema.FunctionCall{Name: "get_weather", Arguments: `{"location": "London, UK", "unit": "c"}`},
 			},
 		}, s.Messages[2].ToolCalls)
-		assert.NotNil(t, msgs[2].Extra[msgClearedFlag])
+		assert.NotNil(t, s.Messages[2].Extra[msgClearedFlag])
 		assert.Equal(t, []schema.ToolCall{
 			{
 				ID:       "call_123456789",
@@ -1422,7 +1422,7 @@ func TestReductionMiddlewareClear(t *testing.T) {
 				Function: schema.FunctionCall{Name: "get_weather", Arguments: `{"location": "London, UK", "unit": "c"}`},
 			},
 		}, s.Messages[2].ToolCalls)
-		assert.NotNil(t, msgs[2].Extra[msgClearedFlag])
+		assert.NotNil(t, s.Messages[2].Extra[msgClearedFlag])
 		assert.Equal(t, []schema.ToolCall{
 			{
 				ID:       "call_123456789",
@@ -1430,7 +1430,7 @@ func TestReductionMiddlewareClear(t *testing.T) {
 				Function: schema.FunctionCall{Name: "get_weather", Arguments: `{"location": "London, UK", "unit": "c"}`},
 			},
 		}, s.Messages[4].ToolCalls)
-		assert.NotNil(t, msgs[4].Extra[msgClearedFlag])
+		assert.NotNil(t, s.Messages[4].Extra[msgClearedFlag])
 		assert.Equal(t, "<persisted-output>Tool result saved to: /tmp/clear/call_987654321\nUse read_file to view</persisted-output>", s.Messages[3].Content)
 		assert.Equal(t, "<persisted-output>Tool result saved to: /tmp/clear/call_123456789\nUse read_file to view</persisted-output>", s.Messages[5].Content)
 	})
@@ -1649,6 +1649,196 @@ func TestReductionMiddlewareClear(t *testing.T) {
 			FilePath: "/tmp/clear/call_987654321",
 		})
 		assert.NoError(t, err)
+	})
+
+	t.Run("ClearPreCommit - invalidates cache before threshold check", func(t *testing.T) {
+		backend := filesystem.NewInMemoryBackend()
+		const cacheKey = "_cached_tokens"
+		config := &Config{
+			SkipTruncation: true,
+			TokenCounter: func(_ context.Context, msgs []adk.Message, _ []*schema.ToolInfo) (int64, error) {
+				var size int64
+				for _, msg := range msgs {
+					if v, ok := msg.Extra[cacheKey]; ok {
+						size += v.(int64)
+					} else {
+						size += int64(len(msg.Content))
+					}
+				}
+				return size, nil
+			},
+			MaxTokensForClear:         50,
+			ClearRetentionSuffixLimit: 1,
+			ClearAtLeastTokens:        30,
+			ClearPreCommit: func(_ context.Context, input *ClearPreCommitInput[adk.Message]) error {
+				for i := range input.ModifiedMessages {
+					delete(input.ModifiedMessages[i].Extra, cacheKey)
+				}
+				return nil
+			},
+			ToolConfig: map[string]*ToolReductionConfig{
+				"get_weather": {
+					Backend:      backend,
+					SkipClear:    false,
+					ClearHandler: defaultClearHandler(testClearOffloadPath("/tmp"), true, "read_file"),
+				},
+			},
+		}
+
+		mw, err := New(ctx, config)
+		assert.NoError(t, err)
+
+		msgs := []adk.Message{
+			schema.SystemMessage("sys"),
+			schema.UserMessage("hello"),
+			schema.AssistantMessage("", []schema.ToolCall{
+				{ID: "call_1", Type: "function", Function: schema.FunctionCall{Name: "get_weather", Arguments: `{}`}},
+			}),
+			func() adk.Message {
+				m := schema.ToolMessage("long content that should be cleared away", "call_1")
+				m.Extra = map[string]any{cacheKey: int64(999)}
+				return m
+			}(),
+			schema.AssistantMessage("", []schema.ToolCall{
+				{ID: "call_2", Type: "function", Function: schema.FunctionCall{Name: "get_weather", Arguments: `{}`}},
+			}),
+			schema.ToolMessage("recent", "call_2"),
+		}
+
+		_, s, err := mw.BeforeModelRewriteState(ctx, &adk.ChatModelAgentState{Messages: msgs}, &adk.ModelContext{Tools: toolsInfo})
+		assert.NoError(t, err)
+		assert.Contains(t, s.Messages[3].Content, "persisted-output")
+	})
+
+	t.Run("ClearPreCommit - without hook, cached tokens prevent clear", func(t *testing.T) {
+		const cacheKey = "_cached_tokens"
+		config := &Config{
+			SkipTruncation: true,
+			TokenCounter: func(_ context.Context, msgs []adk.Message, _ []*schema.ToolInfo) (int64, error) {
+				var size int64
+				for _, msg := range msgs {
+					if v, ok := msg.Extra[cacheKey]; ok {
+						size += v.(int64)
+					} else {
+						size += int64(len(msg.Content))
+					}
+				}
+				return size, nil
+			},
+			MaxTokensForClear:         50,
+			ClearRetentionSuffixLimit: 1,
+			ClearAtLeastTokens:        30,
+			ToolConfig: map[string]*ToolReductionConfig{
+				"get_weather": {
+					SkipClear:    false,
+					ClearHandler: defaultClearHandler(testClearOffloadPath("/tmp"), false, ""),
+				},
+			},
+		}
+
+		mw, err := New(ctx, config)
+		assert.NoError(t, err)
+
+		msgs := []adk.Message{
+			schema.SystemMessage("sys"),
+			schema.UserMessage("hello"),
+			schema.AssistantMessage("", []schema.ToolCall{
+				{ID: "call_1", Type: "function", Function: schema.FunctionCall{Name: "get_weather", Arguments: `{}`}},
+			}),
+			func() adk.Message {
+				m := schema.ToolMessage("long content that should be cleared away", "call_1")
+				m.Extra = map[string]any{cacheKey: int64(999)}
+				return m
+			}(),
+			schema.AssistantMessage("", []schema.ToolCall{
+				{ID: "call_2", Type: "function", Function: schema.FunctionCall{Name: "get_weather", Arguments: `{}`}},
+			}),
+			schema.ToolMessage("recent", "call_2"),
+		}
+
+		_, s, err := mw.BeforeModelRewriteState(ctx, &adk.ChatModelAgentState{Messages: msgs}, &adk.ModelContext{Tools: toolsInfo})
+		assert.NoError(t, err)
+		assert.Equal(t, "long content that should be cleared away", s.Messages[3].Content)
+	})
+
+	t.Run("ClearPreCommit - error aborts clear", func(t *testing.T) {
+		config := &Config{
+			SkipTruncation:            true,
+			TokenCounter:              func(context.Context, []adk.Message, []*schema.ToolInfo) (int64, error) { return 100, nil },
+			MaxTokensForClear:         20,
+			ClearRetentionSuffixLimit: 1,
+			ClearPreCommit: func(_ context.Context, _ *ClearPreCommitInput[adk.Message]) error {
+				return errors.New("pre-commit failed")
+			},
+			ToolConfig: map[string]*ToolReductionConfig{
+				"get_weather": {
+					SkipClear:    false,
+					ClearHandler: defaultClearHandler(testClearOffloadPath("/tmp"), false, ""),
+				},
+			},
+		}
+
+		mw, err := New(ctx, config)
+		assert.NoError(t, err)
+
+		msgs := []adk.Message{
+			schema.SystemMessage("sys"),
+			schema.UserMessage("hello"),
+			schema.AssistantMessage("", []schema.ToolCall{
+				{ID: "call_1", Type: "function", Function: schema.FunctionCall{Name: "get_weather", Arguments: `{}`}},
+			}),
+			schema.ToolMessage("Sunny", "call_1"),
+			schema.AssistantMessage("", []schema.ToolCall{
+				{ID: "call_2", Type: "function", Function: schema.FunctionCall{Name: "get_weather", Arguments: `{}`}},
+			}),
+			schema.ToolMessage("recent", "call_2"),
+		}
+
+		_, _, err = mw.BeforeModelRewriteState(ctx, &adk.ChatModelAgentState{Messages: msgs}, &adk.ModelContext{Tools: toolsInfo})
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "pre-commit failed")
+	})
+
+	t.Run("ClearPreCommit - called even when ClearAtLeastTokens is 0", func(t *testing.T) {
+		var preCommitCalled bool
+		config := &Config{
+			SkipTruncation:            true,
+			TokenCounter:              func(context.Context, []adk.Message, []*schema.ToolInfo) (int64, error) { return 100, nil },
+			MaxTokensForClear:         20,
+			ClearRetentionSuffixLimit: 1,
+			ClearAtLeastTokens:        0,
+			ClearPreCommit: func(_ context.Context, input *ClearPreCommitInput[adk.Message]) error {
+				preCommitCalled = true
+				assert.NotEmpty(t, input.ModifiedMessages)
+				return nil
+			},
+			ToolConfig: map[string]*ToolReductionConfig{
+				"get_weather": {
+					SkipClear:    false,
+					ClearHandler: defaultClearHandler(testClearOffloadPath("/tmp"), false, ""),
+				},
+			},
+		}
+
+		mw, err := New(ctx, config)
+		assert.NoError(t, err)
+
+		msgs := []adk.Message{
+			schema.SystemMessage("sys"),
+			schema.UserMessage("hello"),
+			schema.AssistantMessage("", []schema.ToolCall{
+				{ID: "call_1", Type: "function", Function: schema.FunctionCall{Name: "get_weather", Arguments: `{}`}},
+			}),
+			schema.ToolMessage("Sunny", "call_1"),
+			schema.AssistantMessage("", []schema.ToolCall{
+				{ID: "call_2", Type: "function", Function: schema.FunctionCall{Name: "get_weather", Arguments: `{}`}},
+			}),
+			schema.ToolMessage("recent", "call_2"),
+		}
+
+		_, _, err = mw.BeforeModelRewriteState(ctx, &adk.ChatModelAgentState{Messages: msgs}, &adk.ModelContext{Tools: toolsInfo})
+		assert.NoError(t, err)
+		assert.True(t, preCommitCalled)
 	})
 }
 


### PR DESCRIPTION
…rocessing

#### What type of PR is this?
<!--
Add one of the following kinds:

build: Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)
ci: Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
docs: Documentation only changes
feat: A new feature
optimize: A new optimization
fix: A bug fix
perf: A code change that improves performance
refactor: A code change that neither fixes a bug nor adds a feature
style: Changes that do not affect the meaning of the code (white space, formatting, missing semi-colons, etc)
test: Adding missing tests or correcting existing tests
chore: Changes to the build process or auxiliary tools and libraries such as documentation generation
-->
feat

---

#### Check the PR title.
<!--
The description of the title will be attached in Release Notes, 
so please describe it from user-oriented, what this PR does / why we need it.
Please check your PR title with the below requirements:
-->
- [x] This PR title match the format: \<type\>(optional scope): \<description\>
- [x] The description of this PR title is user-oriented and clear enough for others to understand.
- [ ] Attach the PR updating the user documentation if the current PR requires user awareness at the usage level. [User docs repo](https://github.com/cloudwego/cloudwego.github.io)

---

#### (Optional) Translate the PR title into Chinese.
feat(reduction): 新增 ClearPreCommit 钩子，支持在 clear 提交前对消息进行预处理

---
#### (Optional) More detailed description for this PR(en: English/zh: Chinese).
<!--
Provide more detailed info for review(e.g., it's recommended to provide perf data if this is a perf type PR).
-->
en:
  Add a ClearPreCommit hook to TypedConfig that is invoked after all clear modifications (ClearMessageRewriter + ClearHandlers) have been applied to message copies, but before the framework evaluates the ClearAtLeastTokens threshold check (ClearAtLeastTokens) and commits the result.                                                    
                                                                                                                                                                                                                                                                                                                            
  This enables consumers to:                                                                                                                                                                                                                                                                                                
  - Invalidate per-message cached token counts so that TokenCounter reflects the actual post-clear content.                                                                                                                                                                                                                 
  - Perform pre-commit validation or transformations on the modified messages.                                                                                                                                                                                                                                              
  - Collect metrics about what was modified before the commit/rollback decision.                                                                                                                                                                                                                                            
                                                                                                                                                                                                                                                                                                                            
  Additional changes:                                                                                                                                                                                                                                                                                                       
  - Always deep-copy messages in the clear path (previously conditional on ClearAtLeastTokens > 0), ensuring ClearPreCommit semantics are independent of the threshold configuration.                                                                                                                                       
  - Always defer offload writes until after the threshold check passes (stash pattern), preventing side effects on rollback. 

---
zh(optional): 
  新增 ClearPreCommit 配置项，在 clear 阶段所有消息修改（ClearMessageRewriter + ClearHandlers）完成后、框架执行 ClearAtLeastTokens 阈值判断和提交前调用。                                                                                                                                                                                       
                                                                                                                                                                                                                                                                                                                            
  主要解决的问题：当用户提供的 TokenCounter 依赖消息中缓存的 token 计数时，deep copy 后缓存值不变，导致 ClearAtLeastTokens 阈值判断认为没有清理足够的 token 而回滚。通过 ClearPreCommit 钩子，用户可以在阈值判断前清除缓存，使 TokenCounter 重新计算实际值。                                                                
                                                                                                                                                                                                                                                                                                                            
  同步调整：                                                                                                                                                                                                                                                                                                                
  - clear 路径始终执行消息深拷贝（不再依赖 ClearAtLeastTokens > 0 条件）。                                                                                                                                                                                                                                                  
  - offload 写入始终延迟到阈值检查通过后再执行（之前仅在 ClearAtLeastTokens > 0 时才延迟写入），避免回滚时产生副作用。


---
#### (Optional) Which issue(s) this PR fixes:
<!--
Automatically closes linked issue when PR is merged.
Eg: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

#### (optional) The PR that updates user documentation:
<!--
If the current PR requires user awareness at the usage level, please submit a PR to update user docs. [User docs repo](https://github.com/cloudwego/cloudwego.github.io)
-->