### PR TITLE
feat(adk): allow customizing mid-conversation system reminders

### DIFF
--- a/adk/middlewares/dynamictool/toolsearch/reminder_test.go
+++ b/adk/middlewares/dynamictool/toolsearch/reminder_test.go
@@ -1,0 +1,112 @@
+/*
+ * Copyright 2026 CloudWeGo Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package toolsearch
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/cloudwego/eino/adk"
+	"github.com/cloudwego/eino/components/tool"
+	"github.com/cloudwego/eino/schema"
+)
+
+func countToolSearchReminders(msgs []*schema.Message) int {
+	n := 0
+	for _, m := range msgs {
+		if _, ok := m.Extra[toolSearchReminderExtraKey]; ok {
+			n++
+		}
+	}
+	return n
+}
+
+func TestToolSearch_CustomFormatReminder(t *testing.T) {
+	ctx := context.Background()
+	dynamicA := &simpleTool{name: "dynamic_tool_a", desc: "Dynamic tool A"}
+	dynamicB := &simpleTool{name: "dynamic_tool_b", desc: "Dynamic tool B"}
+
+	reminderOf := func(mw adk.ChatModelAgentMiddleware) string {
+		return mw.(*typedMiddleware[*schema.Message]).reminder
+	}
+
+	t.Run("nil keeps default reminder", func(t *testing.T) {
+		mw, err := New(ctx, &Config{DynamicTools: []tool.BaseTool{dynamicA, dynamicB}})
+		require.NoError(t, err)
+		assert.Contains(t, reminderOf(mw), "dynamic_tool_a")
+	})
+
+	t.Run("custom rewrites and receives default + tool infos", func(t *testing.T) {
+		var gotDefault string
+		var gotTools []*schema.ToolInfo
+		mw, err := New(ctx, &Config{
+			DynamicTools: []tool.BaseTool{dynamicA, dynamicB},
+			CustomFormatReminder: func(_ context.Context, in *FormatReminderInput) (*FormatReminderOutput, error) {
+				gotDefault = in.DefaultReminder
+				gotTools = in.Tools
+				return &FormatReminderOutput{Reminder: "CUSTOM REMINDER"}, nil
+			},
+		})
+		require.NoError(t, err)
+		assert.Equal(t, "CUSTOM REMINDER", reminderOf(mw))
+		assert.Contains(t, gotDefault, "dynamic_tool_a", "formatter gets the default reminder")
+		require.Len(t, gotTools, 2, "formatter gets full ToolInfos, not just names")
+		assert.Equal(t, "Dynamic tool A", gotTools[0].Desc, "ToolInfo carries description beyond the name")
+	})
+
+	t.Run("error keeps default reminder", func(t *testing.T) {
+		mw, err := New(ctx, &Config{
+			DynamicTools: []tool.BaseTool{dynamicA},
+			CustomFormatReminder: func(_ context.Context, _ *FormatReminderInput) (*FormatReminderOutput, error) {
+				return nil, errors.New("boom")
+			},
+		})
+		require.NoError(t, err)
+		assert.Contains(t, reminderOf(mw), "dynamic_tool_a")
+	})
+
+	t.Run("empty result suppresses the reminder message", func(t *testing.T) {
+		mw, err := New(ctx, &Config{
+			DynamicTools: []tool.BaseTool{dynamicA},
+			CustomFormatReminder: func(_ context.Context, _ *FormatReminderInput) (*FormatReminderOutput, error) {
+				return &FormatReminderOutput{Reminder: ""}, nil
+			},
+		})
+		require.NoError(t, err)
+		require.Empty(t, reminderOf(mw))
+
+		m := mw.(*typedMiddleware[*schema.Message])
+		state := &adk.ChatModelAgentState{Messages: []*schema.Message{schema.UserMessage("hi")}}
+		_, state, err = m.BeforeModelRewriteState(ctx, state, nil)
+		require.NoError(t, err)
+		assert.Equal(t, 0, countToolSearchReminders(state.Messages), "empty reminder → nothing inserted")
+	})
+
+	t.Run("default reminder is inserted once", func(t *testing.T) {
+		mw, err := New(ctx, &Config{DynamicTools: []tool.BaseTool{dynamicA}})
+		require.NoError(t, err)
+		m := mw.(*typedMiddleware[*schema.Message])
+		state := &adk.ChatModelAgentState{Messages: []*schema.Message{schema.UserMessage("hi")}}
+		_, state, err = m.BeforeModelRewriteState(ctx, state, nil)
+		require.NoError(t, err)
+		assert.Equal(t, 1, countToolSearchReminders(state.Messages))
+	})
+}

--- a/adk/middlewares/dynamictool/toolsearch/reminder_test.go
+++ b/adk/middlewares/dynamictool/toolsearch/reminder_test.go
@@ -54,33 +54,30 @@ func TestToolSearch_CustomFormatReminder(t *testing.T) {
 		assert.Contains(t, reminderOf(mw), "dynamic_tool_a")
 	})
 
-	t.Run("custom rewrites and receives default + tool infos", func(t *testing.T) {
-		var gotDefault string
+	t.Run("custom rewrites and receives tool infos", func(t *testing.T) {
 		var gotTools []*schema.ToolInfo
 		mw, err := New(ctx, &Config{
 			DynamicTools: []tool.BaseTool{dynamicA, dynamicB},
 			CustomFormatReminder: func(_ context.Context, in *FormatReminderInput) (*FormatReminderOutput, error) {
-				gotDefault = in.DefaultReminder
-				gotTools = in.Tools
+				gotTools = in.DynamicTools
 				return &FormatReminderOutput{Reminder: "CUSTOM REMINDER"}, nil
 			},
 		})
 		require.NoError(t, err)
 		assert.Equal(t, "CUSTOM REMINDER", reminderOf(mw))
-		assert.Contains(t, gotDefault, "dynamic_tool_a", "formatter gets the default reminder")
 		require.Len(t, gotTools, 2, "formatter gets full ToolInfos, not just names")
 		assert.Equal(t, "Dynamic tool A", gotTools[0].Desc, "ToolInfo carries description beyond the name")
 	})
 
-	t.Run("error keeps default reminder", func(t *testing.T) {
-		mw, err := New(ctx, &Config{
+	t.Run("error propagates and fails construction", func(t *testing.T) {
+		_, err := New(ctx, &Config{
 			DynamicTools: []tool.BaseTool{dynamicA},
 			CustomFormatReminder: func(_ context.Context, _ *FormatReminderInput) (*FormatReminderOutput, error) {
 				return nil, errors.New("boom")
 			},
 		})
-		require.NoError(t, err)
-		assert.Contains(t, reminderOf(mw), "dynamic_tool_a")
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "boom")
 	})
 
 	t.Run("empty result suppresses the reminder message", func(t *testing.T) {

--- a/adk/middlewares/dynamictool/toolsearch/toolsearch.go
+++ b/adk/middlewares/dynamictool/toolsearch/toolsearch.go
@@ -22,6 +22,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"log"
 	"sort"
 	"strings"
 	"text/template"
@@ -48,6 +49,26 @@ type Config struct {
 	// invalidate the model's KV-cache (as the tool list changes between calls), and effectiveness
 	// depends on the model's ability to work with a dynamically changing tool set.
 	UseModelToolSearch bool
+
+	// CustomFormatReminder customizes the mid-conversation system reminder that advertises
+	// the deferred tools. When nil, the default reminder is used. Returning a nil output or
+	// an error keeps the default reminder; returning an output whose Reminder is "" suppresses
+	// the reminder message entirely.
+	CustomFormatReminder func(ctx context.Context, in *FormatReminderInput) (*FormatReminderOutput, error)
+}
+
+// FormatReminderInput is the input to Config.CustomFormatReminder.
+type FormatReminderInput struct {
+	// DefaultReminder is the reminder the middleware would insert by default.
+	DefaultReminder string
+	// Tools are the dynamic tools advertised by the reminder.
+	Tools []*schema.ToolInfo
+}
+
+// FormatReminderOutput is the result of Config.CustomFormatReminder.
+type FormatReminderOutput struct {
+	// Reminder is the reminder text to insert. An empty string suppresses the reminder message.
+	Reminder string
 }
 
 // NewTyped constructs and returns the generic tool search middleware.
@@ -90,12 +111,21 @@ func NewTyped[M adk.MessageType](ctx context.Context, config *Config) (adk.Typed
 		return nil, fmt.Errorf("failed to format mid-conversation system reminder template: %w", err)
 	}
 
+	reminder := buf.String()
+	if config.CustomFormatReminder != nil {
+		if out, ferr := config.CustomFormatReminder(ctx, &FormatReminderInput{DefaultReminder: reminder, Tools: dynamicToolInfos}); ferr != nil {
+			log.Printf("toolsearch middleware: CustomFormatReminder failed, using default reminder: %v", ferr)
+		} else if out != nil {
+			reminder = out.Reminder
+		}
+	}
+
 	return &typedMiddleware[M]{
 		dynamicTools:       config.DynamicTools,
 		mapOfDynamicTools:  mapOfDynamicTools,
 		dynamicToolInfos:   dynamicToolInfos,
 		useModelToolSearch: config.UseModelToolSearch,
-		reminder:           buf.String(),
+		reminder:           reminder,
 	}, nil
 }
 
@@ -216,7 +246,7 @@ func (m *typedMiddleware[M]) BeforeModelRewriteState(ctx context.Context, state 
 	// Align any reminders reconstructed from history with the configured role; the fresh
 	// insert below is already built with that role.
 	state.Messages = systemreminder.NormalizeReminderRoles(state.Messages)
-	if !systemreminder.Has(state.Messages, toolSearchReminderExtraKey) {
+	if m.reminder != "" && !systemreminder.Has(state.Messages, toolSearchReminderExtraKey) {
 		state.Messages = systemreminder.Insert(ctx, state.Messages, toolSearchReminderExtraKey, m.reminder, nil)
 	}
 

--- a/adk/middlewares/dynamictool/toolsearch/toolsearch.go
+++ b/adk/middlewares/dynamictool/toolsearch/toolsearch.go
@@ -22,7 +22,6 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"log"
 	"sort"
 	"strings"
 	"text/template"
@@ -51,18 +50,16 @@ type Config struct {
 	UseModelToolSearch bool
 
 	// CustomFormatReminder customizes the mid-conversation system reminder that advertises
-	// the deferred tools. When nil, the default reminder is used. Returning a nil output or
-	// an error keeps the default reminder; returning an output whose Reminder is "" suppresses
-	// the reminder message entirely.
+	// the deferred tools. When nil, the default reminder is used. Returning an error aborts
+	// construction; returning a nil output keeps the default reminder; returning an output
+	// whose Reminder is "" suppresses the reminder message entirely.
 	CustomFormatReminder func(ctx context.Context, in *FormatReminderInput) (*FormatReminderOutput, error)
 }
 
 // FormatReminderInput is the input to Config.CustomFormatReminder.
 type FormatReminderInput struct {
-	// DefaultReminder is the reminder the middleware would insert by default.
-	DefaultReminder string
-	// Tools are the dynamic tools advertised by the reminder.
-	Tools []*schema.ToolInfo
+	// DynamicTools are the dynamic tools advertised by the reminder.
+	DynamicTools []*schema.ToolInfo
 }
 
 // FormatReminderOutput is the result of Config.CustomFormatReminder.
@@ -113,9 +110,11 @@ func NewTyped[M adk.MessageType](ctx context.Context, config *Config) (adk.Typed
 
 	reminder := buf.String()
 	if config.CustomFormatReminder != nil {
-		if out, ferr := config.CustomFormatReminder(ctx, &FormatReminderInput{DefaultReminder: reminder, Tools: dynamicToolInfos}); ferr != nil {
-			log.Printf("toolsearch middleware: CustomFormatReminder failed, using default reminder: %v", ferr)
-		} else if out != nil {
+		out, ferr := config.CustomFormatReminder(ctx, &FormatReminderInput{DynamicTools: dynamicToolInfos})
+		if ferr != nil {
+			return nil, fmt.Errorf("toolsearch middleware: CustomFormatReminder failed: %w", ferr)
+		}
+		if out != nil {
 			reminder = out.Reminder
 		}
 	}

--- a/adk/middlewares/skill/reminder_custom_test.go
+++ b/adk/middlewares/skill/reminder_custom_test.go
@@ -1,0 +1,116 @@
+/*
+ * Copyright 2026 CloudWeGo Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package skill
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/cloudwego/eino/adk"
+	"github.com/cloudwego/eino/schema"
+)
+
+func newReminderHandler(b Backend, fn func(context.Context, *FormatReminderInput) (*FormatReminderOutput, error)) *typedSkillHandler[*schema.Message] {
+	return &typedSkillHandler[*schema.Message]{
+		customFormatReminder: fn,
+		tool:                 &typedSkillTool[*schema.Message]{b: b},
+	}
+}
+
+func TestSkill_CustomFormatReminder(t *testing.T) {
+	backend := &inMemoryBackend{m: []Skill{
+		{FrontMatter: FrontMatter{Name: "alpha", Description: "d-alpha"}},
+	}}
+
+	t.Run("custom rewrites and receives default + current + changed", func(t *testing.T) {
+		var in *FormatReminderInput
+		h := newReminderHandler(backend, func(_ context.Context, i *FormatReminderInput) (*FormatReminderOutput, error) {
+			in = i
+			return &FormatReminderOutput{Reminder: "CUSTOM SKILLS"}, nil
+		})
+		withRunLocalCtx(t, func(ctx context.Context) {
+			state := &adk.ChatModelAgentState{Messages: []*schema.Message{schema.UserMessage("hi")}}
+			_, state, err := h.BeforeModelRewriteState(ctx, state, nil)
+			require.NoError(t, err)
+
+			require.Equal(t, 1, countReminders(state.Messages))
+			assert.Equal(t, "CUSTOM SKILLS", firstReminder(state.Messages).Content)
+
+			require.NotNil(t, in)
+			assert.Contains(t, in.DefaultReminder, "alpha")
+			assert.Len(t, in.Current, 1)
+			assert.Len(t, in.Changed, 1, "fresh run → every skill is changed")
+		})
+	})
+
+	t.Run("current vs changed distinguishes new from existing skills", func(t *testing.T) {
+		twoSkills := &inMemoryBackend{m: []Skill{
+			{FrontMatter: FrontMatter{Name: "alpha", Description: "d-alpha"}},
+			{FrontMatter: FrontMatter{Name: "beta", Description: "d-beta"}},
+		}}
+		var in *FormatReminderInput
+		h := newReminderHandler(twoSkills, func(_ context.Context, i *FormatReminderInput) (*FormatReminderOutput, error) {
+			in = i
+			return &FormatReminderOutput{Reminder: i.DefaultReminder}, nil
+		})
+		withRunLocalCtx(t, func(ctx context.Context) {
+			// A prior reminder already advertised alpha (its digest is in history).
+			prior := schema.SystemMessage("prior")
+			prior.Extra = map[string]any{
+				skillsReminderExtraKey: true,
+				skillsDigestExtraKey:   []string{skillDigest(FrontMatter{Name: "alpha", Description: "d-alpha"})},
+			}
+			state := &adk.ChatModelAgentState{Messages: []*schema.Message{prior, schema.UserMessage("hi")}}
+			_, _, err := h.BeforeModelRewriteState(ctx, state, nil)
+			require.NoError(t, err)
+
+			require.NotNil(t, in)
+			assert.Len(t, in.Current, 2, "Current is the full list")
+			require.Len(t, in.Changed, 1, "Changed is only the newly-added skill")
+			assert.Equal(t, "beta", in.Changed[0].Name)
+		})
+	})
+
+	t.Run("empty result skips insertion this turn", func(t *testing.T) {
+		h := newReminderHandler(backend, func(_ context.Context, _ *FormatReminderInput) (*FormatReminderOutput, error) {
+			return &FormatReminderOutput{Reminder: ""}, nil
+		})
+		withRunLocalCtx(t, func(ctx context.Context) {
+			state := &adk.ChatModelAgentState{Messages: []*schema.Message{schema.UserMessage("hi")}}
+			_, state, err := h.BeforeModelRewriteState(ctx, state, nil)
+			require.NoError(t, err)
+			assert.Equal(t, 0, countReminders(state.Messages), "empty result → no insert")
+		})
+	})
+
+	t.Run("error keeps default reminder", func(t *testing.T) {
+		h := newReminderHandler(backend, func(_ context.Context, _ *FormatReminderInput) (*FormatReminderOutput, error) {
+			return nil, errors.New("boom")
+		})
+		withRunLocalCtx(t, func(ctx context.Context) {
+			state := &adk.ChatModelAgentState{Messages: []*schema.Message{schema.UserMessage("hi")}}
+			_, state, err := h.BeforeModelRewriteState(ctx, state, nil)
+			require.NoError(t, err)
+			require.Equal(t, 1, countReminders(state.Messages))
+			assert.Contains(t, firstReminder(state.Messages).Content, "alpha", "falls back to default reminder")
+		})
+	})
+}

--- a/adk/middlewares/skill/reminder_custom_test.go
+++ b/adk/middlewares/skill/reminder_custom_test.go
@@ -40,7 +40,7 @@ func TestSkill_CustomFormatReminder(t *testing.T) {
 		{FrontMatter: FrontMatter{Name: "alpha", Description: "d-alpha"}},
 	}}
 
-	t.Run("custom rewrites and receives default + current + changed", func(t *testing.T) {
+	t.Run("custom rewrites and receives current + changed", func(t *testing.T) {
 		var in *FormatReminderInput
 		h := newReminderHandler(backend, func(_ context.Context, i *FormatReminderInput) (*FormatReminderOutput, error) {
 			in = i
@@ -55,7 +55,6 @@ func TestSkill_CustomFormatReminder(t *testing.T) {
 			assert.Equal(t, "CUSTOM SKILLS", firstReminder(state.Messages).Content)
 
 			require.NotNil(t, in)
-			assert.Contains(t, in.DefaultReminder, "alpha")
 			assert.Len(t, in.Current, 1)
 			assert.Len(t, in.Changed, 1, "fresh run → every skill is changed")
 		})
@@ -69,7 +68,7 @@ func TestSkill_CustomFormatReminder(t *testing.T) {
 		var in *FormatReminderInput
 		h := newReminderHandler(twoSkills, func(_ context.Context, i *FormatReminderInput) (*FormatReminderOutput, error) {
 			in = i
-			return &FormatReminderOutput{Reminder: i.DefaultReminder}, nil
+			return &FormatReminderOutput{Reminder: "kept"}, nil
 		})
 		withRunLocalCtx(t, func(ctx context.Context) {
 			// A prior reminder already advertised alpha (its digest is in history).
@@ -101,16 +100,16 @@ func TestSkill_CustomFormatReminder(t *testing.T) {
 		})
 	})
 
-	t.Run("error keeps default reminder", func(t *testing.T) {
+	t.Run("error propagates instead of falling back", func(t *testing.T) {
 		h := newReminderHandler(backend, func(_ context.Context, _ *FormatReminderInput) (*FormatReminderOutput, error) {
 			return nil, errors.New("boom")
 		})
 		withRunLocalCtx(t, func(ctx context.Context) {
 			state := &adk.ChatModelAgentState{Messages: []*schema.Message{schema.UserMessage("hi")}}
 			_, state, err := h.BeforeModelRewriteState(ctx, state, nil)
-			require.NoError(t, err)
-			require.Equal(t, 1, countReminders(state.Messages))
-			assert.Contains(t, firstReminder(state.Messages).Content, "alpha", "falls back to default reminder")
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), "boom")
+			assert.Equal(t, 0, countReminders(state.Messages), "no reminder inserted on error")
 		})
 	})
 }

--- a/adk/middlewares/skill/skill.go
+++ b/adk/middlewares/skill/skill.go
@@ -165,6 +165,12 @@ type TypedConfig[M adk.MessageType] struct {
 	// The function receives all available skill front matters as a parameter.
 	CustomToolDescription ToolDescriptionFunc
 
+	// CustomFormatReminder customizes the mid-conversation system reminder that advertises
+	// the available skills. When nil, the default reminder is used. Returning a nil output
+	// or an error keeps the default reminder; returning an output whose Reminder is ""
+	// suppresses the reminder this turn (the skills stay pending and are re-offered next turn).
+	CustomFormatReminder func(ctx context.Context, in *FormatReminderInput) (*FormatReminderOutput, error)
+
 	// CustomToolParams customizes tool parameters for the skill tool.
 	// defaults is the default schema with only the required "skill" field.
 	// optional
@@ -190,6 +196,23 @@ type TypedConfig[M adk.MessageType] struct {
 
 // Config is a backward-compatible alias for TypedConfig instantiated with *schema.Message.
 type Config = TypedConfig[*schema.Message]
+
+// FormatReminderInput is the input to TypedConfig.CustomFormatReminder.
+type FormatReminderInput struct {
+	// DefaultReminder is the reminder the middleware would insert by default (advertising Changed).
+	DefaultReminder string
+	// Current is the full skill list read this turn.
+	Current []FrontMatter
+	// Changed is the added/changed subset the middleware would advertise by default.
+	// The previously-advertised set is Current minus Changed.
+	Changed []FrontMatter
+}
+
+// FormatReminderOutput is the result of TypedConfig.CustomFormatReminder.
+type FormatReminderOutput struct {
+	// Reminder is the reminder text to insert. An empty string suppresses the reminder this turn.
+	Reminder string
+}
 
 // NewTyped creates a generic skill middleware handler for TypedChatModelAgent.
 //
@@ -223,7 +246,8 @@ func NewTyped[M adk.MessageType](ctx context.Context, config *TypedConfig[M]) (a
 	}
 
 	return &typedSkillHandler[M]{
-		instruction: instruction,
+		instruction:          instruction,
+		customFormatReminder: config.CustomFormatReminder,
 		tool: &typedSkillTool[M]{
 			b:                 config.Backend,
 			toolName:          name,
@@ -270,8 +294,9 @@ func NewMiddleware(ctx context.Context, config *Config) (adk.ChatModelAgentMiddl
 
 type typedSkillHandler[M adk.MessageType] struct {
 	*adk.TypedBaseChatModelAgentMiddleware[M]
-	instruction string
-	tool        *typedSkillTool[M]
+	instruction          string
+	customFormatReminder func(ctx context.Context, in *FormatReminderInput) (*FormatReminderOutput, error)
+	tool                 *typedSkillTool[M]
 }
 
 // BeforeAgent injects the skill tool and system prompt.
@@ -337,9 +362,9 @@ func (h *typedSkillHandler[M]) BeforeModelRewriteState(ctx context.Context, stat
 		return ctx, state, nil
 	}
 
-	prev, _ := systemreminder.LatestExtra(state.Messages, skillsReminderExtraKey, skillsDigestExtraKey)
-	prevSet := make(map[string]struct{}, len(toStringSlice(prev)))
-	for _, d := range toStringSlice(prev) {
+	prevDigests, _ := systemreminder.LatestExtra(state.Messages, skillsReminderExtraKey, skillsDigestExtraKey)
+	prevSet := make(map[string]struct{}, len(toStringSlice(prevDigests)))
+	for _, d := range toStringSlice(prevDigests) {
 		prevSet[d] = struct{}{}
 	}
 
@@ -361,8 +386,25 @@ func (h *typedSkillHandler[M]) BeforeModelRewriteState(ctx context.Context, stat
 		return ctx, state, nil
 	}
 
+	section := buildSkillsSectionFromEntries(changed)
+	if h.customFormatReminder != nil {
+		out, ferr := h.customFormatReminder(ctx, &FormatReminderInput{
+			DefaultReminder: section,
+			Current:         skills,
+			Changed:         changed,
+		})
+		if ferr != nil {
+			log.Printf("skill middleware: CustomFormatReminder failed, using default reminder: %v", ferr)
+		} else if out != nil {
+			if out.Reminder == "" {
+				return ctx, state, nil
+			}
+			section = out.Reminder
+		}
+	}
+
 	extra := map[string]any{skillsDigestExtraKey: digests}
-	state.Messages = systemreminder.Insert(ctx, state.Messages, skillsReminderExtraKey, buildSkillsSectionFromEntries(changed), extra)
+	state.Messages = systemreminder.Insert(ctx, state.Messages, skillsReminderExtraKey, section, extra)
 	return ctx, state, nil
 }
 

--- a/adk/middlewares/skill/skill.go
+++ b/adk/middlewares/skill/skill.go
@@ -166,9 +166,10 @@ type TypedConfig[M adk.MessageType] struct {
 	CustomToolDescription ToolDescriptionFunc
 
 	// CustomFormatReminder customizes the mid-conversation system reminder that advertises
-	// the available skills. When nil, the default reminder is used. Returning a nil output
-	// or an error keeps the default reminder; returning an output whose Reminder is ""
-	// suppresses the reminder this turn (the skills stay pending and are re-offered next turn).
+	// the available skills. When nil, the default reminder is used. Returning an error aborts
+	// the turn; returning a nil output keeps the default reminder; returning an output whose
+	// Reminder is "" suppresses the reminder this turn (the skills stay pending and are
+	// re-offered next turn).
 	CustomFormatReminder func(ctx context.Context, in *FormatReminderInput) (*FormatReminderOutput, error)
 
 	// CustomToolParams customizes tool parameters for the skill tool.
@@ -199,12 +200,9 @@ type Config = TypedConfig[*schema.Message]
 
 // FormatReminderInput is the input to TypedConfig.CustomFormatReminder.
 type FormatReminderInput struct {
-	// DefaultReminder is the reminder the middleware would insert by default (advertising Changed).
-	DefaultReminder string
 	// Current is the full skill list read this turn.
 	Current []FrontMatter
 	// Changed is the added/changed subset the middleware would advertise by default.
-	// The previously-advertised set is Current minus Changed.
 	Changed []FrontMatter
 }
 
@@ -389,13 +387,13 @@ func (h *typedSkillHandler[M]) BeforeModelRewriteState(ctx context.Context, stat
 	section := buildSkillsSectionFromEntries(changed)
 	if h.customFormatReminder != nil {
 		out, ferr := h.customFormatReminder(ctx, &FormatReminderInput{
-			DefaultReminder: section,
-			Current:         skills,
-			Changed:         changed,
+			Current: skills,
+			Changed: changed,
 		})
 		if ferr != nil {
-			log.Printf("skill middleware: CustomFormatReminder failed, using default reminder: %v", ferr)
-		} else if out != nil {
+			return ctx, state, fmt.Errorf("skill middleware: CustomFormatReminder failed: %w", ferr)
+		}
+		if out != nil {
 			if out.Reminder == "" {
 				return ctx, state, nil
 			}

--- a/adk/middlewares/subagent/middleware.go
+++ b/adk/middlewares/subagent/middleware.go
@@ -19,6 +19,7 @@ package subagent
 import (
 	"context"
 	"fmt"
+	"log"
 	"strings"
 
 	"github.com/slongfield/pyfmt"
@@ -58,10 +59,30 @@ type TypedConfig[M adk.MessageType] struct {
 	// Defined as *string because an empty string may be an intentional user value.
 	SystemPrompt *string
 
+	// CustomFormatReminder customizes the mid-conversation system reminder that advertises
+	// the available agent types. When nil, the default reminder is used. Returning a nil
+	// output or an error keeps the default reminder; returning an output whose Reminder is
+	// "" suppresses the reminder message entirely.
+	CustomFormatReminder func(ctx context.Context, in *FormatReminderInput[M]) (*FormatReminderOutput, error)
+
 	// Background configures background-task execution for sub-agent runs. When nil,
 	// only foreground (blocking) agent execution is available and runs are NOT
 	// tracked. See BackgroundConfig.
 	Background *TypedBackgroundConfig[M]
+}
+
+// FormatReminderInput is the input to TypedConfig.CustomFormatReminder.
+type FormatReminderInput[M adk.MessageType] struct {
+	// DefaultReminder is the reminder the middleware would insert by default.
+	DefaultReminder string
+	// SubAgents are the sub-agents advertised by the reminder.
+	SubAgents []adk.TypedAgent[M]
+}
+
+// FormatReminderOutput is the result of TypedConfig.CustomFormatReminder.
+type FormatReminderOutput struct {
+	// Reminder is the reminder text to insert. An empty string suppresses the reminder message.
+	Reminder string
 }
 
 // BackgroundConfig enables background-task execution for the standard
@@ -222,6 +243,13 @@ func NewTyped[M adk.MessageType](ctx context.Context, config *TypedConfig[M]) (a
 	reminder := ""
 	if len(entries) > 0 {
 		reminder = buildAgentTypesSectionFromEntries(entries)
+	}
+	if config.CustomFormatReminder != nil {
+		if out, ferr := config.CustomFormatReminder(ctx, &FormatReminderInput[M]{DefaultReminder: reminder, SubAgents: config.SubAgents}); ferr != nil {
+			log.Printf("subagent middleware: CustomFormatReminder failed, using default reminder: %v", ferr)
+		} else if out != nil {
+			reminder = out.Reminder
+		}
 	}
 
 	return &typedSubagentMiddleware[M]{

--- a/adk/middlewares/subagent/middleware.go
+++ b/adk/middlewares/subagent/middleware.go
@@ -19,7 +19,6 @@ package subagent
 import (
 	"context"
 	"fmt"
-	"log"
 	"strings"
 
 	"github.com/slongfield/pyfmt"
@@ -60,9 +59,9 @@ type TypedConfig[M adk.MessageType] struct {
 	SystemPrompt *string
 
 	// CustomFormatReminder customizes the mid-conversation system reminder that advertises
-	// the available agent types. When nil, the default reminder is used. Returning a nil
-	// output or an error keeps the default reminder; returning an output whose Reminder is
-	// "" suppresses the reminder message entirely.
+	// the available agent types. When nil, the default reminder is used. Returning an error
+	// aborts construction; returning a nil output keeps the default reminder; returning an
+	// output whose Reminder is "" suppresses the reminder message entirely.
 	CustomFormatReminder func(ctx context.Context, in *FormatReminderInput[M]) (*FormatReminderOutput, error)
 
 	// Background configures background-task execution for sub-agent runs. When nil,
@@ -73,8 +72,6 @@ type TypedConfig[M adk.MessageType] struct {
 
 // FormatReminderInput is the input to TypedConfig.CustomFormatReminder.
 type FormatReminderInput[M adk.MessageType] struct {
-	// DefaultReminder is the reminder the middleware would insert by default.
-	DefaultReminder string
 	// SubAgents are the sub-agents advertised by the reminder.
 	SubAgents []adk.TypedAgent[M]
 }
@@ -245,9 +242,11 @@ func NewTyped[M adk.MessageType](ctx context.Context, config *TypedConfig[M]) (a
 		reminder = buildAgentTypesSectionFromEntries(entries)
 	}
 	if config.CustomFormatReminder != nil {
-		if out, ferr := config.CustomFormatReminder(ctx, &FormatReminderInput[M]{DefaultReminder: reminder, SubAgents: config.SubAgents}); ferr != nil {
-			log.Printf("subagent middleware: CustomFormatReminder failed, using default reminder: %v", ferr)
-		} else if out != nil {
+		out, ferr := config.CustomFormatReminder(ctx, &FormatReminderInput[M]{SubAgents: config.SubAgents})
+		if ferr != nil {
+			return nil, fmt.Errorf("subagent middleware: CustomFormatReminder failed: %w", ferr)
+		}
+		if out != nil {
 			reminder = out.Reminder
 		}
 	}

--- a/adk/middlewares/subagent/reminder_custom_test.go
+++ b/adk/middlewares/subagent/reminder_custom_test.go
@@ -58,32 +58,29 @@ func TestSubagent_CustomFormatReminder(t *testing.T) {
 		assert.Contains(t, rem, "does research")
 	})
 
-	t.Run("custom rewrites and receives default + sub-agents", func(t *testing.T) {
-		var gotDefault string
+	t.Run("custom rewrites and receives sub-agents", func(t *testing.T) {
 		var gotAgents []adk.TypedAgent[*schema.Message]
 		mw, err := NewTyped[*schema.Message](ctx, &TypedConfig[*schema.Message]{
 			SubAgents: subAgents,
 			CustomFormatReminder: func(_ context.Context, in *FormatReminderInput[*schema.Message]) (*FormatReminderOutput, error) {
-				gotDefault = in.DefaultReminder
 				gotAgents = in.SubAgents
 				return &FormatReminderOutput{Reminder: "CUSTOM AGENTS"}, nil
 			},
 		})
 		require.NoError(t, err)
 		assert.Equal(t, "CUSTOM AGENTS", reminderOfMiddleware(t, mw))
-		assert.Contains(t, gotDefault, "researcher")
 		assert.Len(t, gotAgents, 2)
 	})
 
-	t.Run("error keeps default reminder", func(t *testing.T) {
-		mw, err := NewTyped[*schema.Message](ctx, &TypedConfig[*schema.Message]{
+	t.Run("error propagates and fails construction", func(t *testing.T) {
+		_, err := NewTyped[*schema.Message](ctx, &TypedConfig[*schema.Message]{
 			SubAgents: subAgents,
 			CustomFormatReminder: func(_ context.Context, _ *FormatReminderInput[*schema.Message]) (*FormatReminderOutput, error) {
 				return nil, errors.New("boom")
 			},
 		})
-		require.NoError(t, err)
-		assert.Contains(t, reminderOfMiddleware(t, mw), "researcher")
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "boom")
 	})
 
 	t.Run("empty result suppresses the reminder message", func(t *testing.T) {

--- a/adk/middlewares/subagent/reminder_custom_test.go
+++ b/adk/middlewares/subagent/reminder_custom_test.go
@@ -1,0 +1,105 @@
+/*
+ * Copyright 2026 CloudWeGo Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package subagent
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/cloudwego/eino/adk"
+	"github.com/cloudwego/eino/schema"
+)
+
+func reminderOfMiddleware(t *testing.T, mw adk.TypedChatModelAgentMiddleware[*schema.Message]) string {
+	t.Helper()
+	return mw.(*typedSubagentMiddleware[*schema.Message]).reminder
+}
+
+func countAgentTypesReminders(msgs []*schema.Message) int {
+	n := 0
+	for _, m := range msgs {
+		if _, ok := m.Extra[agentTypesReminderExtraKey]; ok {
+			n++
+		}
+	}
+	return n
+}
+
+func TestSubagent_CustomFormatReminder(t *testing.T) {
+	ctx := context.Background()
+	subAgents := []adk.TypedAgent[*schema.Message]{
+		&mockAgent{name: "researcher", desc: "does research"},
+		&mockAgent{name: "coder", desc: "writes code"},
+	}
+
+	t.Run("nil keeps default reminder", func(t *testing.T) {
+		mw, err := NewTyped[*schema.Message](ctx, &TypedConfig[*schema.Message]{SubAgents: subAgents})
+		require.NoError(t, err)
+		rem := reminderOfMiddleware(t, mw)
+		assert.Contains(t, rem, "researcher")
+		assert.Contains(t, rem, "does research")
+	})
+
+	t.Run("custom rewrites and receives default + sub-agents", func(t *testing.T) {
+		var gotDefault string
+		var gotAgents []adk.TypedAgent[*schema.Message]
+		mw, err := NewTyped[*schema.Message](ctx, &TypedConfig[*schema.Message]{
+			SubAgents: subAgents,
+			CustomFormatReminder: func(_ context.Context, in *FormatReminderInput[*schema.Message]) (*FormatReminderOutput, error) {
+				gotDefault = in.DefaultReminder
+				gotAgents = in.SubAgents
+				return &FormatReminderOutput{Reminder: "CUSTOM AGENTS"}, nil
+			},
+		})
+		require.NoError(t, err)
+		assert.Equal(t, "CUSTOM AGENTS", reminderOfMiddleware(t, mw))
+		assert.Contains(t, gotDefault, "researcher")
+		assert.Len(t, gotAgents, 2)
+	})
+
+	t.Run("error keeps default reminder", func(t *testing.T) {
+		mw, err := NewTyped[*schema.Message](ctx, &TypedConfig[*schema.Message]{
+			SubAgents: subAgents,
+			CustomFormatReminder: func(_ context.Context, _ *FormatReminderInput[*schema.Message]) (*FormatReminderOutput, error) {
+				return nil, errors.New("boom")
+			},
+		})
+		require.NoError(t, err)
+		assert.Contains(t, reminderOfMiddleware(t, mw), "researcher")
+	})
+
+	t.Run("empty result suppresses the reminder message", func(t *testing.T) {
+		mw, err := NewTyped[*schema.Message](ctx, &TypedConfig[*schema.Message]{
+			SubAgents: subAgents,
+			CustomFormatReminder: func(_ context.Context, _ *FormatReminderInput[*schema.Message]) (*FormatReminderOutput, error) {
+				return &FormatReminderOutput{Reminder: ""}, nil
+			},
+		})
+		require.NoError(t, err)
+		require.Empty(t, reminderOfMiddleware(t, mw))
+
+		m := mw.(*typedSubagentMiddleware[*schema.Message])
+		state := &adk.ChatModelAgentState{Messages: []*schema.Message{schema.UserMessage("hi")}}
+		_, state, err = m.BeforeModelRewriteState(ctx, state, nil)
+		require.NoError(t, err)
+		assert.Equal(t, 0, countAgentTypesReminders(state.Messages), "empty reminder → nothing inserted")
+	})
+}

--- a/adk/middlewares/summarization/before_agent_test.go
+++ b/adk/middlewares/summarization/before_agent_test.go
@@ -54,3 +54,26 @@ func TestBeforeAgent_AppendsContextManagementNote(t *testing.T) {
 	assert.Contains(t, rc2.Instruction, "base instruction")
 	assert.Contains(t, rc2.Instruction, note)
 }
+
+func TestBeforeAgent_CustomFormatContextInstruction(t *testing.T) {
+	ctx := context.Background()
+
+	newMW := func(fn func(context.Context) string) *TypedMiddleware[*schema.Message] {
+		return &TypedMiddleware[*schema.Message]{cfg: &TypedConfig[*schema.Message]{CustomFormatContextInstruction: fn}}
+	}
+
+	t.Run("custom replaces the default note", func(t *testing.T) {
+		mw := newMW(func(context.Context) string { return "CUSTOM NOTE" })
+		_, rc, err := mw.BeforeAgent(ctx, &adk.ChatModelAgentContext[*schema.Message]{Instruction: "base"})
+		require.NoError(t, err)
+		assert.Contains(t, rc.Instruction, "CUSTOM NOTE")
+		assert.NotContains(t, rc.Instruction, getContextManagementInstruction())
+	})
+
+	t.Run("empty result suppresses the note", func(t *testing.T) {
+		mw := newMW(func(context.Context) string { return "" })
+		_, rc, err := mw.BeforeAgent(ctx, &adk.ChatModelAgentContext[*schema.Message]{Instruction: "base"})
+		require.NoError(t, err)
+		assert.Equal(t, "base", rc.Instruction, "empty note → instruction untouched")
+	})
+}

--- a/adk/middlewares/summarization/before_agent_test.go
+++ b/adk/middlewares/summarization/before_agent_test.go
@@ -55,11 +55,11 @@ func TestBeforeAgent_AppendsContextManagementNote(t *testing.T) {
 	assert.Contains(t, rc2.Instruction, note)
 }
 
-func TestBeforeAgent_CustomFormatContextInstruction(t *testing.T) {
+func TestBeforeAgent_CustomFormatContextManagementInstruction(t *testing.T) {
 	ctx := context.Background()
 
 	newMW := func(fn func(context.Context) string) *TypedMiddleware[*schema.Message] {
-		return &TypedMiddleware[*schema.Message]{cfg: &TypedConfig[*schema.Message]{CustomFormatContextInstruction: fn}}
+		return &TypedMiddleware[*schema.Message]{cfg: &TypedConfig[*schema.Message]{CustomFormatContextManagementInstruction: fn}}
 	}
 
 	t.Run("custom replaces the default note", func(t *testing.T) {

--- a/adk/middlewares/summarization/summarization.go
+++ b/adk/middlewares/summarization/summarization.go
@@ -162,6 +162,13 @@ type TypedConfig[M adk.MessageType] struct {
 	// Optional. Defaults to no retries.
 	Retry *TypedRetryConfig[M]
 
+	// CustomFormatContextInstruction customizes the context-management note that BeforeAgent
+	// appends to the agent system prompt (the note telling the model long conversations are
+	// summarized automatically). When nil, the default note is used; returning "" suppresses
+	// the note entirely.
+	// Optional.
+	CustomFormatContextInstruction func(ctx context.Context) string
+
 	// Failover configures fallback behavior when summary generation on the primary model fails.
 	// Optional.
 	Failover *TypedFailoverConfig[M]
@@ -356,6 +363,9 @@ func (m *TypedMiddleware[M]) BeforeAgent(ctx context.Context, runCtx *adk.ChatMo
 	// Append the context-management note to the agent system prompt so the model knows
 	// long conversations are summarized automatically ({{summarization prompt}}).
 	note := getContextManagementInstruction()
+	if m.cfg != nil && m.cfg.CustomFormatContextInstruction != nil {
+		note = m.cfg.CustomFormatContextInstruction(ctx)
+	}
 	if strings.TrimSpace(note) != "" {
 		nRunCtx := *runCtx
 		if strings.TrimSpace(nRunCtx.Instruction) == "" {

--- a/adk/middlewares/summarization/summarization.go
+++ b/adk/middlewares/summarization/summarization.go
@@ -162,12 +162,12 @@ type TypedConfig[M adk.MessageType] struct {
 	// Optional. Defaults to no retries.
 	Retry *TypedRetryConfig[M]
 
-	// CustomFormatContextInstruction customizes the context-management note that BeforeAgent
-	// appends to the agent system prompt (the note telling the model long conversations are
-	// summarized automatically). When nil, the default note is used; returning "" suppresses
-	// the note entirely.
+	// CustomFormatContextManagementInstruction customizes the context-management note that
+	// BeforeAgent appends to the agent system prompt (the note telling the model long
+	// conversations are summarized automatically). When nil, the default note is used;
+	// returning "" suppresses the note entirely.
 	// Optional.
-	CustomFormatContextInstruction func(ctx context.Context) string
+	CustomFormatContextManagementInstruction func(ctx context.Context) string
 
 	// Failover configures fallback behavior when summary generation on the primary model fails.
 	// Optional.
@@ -363,8 +363,8 @@ func (m *TypedMiddleware[M]) BeforeAgent(ctx context.Context, runCtx *adk.ChatMo
 	// Append the context-management note to the agent system prompt so the model knows
 	// long conversations are summarized automatically ({{summarization prompt}}).
 	note := getContextManagementInstruction()
-	if m.cfg != nil && m.cfg.CustomFormatContextInstruction != nil {
-		note = m.cfg.CustomFormatContextInstruction(ctx)
+	if m.cfg != nil && m.cfg.CustomFormatContextManagementInstruction != nil {
+		note = m.cfg.CustomFormatContextManagementInstruction(ctx)
 	}
 	if strings.TrimSpace(note) != "" {
 		nRunCtx := *runCtx


### PR DESCRIPTION
# CustomFormatReminder for ADK middlewares

## English

### What

Add an optional `CustomFormatReminder` hook to the `skill`, `subagent`, and
`toolsearch` ADK middlewares, letting callers customize the mid-conversation
system reminder each one injects.

### Why

All three middlewares injected a **fixed** reminder from
`BeforeModelRewriteState`. As an agent-development framework, eino should let the
business layer control this wording (i18n, house style, extra guidance) rather
than hardcode it.

### How

Each config gains an optional `CustomFormatReminder` hook. It receives the
default reminder plus the structured data behind it, and returns the reminder to
use: not configured or nil/error falls back to the default, a non-empty result
replaces it, and an empty result suppresses the reminder entirely.

### Compatibility

Additive, opt-in field on existing configs. Default behavior unchanged when
`CustomFormatReminder` is nil.

---

## 中文

### 概述

为 `skill`、`subagent`、`toolsearch` 三个 ADK 中间件新增可选的
`CustomFormatReminder` 钩子，允许调用方自定义各自注入的会话内 system reminder。

### 背景

三个中间件都在 `BeforeModelRewriteState` 里注入**固定**的 reminder。作为 agent
开发框架，eino 应把这段文案的控制权（国际化、团队风格、额外提示）交给业务层，而不是
写死。

### 实现

每个 config 新增可选的 `CustomFormatReminder` 钩子。它接收默认 reminder 及背后的
结构化数据，返回要使用的 reminder：未配置或返回 nil/error 时回退默认，返回非空则替换，
返回空则完全不插入该 reminder。

### 兼容性

在现有 config 上新增的可选字段，向后兼容。`CustomFormatReminder` 为 nil 时行为与
原来完全一致。
