### PR TITLE
  fix(compose): validate underlying type after pointer dereference in validateStructOrMap

### DIFF
--- a/compose/field_mapping.go
+++ b/compose/field_mapping.go
@@ -636,7 +636,10 @@ func validateStructOrMap(t reflect.Type) bool {
 		t = t.Elem()
 		fallthrough
 	case reflect.Struct:
-		return true
+		// After dereferencing a pointer, the underlying type must still be
+		// a struct or a map (e.g. *map[string]any is acceptable, but *int is
+		// not, since it has no fields to map).
+		return t.Kind() == reflect.Struct || t.Kind() == reflect.Map
 	default:
 		return false
 	}

--- a/compose/field_mapping_test.go
+++ b/compose/field_mapping_test.go
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2026 CloudWeGo Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package compose
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestValidateStructOrMap(t *testing.T) {
+	type S struct {
+		A int
+	}
+	type M map[string]any
+
+	tests := []struct {
+		name string
+		typ  reflect.Type
+		want bool
+	}{
+		{"struct", reflect.TypeOf(S{}), true},
+		{"map", reflect.TypeOf(M{}), true},
+		{"ptr_to_struct", reflect.TypeOf(&S{}), true},
+		{"ptr_to_map", reflect.TypeOf(&M{}), true},
+		{"ptr_to_scalar", reflect.TypeOf((*int)(nil)), false},
+		{"scalar", reflect.TypeOf(0), false},
+		{"ptr_to_string", reflect.TypeOf((*string)(nil)), false},
+		{"slice", reflect.TypeOf([]int{}), false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := validateStructOrMap(tt.typ); got != tt.want {
+				t.Errorf("validateStructOrMap(%v) = %v, want %v", tt.typ, got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
  #### What type of PR is this?
  fix

  #### Check the PR title.
  - [x] This PR title match the format: <type>(optional scope): <description>
  - [x] The description of this PR title is user-oriented and clear enough for others to understand.

  #### Translate the PR title into Chinese.
  `fix(compose): 修复 validateStructOrMap 对指针类型解引用后未校验底层类型的问题`

  #### More detailed description for this PR

  en:
  `validateStructOrMap` dereferences a pointer type via `t = t.Elem()` and then
  falls through to return `true` unconditionally, without checking the underlying
  type. As a result, any pointer type such as `*int` or `*string` is incorrectly
  accepted as a valid struct/map type for field mapping.

  This fix checks that the dereferenced type is still a struct or map
  (e.g. `*map[string]any` is valid, but `*int` is not), keeping the original
  behavior for non-pointer types unchanged.

  The bug was originally surfaced by `staticcheck` (SA4006: "this value of t is
  never used"), which the project's CI does not run, so it went unnoticed.

  Added unit tests covering struct, map, pointer-to-struct, pointer-to-map,
  pointer-to-scalar, scalar, pointer-to-string and slice types.

  zh:
  `validateStructOrMap` 在解引用指针类型（`t = t.Elem()`）后直接 `return true`，
  未校验底层类型，导致 `*int`、`*string` 等任意指针类型被误判为合法的
  struct/map 字段映射目标。

  本次修复在解引用后检查底层类型仍为 struct 或 map（`*map[string]any` 合法，
  `*int` 不合法），非指针类型的原有行为保持不变。

  该问题最初由 `staticcheck`（SA4006："this value of t is never used"）暴露，
  但项目 CI 未运行 staticcheck，因此一直未被发现。

  补充了覆盖 struct / map / 指针→struct / 指针→map / 指针→标量 / 标量 /
  指针→string / slice 共 8 种类型的单元测试。

  #### (Optional) Which issue(s) this PR fixes:
  N/A

  #### (Optional) The PR that updates user documentation:
  N/A