### PR TITLE
feat(adk): add PatchedToolResultGenerator for EnhancedTool-style results

### DIFF
--- a/adk/middlewares/patchtoolcalls/patchtoolcalls.go
+++ b/adk/middlewares/patchtoolcalls/patchtoolcalls.go
@@ -26,14 +26,25 @@ import (
 	"github.com/cloudwego/eino/schema"
 )
 
+// PatchedToolResult is the value returned by PatchedToolResultGenerator.
+//
+// Content and ToolResult are mutually exclusive:
+//   - Content: plain-text tool message (typical for InvokableTool users)
+//   - ToolResult: EnhancedTool-style result (text and/or multimodal parts)
+type PatchedToolResult struct {
+	Content    string
+	ToolResult *schema.ToolResult
+}
+
 // Config defines the configuration options for the patch tool calls middleware.
 type Config struct {
 	// PatchedContentGenerator is an optional custom function to generate the content
 	// of patched tool messages as a plain string.
 	//
-	// Deprecated: Use PatchedToolResultGenerator instead, which aligns with EnhancedTool
-	// (ToolArgument in, ToolResult out) and receives the original tool-call arguments.
-	// Kept for backward compatibility; ignored when PatchedToolResultGenerator is set.
+	// Deprecated: Use PatchedToolResultGenerator instead, which receives the original
+	// tool-call arguments and can return either plain Content or an EnhancedTool
+	// ToolResult. Kept for backward compatibility; ignored when
+	// PatchedToolResultGenerator is set.
 	//
 	// Parameters:
 	//   - ctx: the context for the operation
@@ -45,11 +56,11 @@ type Config struct {
 	//   - error: any error that occurred during generation
 	PatchedContentGenerator func(ctx context.Context, toolName, toolCallID string) (string, error)
 
-	// PatchedToolResultGenerator generates a ToolResult for a dangling tool call.
+	// PatchedToolResultGenerator generates a patched tool result for a dangling tool call.
 	// It is preferred over PatchedContentGenerator when both are set.
 	//
-	// Aligned with EnhancedTool: arguments arrive as *schema.ToolArgument and the
-	// result is a *schema.ToolResult (text and/or multimodal parts).
+	// Return PatchedToolResult.Content for plain text, or PatchedToolResult.ToolResult
+	// for EnhancedTool-style multimodal results. The two fields are mutually exclusive.
 	//
 	// Parameters:
 	//   - ctx: the context for the operation
@@ -58,19 +69,19 @@ type Config struct {
 	//   - toolArgument: the original tool-call arguments (Text is the JSON arguments string)
 	//
 	// Returns:
-	//   - *schema.ToolResult: the patched tool result to insert into history
+	//   - *PatchedToolResult: the patched tool result to insert into history
 	//   - error: any error that occurred during generation
 	PatchedToolResultGenerator func(
 		ctx context.Context,
 		toolName string,
 		toolCallID string,
 		toolArgument *schema.ToolArgument,
-	) (*schema.ToolResult, error)
+	) (*PatchedToolResult, error)
 }
 
 type patchedGenerators struct {
 	content func(ctx context.Context, toolName, toolCallID string) (string, error)
-	result  func(ctx context.Context, toolName, toolCallID string, toolArgument *schema.ToolArgument) (*schema.ToolResult, error)
+	result  func(ctx context.Context, toolName, toolCallID string, toolArgument *schema.ToolArgument) (*PatchedToolResult, error)
 }
 
 // NewTyped creates a new generic patch tool calls middleware.
@@ -258,7 +269,7 @@ func createPatchedToolMessage(ctx context.Context, gens patchedGenerators, tc sc
 		if err != nil {
 			return nil, err
 		}
-		return toolResultToMessage(tc.Function.Name, tc.ID, result)
+		return patchedToolResultToMessage(tc.Function.Name, tc.ID, result)
 	}
 	if gens.content != nil {
 		content, err := gens.content(ctx, tc.Function.Name, tc.ID)
@@ -282,7 +293,7 @@ func createPatchedAgenticToolMessage(ctx context.Context, gens patchedGenerators
 		if err != nil {
 			return nil, err
 		}
-		return toolResultToAgenticMessage(toolName, callID, result)
+		return patchedToolResultToAgenticMessage(toolName, callID, result)
 	}
 
 	var content string
@@ -300,6 +311,43 @@ func createPatchedAgenticToolMessage(ctx context.Context, gens patchedGenerators
 		content = fmt.Sprintf(tpl, toolName, callID)
 	}
 
+	return agenticTextToolResultMessage(toolName, callID, content), nil
+}
+
+func patchedToolResultToMessage(toolName, callID string, result *PatchedToolResult) (*schema.Message, error) {
+	if result == nil {
+		return schema.ToolMessage("", callID, schema.WithToolName(toolName)), nil
+	}
+	if err := validatePatchedToolResult(result); err != nil {
+		return nil, err
+	}
+	if result.ToolResult != nil {
+		return toolResultToMessage(toolName, callID, result.ToolResult)
+	}
+	return schema.ToolMessage(result.Content, callID, schema.WithToolName(toolName)), nil
+}
+
+func patchedToolResultToAgenticMessage(toolName, callID string, result *PatchedToolResult) (*schema.AgenticMessage, error) {
+	if result == nil {
+		return agenticTextToolResultMessage(toolName, callID, ""), nil
+	}
+	if err := validatePatchedToolResult(result); err != nil {
+		return nil, err
+	}
+	if result.ToolResult != nil {
+		return toolResultToAgenticMessage(toolName, callID, result.ToolResult)
+	}
+	return agenticTextToolResultMessage(toolName, callID, result.Content), nil
+}
+
+func validatePatchedToolResult(result *PatchedToolResult) error {
+	if result.Content != "" && result.ToolResult != nil {
+		return fmt.Errorf("patchtoolcalls: PatchedToolResult.Content and ToolResult are mutually exclusive")
+	}
+	return nil
+}
+
+func agenticTextToolResultMessage(toolName, callID, content string) *schema.AgenticMessage {
 	return &schema.AgenticMessage{
 		Role: schema.AgenticRoleTypeUser,
 		ContentBlocks: []*schema.ContentBlock{
@@ -311,7 +359,7 @@ func createPatchedAgenticToolMessage(ctx context.Context, gens patchedGenerators
 				},
 			}),
 		},
-	}, nil
+	}
 }
 
 // toolResultToMessage converts a ToolResult into a tool-role Message.

--- a/adk/middlewares/patchtoolcalls/patchtoolcalls.go
+++ b/adk/middlewares/patchtoolcalls/patchtoolcalls.go
@@ -282,7 +282,7 @@ func createPatchedAgenticToolMessage(ctx context.Context, gens patchedGenerators
 		if err != nil {
 			return nil, err
 		}
-		return toolResultToAgenticMessage(toolName, callID, result), nil
+		return toolResultToAgenticMessage(toolName, callID, result)
 	}
 
 	var content string
@@ -337,10 +337,11 @@ func toolResultToMessage(toolName, callID string, result *schema.ToolResult) (*s
 	return msg, nil
 }
 
-func toolResultToAgenticMessage(toolName, callID string, result *schema.ToolResult) *schema.AgenticMessage {
-	if result != nil && len(result.Parts) == 1 &&
-		result.Parts[0].Type == schema.ToolPartTypeToolSearchResult &&
-		result.Parts[0].ToolSearchResult != nil {
+func toolResultToAgenticMessage(toolName, callID string, result *schema.ToolResult) (*schema.AgenticMessage, error) {
+	if result != nil && len(result.Parts) == 1 && result.Parts[0].Type == schema.ToolPartTypeToolSearchResult {
+		if result.Parts[0].ToolSearchResult == nil {
+			return nil, fmt.Errorf("tool search result is nil for tool part type %v", result.Parts[0].Type)
+		}
 		return &schema.AgenticMessage{
 			Role: schema.AgenticRoleTypeUser,
 			ContentBlocks: []*schema.ContentBlock{
@@ -350,10 +351,15 @@ func toolResultToAgenticMessage(toolName, callID string, result *schema.ToolResu
 					Result: result.Parts[0].ToolSearchResult,
 				}),
 			},
-		}
+		}, nil
 	}
 
-	blocks := toolResultToFunctionBlocks(result)
+	blocks, err := toolResultToFunctionBlocks(result)
+	if err != nil {
+		return nil, err
+	}
+	// Empty ToolResult is valid and maps to an empty text tool result, matching
+	// toolResultToMessage which leaves Content empty for nil/empty results.
 	if len(blocks) == 0 {
 		blocks = []*schema.FunctionToolResultContentBlock{
 			{Type: schema.FunctionToolResultContentBlockTypeText, Text: &schema.UserInputText{Text: ""}},
@@ -368,7 +374,7 @@ func toolResultToAgenticMessage(toolName, callID string, result *schema.ToolResu
 				Content: blocks,
 			}),
 		},
-	}
+	}, nil
 }
 
 func singleTextToolResult(result *schema.ToolResult) (string, bool) {
@@ -378,74 +384,78 @@ func singleTextToolResult(result *schema.ToolResult) (string, bool) {
 	return result.Parts[0].Text, true
 }
 
-func toolResultToFunctionBlocks(result *schema.ToolResult) []*schema.FunctionToolResultContentBlock {
+func toolResultToFunctionBlocks(result *schema.ToolResult) ([]*schema.FunctionToolResultContentBlock, error) {
 	if result == nil || len(result.Parts) == 0 {
-		return nil
+		return nil, nil
 	}
 	blocks := make([]*schema.FunctionToolResultContentBlock, 0, len(result.Parts))
 	for _, p := range result.Parts {
-		var block *schema.FunctionToolResultContentBlock
 		switch p.Type {
 		case schema.ToolPartTypeText:
-			block = &schema.FunctionToolResultContentBlock{
+			blocks = append(blocks, &schema.FunctionToolResultContentBlock{
 				Type:  schema.FunctionToolResultContentBlockTypeText,
 				Text:  &schema.UserInputText{Text: p.Text},
 				Extra: p.Extra,
-			}
+			})
 		case schema.ToolPartTypeImage:
-			if p.Image != nil {
-				block = &schema.FunctionToolResultContentBlock{
-					Type: schema.FunctionToolResultContentBlockTypeImage,
-					Image: &schema.UserInputImage{
-						URL:        derefString(p.Image.URL),
-						Base64Data: derefString(p.Image.Base64Data),
-						MIMEType:   p.Image.MIMEType,
-					},
-					Extra: p.Extra,
-				}
+			if p.Image == nil {
+				return nil, fmt.Errorf("image content is nil for tool part type %v", p.Type)
 			}
+			blocks = append(blocks, &schema.FunctionToolResultContentBlock{
+				Type: schema.FunctionToolResultContentBlockTypeImage,
+				Image: &schema.UserInputImage{
+					URL:        derefString(p.Image.URL),
+					Base64Data: derefString(p.Image.Base64Data),
+					MIMEType:   p.Image.MIMEType,
+				},
+				Extra: p.Extra,
+			})
 		case schema.ToolPartTypeAudio:
-			if p.Audio != nil {
-				block = &schema.FunctionToolResultContentBlock{
-					Type: schema.FunctionToolResultContentBlockTypeAudio,
-					Audio: &schema.UserInputAudio{
-						URL:        derefString(p.Audio.URL),
-						Base64Data: derefString(p.Audio.Base64Data),
-						MIMEType:   p.Audio.MIMEType,
-					},
-					Extra: p.Extra,
-				}
+			if p.Audio == nil {
+				return nil, fmt.Errorf("audio content is nil for tool part type %v", p.Type)
 			}
+			blocks = append(blocks, &schema.FunctionToolResultContentBlock{
+				Type: schema.FunctionToolResultContentBlockTypeAudio,
+				Audio: &schema.UserInputAudio{
+					URL:        derefString(p.Audio.URL),
+					Base64Data: derefString(p.Audio.Base64Data),
+					MIMEType:   p.Audio.MIMEType,
+				},
+				Extra: p.Extra,
+			})
 		case schema.ToolPartTypeVideo:
-			if p.Video != nil {
-				block = &schema.FunctionToolResultContentBlock{
-					Type: schema.FunctionToolResultContentBlockTypeVideo,
-					Video: &schema.UserInputVideo{
-						URL:        derefString(p.Video.URL),
-						Base64Data: derefString(p.Video.Base64Data),
-						MIMEType:   p.Video.MIMEType,
-					},
-					Extra: p.Extra,
-				}
+			if p.Video == nil {
+				return nil, fmt.Errorf("video content is nil for tool part type %v", p.Type)
 			}
+			blocks = append(blocks, &schema.FunctionToolResultContentBlock{
+				Type: schema.FunctionToolResultContentBlockTypeVideo,
+				Video: &schema.UserInputVideo{
+					URL:        derefString(p.Video.URL),
+					Base64Data: derefString(p.Video.Base64Data),
+					MIMEType:   p.Video.MIMEType,
+				},
+				Extra: p.Extra,
+			})
 		case schema.ToolPartTypeFile:
-			if p.File != nil {
-				block = &schema.FunctionToolResultContentBlock{
-					Type: schema.FunctionToolResultContentBlockTypeFile,
-					File: &schema.UserInputFile{
-						URL:        derefString(p.File.URL),
-						Base64Data: derefString(p.File.Base64Data),
-						MIMEType:   p.File.MIMEType,
-					},
-					Extra: p.Extra,
-				}
+			if p.File == nil {
+				return nil, fmt.Errorf("file content is nil for tool part type %v", p.Type)
 			}
-		}
-		if block != nil {
-			blocks = append(blocks, block)
+			blocks = append(blocks, &schema.FunctionToolResultContentBlock{
+				Type: schema.FunctionToolResultContentBlockTypeFile,
+				File: &schema.UserInputFile{
+					URL:        derefString(p.File.URL),
+					Base64Data: derefString(p.File.Base64Data),
+					MIMEType:   p.File.MIMEType,
+				},
+				Extra: p.Extra,
+			})
+		case schema.ToolPartTypeToolSearchResult:
+			return nil, fmt.Errorf("tool search result must be the sole part of a ToolResult")
+		default:
+			return nil, fmt.Errorf("unknown tool part type: %v", p.Type)
 		}
 	}
-	return blocks
+	return blocks, nil
 }
 
 func derefString(s *string) string {

--- a/adk/middlewares/patchtoolcalls/patchtoolcalls.go
+++ b/adk/middlewares/patchtoolcalls/patchtoolcalls.go
@@ -29,7 +29,11 @@ import (
 // Config defines the configuration options for the patch tool calls middleware.
 type Config struct {
 	// PatchedContentGenerator is an optional custom function to generate the content
-	// of patched tool messages. If not provided, a default message will be used.
+	// of patched tool messages as a plain string.
+	//
+	// Deprecated: Use PatchedToolResultGenerator instead, which aligns with EnhancedTool
+	// (ToolArgument in, ToolResult out) and receives the original tool-call arguments.
+	// Kept for backward compatibility; ignored when PatchedToolResultGenerator is set.
 	//
 	// Parameters:
 	//   - ctx: the context for the operation
@@ -40,6 +44,33 @@ type Config struct {
 	//   - string: the content to use for the patched tool message
 	//   - error: any error that occurred during generation
 	PatchedContentGenerator func(ctx context.Context, toolName, toolCallID string) (string, error)
+
+	// PatchedToolResultGenerator generates a ToolResult for a dangling tool call.
+	// It is preferred over PatchedContentGenerator when both are set.
+	//
+	// Aligned with EnhancedTool: arguments arrive as *schema.ToolArgument and the
+	// result is a *schema.ToolResult (text and/or multimodal parts).
+	//
+	// Parameters:
+	//   - ctx: the context for the operation
+	//   - toolName: the name of the tool that was called
+	//   - toolCallID: the id of the tool call
+	//   - toolArgument: the original tool-call arguments (Text is the JSON arguments string)
+	//
+	// Returns:
+	//   - *schema.ToolResult: the patched tool result to insert into history
+	//   - error: any error that occurred during generation
+	PatchedToolResultGenerator func(
+		ctx context.Context,
+		toolName string,
+		toolCallID string,
+		toolArgument *schema.ToolArgument,
+	) (*schema.ToolResult, error)
+}
+
+type patchedGenerators struct {
+	content func(ctx context.Context, toolName, toolCallID string) (string, error)
+	result  func(ctx context.Context, toolName, toolCallID string, toolArgument *schema.ToolArgument) (*schema.ToolResult, error)
 }
 
 // NewTyped creates a new generic patch tool calls middleware.
@@ -51,7 +82,10 @@ func NewTyped[M adk.MessageType](_ context.Context, cfg *Config) (adk.TypedChatM
 		cfg = &Config{}
 	}
 	return &typedMiddleware[M]{
-		gen: cfg.PatchedContentGenerator,
+		gens: patchedGenerators{
+			content: cfg.PatchedContentGenerator,
+			result:  cfg.PatchedToolResultGenerator,
+		},
 	}, nil
 }
 
@@ -65,7 +99,7 @@ func New(ctx context.Context, cfg *Config) (adk.ChatModelAgentMiddleware, error)
 
 type typedMiddleware[M adk.MessageType] struct {
 	*adk.TypedBaseChatModelAgentMiddleware[M]
-	gen func(ctx context.Context, toolName, toolCallID string) (string, error)
+	gens patchedGenerators
 }
 
 func (m *typedMiddleware[M]) BeforeModelRewriteState(ctx context.Context, state *adk.TypedChatModelAgentState[M],
@@ -78,16 +112,16 @@ func (m *typedMiddleware[M]) BeforeModelRewriteState(ctx context.Context, state 
 	var zero M
 	switch any(zero).(type) {
 	case *schema.Message:
-		return patchToolCallsForMessage(ctx, m.gen, any(state).(*adk.TypedChatModelAgentState[*schema.Message]), mc)
+		return patchToolCallsForMessage(ctx, m.gens, any(state).(*adk.TypedChatModelAgentState[*schema.Message]), mc)
 	case *schema.AgenticMessage:
-		return patchToolCallsForAgenticMessage(ctx, m.gen, any(state).(*adk.TypedChatModelAgentState[*schema.AgenticMessage]), mc)
+		return patchToolCallsForAgenticMessage(ctx, m.gens, any(state).(*adk.TypedChatModelAgentState[*schema.AgenticMessage]), mc)
 	default:
 		panic("unreachable: unknown MessageType")
 	}
 }
 
 func patchToolCallsForMessage[M adk.MessageType](ctx context.Context,
-	gen func(ctx context.Context, toolName, toolCallID string) (string, error),
+	gens patchedGenerators,
 	state *adk.TypedChatModelAgentState[*schema.Message],
 	_ *adk.TypedModelContext[M],
 ) (context.Context, *adk.TypedChatModelAgentState[M], error) {
@@ -105,7 +139,7 @@ func patchToolCallsForMessage[M adk.MessageType](ctx context.Context,
 				continue
 			}
 
-			toolMsg, err := createPatchedToolMessage(ctx, gen, tc)
+			toolMsg, err := createPatchedToolMessage(ctx, gens, tc)
 			if err != nil {
 				return ctx, nil, err
 			}
@@ -119,7 +153,7 @@ func patchToolCallsForMessage[M adk.MessageType](ctx context.Context,
 }
 
 func patchToolCallsForAgenticMessage[M adk.MessageType](ctx context.Context,
-	gen func(ctx context.Context, toolName, toolCallID string) (string, error),
+	gens patchedGenerators,
 	state *adk.TypedChatModelAgentState[*schema.AgenticMessage],
 	_ *adk.TypedModelContext[M],
 ) (context.Context, *adk.TypedChatModelAgentState[M], error) {
@@ -136,13 +170,19 @@ func patchToolCallsForAgenticMessage[M adk.MessageType](ctx context.Context,
 		var toolCalls []struct {
 			callID string
 			name   string
+			args   string
 		}
 		for _, block := range msg.ContentBlocks {
 			if block != nil && block.Type == schema.ContentBlockTypeFunctionToolCall && block.FunctionToolCall != nil {
 				toolCalls = append(toolCalls, struct {
 					callID string
 					name   string
-				}{callID: block.FunctionToolCall.CallID, name: block.FunctionToolCall.Name})
+					args   string
+				}{
+					callID: block.FunctionToolCall.CallID,
+					name:   block.FunctionToolCall.Name,
+					args:   block.FunctionToolCall.Arguments,
+				})
 			}
 		}
 		if len(toolCalls) == 0 {
@@ -154,7 +194,7 @@ func patchToolCallsForAgenticMessage[M adk.MessageType](ctx context.Context,
 				continue
 			}
 
-			toolMsg, err := createPatchedAgenticToolMessage(ctx, gen, tc.name, tc.callID)
+			toolMsg, err := createPatchedAgenticToolMessage(ctx, gens, tc.name, tc.callID, tc.args)
 			if err != nil {
 				return ctx, nil, err
 			}
@@ -211,9 +251,17 @@ func hasCorrespondingAgenticToolResult(messages []*schema.AgenticMessage, toolCa
 	return false
 }
 
-func createPatchedToolMessage(ctx context.Context, gen func(ctx context.Context, toolName, toolCallID string) (string, error), tc schema.ToolCall) (*schema.Message, error) {
-	if gen != nil {
-		content, err := gen(ctx, tc.Function.Name, tc.ID)
+func createPatchedToolMessage(ctx context.Context, gens patchedGenerators, tc schema.ToolCall) (*schema.Message, error) {
+	if gens.result != nil {
+		arg := &schema.ToolArgument{Text: tc.Function.Arguments}
+		result, err := gens.result(ctx, tc.Function.Name, tc.ID, arg)
+		if err != nil {
+			return nil, err
+		}
+		return toolResultToMessage(tc.Function.Name, tc.ID, result)
+	}
+	if gens.content != nil {
+		content, err := gens.content(ctx, tc.Function.Name, tc.ID)
 		if err != nil {
 			return nil, err
 		}
@@ -227,11 +275,20 @@ func createPatchedToolMessage(ctx context.Context, gen func(ctx context.Context,
 	return schema.ToolMessage(fmt.Sprintf(tpl, tc.Function.Name, tc.ID), tc.ID, schema.WithToolName(tc.Function.Name)), nil
 }
 
-func createPatchedAgenticToolMessage(ctx context.Context, gen func(ctx context.Context, toolName, toolCallID string) (string, error), toolName, callID string) (*schema.AgenticMessage, error) {
+func createPatchedAgenticToolMessage(ctx context.Context, gens patchedGenerators, toolName, callID, arguments string) (*schema.AgenticMessage, error) {
+	if gens.result != nil {
+		arg := &schema.ToolArgument{Text: arguments}
+		result, err := gens.result(ctx, toolName, callID, arg)
+		if err != nil {
+			return nil, err
+		}
+		return toolResultToAgenticMessage(toolName, callID, result), nil
+	}
+
 	var content string
-	if gen != nil {
+	if gens.content != nil {
 		var err error
-		content, err = gen(ctx, toolName, callID)
+		content, err = gens.content(ctx, toolName, callID)
 		if err != nil {
 			return nil, err
 		}
@@ -255,6 +312,143 @@ func createPatchedAgenticToolMessage(ctx context.Context, gen func(ctx context.C
 			}),
 		},
 	}, nil
+}
+
+// toolResultToMessage converts a ToolResult into a tool-role Message.
+// Multimodal parts are placed in UserInputMultiContent. When the result is a
+// single text part, Content is also set for callers that still read Content.
+func toolResultToMessage(toolName, callID string, result *schema.ToolResult) (*schema.Message, error) {
+	msg := schema.ToolMessage("", callID, schema.WithToolName(toolName))
+	if result == nil || len(result.Parts) == 0 {
+		return msg, nil
+	}
+	parts, err := result.ToMessageInputParts()
+	if err != nil {
+		return nil, err
+	}
+	msg.UserInputMultiContent = parts
+	if text, ok := singleTextToolResult(result); ok {
+		msg.Content = text
+	}
+	return msg, nil
+}
+
+func toolResultToAgenticMessage(toolName, callID string, result *schema.ToolResult) *schema.AgenticMessage {
+	if result != nil && len(result.Parts) == 1 &&
+		result.Parts[0].Type == schema.ToolPartTypeToolSearchResult &&
+		result.Parts[0].ToolSearchResult != nil {
+		return &schema.AgenticMessage{
+			Role: schema.AgenticRoleTypeUser,
+			ContentBlocks: []*schema.ContentBlock{
+				schema.NewContentBlock(&schema.ToolSearchFunctionToolResult{
+					CallID: callID,
+					Name:   toolName,
+					Result: result.Parts[0].ToolSearchResult,
+				}),
+			},
+		}
+	}
+
+	blocks := toolResultToFunctionBlocks(result)
+	if len(blocks) == 0 {
+		blocks = []*schema.FunctionToolResultContentBlock{
+			{Type: schema.FunctionToolResultContentBlockTypeText, Text: &schema.UserInputText{Text: ""}},
+		}
+	}
+	return &schema.AgenticMessage{
+		Role: schema.AgenticRoleTypeUser,
+		ContentBlocks: []*schema.ContentBlock{
+			schema.NewContentBlock(&schema.FunctionToolResult{
+				CallID:  callID,
+				Name:    toolName,
+				Content: blocks,
+			}),
+		},
+	}
+}
+
+func singleTextToolResult(result *schema.ToolResult) (string, bool) {
+	if result == nil || len(result.Parts) != 1 || result.Parts[0].Type != schema.ToolPartTypeText {
+		return "", false
+	}
+	return result.Parts[0].Text, true
+}
+
+func toolResultToFunctionBlocks(result *schema.ToolResult) []*schema.FunctionToolResultContentBlock {
+	if result == nil || len(result.Parts) == 0 {
+		return nil
+	}
+	blocks := make([]*schema.FunctionToolResultContentBlock, 0, len(result.Parts))
+	for _, p := range result.Parts {
+		var block *schema.FunctionToolResultContentBlock
+		switch p.Type {
+		case schema.ToolPartTypeText:
+			block = &schema.FunctionToolResultContentBlock{
+				Type:  schema.FunctionToolResultContentBlockTypeText,
+				Text:  &schema.UserInputText{Text: p.Text},
+				Extra: p.Extra,
+			}
+		case schema.ToolPartTypeImage:
+			if p.Image != nil {
+				block = &schema.FunctionToolResultContentBlock{
+					Type: schema.FunctionToolResultContentBlockTypeImage,
+					Image: &schema.UserInputImage{
+						URL:        derefString(p.Image.URL),
+						Base64Data: derefString(p.Image.Base64Data),
+						MIMEType:   p.Image.MIMEType,
+					},
+					Extra: p.Extra,
+				}
+			}
+		case schema.ToolPartTypeAudio:
+			if p.Audio != nil {
+				block = &schema.FunctionToolResultContentBlock{
+					Type: schema.FunctionToolResultContentBlockTypeAudio,
+					Audio: &schema.UserInputAudio{
+						URL:        derefString(p.Audio.URL),
+						Base64Data: derefString(p.Audio.Base64Data),
+						MIMEType:   p.Audio.MIMEType,
+					},
+					Extra: p.Extra,
+				}
+			}
+		case schema.ToolPartTypeVideo:
+			if p.Video != nil {
+				block = &schema.FunctionToolResultContentBlock{
+					Type: schema.FunctionToolResultContentBlockTypeVideo,
+					Video: &schema.UserInputVideo{
+						URL:        derefString(p.Video.URL),
+						Base64Data: derefString(p.Video.Base64Data),
+						MIMEType:   p.Video.MIMEType,
+					},
+					Extra: p.Extra,
+				}
+			}
+		case schema.ToolPartTypeFile:
+			if p.File != nil {
+				block = &schema.FunctionToolResultContentBlock{
+					Type: schema.FunctionToolResultContentBlockTypeFile,
+					File: &schema.UserInputFile{
+						URL:        derefString(p.File.URL),
+						Base64Data: derefString(p.File.Base64Data),
+						MIMEType:   p.File.MIMEType,
+					},
+					Extra: p.Extra,
+				}
+			}
+		}
+		if block != nil {
+			blocks = append(blocks, block)
+		}
+	}
+	return blocks
+}
+
+func derefString(s *string) string {
+	if s == nil {
+		return ""
+	}
+	return *s
 }
 
 const (

--- a/adk/middlewares/patchtoolcalls/patchtoolcalls.go
+++ b/adk/middlewares/patchtoolcalls/patchtoolcalls.go
@@ -315,11 +315,18 @@ func createPatchedAgenticToolMessage(ctx context.Context, gens patchedGenerators
 }
 
 // toolResultToMessage converts a ToolResult into a tool-role Message.
-// Multimodal parts are placed in UserInputMultiContent. When the result is a
-// single text part, Content is also set for callers that still read Content.
+//
+// Pure-text results (single text part) only set Content. Setting both Content
+// and UserInputMultiContent would break OpenAI-compatible serializers that
+// reject ChatCompletionMessage with Content and MultiContent simultaneously.
+// Multimodal / non-text parts go exclusively into UserInputMultiContent.
 func toolResultToMessage(toolName, callID string, result *schema.ToolResult) (*schema.Message, error) {
 	msg := schema.ToolMessage("", callID, schema.WithToolName(toolName))
 	if result == nil || len(result.Parts) == 0 {
+		return msg, nil
+	}
+	if text, ok := singleTextToolResult(result); ok {
+		msg.Content = text
 		return msg, nil
 	}
 	parts, err := result.ToMessageInputParts()
@@ -327,9 +334,6 @@ func toolResultToMessage(toolName, callID string, result *schema.ToolResult) (*s
 		return nil, err
 	}
 	msg.UserInputMultiContent = parts
-	if text, ok := singleTextToolResult(result); ok {
-		msg.Content = text
-	}
 	return msg, nil
 }
 

--- a/adk/middlewares/patchtoolcalls/patchtoolcalls_test.go
+++ b/adk/middlewares/patchtoolcalls/patchtoolcalls_test.go
@@ -222,6 +222,63 @@ func testPatchToolCallsGeneric[M adk.MessageType](t *testing.T) {
 			wantContent:    "123 tool_b call_2",
 		},
 		{
+			name: "custom tool result generator",
+			config: &Config{
+				PatchedToolResultGenerator: func(ctx context.Context, toolName, toolCallID string, toolArgument *schema.ToolArgument) (*schema.ToolResult, error) {
+					argText := ""
+					if toolArgument != nil {
+						argText = toolArgument.Text
+					}
+					return &schema.ToolResult{
+						Parts: []schema.ToolOutputPart{{
+							Type: schema.ToolPartTypeText,
+							Text: fmt.Sprintf("result %s %s %s", toolName, toolCallID, argText),
+						}},
+					}, nil
+				},
+			},
+			messages: []M{
+				makeUserMsg[M]("hello"),
+				makeAssistantMsgWithToolCalls[M]("", []testToolCall{
+					{ID: "call_1", Name: "tool_a", Arguments: "{}"},
+					{ID: "call_2", Name: "tool_b", Arguments: `{"x":1}`},
+				}),
+				makeToolResultMsg[M]("result_a", "call_1", "tool_a"),
+			},
+			wantLen:        4,
+			checkPatchedAt: 2,
+			wantCallID:     "call_2",
+			wantToolName:   "tool_b",
+			wantContent:    `result tool_b call_2 {"x":1}`,
+		},
+		{
+			name: "tool result generator takes precedence over content generator",
+			config: &Config{
+				PatchedContentGenerator: func(ctx context.Context, toolName, toolCallID string) (string, error) {
+					return "legacy", nil
+				},
+				PatchedToolResultGenerator: func(ctx context.Context, toolName, toolCallID string, toolArgument *schema.ToolArgument) (*schema.ToolResult, error) {
+					return &schema.ToolResult{
+						Parts: []schema.ToolOutputPart{{
+							Type: schema.ToolPartTypeText,
+							Text: "enhanced",
+						}},
+					}, nil
+				},
+			},
+			messages: []M{
+				makeUserMsg[M]("hello"),
+				makeAssistantMsgWithToolCalls[M]("", []testToolCall{
+					{ID: "call_1", Name: "tool_a", Arguments: "{}"},
+				}),
+			},
+			wantLen:        3,
+			checkPatchedAt: 2,
+			wantCallID:     "call_1",
+			wantToolName:   "tool_a",
+			wantContent:    "enhanced",
+		},
+		{
 			name:   "two consecutive assistant messages with tool calls",
 			config: nil,
 			messages: []M{
@@ -280,6 +337,46 @@ func testPatchToolCallsGeneric[M adk.MessageType](t *testing.T) {
 func TestPatchToolCallsGeneric(t *testing.T) {
 	t.Run("Message", testPatchToolCallsGeneric[*schema.Message])
 	t.Run("AgenticMessage", testPatchToolCallsGeneric[*schema.AgenticMessage])
+}
+
+func TestPatchedToolResultGenerator_SetsContentAndMultiContent(t *testing.T) {
+	ctx := context.Background()
+	mw, err := New(ctx, &Config{
+		PatchedToolResultGenerator: func(ctx context.Context, toolName, toolCallID string, toolArgument *schema.ToolArgument) (*schema.ToolResult, error) {
+			require.Equal(t, "tool_a", toolName)
+			require.Equal(t, "call_1", toolCallID)
+			require.NotNil(t, toolArgument)
+			require.Equal(t, `{"q":"hi"}`, toolArgument.Text)
+			return &schema.ToolResult{
+				Parts: []schema.ToolOutputPart{{
+					Type: schema.ToolPartTypeText,
+					Text: "patched text",
+				}},
+			}, nil
+		},
+	})
+	require.NoError(t, err)
+
+	state := &adk.ChatModelAgentState{
+		Messages: []adk.Message{
+			schema.UserMessage("hello"),
+			schema.AssistantMessage("", []schema.ToolCall{
+				{ID: "call_1", Function: schema.FunctionCall{Name: "tool_a", Arguments: `{"q":"hi"}`}},
+			}),
+		},
+	}
+	_, newState, err := mw.BeforeModelRewriteState(ctx, state, nil)
+	require.NoError(t, err)
+	require.Len(t, newState.Messages, 3)
+
+	patched := newState.Messages[2]
+	assert.Equal(t, schema.Tool, patched.Role)
+	assert.Equal(t, "call_1", patched.ToolCallID)
+	assert.Equal(t, "tool_a", patched.ToolName)
+	assert.Equal(t, "patched text", patched.Content)
+	require.Len(t, patched.UserInputMultiContent, 1)
+	assert.Equal(t, schema.ChatMessagePartTypeText, patched.UserInputMultiContent[0].Type)
+	assert.Equal(t, "patched text", patched.UserInputMultiContent[0].Text)
 }
 
 func TestPatchToolCallsAgenticToolSearchResult(t *testing.T) {

--- a/adk/middlewares/patchtoolcalls/patchtoolcalls_test.go
+++ b/adk/middlewares/patchtoolcalls/patchtoolcalls_test.go
@@ -618,22 +618,38 @@ func TestToolResultToMessage_MultimodalDoesNotSetContent(t *testing.T) {
 
 func TestToolResultToAgenticMessage_ToolSearchAndEmpty(t *testing.T) {
 	search := &schema.ToolSearchResult{Tools: []*schema.ToolInfo{{Name: "dyn"}}}
-	msg := toolResultToAgenticMessage("tool_search", "call_1", &schema.ToolResult{
+	msg, err := toolResultToAgenticMessage("tool_search", "call_1", &schema.ToolResult{
 		Parts: []schema.ToolOutputPart{{
 			Type:             schema.ToolPartTypeToolSearchResult,
 			ToolSearchResult: search,
 		}},
 	})
+	require.NoError(t, err)
 	require.Len(t, msg.ContentBlocks, 1)
 	assert.Equal(t, schema.ContentBlockTypeToolSearchResult, msg.ContentBlocks[0].Type)
 	require.NotNil(t, msg.ContentBlocks[0].ToolSearchFunctionToolResult)
 	assert.Equal(t, search, msg.ContentBlocks[0].ToolSearchFunctionToolResult.Result)
 
-	empty := toolResultToAgenticMessage("tool_a", "call_2", nil)
+	empty, err := toolResultToAgenticMessage("tool_a", "call_2", nil)
+	require.NoError(t, err)
 	require.Len(t, empty.ContentBlocks, 1)
 	require.NotNil(t, empty.ContentBlocks[0].FunctionToolResult)
 	require.Len(t, empty.ContentBlocks[0].FunctionToolResult.Content, 1)
 	assert.Equal(t, "", empty.ContentBlocks[0].FunctionToolResult.Content[0].Text.Text)
+}
+
+func TestToolResultToAgenticMessage_MalformedPartsError(t *testing.T) {
+	_, err := toolResultToAgenticMessage("vision", "call_1", &schema.ToolResult{
+		Parts: []schema.ToolOutputPart{{Type: schema.ToolPartTypeImage}},
+	})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "image content is nil")
+
+	_, err = toolResultToAgenticMessage("tool_search", "call_2", &schema.ToolResult{
+		Parts: []schema.ToolOutputPart{{Type: schema.ToolPartTypeToolSearchResult}},
+	})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "tool search result is nil")
 }
 
 func TestToolResultToFunctionBlocks_AllModalities(t *testing.T) {
@@ -648,33 +664,29 @@ func TestToolResultToFunctionBlocks_AllModalities(t *testing.T) {
 					MessagePartCommon: schema.MessagePartCommon{URL: &url, Base64Data: &b64, MIMEType: "image/png"},
 				},
 			},
-			{Type: schema.ToolPartTypeImage}, // nil Image skipped
 			{
 				Type: schema.ToolPartTypeAudio,
 				Audio: &schema.ToolOutputAudio{
 					MessagePartCommon: schema.MessagePartCommon{URL: &url, MIMEType: "audio/mpeg"},
 				},
 			},
-			{Type: schema.ToolPartTypeAudio},
 			{
 				Type: schema.ToolPartTypeVideo,
 				Video: &schema.ToolOutputVideo{
 					MessagePartCommon: schema.MessagePartCommon{URL: &url, MIMEType: "video/mp4"},
 				},
 			},
-			{Type: schema.ToolPartTypeVideo},
 			{
 				Type: schema.ToolPartTypeFile,
 				File: &schema.ToolOutputFile{
 					MessagePartCommon: schema.MessagePartCommon{URL: nil, Base64Data: &b64, MIMEType: "application/pdf"},
 				},
 			},
-			{Type: schema.ToolPartTypeFile},
-			{Type: schema.ToolPartTypeToolSearchResult}, // ignored by function-block conversion
 		},
 	}
 
-	blocks := toolResultToFunctionBlocks(result)
+	blocks, err := toolResultToFunctionBlocks(result)
+	require.NoError(t, err)
 	require.Len(t, blocks, 5)
 	assert.Equal(t, schema.FunctionToolResultContentBlockTypeText, blocks[0].Type)
 	assert.Equal(t, "hello", blocks[0].Text.Text)
@@ -687,8 +699,57 @@ func TestToolResultToFunctionBlocks_AllModalities(t *testing.T) {
 	assert.Equal(t, "", blocks[4].File.URL)
 	assert.Equal(t, b64, blocks[4].File.Base64Data)
 
-	assert.Nil(t, toolResultToFunctionBlocks(nil))
-	assert.Nil(t, toolResultToFunctionBlocks(&schema.ToolResult{}))
+	blocks, err = toolResultToFunctionBlocks(nil)
+	require.NoError(t, err)
+	assert.Nil(t, blocks)
+	blocks, err = toolResultToFunctionBlocks(&schema.ToolResult{})
+	require.NoError(t, err)
+	assert.Nil(t, blocks)
+}
+
+func TestToolResultToFunctionBlocks_MalformedPartsError(t *testing.T) {
+	tests := []struct {
+		name    string
+		part    schema.ToolOutputPart
+		wantSub string
+	}{
+		{name: "nil image", part: schema.ToolOutputPart{Type: schema.ToolPartTypeImage}, wantSub: "image content is nil"},
+		{name: "nil audio", part: schema.ToolOutputPart{Type: schema.ToolPartTypeAudio}, wantSub: "audio content is nil"},
+		{name: "nil video", part: schema.ToolOutputPart{Type: schema.ToolPartTypeVideo}, wantSub: "video content is nil"},
+		{name: "nil file", part: schema.ToolOutputPart{Type: schema.ToolPartTypeFile}, wantSub: "file content is nil"},
+		{name: "tool search mixed", part: schema.ToolOutputPart{Type: schema.ToolPartTypeToolSearchResult, ToolSearchResult: &schema.ToolSearchResult{}}, wantSub: "tool search result must be the sole part"},
+		{name: "unknown type", part: schema.ToolOutputPart{Type: schema.ToolPartType("nope")}, wantSub: "unknown tool part type"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := toolResultToFunctionBlocks(&schema.ToolResult{Parts: []schema.ToolOutputPart{tt.part}})
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), tt.wantSub)
+		})
+	}
+}
+
+func TestPatchedToolResultGenerator_AgenticNilImagePropagatesError(t *testing.T) {
+	ctx := context.Background()
+	mw, err := NewTyped[*schema.AgenticMessage](ctx, &Config{
+		PatchedToolResultGenerator: func(context.Context, string, string, *schema.ToolArgument) (*schema.ToolResult, error) {
+			return &schema.ToolResult{
+				Parts: []schema.ToolOutputPart{{Type: schema.ToolPartTypeImage}},
+			}, nil
+		},
+	})
+	require.NoError(t, err)
+
+	state := &adk.TypedChatModelAgentState[*schema.AgenticMessage]{
+		Messages: []*schema.AgenticMessage{
+			makeAssistantMsgWithToolCalls[*schema.AgenticMessage]("", []testToolCall{
+				{ID: "call_1", Name: "vision", Arguments: "{}"},
+			}),
+		},
+	}
+	_, _, err = mw.BeforeModelRewriteState(ctx, state, nil)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "image content is nil")
 }
 
 func TestPatchedToolResultGenerator_AgenticMultimodal(t *testing.T) {

--- a/adk/middlewares/patchtoolcalls/patchtoolcalls_test.go
+++ b/adk/middlewares/patchtoolcalls/patchtoolcalls_test.go
@@ -224,16 +224,13 @@ func testPatchToolCallsGeneric[M adk.MessageType](t *testing.T) {
 		{
 			name: "custom tool result generator",
 			config: &Config{
-				PatchedToolResultGenerator: func(ctx context.Context, toolName, toolCallID string, toolArgument *schema.ToolArgument) (*schema.ToolResult, error) {
+				PatchedToolResultGenerator: func(ctx context.Context, toolName, toolCallID string, toolArgument *schema.ToolArgument) (*PatchedToolResult, error) {
 					argText := ""
 					if toolArgument != nil {
 						argText = toolArgument.Text
 					}
-					return &schema.ToolResult{
-						Parts: []schema.ToolOutputPart{{
-							Type: schema.ToolPartTypeText,
-							Text: fmt.Sprintf("result %s %s %s", toolName, toolCallID, argText),
-						}},
+					return &PatchedToolResult{
+						Content: fmt.Sprintf("result %s %s %s", toolName, toolCallID, argText),
 					}, nil
 				},
 			},
@@ -257,13 +254,8 @@ func testPatchToolCallsGeneric[M adk.MessageType](t *testing.T) {
 				PatchedContentGenerator: func(ctx context.Context, toolName, toolCallID string) (string, error) {
 					return "legacy", nil
 				},
-				PatchedToolResultGenerator: func(ctx context.Context, toolName, toolCallID string, toolArgument *schema.ToolArgument) (*schema.ToolResult, error) {
-					return &schema.ToolResult{
-						Parts: []schema.ToolOutputPart{{
-							Type: schema.ToolPartTypeText,
-							Text: "enhanced",
-						}},
-					}, nil
+				PatchedToolResultGenerator: func(ctx context.Context, toolName, toolCallID string, toolArgument *schema.ToolArgument) (*PatchedToolResult, error) {
+					return &PatchedToolResult{Content: "enhanced"}, nil
 				},
 			},
 			messages: []M{
@@ -342,17 +334,12 @@ func TestPatchToolCallsGeneric(t *testing.T) {
 func TestPatchedToolResultGenerator_SetsContentOnlyForPlainText(t *testing.T) {
 	ctx := context.Background()
 	mw, err := New(ctx, &Config{
-		PatchedToolResultGenerator: func(ctx context.Context, toolName, toolCallID string, toolArgument *schema.ToolArgument) (*schema.ToolResult, error) {
+		PatchedToolResultGenerator: func(ctx context.Context, toolName, toolCallID string, toolArgument *schema.ToolArgument) (*PatchedToolResult, error) {
 			require.Equal(t, "tool_a", toolName)
 			require.Equal(t, "call_1", toolCallID)
 			require.NotNil(t, toolArgument)
 			require.Equal(t, `{"q":"hi"}`, toolArgument.Text)
-			return &schema.ToolResult{
-				Parts: []schema.ToolOutputPart{{
-					Type: schema.ToolPartTypeText,
-					Text: "patched text",
-				}},
-			}, nil
+			return &PatchedToolResult{Content: "patched text"}, nil
 		},
 	})
 	require.NoError(t, err)
@@ -376,6 +363,62 @@ func TestPatchedToolResultGenerator_SetsContentOnlyForPlainText(t *testing.T) {
 	assert.Equal(t, "patched text", patched.Content)
 	assert.Empty(t, patched.UserInputMultiContent,
 		"plain-text tool results must not set UserInputMultiContent (OpenAI Content/MultiContent exclusivity)")
+}
+
+func TestPatchedToolResultGenerator_ToolResultPath(t *testing.T) {
+	ctx := context.Background()
+	mw, err := New(ctx, &Config{
+		PatchedToolResultGenerator: func(context.Context, string, string, *schema.ToolArgument) (*PatchedToolResult, error) {
+			return &PatchedToolResult{
+				ToolResult: &schema.ToolResult{
+					Parts: []schema.ToolOutputPart{{
+						Type: schema.ToolPartTypeText,
+						Text: "via tool result",
+					}},
+				},
+			}, nil
+		},
+	})
+	require.NoError(t, err)
+
+	state := &adk.ChatModelAgentState{
+		Messages: []adk.Message{
+			schema.AssistantMessage("", []schema.ToolCall{
+				{ID: "call_1", Function: schema.FunctionCall{Name: "tool_a", Arguments: "{}"}},
+			}),
+		},
+	}
+	_, newState, err := mw.BeforeModelRewriteState(ctx, state, nil)
+	require.NoError(t, err)
+	require.Len(t, newState.Messages, 2)
+	assert.Equal(t, "via tool result", newState.Messages[1].Content)
+	assert.Empty(t, newState.Messages[1].UserInputMultiContent)
+}
+
+func TestPatchedToolResultGenerator_ContentAndToolResultMutuallyExclusive(t *testing.T) {
+	ctx := context.Background()
+	mw, err := New(ctx, &Config{
+		PatchedToolResultGenerator: func(context.Context, string, string, *schema.ToolArgument) (*PatchedToolResult, error) {
+			return &PatchedToolResult{
+				Content: "plain",
+				ToolResult: &schema.ToolResult{
+					Parts: []schema.ToolOutputPart{{Type: schema.ToolPartTypeText, Text: "also"}},
+				},
+			}, nil
+		},
+	})
+	require.NoError(t, err)
+
+	state := &adk.ChatModelAgentState{
+		Messages: []adk.Message{
+			schema.AssistantMessage("", []schema.ToolCall{
+				{ID: "call_1", Function: schema.FunctionCall{Name: "tool_a", Arguments: "{}"}},
+			}),
+		},
+	}
+	_, _, err = mw.BeforeModelRewriteState(ctx, state, nil)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "mutually exclusive")
 }
 
 func TestPatchToolCallsAgenticToolSearchResult(t *testing.T) {
@@ -495,7 +538,7 @@ func TestPatchedToolResultGenerator_ErrorPropagation(t *testing.T) {
 
 	t.Run("Message", func(t *testing.T) {
 		mw, err := New(ctx, &Config{
-			PatchedToolResultGenerator: func(context.Context, string, string, *schema.ToolArgument) (*schema.ToolResult, error) {
+			PatchedToolResultGenerator: func(context.Context, string, string, *schema.ToolArgument) (*PatchedToolResult, error) {
 				return nil, wantErr
 			},
 		})
@@ -513,7 +556,7 @@ func TestPatchedToolResultGenerator_ErrorPropagation(t *testing.T) {
 
 	t.Run("AgenticMessage", func(t *testing.T) {
 		mw, err := NewTyped[*schema.AgenticMessage](ctx, &Config{
-			PatchedToolResultGenerator: func(context.Context, string, string, *schema.ToolArgument) (*schema.ToolResult, error) {
+			PatchedToolResultGenerator: func(context.Context, string, string, *schema.ToolArgument) (*PatchedToolResult, error) {
 				return nil, wantErr
 			},
 		})
@@ -732,9 +775,11 @@ func TestToolResultToFunctionBlocks_MalformedPartsError(t *testing.T) {
 func TestPatchedToolResultGenerator_AgenticNilImagePropagatesError(t *testing.T) {
 	ctx := context.Background()
 	mw, err := NewTyped[*schema.AgenticMessage](ctx, &Config{
-		PatchedToolResultGenerator: func(context.Context, string, string, *schema.ToolArgument) (*schema.ToolResult, error) {
-			return &schema.ToolResult{
-				Parts: []schema.ToolOutputPart{{Type: schema.ToolPartTypeImage}},
+		PatchedToolResultGenerator: func(context.Context, string, string, *schema.ToolArgument) (*PatchedToolResult, error) {
+			return &PatchedToolResult{
+				ToolResult: &schema.ToolResult{
+					Parts: []schema.ToolOutputPart{{Type: schema.ToolPartTypeImage}},
+				},
 			}, nil
 		},
 	})
@@ -756,15 +801,17 @@ func TestPatchedToolResultGenerator_AgenticMultimodal(t *testing.T) {
 	ctx := context.Background()
 	url := "https://example.com/img.png"
 	mw, err := NewTyped[*schema.AgenticMessage](ctx, &Config{
-		PatchedToolResultGenerator: func(ctx context.Context, toolName, toolCallID string, toolArgument *schema.ToolArgument) (*schema.ToolResult, error) {
+		PatchedToolResultGenerator: func(ctx context.Context, toolName, toolCallID string, toolArgument *schema.ToolArgument) (*PatchedToolResult, error) {
 			require.Equal(t, `{"q":1}`, toolArgument.Text)
-			return &schema.ToolResult{
-				Parts: []schema.ToolOutputPart{
-					{Type: schema.ToolPartTypeText, Text: "see image"},
-					{
-						Type: schema.ToolPartTypeImage,
-						Image: &schema.ToolOutputImage{
-							MessagePartCommon: schema.MessagePartCommon{URL: &url},
+			return &PatchedToolResult{
+				ToolResult: &schema.ToolResult{
+					Parts: []schema.ToolOutputPart{
+						{Type: schema.ToolPartTypeText, Text: "see image"},
+						{
+							Type: schema.ToolPartTypeImage,
+							Image: &schema.ToolOutputImage{
+								MessagePartCommon: schema.MessagePartCommon{URL: &url},
+							},
 						},
 					},
 				},

--- a/adk/middlewares/patchtoolcalls/patchtoolcalls_test.go
+++ b/adk/middlewares/patchtoolcalls/patchtoolcalls_test.go
@@ -489,3 +489,239 @@ func TestPatchToolCalls_AgenticMessage_NilBlockInUserMessage(t *testing.T) {
 	}
 	assert.True(t, foundResult, "patched message should contain tool result for call_1")
 }
+
+func TestPatchedToolResultGenerator_ErrorPropagation(t *testing.T) {
+	ctx := context.Background()
+	wantErr := fmt.Errorf("boom")
+
+	t.Run("Message", func(t *testing.T) {
+		mw, err := New(ctx, &Config{
+			PatchedToolResultGenerator: func(context.Context, string, string, *schema.ToolArgument) (*schema.ToolResult, error) {
+				return nil, wantErr
+			},
+		})
+		require.NoError(t, err)
+		state := &adk.ChatModelAgentState{
+			Messages: []adk.Message{
+				schema.AssistantMessage("", []schema.ToolCall{
+					{ID: "call_1", Function: schema.FunctionCall{Name: "tool_a", Arguments: "{}"}},
+				}),
+			},
+		}
+		_, _, err = mw.BeforeModelRewriteState(ctx, state, nil)
+		require.ErrorIs(t, err, wantErr)
+	})
+
+	t.Run("AgenticMessage", func(t *testing.T) {
+		mw, err := NewTyped[*schema.AgenticMessage](ctx, &Config{
+			PatchedToolResultGenerator: func(context.Context, string, string, *schema.ToolArgument) (*schema.ToolResult, error) {
+				return nil, wantErr
+			},
+		})
+		require.NoError(t, err)
+		state := &adk.TypedChatModelAgentState[*schema.AgenticMessage]{
+			Messages: []*schema.AgenticMessage{
+				makeAssistantMsgWithToolCalls[*schema.AgenticMessage]("", []testToolCall{
+					{ID: "call_1", Name: "tool_a", Arguments: `{"a":1}`},
+				}),
+			},
+		}
+		_, _, err = mw.BeforeModelRewriteState(ctx, state, nil)
+		require.ErrorIs(t, err, wantErr)
+	})
+}
+
+func TestPatchedContentGenerator_ErrorPropagation(t *testing.T) {
+	ctx := context.Background()
+	wantErr := fmt.Errorf("legacy boom")
+
+	t.Run("Message", func(t *testing.T) {
+		mw, err := New(ctx, &Config{
+			PatchedContentGenerator: func(context.Context, string, string) (string, error) {
+				return "", wantErr
+			},
+		})
+		require.NoError(t, err)
+		state := &adk.ChatModelAgentState{
+			Messages: []adk.Message{
+				schema.AssistantMessage("", []schema.ToolCall{
+					{ID: "call_1", Function: schema.FunctionCall{Name: "tool_a"}},
+				}),
+			},
+		}
+		_, _, err = mw.BeforeModelRewriteState(ctx, state, nil)
+		require.ErrorIs(t, err, wantErr)
+	})
+
+	t.Run("AgenticMessage", func(t *testing.T) {
+		mw, err := NewTyped[*schema.AgenticMessage](ctx, &Config{
+			PatchedContentGenerator: func(context.Context, string, string) (string, error) {
+				return "", wantErr
+			},
+		})
+		require.NoError(t, err)
+		state := &adk.TypedChatModelAgentState[*schema.AgenticMessage]{
+			Messages: []*schema.AgenticMessage{
+				makeAssistantMsgWithToolCalls[*schema.AgenticMessage]("", []testToolCall{
+					{ID: "call_1", Name: "tool_a", Arguments: "{}"},
+				}),
+			},
+		}
+		_, _, err = mw.BeforeModelRewriteState(ctx, state, nil)
+		require.ErrorIs(t, err, wantErr)
+	})
+}
+
+func TestToolResultToMessage_NilAndEmpty(t *testing.T) {
+	msg, err := toolResultToMessage("tool_a", "call_1", nil)
+	require.NoError(t, err)
+	assert.Equal(t, "call_1", msg.ToolCallID)
+	assert.Equal(t, "tool_a", msg.ToolName)
+	assert.Empty(t, msg.Content)
+	assert.Empty(t, msg.UserInputMultiContent)
+
+	msg, err = toolResultToMessage("tool_a", "call_1", &schema.ToolResult{})
+	require.NoError(t, err)
+	assert.Empty(t, msg.Content)
+	assert.Empty(t, msg.UserInputMultiContent)
+}
+
+func TestToolResultToMessage_MultimodalDoesNotSetContent(t *testing.T) {
+	url := "https://example.com/a.png"
+	result := &schema.ToolResult{
+		Parts: []schema.ToolOutputPart{
+			{Type: schema.ToolPartTypeText, Text: "caption"},
+			{
+				Type: schema.ToolPartTypeImage,
+				Image: &schema.ToolOutputImage{
+					MessagePartCommon: schema.MessagePartCommon{URL: &url, MIMEType: "image/png"},
+				},
+			},
+		},
+	}
+	msg, err := toolResultToMessage("vision", "call_1", result)
+	require.NoError(t, err)
+	assert.Empty(t, msg.Content, "multi-part results should not set Content")
+	require.Len(t, msg.UserInputMultiContent, 2)
+}
+
+func TestToolResultToAgenticMessage_ToolSearchAndEmpty(t *testing.T) {
+	search := &schema.ToolSearchResult{Tools: []*schema.ToolInfo{{Name: "dyn"}}}
+	msg := toolResultToAgenticMessage("tool_search", "call_1", &schema.ToolResult{
+		Parts: []schema.ToolOutputPart{{
+			Type:             schema.ToolPartTypeToolSearchResult,
+			ToolSearchResult: search,
+		}},
+	})
+	require.Len(t, msg.ContentBlocks, 1)
+	assert.Equal(t, schema.ContentBlockTypeToolSearchResult, msg.ContentBlocks[0].Type)
+	require.NotNil(t, msg.ContentBlocks[0].ToolSearchFunctionToolResult)
+	assert.Equal(t, search, msg.ContentBlocks[0].ToolSearchFunctionToolResult.Result)
+
+	empty := toolResultToAgenticMessage("tool_a", "call_2", nil)
+	require.Len(t, empty.ContentBlocks, 1)
+	require.NotNil(t, empty.ContentBlocks[0].FunctionToolResult)
+	require.Len(t, empty.ContentBlocks[0].FunctionToolResult.Content, 1)
+	assert.Equal(t, "", empty.ContentBlocks[0].FunctionToolResult.Content[0].Text.Text)
+}
+
+func TestToolResultToFunctionBlocks_AllModalities(t *testing.T) {
+	url := "https://example.com/x"
+	b64 := "YmFzZTY0"
+	result := &schema.ToolResult{
+		Parts: []schema.ToolOutputPart{
+			{Type: schema.ToolPartTypeText, Text: "hello", Extra: map[string]any{"k": "v"}},
+			{
+				Type: schema.ToolPartTypeImage,
+				Image: &schema.ToolOutputImage{
+					MessagePartCommon: schema.MessagePartCommon{URL: &url, Base64Data: &b64, MIMEType: "image/png"},
+				},
+			},
+			{Type: schema.ToolPartTypeImage}, // nil Image skipped
+			{
+				Type: schema.ToolPartTypeAudio,
+				Audio: &schema.ToolOutputAudio{
+					MessagePartCommon: schema.MessagePartCommon{URL: &url, MIMEType: "audio/mpeg"},
+				},
+			},
+			{Type: schema.ToolPartTypeAudio},
+			{
+				Type: schema.ToolPartTypeVideo,
+				Video: &schema.ToolOutputVideo{
+					MessagePartCommon: schema.MessagePartCommon{URL: &url, MIMEType: "video/mp4"},
+				},
+			},
+			{Type: schema.ToolPartTypeVideo},
+			{
+				Type: schema.ToolPartTypeFile,
+				File: &schema.ToolOutputFile{
+					MessagePartCommon: schema.MessagePartCommon{URL: nil, Base64Data: &b64, MIMEType: "application/pdf"},
+				},
+			},
+			{Type: schema.ToolPartTypeFile},
+			{Type: schema.ToolPartTypeToolSearchResult}, // ignored by function-block conversion
+		},
+	}
+
+	blocks := toolResultToFunctionBlocks(result)
+	require.Len(t, blocks, 5)
+	assert.Equal(t, schema.FunctionToolResultContentBlockTypeText, blocks[0].Type)
+	assert.Equal(t, "hello", blocks[0].Text.Text)
+	assert.Equal(t, schema.FunctionToolResultContentBlockTypeImage, blocks[1].Type)
+	assert.Equal(t, url, blocks[1].Image.URL)
+	assert.Equal(t, b64, blocks[1].Image.Base64Data)
+	assert.Equal(t, schema.FunctionToolResultContentBlockTypeAudio, blocks[2].Type)
+	assert.Equal(t, schema.FunctionToolResultContentBlockTypeVideo, blocks[3].Type)
+	assert.Equal(t, schema.FunctionToolResultContentBlockTypeFile, blocks[4].Type)
+	assert.Equal(t, "", blocks[4].File.URL)
+	assert.Equal(t, b64, blocks[4].File.Base64Data)
+
+	assert.Nil(t, toolResultToFunctionBlocks(nil))
+	assert.Nil(t, toolResultToFunctionBlocks(&schema.ToolResult{}))
+}
+
+func TestPatchedToolResultGenerator_AgenticMultimodal(t *testing.T) {
+	ctx := context.Background()
+	url := "https://example.com/img.png"
+	mw, err := NewTyped[*schema.AgenticMessage](ctx, &Config{
+		PatchedToolResultGenerator: func(ctx context.Context, toolName, toolCallID string, toolArgument *schema.ToolArgument) (*schema.ToolResult, error) {
+			require.Equal(t, `{"q":1}`, toolArgument.Text)
+			return &schema.ToolResult{
+				Parts: []schema.ToolOutputPart{
+					{Type: schema.ToolPartTypeText, Text: "see image"},
+					{
+						Type: schema.ToolPartTypeImage,
+						Image: &schema.ToolOutputImage{
+							MessagePartCommon: schema.MessagePartCommon{URL: &url},
+						},
+					},
+				},
+			}, nil
+		},
+	})
+	require.NoError(t, err)
+
+	state := &adk.TypedChatModelAgentState[*schema.AgenticMessage]{
+		Messages: []*schema.AgenticMessage{
+			makeAssistantMsgWithToolCalls[*schema.AgenticMessage]("", []testToolCall{
+				{ID: "call_1", Name: "vision", Arguments: `{"q":1}`},
+			}),
+		},
+	}
+	_, newState, err := mw.BeforeModelRewriteState(ctx, state, nil)
+	require.NoError(t, err)
+	require.Len(t, newState.Messages, 2)
+	patched := newState.Messages[1]
+	require.Len(t, patched.ContentBlocks, 1)
+	fr := patched.ContentBlocks[0].FunctionToolResult
+	require.NotNil(t, fr)
+	require.Len(t, fr.Content, 2)
+	assert.Equal(t, "see image", fr.Content[0].Text.Text)
+	assert.Equal(t, url, fr.Content[1].Image.URL)
+}
+
+func TestDerefString(t *testing.T) {
+	assert.Equal(t, "", derefString(nil))
+	s := "x"
+	assert.Equal(t, "x", derefString(&s))
+}

--- a/adk/middlewares/patchtoolcalls/patchtoolcalls_test.go
+++ b/adk/middlewares/patchtoolcalls/patchtoolcalls_test.go
@@ -339,7 +339,7 @@ func TestPatchToolCallsGeneric(t *testing.T) {
 	t.Run("AgenticMessage", testPatchToolCallsGeneric[*schema.AgenticMessage])
 }
 
-func TestPatchedToolResultGenerator_SetsContentAndMultiContent(t *testing.T) {
+func TestPatchedToolResultGenerator_SetsContentOnlyForPlainText(t *testing.T) {
 	ctx := context.Background()
 	mw, err := New(ctx, &Config{
 		PatchedToolResultGenerator: func(ctx context.Context, toolName, toolCallID string, toolArgument *schema.ToolArgument) (*schema.ToolResult, error) {
@@ -374,9 +374,8 @@ func TestPatchedToolResultGenerator_SetsContentAndMultiContent(t *testing.T) {
 	assert.Equal(t, "call_1", patched.ToolCallID)
 	assert.Equal(t, "tool_a", patched.ToolName)
 	assert.Equal(t, "patched text", patched.Content)
-	require.Len(t, patched.UserInputMultiContent, 1)
-	assert.Equal(t, schema.ChatMessagePartTypeText, patched.UserInputMultiContent[0].Type)
-	assert.Equal(t, "patched text", patched.UserInputMultiContent[0].Text)
+	assert.Empty(t, patched.UserInputMultiContent,
+		"plain-text tool results must not set UserInputMultiContent (OpenAI Content/MultiContent exclusivity)")
 }
 
 func TestPatchToolCallsAgenticToolSearchResult(t *testing.T) {
@@ -583,6 +582,18 @@ func TestToolResultToMessage_NilAndEmpty(t *testing.T) {
 	msg, err = toolResultToMessage("tool_a", "call_1", &schema.ToolResult{})
 	require.NoError(t, err)
 	assert.Empty(t, msg.Content)
+	assert.Empty(t, msg.UserInputMultiContent)
+}
+
+func TestToolResultToMessage_PlainTextSetsContentOnly(t *testing.T) {
+	msg, err := toolResultToMessage("tool_a", "call_1", &schema.ToolResult{
+		Parts: []schema.ToolOutputPart{{
+			Type: schema.ToolPartTypeText,
+			Text: "hello",
+		}},
+	})
+	require.NoError(t, err)
+	assert.Equal(t, "hello", msg.Content)
 	assert.Empty(t, msg.UserInputMultiContent)
 }
 


### PR DESCRIPTION
## Summary

- Deprecate `PatchedContentGenerator` (plain string) in `adk/middlewares/patchtoolcalls`.
- Add `PatchedToolResultGenerator`, aligned with EnhancedTool: receives `*schema.ToolArgument` and returns `*schema.ToolResult`.
- When both are set, `PatchedToolResultGenerator` takes precedence; otherwise fall back to the legacy generator, then the default cancel message.
- Message path maps `ToolResult` to tool messages via `UserInputMultiContent` (and sets `Content` for single-text results). AgenticMessage path maps to `FunctionToolResult` / tool-search result blocks.

This lets callers customize patched dangling-tool messages using the original tool-call arguments (e.g. inspect chapter write payload when a confirmation interrupt is abandoned).

## Test plan

- [x] `go test ./adk/middlewares/patchtoolcalls/ -count=1`
- [x] Existing generic Message / AgenticMessage cases still pass
- [x] New cases: result generator receives arguments; result generator overrides content generator; single-text result sets both `Content` and `UserInputMultiContent`


Made with [Cursor](https://cursor.com)