### PR TITLE
  fix(compose): validate underlying type after pointer dereference in validateStructOrMap

### DIFF
--- a/compose/field_mapping.go
+++ b/compose/field_mapping.go
@@ -636,7 +636,10 @@ func validateStructOrMap(t reflect.Type) bool {
 		t = t.Elem()
 		fallthrough
 	case reflect.Struct:
-		return true
+		// After dereferencing a pointer, the underlying type must still be
+		// a struct or a map (e.g. *map[string]any is acceptable, but *int is
+		// not, since it has no fields to map).
+		return t.Kind() == reflect.Struct || t.Kind() == reflect.Map
 	default:
 		return false
 	}

--- a/compose/field_mapping_test.go
+++ b/compose/field_mapping_test.go
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2026 CloudWeGo Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package compose
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestValidateStructOrMap(t *testing.T) {
+	type S struct {
+		A int
+	}
+	type M map[string]any
+
+	tests := []struct {
+		name string
+		typ  reflect.Type
+		want bool
+	}{
+		{"struct", reflect.TypeOf(S{}), true},
+		{"map", reflect.TypeOf(M{}), true},
+		{"ptr_to_struct", reflect.TypeOf(&S{}), true},
+		{"ptr_to_map", reflect.TypeOf(&M{}), true},
+		{"ptr_to_scalar", reflect.TypeOf((*int)(nil)), false},
+		{"scalar", reflect.TypeOf(0), false},
+		{"ptr_to_string", reflect.TypeOf((*string)(nil)), false},
+		{"slice", reflect.TypeOf([]int{}), false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := validateStructOrMap(tt.typ); got != tt.want {
+				t.Errorf("validateStructOrMap(%v) = %v, want %v", tt.typ, got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
#### What type of PR is this?
fix

#### Check the PR title.
- [x] This PR title match the format: <type>(optional scope): <description>
- [x] The description of this PR title is user-oriented and clear enough for others to understand.

#### Translate the PR title into Chinese.
`fix(compose): 修复 validateStructOrMap 对指针类型解引用后未校验底层类型的问题`

#### More detailed description for this PR
##### English
`validateStructOrMap` dereferences a pointer type via `t = t.Elem()` and then falls through to return `true` unconditionally, without checking the underlying type. As a result, any pointer type such as `*int` or `*string` is incorrectly accepted as a valid struct/map type for field mapping.

This fix checks that the dereferenced type is still a struct or map
(e.g. `*map[string]any` is valid, but `*int` is not), keeping the original behavior for non-pointer types unchanged.

The bug was originally surfaced by `staticcheck` (SA4006: "this value of t is never used"), which the project's CI does not run, so it went unnoticed.

Added unit tests covering struct, map, pointer-to-struct, pointer-to-map,
pointer-to-scalar, scalar, pointer-to-string and slice types.

##### 中文说明
`validateStructOrMap` 在通过 `t = t.Elem()` 解引用指针类型之后直接无条件返回 `true`，没有对解引用后的底层类型做合法性校验。
这就造成 `*int`、`*string` 这类普通指针会被错误判定为可用于字段映射的合法结构体/Map 类型。

本次修复逻辑：指针解引用之后二次校验底层类型必须是 struct 或 map。
示例：`*map[string]any` 合法，`*int`、`*string` 这类基础类型指针拦截不通过；非指针类型原有校验逻辑完全保留不变。

该隐患最先是 staticcheck 规则 SA4006（变量t赋值后未使用）检测出来的，项目现有CI未接入 staticcheck，因此长期遗漏。

配套新增单元测试，覆盖场景：
普通结构体、普通Map、结构体指针、Map指针、基础类型指针、原生基础类型、string指针、切片类型。

#### (Optional) Which issue(s) this PR fixes:
N/A

#### (Optional) The PR that updates user documentation:
N/A