### PR TITLE
feat(adk): add session event status enums

### DIFF
--- a/adk/failover_chatmodel.go
+++ b/adk/failover_chatmodel.go
@@ -486,7 +486,7 @@ func emitFailoverRetryingTimeline[M MessageType](ctx context.Context, err error)
 		Error: &SessionErrorEvent{
 			Type:        SessionErrorTypeModelFailover,
 			Message:     timelineErrorMessage(err, nil),
-			RetryStatus: &RetryStatus{Type: "retrying"},
+			RetryStatus: &RetryStatus{Type: RetryStatusRetrying},
 		},
 	})
 }
@@ -501,7 +501,7 @@ func emitFailoverExhaustedTimeline[M MessageType](ctx context.Context, err error
 		Error: &SessionErrorEvent{
 			Type:        SessionErrorTypeModelFailover,
 			Message:     timelineErrorMessage(err, nil),
-			RetryStatus: &RetryStatus{Type: "exhausted"},
+			RetryStatus: &RetryStatus{Type: RetryStatusExhausted},
 		},
 	})
 }

--- a/adk/retry_chatmodel.go
+++ b/adk/retry_chatmodel.go
@@ -323,7 +323,7 @@ func emitRetryingTimeline[M MessageType](ctx context.Context, err error, rejectR
 		Error: &SessionErrorEvent{
 			Type:        SessionErrorTypeModelRetry,
 			Message:     timelineErrorMessage(err, reason),
-			RetryStatus: &RetryStatus{Type: "retrying"},
+			RetryStatus: &RetryStatus{Type: RetryStatusRetrying},
 		},
 	})
 }
@@ -335,7 +335,7 @@ func emitRetryExhaustedTimeline[M MessageType](ctx context.Context, err error) {
 		Error: &SessionErrorEvent{
 			Type:        SessionErrorTypeModelRetry,
 			Message:     timelineErrorMessage(err, nil),
-			RetryStatus: &RetryStatus{Type: "exhausted"},
+			RetryStatus: &RetryStatus{Type: RetryStatusExhausted},
 		},
 	})
 }

--- a/adk/runner.go
+++ b/adk/runner.go
@@ -1132,20 +1132,20 @@ func typedRunnerHandleIterImpl[M MessageType](enableStreaming bool, store CheckP
 		gen.Send(event)
 	}
 	if persister != nil {
-		stopReason := "end_turn"
+		stopReason := StopReasonEndTurn
 		switch {
 		case interrupted:
-			stopReason = "interrupted"
+			stopReason = StopReasonInterrupted
 		case cancelled:
-			stopReason = "cancelled"
+			stopReason = StopReasonCancelled
 		case retryExhausted:
-			stopReason = "retries_exhausted"
+			stopReason = StopReasonRetriesExhausted
 		case persistErr != nil:
-			stopReason = "failed"
+			stopReason = StopReasonFailed
 		case terminalErr != nil:
-			stopReason = "failed"
+			stopReason = StopReasonFailed
 		}
-		if stopReason == "failed" {
+		if stopReason == StopReasonFailed {
 			errMsg := ""
 			if persistErr != nil {
 				errMsg = persistErr.Error()

--- a/adk/session.go
+++ b/adk/session.go
@@ -279,8 +279,27 @@ const (
 )
 
 type StopReason struct {
+	// Type identifies why a session run returned to idle. It remains a string
+	// for gob compatibility with previously persisted SessionEvent bytes;
+	// compare it with the StopReason* constants.
 	Type string `json:"type,omitempty"`
 }
+
+// StopReasonType identifies why a session run returned to idle.
+type StopReasonType = string
+
+const (
+	// StopReasonEndTurn means the agent completed the current turn normally.
+	StopReasonEndTurn StopReasonType = "end_turn"
+	// StopReasonInterrupted means the run paused for an interrupt.
+	StopReasonInterrupted StopReasonType = "interrupted"
+	// StopReasonCancelled means the run was cancelled before normal completion.
+	StopReasonCancelled StopReasonType = "cancelled"
+	// StopReasonRetriesExhausted means model retry attempts were exhausted.
+	StopReasonRetriesExhausted StopReasonType = "retries_exhausted"
+	// StopReasonFailed means the run ended with a non-retry terminal failure.
+	StopReasonFailed StopReasonType = "failed"
+)
 
 type ModelContextEvent struct {
 	ToolInfos         []*schema.ToolInfo `json:"tool_infos,omitempty"`
@@ -302,8 +321,23 @@ const (
 )
 
 type RetryStatus struct {
+	// Type identifies whether a retry-like mechanism is still retrying or has
+	// exhausted its attempts. It remains a string for gob compatibility with
+	// previously persisted SessionEvent bytes; compare it with the RetryStatus*
+	// constants.
 	Type string `json:"type,omitempty"`
 }
+
+// RetryStatusType identifies whether a retry-like mechanism is still retrying
+// or has exhausted its configured attempts.
+type RetryStatusType = string
+
+const (
+	// RetryStatusRetrying means another retry or failover attempt will be made.
+	RetryStatusRetrying RetryStatusType = "retrying"
+	// RetryStatusExhausted means the configured retry or failover attempts are exhausted.
+	RetryStatusExhausted RetryStatusType = "exhausted"
+)
 
 type SpanEvent struct {
 	SpanID       string `json:"span_id"`
@@ -1793,5 +1827,5 @@ func isCommittedIdleEvent[M MessageType](event *SessionEvent[M]) bool {
 		event.Lifecycle != nil &&
 		event.Lifecycle.State == SessionRunStateIdle &&
 		event.Lifecycle.StopReason != nil &&
-		event.Lifecycle.StopReason.Type == "end_turn"
+		event.Lifecycle.StopReason.Type == StopReasonEndTurn
 }

--- a/adk/session/conformance.go
+++ b/adk/session/conformance.go
@@ -425,7 +425,7 @@ func committedIdleEvent[M adk.MessageType](id string) *adk.SessionEvent[M] {
 		Kind:    adk.SessionEventSessionStatusIdle,
 		Lifecycle: &adk.LifecycleEvent{
 			State:      adk.SessionRunStateIdle,
-			StopReason: &adk.StopReason{Type: "end_turn"},
+			StopReason: &adk.StopReason{Type: adk.StopReasonEndTurn},
 		},
 	}
 }

--- a/adk/session/in_memory_store_test.go
+++ b/adk/session/in_memory_store_test.go
@@ -203,7 +203,7 @@ func testCommittedIdleEvent(id, turnID string) *adk.SessionEvent[*schema.Message
 		Kind:    adk.SessionEventSessionStatusIdle,
 		Lifecycle: &adk.LifecycleEvent{
 			State:      adk.SessionRunStateIdle,
-			StopReason: &adk.StopReason{Type: "end_turn"},
+			StopReason: &adk.StopReason{Type: adk.StopReasonEndTurn},
 		},
 	}
 }

--- a/adk/session_test.go
+++ b/adk/session_test.go
@@ -137,7 +137,7 @@ func withTestCommittedIdle[M MessageType](eventID string) *SessionEvent[M] {
 		Kind:    SessionEventSessionStatusIdle,
 		Lifecycle: &LifecycleEvent{
 			State:      SessionRunStateIdle,
-			StopReason: &StopReason{Type: "end_turn"},
+			StopReason: &StopReason{Type: StopReasonEndTurn},
 		},
 	})
 }
@@ -218,7 +218,7 @@ func appendCommittedTestTurn(t *testing.T, ctx context.Context, store testSessio
 		Kind:    SessionEventSessionStatusIdle,
 		Lifecycle: &LifecycleEvent{
 			State:      SessionRunStateIdle,
-			StopReason: &StopReason{Type: "end_turn"},
+			StopReason: &StopReason{Type: StopReasonEndTurn},
 		},
 	})
 }
@@ -3179,7 +3179,7 @@ func TestAttack_ReconstructionIncludesInterruptedTailOnResume(t *testing.T) {
 	events := []*SessionEvent[*schema.Message]{
 		{EventID: uuid.NewString(), Kind: SessionEventSessionStatusRunning, Lifecycle: &LifecycleEvent{State: SessionRunStateRunning}},
 		{EventID: uuid.NewString(), Kind: SessionEventMessage, Message: committedMsg},
-		{EventID: uuid.NewString(), Kind: SessionEventSessionStatusIdle, Lifecycle: &LifecycleEvent{State: SessionRunStateIdle, StopReason: &StopReason{Type: "end_turn"}}},
+		{EventID: uuid.NewString(), Kind: SessionEventSessionStatusIdle, Lifecycle: &LifecycleEvent{State: SessionRunStateIdle, StopReason: &StopReason{Type: StopReasonEndTurn}}},
 	}
 
 	// An interrupted run: a Message event with no committed idle.
@@ -3698,7 +3698,7 @@ func TestStreamPersistence_IncompleteStreamExcludedFromReconstruction(t *testing
 		Kind: SessionEventSessionStatusIdle,
 		Lifecycle: &LifecycleEvent{
 			State:      SessionRunStateIdle,
-			StopReason: &StopReason{Type: "end_turn"},
+			StopReason: &StopReason{Type: StopReasonEndTurn},
 		},
 	})
 

--- a/adk/session_timeline_test.go
+++ b/adk/session_timeline_test.go
@@ -44,7 +44,7 @@ func init() {
 	schema.RegisterName[*sessionTimelineExtensionPayload]("_eino_adk_session_timeline_extension_payload")
 }
 
-func requireStoredIdleStopReason(t *testing.T, raw []storedSessionEvent, want string) *SessionEvent[*schema.Message] {
+func requireStoredIdleStopReason(t *testing.T, raw []storedSessionEvent, want StopReasonType) *SessionEvent[*schema.Message] {
 	t.Helper()
 	idleEvents := filterStoredSessionEvents(t, raw, func(se *SessionEvent[*schema.Message]) bool {
 		return se.Kind == SessionEventSessionStatusIdle
@@ -55,6 +55,54 @@ func requireStoredIdleStopReason(t *testing.T, raw []storedSessionEvent, want st
 	require.NotNil(t, last.Lifecycle.StopReason)
 	assert.Equal(t, want, last.Lifecycle.StopReason.Type)
 	return last
+}
+
+func TestSessionTimeline_GobDecodesLegacyStringStatusFields(t *testing.T) {
+	type legacyStopReason struct {
+		Type string
+	}
+	type legacyLifecycleEvent struct {
+		State      SessionRunState
+		StopReason *legacyStopReason
+	}
+	type legacyRetryStatus struct {
+		Type string
+	}
+	type legacySessionErrorEvent struct {
+		Type        string
+		Message     string
+		RetryStatus *legacyRetryStatus
+	}
+	type legacySessionEvent struct {
+		Kind      SessionEventKind
+		Lifecycle *legacyLifecycleEvent
+		Error     *legacySessionErrorEvent
+	}
+
+	legacy := legacySessionEvent{
+		Kind: SessionEventSessionStatusIdle,
+		Lifecycle: &legacyLifecycleEvent{
+			State:      SessionRunStateIdle,
+			StopReason: &legacyStopReason{Type: StopReasonEndTurn},
+		},
+		Error: &legacySessionErrorEvent{
+			Type:        SessionErrorTypeModelRetry,
+			Message:     "retry pending",
+			RetryStatus: &legacyRetryStatus{Type: RetryStatusRetrying},
+		},
+	}
+
+	var buf bytes.Buffer
+	require.NoError(t, gob.NewEncoder(&buf).Encode(legacy))
+
+	var decoded SessionEvent[*schema.Message]
+	require.NoError(t, gob.NewDecoder(&buf).Decode(&decoded))
+	require.NotNil(t, decoded.Lifecycle)
+	require.NotNil(t, decoded.Lifecycle.StopReason)
+	assert.Equal(t, StopReasonEndTurn, decoded.Lifecycle.StopReason.Type)
+	require.NotNil(t, decoded.Error)
+	require.NotNil(t, decoded.Error.RetryStatus)
+	assert.Equal(t, RetryStatusRetrying, decoded.Error.RetryStatus.Type)
 }
 
 func TestSessionTimeline_ClassifyAndSerializeVariants(t *testing.T) {
@@ -72,7 +120,7 @@ func TestSessionTimeline_ClassifyAndSerializeVariants(t *testing.T) {
 		},
 		{
 			name: "session error",
-			se:   &SessionEvent[*schema.Message]{Error: &SessionErrorEvent{Type: SessionErrorTypeModelRetry, Message: "busy", RetryStatus: &RetryStatus{Type: "retrying"}}},
+			se:   &SessionEvent[*schema.Message]{Error: &SessionErrorEvent{Type: SessionErrorTypeModelRetry, Message: "busy", RetryStatus: &RetryStatus{Type: RetryStatusRetrying}}},
 			kind: SessionEventSessionError,
 		},
 		{
@@ -236,7 +284,7 @@ func TestSessionTimeline_ReconstructionIgnoresNonContextVariants(t *testing.T) {
 				},
 			},
 		}},
-		{EventID: uuid.NewString(), Kind: SessionEventSessionError, Error: &SessionErrorEvent{Type: "transient", RetryStatus: &RetryStatus{Type: "retrying"}}},
+		{EventID: uuid.NewString(), Kind: SessionEventSessionError, Error: &SessionErrorEvent{Type: "transient", RetryStatus: &RetryStatus{Type: RetryStatusRetrying}}},
 		{EventID: uuid.NewString(), Kind: SessionEventModelContext, ModelContext: &ModelContextEvent{}},
 	}
 	for _, se := range events {
@@ -358,7 +406,7 @@ func TestRunner_PersistsAgentInterruptSessionEvent(t *testing.T) {
 	ctx0 := interrupts[0].Interrupt.Contexts[0]
 	assert.Equal(t, liveInterruptContexts[0].ID, ctx0.InterruptID)
 	assert.Equal(t, liveInterruptContexts[0].Info, ctx0.Info)
-	requireStoredIdleStopReason(t, store.events, "interrupted")
+	requireStoredIdleStopReason(t, store.events, StopReasonInterrupted)
 
 	committedIdleEvents := filterStoredSessionEvents(t, store.events, func(se *SessionEvent[*schema.Message]) bool {
 		return isCommittedIdleEvent(se)
@@ -382,11 +430,11 @@ func TestSessionTimeline_ReconstructionIncludesPartialContextAfterLatestCommitte
 	events := []*SessionEvent[*schema.Message]{
 		{EventID: uuid.NewString(), Kind: SessionEventMessage, Message: committedUser},
 		{EventID: uuid.NewString(), Kind: SessionEventMessage, Message: committedAssistant},
-		{EventID: uuid.NewString(), Kind: SessionEventSessionStatusIdle, Lifecycle: &LifecycleEvent{State: SessionRunStateIdle, StopReason: &StopReason{Type: "end_turn"}}},
+		{EventID: uuid.NewString(), Kind: SessionEventSessionStatusIdle, Lifecycle: &LifecycleEvent{State: SessionRunStateIdle, StopReason: &StopReason{Type: StopReasonEndTurn}}},
 		{EventID: uuid.NewString(), Kind: SessionEventSessionStatusRunning, Lifecycle: &LifecycleEvent{State: SessionRunStateRunning}},
 		{EventID: uuid.NewString(), Kind: SessionEventMessage, Message: partialUser},
 		{EventID: uuid.NewString(), Kind: SessionEventMessage, Message: partialAssistant},
-		{EventID: uuid.NewString(), Kind: SessionEventSessionError, Error: &SessionErrorEvent{Type: SessionErrorTypeModelRetry, RetryStatus: &RetryStatus{Type: "retrying"}}},
+		{EventID: uuid.NewString(), Kind: SessionEventSessionError, Error: &SessionErrorEvent{Type: SessionErrorTypeModelRetry, RetryStatus: &RetryStatus{Type: RetryStatusRetrying}}},
 	}
 	for _, se := range events {
 		require.NoError(t, store.AppendEventsForSession(ctx, sid, []*SessionEvent[*schema.Message]{se}))
@@ -415,7 +463,7 @@ func TestSessionTimeline_ReconstructionPartialContextMissingAnchorFails(t *testi
 
 	events := []*SessionEvent[*schema.Message]{
 		{EventID: uuid.NewString(), Kind: SessionEventMessage, Message: committedUser},
-		{EventID: uuid.NewString(), Kind: SessionEventSessionStatusIdle, Lifecycle: &LifecycleEvent{State: SessionRunStateIdle, StopReason: &StopReason{Type: "end_turn"}}},
+		{EventID: uuid.NewString(), Kind: SessionEventSessionStatusIdle, Lifecycle: &LifecycleEvent{State: SessionRunStateIdle, StopReason: &StopReason{Type: StopReasonEndTurn}}},
 		{EventID: uuid.NewString(), Kind: SessionEventMessageInserted, MessageInserted: &MessageInsertedEvent[*schema.Message]{
 			Message:         inserted,
 			BeforeMessageID: "missing-anchor",
@@ -439,7 +487,7 @@ func TestSessionTimeline_CommittedIdleIsReplayBoundaryOnly(t *testing.T) {
 
 	events := []*SessionEvent[*schema.Message]{
 		{EventID: uuid.NewString(), Kind: SessionEventMessage, Message: committedUser},
-		{EventID: uuid.NewString(), Kind: SessionEventSessionStatusIdle, Lifecycle: &LifecycleEvent{State: SessionRunStateIdle, StopReason: &StopReason{Type: "end_turn"}}},
+		{EventID: uuid.NewString(), Kind: SessionEventSessionStatusIdle, Lifecycle: &LifecycleEvent{State: SessionRunStateIdle, StopReason: &StopReason{Type: StopReasonEndTurn}}},
 		{EventID: uuid.NewString(), Kind: SessionEventMessage, Message: partialUser},
 		{EventID: uuid.NewString(), Kind: "turn_end"},
 	}
@@ -473,7 +521,7 @@ func TestWithTimelineEvents_LiveExposure(t *testing.T) {
 			return se.Kind == SessionEventSessionStatusRunning || se.Kind == SessionEventSessionStatusIdle
 		})
 		require.Len(t, lifecycle, 2)
-		requireStoredIdleStopReason(t, store.events, "end_turn")
+		requireStoredIdleStopReason(t, store.events, StopReasonEndTurn)
 	})
 
 	t.Run("exposed when requested", func(t *testing.T) {
@@ -1019,7 +1067,7 @@ func TestFailoverTimelineLinksAttemptsAndEmitsSessionErrors(t *testing.T) {
 	assert.Equal(t, 2, starts[1].Span.Model.Attempt)
 	assert.Equal(t, "logical-model", starts[0].Span.Model.Model)
 	require.Len(t, failoverErrors, 1)
-	assert.Equal(t, "retrying", failoverErrors[0].Error.RetryStatus.Type)
+	assert.Equal(t, RetryStatusRetrying, failoverErrors[0].Error.RetryStatus.Type)
 }
 
 func TestSessionTimeline_EventIDMismatchRejectedAtPersistenceBoundary(t *testing.T) {
@@ -1177,11 +1225,11 @@ func TestRetryAndFailoverTimelineKeepsDistinctErrorTypes(t *testing.T) {
 		}
 		switch event.SessionEventVariant.Event.Error.Type {
 		case SessionErrorTypeModelRetry:
-			if event.SessionEventVariant.Event.Error.RetryStatus != nil && event.SessionEventVariant.Event.Error.RetryStatus.Type == "exhausted" {
+			if event.SessionEventVariant.Event.Error.RetryStatus != nil && event.SessionEventVariant.Event.Error.RetryStatus.Type == RetryStatusExhausted {
 				retryExhausted = true
 			}
 		case SessionErrorTypeModelFailover:
-			if event.SessionEventVariant.Event.Error.RetryStatus != nil && event.SessionEventVariant.Event.Error.RetryStatus.Type == "retrying" {
+			if event.SessionEventVariant.Event.Error.RetryStatus != nil && event.SessionEventVariant.Event.Error.RetryStatus.Type == RetryStatusRetrying {
 				failoverRetrying = true
 			}
 		}
@@ -1228,7 +1276,7 @@ func TestRunnerTimelineRetryExhaustedStopReason(t *testing.T) {
 		}
 	}
 
-	requireStoredIdleStopReason(t, store.events, "retries_exhausted")
+	requireStoredIdleStopReason(t, store.events, StopReasonRetriesExhausted)
 
 	turnEnds := filterStoredSessionEvents(t, store.events, func(se *SessionEvent[*schema.Message]) bool {
 		return isCommittedIdleEvent(se)
@@ -1269,7 +1317,7 @@ func TestRunnerTimelineFailedStopReason(t *testing.T) {
 	require.NotNil(t, sessionErrors[len(sessionErrors)-1].Error)
 	assert.Equal(t, SessionErrorTypeFatal, sessionErrors[len(sessionErrors)-1].Error.Type)
 	assert.Equal(t, "boom", sessionErrors[len(sessionErrors)-1].Error.Message)
-	requireStoredIdleStopReason(t, store.events, "failed")
+	requireStoredIdleStopReason(t, store.events, StopReasonFailed)
 
 	committedIdleEvents := filterStoredSessionEvents(t, store.events, func(se *SessionEvent[*schema.Message]) bool {
 		return isCommittedIdleEvent(se)
@@ -1320,7 +1368,7 @@ func TestRunnerTimelineModelCallFatalDoesNotRequireCommitMarker(t *testing.T) {
 	require.NotNil(t, sessionErrors[len(sessionErrors)-1].Error)
 	assert.Equal(t, SessionErrorTypeFatal, sessionErrors[len(sessionErrors)-1].Error.Type)
 	assert.Contains(t, sessionErrors[len(sessionErrors)-1].Error.Message, modelErr.Error())
-	requireStoredIdleStopReason(t, store.events, "failed")
+	requireStoredIdleStopReason(t, store.events, StopReasonFailed)
 
 	turnEnds := filterStoredSessionEvents(t, store.events, func(se *SessionEvent[*schema.Message]) bool {
 		return isCommittedIdleEvent(se)
@@ -1386,7 +1434,7 @@ func TestRunnerTimelineCancelStopReasonAndUserInterruptPersisted(t *testing.T) {
 	assert.Equal(t, SessionEventKind("cancel"), userInterrupts[0].Kind)
 	require.NotNil(t, userInterrupts[0].Cancel)
 	assert.Equal(t, "cancelled", userInterrupts[0].Cancel.Reason)
-	requireStoredIdleStopReason(t, store.events, "cancelled")
+	requireStoredIdleStopReason(t, store.events, StopReasonCancelled)
 
 	turnEnds := filterStoredSessionEvents(t, store.events, func(se *SessionEvent[*schema.Message]) bool {
 		return isCommittedIdleEvent(se)


### PR DESCRIPTION
# Typed Session Event Status Values

## Problem

`status_idle.stop_reason.type` and `session.error.retry_status.type` were exposed as plain strings. The wire values were stable, but Go clients had no exported names to compare against, so integrations had to repeat string literals such as `"end_turn"`, `"retries_exhausted"`, `"retrying"`, and `"exhausted"`.

That makes client code brittle: a typo still compiles, and every integration has to rediscover the same status vocabulary.

## Solution

Add exported constants for the existing status vocabulary:

```go
type StopReasonType = string
type RetryStatusType = string
```

`StopReason.Type` and `RetryStatus.Type` intentionally remain `string`. This keeps gob compatibility for already persisted `SessionEvent` bytes while still giving clients stable exported names to compare against.

## Key Insight

Session timeline events are already the compatibility boundary for clients. The right fix is not to change the event shape or persisted field types, but to give the existing event vocabulary exported Go names while keeping the model-facing, wire-facing, and gob-facing strings unchanged.

## Summary

| Problem | Solution |
|---------|----------|
| Clients compare `StopReason.Type` using raw strings | Export `StopReason*` constants for all current stop reasons |
| Clients compare `RetryStatus.Type` using raw strings | Export `RetryStatus*` constants for retrying and exhausted states |
| Existing persisted gob events encode `Type` as `string` | Keep `StopReason.Type` and `RetryStatus.Type` as `string` |

---

# 类型化 Session Event 状态值

## 问题

`status_idle.stop_reason.type` 和 `session.error.retry_status.type` 之前以普通字符串暴露。wire value 是稳定的，但 Go 客户端没有可引用的导出名称，只能重复写 `"end_turn"`、`"retries_exhausted"`、`"retrying"`、`"exhausted"` 这类字符串。

这会让集成代码变脆：拼写错误也能编译通过，而且每个集成都要重新维护同一套状态词表。

## 解决方案

为现有状态词表增加导出常量：

```go
type StopReasonType = string
type RetryStatusType = string
```

`StopReason.Type` 和 `RetryStatus.Type` 刻意保持为 `string`。这样既能让客户端使用稳定的导出名称进行比较，也能保持已持久化 `SessionEvent` gob bytes 的兼容性。

## 关键洞察

Session timeline event 本身就是客户端兼容边界。这里不应该改变事件结构或持久化字段类型；正确做法是给现有事件词表提供导出的 Go 名称，同时保持 model-facing、wire-facing 和 gob-facing 的字符串不变。

## 总结

| 问题 | 解决方案 |
|------|----------|
| 客户端只能用 raw string 比较 `StopReason.Type` | 为所有当前 stop reason 导出 `StopReason*` 常量 |
| 客户端只能用 raw string 比较 `RetryStatus.Type` | 为 retrying 和 exhausted 状态导出 `RetryStatus*` 常量 |
| 已持久化 gob event 将 `Type` 编码为 `string` | 保持 `StopReason.Type` 和 `RetryStatus.Type` 为 `string` |
