### PR TITLE
fix(adk): move once-per-run reminder gate out of BeforeAgent into BeforeModelRewriteState

### DIFF
--- a/adk/middlewares/skill/skill.go
+++ b/adk/middlewares/skill/skill.go
@@ -274,34 +274,33 @@ type typedSkillHandler[M adk.MessageType] struct {
 	tool        *typedSkillTool[M]
 }
 
-// BeforeAgent injects the skill tool and system prompt, then marks the start of a new
-// turn for the available-skills reminder.
+// BeforeAgent injects the skill tool and system prompt.
 //
-// It does NOT call List() or build the reminder here. Both are deferred to the first
-// model call of the turn (BeforeModelRewriteState), because the add/change diff needs the
-// previous reminder's digest, which lives in the full message history — and
-// runCtx.AgentInput.Messages holds only the current turn's input, so the prior reminder
-// is not visible from here. This hook only sets a run-local "new turn" mark;
-// BeforeModelRewriteState sees it, does List()+diff+insert once, then clears it, so a
-// multi-call ReAct turn lists skills at most once.
+// It does NOT touch the available-skills reminder. The reminder is refreshed on the
+// first model call (BeforeModelRewriteState), for two reasons: the add/change diff needs
+// the previous reminder's digest, which lives in the full message history (not in
+// runCtx.AgentInput.Messages, which holds only the current input); and run-local values
+// are backed by the compose graph State, which does not exist yet here — BeforeAgent runs
+// before the graph is invoked, so a SetRunLocalValue here is silently dropped.
 func (h *typedSkillHandler[M]) BeforeAgent(ctx context.Context, runCtx *adk.ChatModelAgentContext[M]) (context.Context, *adk.ChatModelAgentContext[M], error) {
 	runCtx.Instruction = runCtx.Instruction + "\n" + h.instruction
 	runCtx.Tools = append(runCtx.Tools, h.tool)
-
-	if runCtx.AgentInput == nil {
-		return ctx, runCtx, nil
-	}
-	_ = adk.SetRunLocalValue(ctx, skillsPendingKey, true)
 	return ctx, runCtx, nil
 }
 
 // BeforeModelRewriteState refreshes the available-skills reminder on the first model call
-// of a turn: if BeforeAgent marked a new turn, it lists the current skills, diffs them
-// against the previous reminder's digest — read from the FULL history (state.Messages) —
-// and inserts a reminder advertising only the added/changed skills, then clears the mark
-// so later model calls in the same ReAct turn do nothing (List() runs at most once/turn).
+// of a turn: it lists the current skills, diffs them against the previous reminder's
+// digest — read from the FULL history (state.Messages) — and inserts a reminder advertising
+// only the added/changed skills. A run-local mark makes this run at most once per agent Run:
+// the first model call finds the mark absent, does the work, and sets it; later model calls
+// in the same ReAct turn find it set and skip.
 //
-// List() runs here, not in BeforeAgent, because the diff needs prior turns' reminders,
+// The mark lives here, not in BeforeAgent, because run-local values are backed by the
+// compose graph State, which is not built until the graph runs — after BeforeAgent. Set in
+// BeforeAgent it would be silently dropped. Run-local state is fresh per Run (and restored
+// across interrupt/resume), so the mark naturally scopes to one logical turn.
+//
+// List() runs here, not in BeforeAgent, because the diff also needs prior turns' reminders,
 // which only state.Messages carries; BeforeAgent's runCtx.AgentInput.Messages holds just
 // the current input.
 //
@@ -319,19 +318,15 @@ func (h *typedSkillHandler[M]) BeforeModelRewriteState(ctx context.Context, stat
 	// model call; the fresh insert below is already built with that role.
 	state.Messages = systemreminder.NormalizeReminderRoles(state.Messages)
 
-	pv, ok, err := adk.GetRunLocalValue(ctx, skillsPendingKey)
-	if err != nil || !ok {
-		// err only happens when called outside a valid agent execution context (a
-		// structural misuse). The reminder is best-effort, so skip it rather than
-		// fail the whole model call.
+	// Once per agent Run: the mark's presence means this turn already refreshed the
+	// reminder, so later model calls in the same ReAct turn skip. Absent = new turn.
+	if _, handled, _ := adk.GetRunLocalValue(ctx, skillsHandledKey); handled {
 		return ctx, state, nil
 	}
-	if pending, _ := pv.(bool); !pending {
-		// Already handled this turn (or never marked): later model calls skip.
-		return ctx, state, nil
-	}
-	// Consume the new-turn mark so List()+diff runs at most once per turn.
-	_ = adk.SetRunLocalValue(ctx, skillsPendingKey, false)
+	// Mark before doing the work so a multi-call ReAct turn lists skills at most once.
+	// A best-effort set failure only means a redundant List() on the next model call
+	// (the history digest still dedups the insert), so the reminder stays correct.
+	_ = adk.SetRunLocalValue(ctx, skillsHandledKey, true)
 
 	skills, err := h.tool.b.List(ctx)
 	if err != nil {
@@ -377,11 +372,12 @@ const (
 	// skillsDigestExtraKey stores, in a skill reminder's Extra, the JSON array of
 	// MD5(name+description) digests of the skills it advertised, for cross-turn diffing.
 	skillsDigestExtraKey = "__eino_skill_digests__"
-	// skillsPendingKey marks (run-local) the start of a new turn, set by BeforeAgent. On
-	// the first model call of the turn BeforeModelRewriteState sees the mark, refreshes the
-	// available-skills reminder (List + diff + insert), then clears it so a multi-call ReAct
-	// turn lists skills at most once.
-	skillsPendingKey = "__eino_skill_reminder_pending__"
+	// skillsHandledKey marks (run-local) that the available-skills reminder has already been
+	// refreshed this agent Run. The first model call of the turn finds it absent, does
+	// List()+diff+insert, and sets it; later model calls in the same ReAct turn find it set
+	// and skip, so List() runs at most once per turn. It lives in run-local (compose State)
+	// rather than being set in BeforeAgent, where the State does not exist yet.
+	skillsHandledKey = "__eino_skill_reminder_handled__"
 )
 
 // skillDigest returns the MD5(name+description) digest of a single skill.

--- a/adk/middlewares/skill/skill_refresh_test.go
+++ b/adk/middlewares/skill/skill_refresh_test.go
@@ -121,19 +121,19 @@ func withRunLocalCtx(t *testing.T, fn func(ctx context.Context)) {
 	}
 }
 
-// markPending sets the run-local "new turn" mark, mirroring what BeforeAgent does via
-// SetRunLocalValue. BeforeModelRewriteState reads it back, then lists the backend's
-// skills, diffs against history, and builds the reminder section.
-func markPending(t *testing.T, ctx context.Context) {
+// markHandled sets the run-local "already refreshed this Run" mark, mirroring what the
+// first BeforeModelRewriteState call does after it inserts. A later model call in the same
+// Run reads it back and skips, so the reminder is refreshed at most once per turn.
+func markHandled(t *testing.T, ctx context.Context) {
 	t.Helper()
-	require.NoError(t, adk.SetRunLocalValue(ctx, skillsPendingKey, true))
+	require.NoError(t, adk.SetRunLocalValue(ctx, skillsHandledKey, true))
 }
 
-// TestSkill_BeforeModelRewriteState_InsertsPending verifies the first-turn insertion:
-// given a pending mark, BeforeModelRewriteState lists skills and inserts exactly one
-// System reminder after the user message, listing the section and carrying the digest
-// array in Extra.
-func TestSkill_BeforeModelRewriteState_InsertsPending(t *testing.T) {
+// TestSkill_BeforeModelRewriteState_InsertsOnFreshRun verifies the first-call insertion:
+// with no handled mark yet (a fresh Run), BeforeModelRewriteState lists skills and inserts
+// exactly one System reminder after the user message, listing the section and carrying the
+// digest array in Extra.
+func TestSkill_BeforeModelRewriteState_InsertsOnFreshRun(t *testing.T) {
 	h := &typedSkillHandler[*schema.Message]{
 		tool: &typedSkillTool[*schema.Message]{b: &inMemoryBackend{m: []Skill{
 			{FrontMatter: FrontMatter{Name: "alpha", Description: "desc-alpha"}},
@@ -143,8 +143,7 @@ func TestSkill_BeforeModelRewriteState_InsertsPending(t *testing.T) {
 	digests := []string{skillDigest(skills[0])}
 
 	withRunLocalCtx(t, func(ctx context.Context) {
-		markPending(t, ctx)
-
+		// No handled mark → this is the turn's first model call → insert.
 		state := &adk.ChatModelAgentState{Messages: []*schema.Message{schema.UserMessage("hi")}}
 		_, state, err := h.BeforeModelRewriteState(ctx, state, nil)
 		require.NoError(t, err)
@@ -166,10 +165,10 @@ func TestSkill_BeforeModelRewriteState_InsertsPending(t *testing.T) {
 	})
 }
 
-// TestSkill_BeforeModelRewriteState_NoInsertWithoutPending verifies that when no new-turn
-// mark is set (BeforeAgent never ran, or the mark was already consumed this turn),
+// TestSkill_BeforeModelRewriteState_NoInsertWhenHandled verifies that once the run-local
+// handled mark is set (an earlier model call this Run already refreshed the reminder),
 // BeforeModelRewriteState inserts nothing.
-func TestSkill_BeforeModelRewriteState_NoInsertWithoutPending(t *testing.T) {
+func TestSkill_BeforeModelRewriteState_NoInsertWhenHandled(t *testing.T) {
 	h := &typedSkillHandler[*schema.Message]{
 		tool: &typedSkillTool[*schema.Message]{b: &inMemoryBackend{m: []Skill{
 			{FrontMatter: FrontMatter{Name: "alpha", Description: "desc-alpha"}},
@@ -177,24 +176,18 @@ func TestSkill_BeforeModelRewriteState_NoInsertWithoutPending(t *testing.T) {
 	}
 
 	withRunLocalCtx(t, func(ctx context.Context) {
-		// No mark at all.
+		// Simulate an earlier model call in this Run having already refreshed the reminder.
+		markHandled(t, ctx)
 		state := &adk.ChatModelAgentState{Messages: []*schema.Message{schema.UserMessage("hi")}}
 		_, state, err := h.BeforeModelRewriteState(ctx, state, nil)
 		require.NoError(t, err)
-		assert.Equal(t, 0, countReminders(state.Messages), "no mark → no insert")
-
-		// A consumed mark (false, how BeforeModelRewriteState clears it) is also a no-op.
-		require.NoError(t, adk.SetRunLocalValue(ctx, skillsPendingKey, false))
-		state = &adk.ChatModelAgentState{Messages: []*schema.Message{schema.UserMessage("hi")}}
-		_, state, err = h.BeforeModelRewriteState(ctx, state, nil)
-		require.NoError(t, err)
-		assert.Equal(t, 0, countReminders(state.Messages), "consumed mark → no insert")
+		assert.Equal(t, 0, countReminders(state.Messages), "handled mark set → no insert")
 	})
 }
 
 // TestSkill_InsertOncePerTurn verifies BeforeModelRewriteState inserts the reminder
-// exactly once: the first call lists+inserts and consumes the new-turn mark; a second
-// call in the same turn inserts nothing.
+// exactly once: the first call lists+inserts and sets the handled mark; a second call in
+// the same Run finds the mark set and inserts nothing.
 func TestSkill_InsertOncePerTurn(t *testing.T) {
 	h := &typedSkillHandler[*schema.Message]{
 		tool: &typedSkillTool[*schema.Message]{b: &inMemoryBackend{m: []Skill{
@@ -203,8 +196,6 @@ func TestSkill_InsertOncePerTurn(t *testing.T) {
 	}
 
 	withRunLocalCtx(t, func(ctx context.Context) {
-		markPending(t, ctx)
-
 		s1 := &adk.ChatModelAgentState{Messages: []*schema.Message{schema.UserMessage("hi")}}
 		_, s1, err := h.BeforeModelRewriteState(ctx, s1, nil)
 		require.NoError(t, err)
@@ -213,14 +204,14 @@ func TestSkill_InsertOncePerTurn(t *testing.T) {
 		s2 := &adk.ChatModelAgentState{Messages: []*schema.Message{schema.UserMessage("hi")}}
 		_, s2, err = h.BeforeModelRewriteState(ctx, s2, nil)
 		require.NoError(t, err)
-		assert.Equal(t, 0, countReminders(s2.Messages), "stash consumed → second call inserts nothing")
+		assert.Equal(t, 0, countReminders(s2.Messages), "handled mark set → second call inserts nothing")
 	})
 }
 
-// TestSkill_BeforeAgentToRewriteState_Bridge exercises the real run-local bridge:
-// BeforeAgent marks a new turn via SetRunLocalValue (which gob-checks the stored value),
-// then BeforeModelRewriteState reads it back, lists+diffs, and inserts. This is the
-// end-to-end path a Runner takes.
+// TestSkill_BeforeAgentToRewriteState_Bridge exercises the real end-to-end path a Runner
+// takes: BeforeAgent injects the tool + instruction (no run-local, no List), then the
+// first BeforeModelRewriteState of the turn lists+diffs and inserts. The handled mark is
+// self-managed inside BeforeModelRewriteState — BeforeAgent no longer seeds it.
 func TestSkill_BeforeAgentToRewriteState_Bridge(t *testing.T) {
 	newHandler := func(b Backend) *typedSkillHandler[*schema.Message] {
 		mw, err := NewMiddleware(context.Background(), &Config{Backend: b})
@@ -242,7 +233,7 @@ func TestSkill_BeforeAgentToRewriteState_Bridge(t *testing.T) {
 			state := &adk.ChatModelAgentState{Messages: []*schema.Message{schema.UserMessage("hi")}}
 			_, state, err = h.BeforeModelRewriteState(ctx, state, nil)
 			require.NoError(t, err)
-			require.Equal(t, 1, countReminders(state.Messages), "BeforeAgent stash must bridge to an insertion")
+			require.Equal(t, 1, countReminders(state.Messages), "first model call of the turn must insert")
 			assert.Contains(t, firstReminder(state.Messages).Content, "alpha")
 		})
 	})


### PR DESCRIPTION
# fix(adk): move once-per-run reminder gate out of BeforeAgent into BeforeModelRewriteState

## Problem

The skill middleware's "available-skills" reminder is meant to be refreshed at most once per agent Run. That gate was implemented by setting a run-local flag in `BeforeAgent`:

```go
_ = adk.SetRunLocalValue(ctx, skillsPendingKey, true)
```

But `SetRunLocalValue` is backed by the compose graph State (`compose.ProcessState` → `State.Extra`), and `BeforeAgent` runs **before** the compose graph is invoked (`applyBeforeAgent` in `chatmodel.go` executes prior to `run()`). At that point the State does not exist yet, so the call fails and its error is silently discarded by `_ =`. The flag was never actually stored.

The bug was masked in tests because the test harness (`runLocalProbe`) drives the probe function from *inside* `BeforeModelRewriteState`, where State already exists — so `SetRunLocalValue` there succeeded and the broken production timing was never exercised.

## Fix

Move the once-per-run gate into `BeforeModelRewriteState`, where the compose State is guaranteed to exist, and make it self-managing:

- **mark absent** → this is the turn's first model call → List + diff + insert the delta reminder, then set the mark.
- **mark present** → a later model call in the same ReAct turn → skip.

Run-local state is fresh per Run and restored across interrupt/resume, so the mark scopes naturally to one logical turn. This mirrors the existing, correct pattern in the `toolsearch` middleware (`isInitialized`/`markInitialized`, gated in `BeforeModelRewriteState`).

`BeforeAgent` now only injects the skill tool + system prompt (no run-local, no `List()`). The diff also genuinely needs `state.Messages` (full history) for the prior reminder's digest, which `BeforeAgent`'s `runCtx.AgentInput.Messages` (current input only) does not carry — another reason the work belongs in `BeforeModelRewriteState`.

## Notes

Behavioral impact: the reminder now actually gets deduped once per Run as intended. Previously the ineffective flag meant the gate leaned entirely on the history-digest diff to avoid duplicate inserts — correct output, but `List()` ran on every model call of a multi-step turn.

---

# fix(adk): 将每个 Run 只刷新一次的 reminder 门控从 BeforeAgent 移到 BeforeModelRewriteState

## 问题

skill middleware 的 "available-skills" reminder 设计上每个 agent Run 最多刷新一次。原实现通过在 `BeforeAgent` 里设置一个 run-local 标记来做门控：

```go
_ = adk.SetRunLocalValue(ctx, skillsPendingKey, true)
```

但 `SetRunLocalValue` 依赖 compose graph State（`compose.ProcessState` → `State.Extra`），而 `BeforeAgent` 在 compose graph 执行**之前**运行（`chatmodel.go` 中 `applyBeforeAgent` 早于 `run()`）。此时 State 尚未建立，该调用会失败，错误又被 `_ =` 静默丢弃——标记从未真正写入。

该 bug 被测试掩盖了：测试 harness（`runLocalProbe`）是从 `BeforeModelRewriteState` **内部**驱动探针函数的，此时 State 已存在，`SetRunLocalValue` 得以成功，因此生产环境真实的时机问题从未被触发。

## 修复

把每个 Run 只执行一次的门控移到 `BeforeModelRewriteState`——此处 compose State 一定存在——并让它自管理：

- **标记不存在** → 本 turn 的首个 model call → List + diff + 插入增量 reminder，然后置标记。
- **标记存在** → 同一 ReAct turn 的后续 model call → 跳过。

run-local 状态每个 Run 都是全新的，且能跨 interrupt/resume 恢复，因此标记天然地限定在一个逻辑 turn 内。这与 `toolsearch` middleware 中已有的正确模式一致（`isInitialized`/`markInitialized`，同样在 `BeforeModelRewriteState` 中门控）。

`BeforeAgent` 现在只注入 skill tool + system prompt（不再碰 run-local，也不再 `List()`）。diff 本身还需要 `state.Messages`（完整历史）来取上一条 reminder 的 digest，而 `BeforeAgent` 的 `runCtx.AgentInput.Messages`（仅当前输入）不携带这些历史——这也是该逻辑应放在 `BeforeModelRewriteState` 的另一个原因。

## 说明

行为影响：reminder 现在真正做到了每个 Run 只去重刷新一次。此前失效的标记意味着门控完全依赖 history-digest diff 来避免重复插入——输出仍正确，但多步 turn 里每次 model call 都会跑一遍 `List()`。
