### PR TITLE
fix(adk): harden background task cancellation and shutdown

### DIFF
--- a/adk/backgroundtask/executor.go
+++ b/adk/backgroundtask/executor.go
@@ -203,6 +203,8 @@ type activeAttempt struct {
 	ready         chan struct{}
 	readyOnce     sync.Once
 	done          chan error
+	drainOnReady  bool
+	drainReason   string
 }
 
 func (a *activeAttempt) signalReady() {
@@ -908,6 +910,9 @@ func (m *Manager) execute(
 	attempt.cancel = cancel
 	attempt.runtime = runtime
 	attempt.supportsDrain = executor.SupportsDrain()
+	if attempt.drainOnReady && attempt.supportsDrain {
+		runtime.requestControlWithReason(ControlDrain, attempt.drainReason)
+	}
 	attempt.signalReady()
 	m.attemptsMu.Unlock()
 	defer cancel()

--- a/adk/backgroundtask/local/local_test.go
+++ b/adk/backgroundtask/local/local_test.go
@@ -54,6 +54,19 @@ func mustNewBackgroundManager(
 	return manager
 }
 
+type countingGetStore struct {
+	*backgroundtask.InMemoryStore
+	getCount int64
+}
+
+func (s *countingGetStore) Get(
+	ctx context.Context,
+	taskID string,
+) (*backgroundtask.Task, error) {
+	atomic.AddInt64(&s.getCount, 1)
+	return s.InMemoryStore.Get(ctx, taskID)
+}
+
 func TestInputUsesKindVocabulary_BitsUT(t *testing.T) {
 	inputType := reflect.TypeOf(Input{})
 	_, hasKind := inputType.FieldByName("Kind")
@@ -348,6 +361,13 @@ func TestProjectStreamTerminalBoundaries(t *testing.T) {
 	})
 
 	t.Run("context canceled", func(t *testing.T) {
+		store := &countingGetStore{
+			InMemoryStore: backgroundtask.NewInMemoryStore(nil),
+		}
+		manager := mustNewBackgroundManager(t, context.Background(), &backgroundtask.Config{
+			Tasks: store, TaskEvents: store,
+		})
+		runner := &Runner{manager: manager}
 		ctx, cancel := context.WithCancel(context.Background())
 		cancel()
 		chunks := make(chan streamChunk)
@@ -360,6 +380,8 @@ func TestProjectStreamTerminalBoundaries(t *testing.T) {
 		}()
 		_, err := reader.Recv()
 		require.ErrorIs(t, err, io.EOF)
+		time.Sleep(20 * time.Millisecond)
+		require.Equal(t, int64(1), atomic.LoadInt64(&store.getCount))
 		close(chunks)
 		<-done
 	})

--- a/adk/backgroundtask/local/stream.go
+++ b/adk/backgroundtask/local/stream.go
@@ -52,6 +52,7 @@ func (r *Runner) projectStream(
 	}
 	forward := !input.RunInBackground || preview != nil
 	callerOpen := true
+	callerDone := ctx.Done()
 	if input.RunInBackground && preview == nil {
 		r.sendNotice(ctx, writer, taskID, false)
 		writer.Close()
@@ -109,7 +110,8 @@ func (r *Runner) projectStream(
 				writer.Close()
 				callerOpen = false
 			}
-		case <-ctx.Done():
+		case <-callerDone:
+			callerDone = nil
 			if !input.RunInBackground {
 				_, _ = r.manager.RequestCancel(context.Background(), taskID)
 			}

--- a/adk/backgroundtask/manager.go
+++ b/adk/backgroundtask/manager.go
@@ -260,9 +260,16 @@ func (m *Manager) Close(ctx context.Context, options ...CloseOption) error {
 	for _, attempt := range m.activeAttempts {
 		if attempt != nil {
 			closingAttempts = append(closingAttempts, attempt)
-		}
-		if attempt != nil && attempt.supportsDrain {
-			attempt.runtime.requestControlWithReason(ControlDrain, closeConfig.drainReason)
+			if !attempt.drainOnReady {
+				attempt.drainOnReady = true
+				attempt.drainReason = closeConfig.drainReason
+			}
+			if attempt.supportsDrain && attempt.runtime != nil {
+				attempt.runtime.requestControlWithReason(
+					ControlDrain,
+					attempt.drainReason,
+				)
+			}
 		}
 	}
 	m.attemptsMu.Unlock()

--- a/adk/backgroundtask/manager_test.go
+++ b/adk/backgroundtask/manager_test.go
@@ -195,6 +195,62 @@ func TestManagerCloseDrainsActiveAttempt(t *testing.T) {
 	require.Equal(t, task.Spec.ID, pending.Tasks[0].Spec.ID)
 }
 
+func TestManagerCloseDrainsAttemptInitializedDuringClose(t *testing.T) {
+	baseStore := NewInMemoryStore(nil)
+	store := &firstGetBlockingStore{
+		TaskStore: baseStore, entered: make(chan struct{}), release: make(chan struct{}),
+	}
+	observed := make(chan ControlRequest, 1)
+	executor := &scriptedExecutor{
+		execute: func(
+			_ context.Context,
+			_ *Task,
+			runtime ExecutionRuntime,
+		) (*ExecutionResult, error) {
+			control := <-runtime.Controls()
+			observed <- control
+			return &ExecutionResult{
+				Status: StatusSuspended, Checkpoint: []byte("checkpoint"),
+			}, nil
+		},
+	}
+	manager := managerWithExecutor(t, store, executor, time.Minute)
+	spec := validSpec("close-initializing")
+	spec.SessionID = ""
+	spec.NotifySession = false
+	task, err := manager.Submit(context.Background(), spec)
+	require.NoError(t, err)
+	executeDone := make(chan error, 1)
+	go func() {
+		executeDone <- manager.Execute(context.Background(), task.Spec.ID)
+	}()
+	<-store.entered
+
+	closeCtx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+	closeDone := make(chan error, 1)
+	go func() {
+		closeDone <- manager.Close(closeCtx, WithDrainReason("worker maintenance"))
+	}()
+	require.Eventually(t, func() bool {
+		manager.mu.Lock()
+		defer manager.mu.Unlock()
+		return manager.closed
+	}, time.Second, time.Millisecond)
+	time.Sleep(10 * time.Millisecond)
+	close(store.release)
+
+	require.NoError(t, <-closeDone)
+	require.NoError(t, <-executeDone)
+	require.Equal(t, ControlRequest{
+		Kind: ControlDrain, Reason: "worker maintenance",
+	}, <-observed)
+	suspended, err := manager.Get(context.Background(), task.Spec.ID)
+	require.NoError(t, err)
+	require.Equal(t, StatusSuspended, suspended.Status)
+	require.Equal(t, "checkpoint", string(suspended.Checkpoint))
+}
+
 func TestManagerReleaseSuspensionRetriesVersionConflict_BitsUT(t *testing.T) {
 	store := NewInMemoryStore(nil)
 	started := createAndStart(t, store, "release-retry")


### PR DESCRIPTION
#### What type of PR is this?
<!--
Add one of the following kinds:

build: Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)
ci: Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
docs: Documentation only changes
feat: A new feature
optimize: A new optimization
fix: A bug fix
perf: A code change that improves performance
refactor: A code change that neither fixes a bug nor adds a feature
style: Changes that do not affect the meaning of the code (white space, formatting, missing semi-colons, etc)
test: Adding missing tests or correcting existing tests
chore: Changes to the build process or auxiliary tools and libraries such as documentation generation
-->
fix

#### Check the PR title.
<!--
The description of the title will be attached in Release Notes, 
so please describe it from user-oriented, what this PR does / why we need it.
Please check your PR title with the below requirements:
-->
- [x] This PR title match the format: \<type\>(optional scope): \<description\>
- [x] The description of this PR title is user-oriented and clear enough for others to understand.
- [ ] Attach the PR updating the user documentation if the current PR requires user awareness at the usage level. [User docs repo](https://github.com/cloudwego/cloudwego.github.io)


#### (Optional) Translate the PR title into Chinese.

#### (Optional) More detailed description for this PR(en: English/zh: Chinese).
<!--
Provide more detailed info for review(e.g., it's recommended to provide perf data if this is a perf type PR).
-->
en:
zh(optional): 
1. stream.go：ctx.Done() 关闭后永久 ready，而循环仍以 chunks != nil 为条件继续运行。若后台流暂未关闭，select 会反复进入取消分支并调用 Manager.RequestCancel
2. Manager.execute 在 activeAttempts 中登记 attempt 后才加载任务和 executor，并在更晚的位置设置 runtime/supportsDrain。Close 在该窗口内快照时看到 supportsDrain=false，因此不会发送 ControlDrain；当执行随后初始化完成，超时分支又按最新的 supportsDrain=true 将它排除在 cancel 列表外。结果是 Close 返回 context deadline exceeded，而任务仍继续运行。


#### (Optional) Which issue(s) this PR fixes:
<!--
Automatically closes linked issue when PR is merged.
Eg: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

#### (optional) The PR that updates user documentation:
<!--
If the current PR requires user awareness at the usage level, please submit a PR to update user docs. [User docs repo](https://github.com/cloudwego/cloudwego.github.io)
-->
