### PR TITLE
feat(adk): add CustomSystemPrompt override for backgroundtask middleware

### DIFF
--- a/adk/middlewares/backgroundtask/middleware.go
+++ b/adk/middlewares/backgroundtask/middleware.go
@@ -85,6 +85,20 @@ type TypedConfig[M adk.MessageType] struct {
 	TaskOutputToolConfig *ToolConfig
 	// TaskStopToolConfig configures the task_stop tool. Optional.
 	TaskStopToolConfig *ToolConfig
+
+	// CustomSystemPrompt fully replaces the default background-task instruction
+	// appended to the agent instruction. Optional; when nil the built-in instruction
+	// is used. It receives the default control-tool names so the returned text can
+	// reference them; returning "" injects no instruction.
+	CustomSystemPrompt func(ctx context.Context, in *SystemPromptInput) string
+}
+
+// SystemPromptInput carries the default control-tool names passed to CustomSystemPrompt.
+type SystemPromptInput struct {
+	// the default task_output tool name.
+	DefaultTaskOutputToolName string
+	// the default task_stop tool name.
+	DefaultTaskStopToolName string
 }
 
 // New creates a middleware that injects the task_output and task_stop tools, bound
@@ -127,6 +141,12 @@ func NewTyped[M adk.MessageType](ctx context.Context, config *TypedConfig[M]) (a
 	}
 
 	instruction := buildInstruction(config.TaskOutputToolConfig, outputEnabled, config.TaskStopToolConfig, stopEnabled)
+	if config.CustomSystemPrompt != nil {
+		instruction = config.CustomSystemPrompt(ctx, &SystemPromptInput{
+			DefaultTaskOutputToolName: taskOutputToolName,
+			DefaultTaskStopToolName:   taskStopToolName,
+		})
+	}
 
 	return &typedMiddleware[M]{
 		tools:       tools,

--- a/adk/middlewares/backgroundtask/middleware_test.go
+++ b/adk/middlewares/backgroundtask/middleware_test.go
@@ -348,6 +348,47 @@ func TestMiddleware_InstructionEmptyWhenAllDisabled(t *testing.T) {
 	assert.Empty(t, runCtx.Tools)
 }
 
+// TestMiddleware_CustomSystemPrompt verifies CustomSystemPrompt fully replaces the
+// built-in instruction and receives the default control-tool names.
+func TestMiddleware_CustomSystemPrompt(t *testing.T) {
+	mgr := newBackgroundManager(t, context.Background(), &bgtask.Config{})
+	defer closeWithTimeout(mgr)
+
+	var got *SystemPromptInput
+	mw, err := New(context.Background(), &Config{
+		Manager: mgr,
+		CustomSystemPrompt: func(_ context.Context, in *SystemPromptInput) string {
+			got = in
+			return "CUSTOM " + in.DefaultTaskOutputToolName
+		},
+	})
+	require.NoError(t, err)
+	_, runCtx, err := mw.BeforeAgent(context.Background(), &adk.ChatModelAgentContext[*schema.Message]{Instruction: "base"})
+	require.NoError(t, err)
+
+	require.NotNil(t, got)
+	assert.Equal(t, taskOutputToolName, got.DefaultTaskOutputToolName)
+	assert.Equal(t, taskStopToolName, got.DefaultTaskStopToolName)
+	assert.Equal(t, "base\nCUSTOM task_output", runCtx.Instruction)
+	assert.NotContains(t, runCtx.Instruction, "you will be notified when they complete")
+}
+
+// TestMiddleware_CustomSystemPromptEmptyInjectsNothing verifies returning "" from
+// CustomSystemPrompt appends no instruction.
+func TestMiddleware_CustomSystemPromptEmptyInjectsNothing(t *testing.T) {
+	mgr := newBackgroundManager(t, context.Background(), &bgtask.Config{})
+	defer closeWithTimeout(mgr)
+
+	mw, err := New(context.Background(), &Config{
+		Manager:            mgr,
+		CustomSystemPrompt: func(context.Context, *SystemPromptInput) string { return "" },
+	})
+	require.NoError(t, err)
+	_, runCtx, err := mw.BeforeAgent(context.Background(), &adk.ChatModelAgentContext[*schema.Message]{Instruction: "base"})
+	require.NoError(t, err)
+	assert.Equal(t, "base", runCtx.Instruction)
+}
+
 func TestTaskOutputTool(t *testing.T) {
 	mgr := newBackgroundManager(t, context.Background(), &bgtask.Config{})
 	defer closeWithTimeout(mgr)


### PR DESCRIPTION
## What

Add `CustomSystemPrompt` to the background-task middleware's `TypedConfig`, letting callers override the injected instruction.

```go
CustomSystemPrompt func(ctx context.Context, in *SystemPromptInput) string
```

## Why

Every other instruction-injecting middleware (subagent, filesystem/skill, summarization, automemory) already exposes an override; backgroundtask was the only one hardcoded.

## How

- `nil` → built-in instruction (default unchanged)
- non-`nil` → return value **fully replaces** it; `""` injects nothing
- input carries the default tool names (`task_output` / `task_stop`)

---

## What（中文）

给 background-task middleware 的 `TypedConfig` 加 `CustomSystemPrompt`，允许覆盖注入的指令。

```go
CustomSystemPrompt func(ctx context.Context, in *SystemPromptInput) string
```

## Why

其他注入指令的 middleware（subagent、filesystem/skill、summarization、automemory）都有覆盖入口，只有 backgroundtask 的指令是写死的。

## How

- `nil` → 内置指令（默认不变）
- 非 `nil` → 返回值**完全替换**内置指令；`""` 不注入
- 入参携带 default 工具名（`task_output` / `task_stop`）