### PR TITLE
feat(adk): Add MultiModalURLReader

### DIFF
--- a/adk/filesystem/backend.go
+++ b/adk/filesystem/backend.go
@@ -159,6 +159,12 @@ type WriteRequest struct {
 	Content string
 }
 
+// UploadRequest contains parameters for uploading a file's content
+type UploadRequest struct {
+	// FilePath is the path of the file to upload.
+	FilePath string
+}
+
 // OpenAppendRequest contains parameters for opening an append stream.
 type OpenAppendRequest struct {
 	// FilePath is the path of the file to append to; it is created if absent.
@@ -241,6 +247,29 @@ type MultiFileContent struct {
 //     or use the built-in reduction middleware with configurable policies.
 type MultiModalReader interface {
 	MultiModalRead(ctx context.Context, req *MultiModalReadRequest) (*MultiFileContent, error)
+}
+
+// MultiModalURLReader is an optional Backend extension for backends that cannot
+// stream a file's bytes back to the caller. Instead of returning content, it makes the
+// file's content fetchable by uploading it to temporary object storage and
+// returning a URL that a downstream parser or fetch service can retrieve
+// directly.
+//
+// A backend that implements this is preferred over MultiModalReader by callers
+// that can consume a URL. Backends that can return bytes directly implement MultiModalReader instead.
+// Size limits are the implementation's responsibility, since the caller never sees the bytes.
+type MultiModalURLReader interface {
+	MultiModalReadAsURL(ctx context.Context, req *MultiModalReadRequest) (*MultiModalURLContent, error)
+}
+
+// MultiModalURLContent is the result of MultiModalReadAsURL: a fetchable URL for
+// the file's content. It is a struct rather than a bare URL string so future
+// backends can attach metadata (MIME type, size, expiry) without changing the
+// interface signature.
+type MultiModalURLContent struct {
+	// URL is the fetchable location of the file's content in temporary object
+	// storage.
+	URL string
 }
 
 // AppendOpener opens a write-only, tail-appending session to a file, letting


### PR DESCRIPTION
# Add MultiModalURLReader: an optional Backend extension for URL-yielding reads

## English

### What

Adds a new optional `filesystem.Backend` extension for backends that cannot
stream a file's bytes back to the caller (e.g. a device gateway whose read wire
is text-only). Instead of returning content inline, the backend uploads the file
to temporary object storage and returns a fetchable URL.

- `MultiModalURLReader` interface — `MultiModalReadAsURL(ctx, *MultiModalReadRequest) (*MultiModalURLContent, error)`
- `MultiModalURLContent` struct — carries the `URL` (a struct rather than a bare
  string so metadata like MIME/size/expiry can be added later without breaking
  the signature)
- `UploadRequest` struct — request counterpart for the upload operation

### Why

`MultiModalReader` assumes the backend can return raw bytes. Some backends
physically can't (bytes never cross their wire), but they can make the content
fetchable via URL. This is modeled as a separate optional capability rather than
a field on `MultiFileContent`, so:

- capability negotiation stays at compile time (interface type-assertion), and
- the shared `MultiFileContent` type keeps its clean bytes-only `one-of` semantics.

Backends that can return bytes keep implementing `MultiModalReader`; the two are
independent and a backend may implement either.

### Compatibility

Purely additive — new interface + types, no changes to existing ones. No impact
on current `Backend` / `MultiModalReader` implementations.

---

## 中文

### 改动内容

为「无法把文件字节流回调用方」的 backend（例如读通道是纯文本的设备网关）新增一个可选的
`filesystem.Backend` 扩展能力。这类 backend 不再内联返回内容，而是把文件上传到临时对象存储，
返回一个可 fetch 的 URL。

- `MultiModalURLReader` 接口 —— `MultiModalReadAsURL(ctx, *MultiModalReadRequest) (*MultiModalURLContent, error)`
- `MultiModalURLContent` 结构体 —— 承载 `URL`（用结构体而非裸 string，方便后续加
  MIME/size/expiry 等元信息而不破坏签名）
- `UploadRequest` 结构体 —— upload 操作对应的 request 类型

### 为什么这么设计

`MultiModalReader` 假设 backend 能返回原始字节，但有些 backend 物理上做不到（字节过不了它的
wire），只能以 URL 形式暴露内容。这里把它建模成**独立的可选能力**，而不是在 `MultiFileContent`
上加字段，原因：

- 能力协商保持在**编译期**（通过 interface 类型断言判断），而非运行期看返回字段；
- 共享类型 `MultiFileContent` 保持干净的「仅字节」`one-of` 语义，不被小众诉求污染。

能返回字节的 backend 继续实现 `MultiModalReader`；两者相互独立，backend 可只实现其中之一。

### 兼容性

纯新增 —— 只加接口和类型，不改动任何现有定义，对现有 `Backend` / `MultiModalReader` 实现无影响。
