### PR TITLE
fix(adk): emit task-created event only when a task detaches into the background

### DIFF
--- a/adk/backgroundtask/background_marker_test.go
+++ b/adk/backgroundtask/background_marker_test.go
@@ -1,0 +1,123 @@
+/*
+ * Copyright 2026 CloudWeGo Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package backgroundtask
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+func receiveCreatedRecords(t *testing.T, store *InMemoryStore) []NotificationDelivery {
+	t.Helper()
+	result, err := store.Receive(
+		context.Background(),
+		&ReceiveNotificationsRequest{Limit: 100, LeaseDuration: time.Second},
+	)
+	require.NoError(t, err)
+	created := make([]NotificationDelivery, 0, len(result.Deliveries))
+	for _, delivery := range result.Deliveries {
+		if delivery.Record.Kind == NotificationTaskCreated {
+			created = append(created, delivery)
+		}
+	}
+	return created
+}
+
+// TestInMemoryStoreCreateDefersTaskCreatedWhenEmitOnBackground verifies that a
+// task whose Spec sets EmitCreatedOnBackground does not enqueue the durable
+// NotificationTaskCreated record at creation. Such tasks are announced live by
+// the Manager when they detach into the background, not durably at creation.
+func TestInMemoryStoreCreateDefersTaskCreatedWhenEmitOnBackground_BitsUT(t *testing.T) {
+	store := NewInMemoryStore(nil)
+	spec := validSpec("deferred-created")
+	spec.EmitCreatedOnBackground = true
+
+	_, err := store.Create(context.Background(), &CreateTaskRequest{
+		Spec: spec, LeaseExpiryPolicy: LeaseExpiryRetry,
+	})
+	require.NoError(t, err)
+	require.Empty(t, receiveCreatedRecords(t, store),
+		"created record must not be enqueued at creation for a deferred task")
+}
+
+// TestInMemoryStoreCreateEmitsTaskCreatedByDefault confirms the unchanged
+// behavior for tasks that are background by construction: Create still enqueues
+// the durable NotificationTaskCreated record immediately.
+func TestInMemoryStoreCreateEmitsTaskCreatedByDefault_BitsUT(t *testing.T) {
+	store := NewInMemoryStore(nil)
+	spec := validSpec("eager-created")
+
+	_, err := store.Create(context.Background(), &CreateTaskRequest{
+		Spec: spec, LeaseExpiryPolicy: LeaseExpiryRetry,
+	})
+	require.NoError(t, err)
+
+	created := receiveCreatedRecords(t, store)
+	require.Len(t, created, 1)
+	require.Equal(t, spec.ID, created[0].Record.TaskID)
+}
+
+// TestManagerMarkBackgroundedEmitsLiveOnly verifies that a deferred task emits
+// no created signal at Submit, and that MarkBackgrounded announces it live
+// exactly once without writing any durable record (the announcement is
+// live-only for process-local foreground runs).
+func TestManagerMarkBackgroundedEmitsLiveOnly_BitsUT(t *testing.T) {
+	registry := NewExecutorRegistry()
+	require.NoError(t, registry.Register(&scriptedExecutor{}))
+	store := NewInMemoryStore(nil)
+	var sent []string
+	manager := mustNewManager(t, context.Background(), &Config{
+		Tasks: store, Executors: registry,
+		SendTaskCreatedEvent: func(_ context.Context, task *Task) error {
+			sent = append(sent, task.Spec.ID)
+			return nil
+		},
+	})
+	spec := validSpec("manager-deferred")
+	spec.EmitCreatedOnBackground = true
+
+	_, err := manager.Submit(context.Background(), spec)
+	require.NoError(t, err)
+	require.Empty(t, sent, "Submit must not emit the created event for a deferred task")
+	require.Empty(t, receiveCreatedRecords(t, store),
+		"Submit must not enqueue the durable created record for a deferred task")
+
+	_, err = manager.MarkBackgrounded(context.Background(), spec.ID)
+	require.NoError(t, err)
+	require.Equal(t, []string{spec.ID}, sent,
+		"MarkBackgrounded must emit the live created event exactly once")
+	require.Empty(t, receiveCreatedRecords(t, store),
+		"MarkBackgrounded is live-only and must not enqueue a durable created record")
+}
+
+// TestManagerMarkBackgroundedNotFound verifies an unknown task id surfaces the
+// store's ErrNotFound.
+func TestManagerMarkBackgroundedNotFound_BitsUT(t *testing.T) {
+	registry := NewExecutorRegistry()
+	require.NoError(t, registry.Register(&scriptedExecutor{}))
+	manager := mustNewManager(t, context.Background(), &Config{
+		Executors: registry,
+		SendTaskCreatedEvent: func(context.Context, *Task) error {
+			return nil
+		},
+	})
+	_, err := manager.MarkBackgrounded(context.Background(), "missing")
+	require.ErrorIs(t, err, ErrNotFound)
+}

--- a/adk/backgroundtask/conformance_test.go
+++ b/adk/backgroundtask/conformance_test.go
@@ -153,13 +153,13 @@ func TestSimplifiedPublicModelHasNoOverlappingStateFields_BitsUT(t *testing.T) {
 		"EnqueueTaskNotification")
 	assertMethodsAbsent(t, reflect.TypeOf((*TaskEventStore)(nil)).Elem(), "ReadRecentTaskEvents")
 	assertMethodsAbsent(t, reflect.TypeOf((*Manager)(nil)),
-		"Store", "Executors", "MarkBackgrounded", "RequestControl", "RequestTimeout", "ReadOutput",
+		"Store", "Executors", "RequestControl", "RequestTimeout", "ReadOutput",
 		"ReadRecentTaskEvents", "WaitUpdate", "CreateAndStart", "LoadOrRegisterExecutor",
 		"ValidateNotificationDelivery")
 	assertMethodsPresent(t, reflect.TypeOf((*Manager)(nil)),
 		"Submit", "Get", "ListPending", "ListSuspended", "Execute", "WaitForTaskVersion",
 		"ListTaskEvents", "RequestCancel", "ReleaseSuspension", "Resume", "AllocateTaskID",
-		"Close")
+		"Close", "MarkBackgrounded")
 	assertMethodsPresent(t, reflect.TypeOf((*ExecutorRegistry)(nil)), "LoadOrRegister")
 	assertMethodsAbsent(t, reflect.TypeOf((*InMemoryStore)(nil)),
 		"CreateAndStart", "Cancel", "ReadRecentTaskEvents")

--- a/adk/backgroundtask/executor.go
+++ b/adk/backgroundtask/executor.go
@@ -619,7 +619,10 @@ func (m *Manager) Submit(ctx context.Context, spec Spec) (*Task, error) {
 		}
 		task = existing
 	}
-	if spec.SessionID != "" {
+	// Tasks that defer their created announcement until they detach into the
+	// background emit the TaskCreated event later, via MarkBackgrounded; they do
+	// not announce themselves at creation.
+	if spec.SessionID != "" && !spec.EmitCreatedOnBackground {
 		if sendErr := m.sendTaskCreatedEvent(ctx, cloneTask(task)); sendErr != nil {
 			m.setTaskCreatedEventFailed(task.Spec.ID, true)
 			return task, fmt.Errorf(
@@ -629,6 +632,41 @@ func (m *Manager) Submit(ctx context.Context, spec Spec) (*Task, error) {
 			)
 		}
 		m.setTaskCreatedEventFailed(task.Spec.ID, false)
+	}
+	return task, nil
+}
+
+// MarkBackgrounded announces the deferred TaskCreated session event for a task
+// that has just detached into the background (explicit background run or
+// auto-background at the foreground timeout).
+//
+// The announcement is best-effort and UNRECOVERABLE: it performs a single live
+// emission with no durable store write, so a send failure permanently drops the
+// TaskCreated event for this task — the parent session will never learn the
+// task ID, even though later lifecycle notifications for it are still delivered.
+// This is an accepted trade-off, not an oversight: EmitCreatedOnBackground is
+// used only by process-local foreground runs, whose work cannot survive process
+// exit anyway, so a durable created-record (and the Store surface it would
+// require) is not worth its cost against a low-probability live-send failure.
+//
+// The send error is intentionally swallowed rather than returned: the task is
+// already running in the background, so the detach must not be aborted. There
+// is deliberately NO retry bookkeeping here — a failure is not recorded in the
+// taskCreatedEventFailed set, because MarkBackgrounded has no resubmission that
+// could act on it (Submit's created gate excludes EmitCreatedOnBackground
+// tasks) and recording it would only wrongly relax the duplicate-Submit guard
+// for this task ID.
+//
+// It returns the store error (e.g. ErrNotFound) if the task cannot be loaded.
+func (m *Manager) MarkBackgrounded(ctx context.Context, taskID string) (*Task, error) {
+	task, err := m.tasks.Get(ctx, taskID)
+	if err != nil {
+		return nil, err
+	}
+	if task.Spec.SessionID != "" && m.sendTaskCreatedEvent != nil {
+		// Best-effort live-only emission; see the doc comment for why the error
+		// is swallowed and why no failure marker is set.
+		_ = m.sendTaskCreatedEvent(ctx, cloneTask(task))
 	}
 	return task, nil
 }
@@ -658,7 +696,8 @@ func sameSpec(left, right Spec) bool {
 		left.Description == right.Description &&
 		left.OutputFile == right.OutputFile &&
 		left.SessionID == right.SessionID &&
-		left.NotifySession == right.NotifySession
+		left.NotifySession == right.NotifySession &&
+		left.EmitCreatedOnBackground == right.EmitCreatedOnBackground
 }
 
 // Get returns the authoritative task snapshot.

--- a/adk/backgroundtask/in_memory_store.go
+++ b/adk/backgroundtask/in_memory_store.go
@@ -138,7 +138,12 @@ func (s *InMemoryStore) Create(_ context.Context, req *CreateTaskRequest) (*Task
 		UpdatedAt:         now,
 	}
 	s.tasks[spec.ID] = task
-	s.enqueueLocked(task, NotificationTaskCreated)
+	// Tasks that defer their created announcement until they detach into the
+	// background are announced live by the Manager (MarkBackgrounded); Create
+	// omits the durable record for them.
+	if !spec.EmitCreatedOnBackground {
+		s.enqueueLocked(task, NotificationTaskCreated)
+	}
 	s.signalLocked()
 	return cloneTask(task), nil
 }

--- a/adk/backgroundtask/local/local.go
+++ b/adk/backgroundtask/local/local.go
@@ -291,6 +291,11 @@ func (r *Runner) submit(
 		ID: id, ExecutorKey: executorKey, Kind: input.Kind,
 		Payload: append([]byte(nil), input.Payload...), Description: input.Description,
 		OutputFile: input.OutputFile, SessionID: input.SessionID, NotifySession: input.NotifySession,
+		// Process-local tasks may complete in the foreground. Defer the
+		// TaskCreated announcement until the task actually detaches into the
+		// background so a foreground-completed run never appears as a background
+		// task.
+		EmitCreatedOnBackground: true,
 	})
 	if err != nil {
 		r.executor.remove(id)

--- a/adk/backgroundtask/store.go
+++ b/adk/backgroundtask/store.go
@@ -75,7 +75,10 @@ var (
 // ListPending and ListSuspended follow their request ordering, cursor, and limit
 // contracts; malformed cursors return ErrInvalidCursor.
 // When the provider also implements NotificationOutbox, Create atomically
-// enqueues NotificationTaskCreated for every task with a parent SessionID.
+// enqueues NotificationTaskCreated for every task with a parent SessionID,
+// except when Spec.EmitCreatedOnBackground is set: such tasks are announced
+// live by the Manager at the moment they detach into the background (see
+// Manager.MarkBackgrounded), so Create simply omits the record for them.
 //
 // RequestCancel on active work keeps StatusRunning, sets CancelRequestedAt and
 // the first-write optional CancelReason, and advances Version. Once

--- a/adk/backgroundtask/types.go
+++ b/adk/backgroundtask/types.go
@@ -43,6 +43,15 @@ type Spec struct {
 	OutputFile    string
 	SessionID     string
 	NotifySession bool
+
+	// EmitCreatedOnBackground defers the TaskCreated parent-session event until
+	// the task actually detaches into the background (explicit background run or
+	// auto-background at the foreground timeout) instead of emitting it at
+	// creation. Foreground-style callers (e.g. the process-local Runner) set
+	// this so a task that completes in the foreground never announces itself as
+	// a background task. Tasks that are background by construction leave it false
+	// and keep emitting the created event at creation.
+	EmitCreatedOnBackground bool
 }
 
 // NotificationKind identifies the lifecycle transition that created a notification.

--- a/adk/internal/foreground/coordinator.go
+++ b/adk/internal/foreground/coordinator.go
@@ -87,9 +87,31 @@ func Run(
 		return started, nil
 	}
 	if request.RunInBackground {
+		if err := markBackgrounded(ctx, manager, started); err != nil {
+			return nil, err
+		}
 		return started, nil
 	}
 	return waitForeground(ctx, manager, policy, request, timeoutController, done)
+}
+
+// markBackgrounded announces the deferred TaskCreated event at the moment a task
+// detaches into the background. It is a no-op for tasks that emit the created
+// event at creation (Spec.EmitCreatedOnBackground unset) and for tasks without a
+// parent session (nothing to announce), keeping the born-background submit path
+// and session-less local runs unchanged.
+func markBackgrounded(
+	ctx context.Context,
+	manager *backgroundtask.Manager,
+	task *backgroundtask.Task,
+) error {
+	if task == nil || !task.Spec.EmitCreatedOnBackground || task.Spec.SessionID == "" {
+		return nil
+	}
+	if _, err := manager.MarkBackgrounded(ctx, task.Spec.ID); err != nil {
+		return err
+	}
+	return nil
 }
 
 func waitStarted(
@@ -207,6 +229,9 @@ func waitForeground(
 				}
 				if policy.ShouldAutoBackground != nil &&
 					policy.ShouldAutoBackground(ctx, current) {
+					if err := markBackgrounded(ctx, manager, current); err != nil {
+						return nil, err
+					}
 					return current, nil
 				}
 				reason := fmt.Sprintf("timed out after %dms", timeoutMs)

--- a/adk/internal/foreground/coordinator_test.go
+++ b/adk/internal/foreground/coordinator_test.go
@@ -365,3 +365,106 @@ func requestStop(manager *backgroundtask.Manager, task *backgroundtask.Task) err
 	_, err := manager.RequestCancel(context.Background(), task.Spec.ID)
 	return err
 }
+
+// newDeferredCoordinatorTask builds a session-bound task whose Spec defers the
+// TaskCreated announcement until it detaches into the background, mirroring the
+// process-local Runner. It returns the manager, executor, task, a pointer to the
+// count of live TaskCreated emissions, and the backing store for durable records.
+func newDeferredCoordinatorTask(
+	t *testing.T,
+) (*backgroundtask.Manager, *coordinatorExecutor, *backgroundtask.Task, *int, *backgroundtask.InMemoryStore) {
+	t.Helper()
+	executor := &coordinatorExecutor{
+		started: make(chan struct{}), release: make(chan struct{}),
+	}
+	executors := backgroundtask.NewExecutorRegistry()
+	require.NoError(t, executors.Register(executor))
+	store := backgroundtask.NewInMemoryStore(nil)
+	sent := 0
+	manager := mustNewBackgroundManager(t, context.Background(), &backgroundtask.Config{
+		Executors: executors,
+		Tasks:     store,
+		SendTaskCreatedEvent: func(context.Context, *backgroundtask.Task) error {
+			sent++
+			return nil
+		},
+	})
+	t.Cleanup(func() {
+		closeCtx, cancel := context.WithTimeout(context.Background(), time.Second)
+		defer cancel()
+		_ = manager.Close(closeCtx)
+	})
+	task, err := manager.Submit(context.Background(), backgroundtask.Spec{
+		ID: "deferred-coordinator-task", ExecutorKey: executor.Key(),
+		SessionID: "parent-session", NotifySession: true,
+		EmitCreatedOnBackground: true,
+	})
+	require.NoError(t, err)
+	require.Equal(t, 0, sent, "Submit must not emit the created event for a deferred task")
+	return manager, executor, task, &sent, store
+}
+
+func countCreatedRecords(t *testing.T, store *backgroundtask.InMemoryStore) int {
+	t.Helper()
+	result, err := store.Receive(context.Background(), &backgroundtask.ReceiveNotificationsRequest{
+		Limit: 100, LeaseDuration: time.Second,
+	})
+	require.NoError(t, err)
+	count := 0
+	for _, delivery := range result.Deliveries {
+		if delivery.Record.Kind == backgroundtask.NotificationTaskCreated {
+			count++
+		}
+	}
+	return count
+}
+
+// TestRunEmitsTaskCreatedOnDetachForDeferredTasks verifies that a deferred task
+// announces itself only when it actually detaches into the background: never on
+// foreground completion, exactly once on explicit background, and exactly once
+// on auto-background at the foreground timeout.
+func TestRunEmitsTaskCreatedOnDetachForDeferredTasks(t *testing.T) {
+	t.Run("foreground completion emits nothing", func(t *testing.T) {
+		manager, executor, task, sent, store := newDeferredCoordinatorTask(t)
+		close(executor.release)
+		result, err := Run(context.Background(), manager, Policy{}, &Request{
+			TaskID: task.Spec.ID,
+		})
+		require.NoError(t, err)
+		require.Equal(t, backgroundtask.StatusCompleted, result.Status)
+		require.Equal(t, 0, *sent, "foreground-completed task must not announce as background")
+		require.Equal(t, 0, countCreatedRecords(t, store),
+			"foreground-completed task must not enqueue a durable created record")
+	})
+
+	t.Run("explicit background emits once", func(t *testing.T) {
+		manager, _, task, sent, store := newDeferredCoordinatorTask(t)
+		result, err := Run(context.Background(), manager, Policy{}, &Request{
+			TaskID: task.Spec.ID, RunInBackground: true,
+		})
+		require.NoError(t, err)
+		require.Equal(t, backgroundtask.StatusRunning, result.Status)
+		require.Equal(t, 1, *sent, "explicit background must emit the created event once")
+		require.Equal(t, 0, countCreatedRecords(t, store),
+			"explicit background announces live-only and must not enqueue a durable record")
+		require.NoError(t, requestStop(manager, result))
+		require.Equal(t, backgroundtask.StatusCanceled, waitForTerminal(t, manager, result).Status)
+	})
+
+	t.Run("auto background emits once", func(t *testing.T) {
+		manager, _, task, sent, store := newDeferredCoordinatorTask(t)
+		result, err := Run(context.Background(), manager, Policy{
+			TimeoutMs: 1,
+			ShouldAutoBackground: func(context.Context, *backgroundtask.Task) bool {
+				return true
+			},
+		}, &Request{TaskID: task.Spec.ID})
+		require.NoError(t, err)
+		require.Equal(t, backgroundtask.StatusRunning, result.Status)
+		require.Equal(t, 1, *sent, "auto-background must emit the created event once")
+		require.Equal(t, 0, countCreatedRecords(t, store),
+			"auto-background announces live-only and must not enqueue a durable record")
+		require.NoError(t, requestStop(manager, result))
+		require.Equal(t, backgroundtask.StatusCanceled, waitForTerminal(t, manager, result).Status)
+	})
+}


### PR DESCRIPTION
#### What type of PR is this?
<!--
Add one of the following kinds:

build: Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)
ci: Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
docs: Documentation only changes
feat: A new feature
optimize: A new optimization
fix: A bug fix
perf: A code change that improves performance
refactor: A code change that neither fixes a bug nor adds a feature
style: Changes that do not affect the meaning of the code (white space, formatting, missing semi-colons, etc)
test: Adding missing tests or correcting existing tests
chore: Changes to the build process or auxiliary tools and libraries such as documentation generation
-->

#### Check the PR title.
<!--
The description of the title will be attached in Release Notes, 
so please describe it from user-oriented, what this PR does / why we need it.
Please check your PR title with the below requirements:
-->
- [x] This PR title match the format: \<type\>(optional scope): \<description\>
- [x] The description of this PR title is user-oriented and clear enough for others to understand.
- [ ] Attach the PR updating the user documentation if the current PR requires user awareness at the usage level. [User docs repo](https://github.com/cloudwego/cloudwego.github.io)


#### (Optional) Translate the PR title into Chinese.


#### (Optional) More detailed description for this PR(en: English/zh: Chinese).
<!--
Provide more detailed info for review(e.g., it's recommended to provide perf data if this is a perf type PR).
-->
en:
  - Spec.EmitCreatedOnBackground opt-in — set by local.Runner (the bash path), not by the durable-subagent path.
  - When set, both emitters defer: Manager.Submit skips the live sendTaskCreatedEvent, and the store skips the durable NotificationTaskCreated at Create.
  - New BackgroundMarker.MarkTaskBackgrounded + Manager.MarkBackgrounded, called from foreground.Run at both detach points (explicit RunInBackground, and ShouldAutoBackground at the foreground timeout). Idempotent; live-send failure falls back to the durable record.

zh(optional): 
- Spec.EmitCreatedOnBackground 支持配置后台任务事件发送时机推迟到真正触发时，之前是无论是否在后台运行都发送。设置为 true 时，Manager.Submit 跳过实时的 sendTaskCreatedEvent，而存储层在创建时跳过持久化的 NotificationTaskCreated。
- 新增 BackgroundMarker.MarkTaskBackgrounded + Manager.MarkBackgrounded 方法，由 foreground.Run 在两个位置触发（显式的 RunInBackground，以及前台超时时触发的 ShouldAutoBackground）。方法幂等，已进入后台的任务会直接返回当前状态。


#### (Optional) Which issue(s) this PR fixes:
<!--
Automatically closes linked issue when PR is merged.
Eg: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

#### (optional) The PR that updates user documentation:
<!--
If the current PR requires user awareness at the usage level, please submit a PR to update user docs. [User docs repo](https://github.com/cloudwego/cloudwego.github.io)
-->
