### PR TITLE
fix(adk): report out-of-range read offset instead of emitting the offset value

### DIFF
--- a/adk/middlewares/filesystem/filesystem.go
+++ b/adk/middlewares/filesystem/filesystem.go
@@ -628,14 +628,30 @@ func newReadFileTool(fs filesystem.Backend, name string, desc string) (tool.Base
 			return fmt.Sprintf("No content found at path: %s", input.FilePath), nil
 		}
 
-		return formatLineNumbers(fileCt.Content, input.Offset), nil
+		return formatReadResult(fileCt.Content, input.FilePath, input.Offset), nil
 	})
+}
+
+// formatReadResult renders file content with line numbers, or an explanatory
+// message when the read produced no content at all. Backends report an Offset
+// past the last line as empty content rather than an error, and empty files are
+// legitimately empty; in both cases numbering would emit a single bogus line
+// (e.g. "   300\t") that reads as if the file contained the offset value.
+func formatReadResult(content, filePath string, startLine int) string {
+	if content == "" {
+		return fmt.Sprintf("No content read from %s: the file is empty, or offset %d is past its last line", filePath, startLine)
+	}
+	return formatLineNumbers(content, startLine)
 }
 
 // formatLineNumbers prefixes each line of content with a 1-based line number
 // starting at startLine (e.g. "     1\tfoo"). startLine corresponds to the
 // line number of the first line in content (usually ReadRequest.Offset).
+// Empty content yields an empty string rather than one blank numbered line.
 func formatLineNumbers(content string, startLine int) string {
+	if content == "" {
+		return ""
+	}
 	lines := strings.Split(content, "\n")
 	var b strings.Builder
 	for i, line := range lines {
@@ -779,7 +795,7 @@ func newMultiModalReadFileTool(fs filesystem.Backend, name string, desc string) 
 		}
 
 		return &schema.ToolResult{
-			Parts: []schema.ToolOutputPart{{Type: schema.ToolPartTypeText, Text: formatLineNumbers(fileCt.Content, input.Offset)}},
+			Parts: []schema.ToolOutputPart{{Type: schema.ToolPartTypeText, Text: formatReadResult(fileCt.Content, input.FilePath, input.Offset)}},
 		}, nil
 	})
 }

--- a/adk/middlewares/filesystem/filesystem_test.go
+++ b/adk/middlewares/filesystem/filesystem_test.go
@@ -2613,6 +2613,71 @@ func TestMultiModalReadFileTool_NilResult(t *testing.T) {
 	assert.Contains(t, result.Parts[0].Text, "/missing.txt")
 }
 
+// TestFormatLineNumbers_EmptyContent verifies that empty content produces no
+// output at all, instead of one blank line numbered startLine — which used to
+// render as the bare offset value (e.g. "   300\t").
+func TestFormatLineNumbers_EmptyContent(t *testing.T) {
+	assert.Equal(t, "", formatLineNumbers("", 300))
+	assert.Equal(t, "   300\ta", formatLineNumbers("a", 300))
+}
+
+// TestReadFileTool_OffsetBeyondEOF verifies that an Offset past the last line
+// of the file yields an explanatory message rather than the offset value.
+func TestReadFileTool_OffsetBeyondEOF(t *testing.T) {
+	backend := setupTestBackend()
+	readTool, err := newReadFileTool(backend, "", "")
+	assert.NoError(t, err)
+
+	// /file1.txt has 5 lines.
+	out, err := invokeTool(t, readTool, `{"file_path": "/file1.txt", "offset": 300, "limit": 100}`)
+	assert.NoError(t, err)
+	assert.NotEqual(t, "   300\t", out)
+	assert.Contains(t, out, "/file1.txt")
+	assert.Contains(t, out, "offset 300")
+}
+
+// TestReadFileTool_EmptyFile verifies that reading a legitimately empty file
+// reports no content instead of a phantom line 1.
+func TestReadFileTool_EmptyFile(t *testing.T) {
+	backend := setupTestBackend()
+	err := backend.Write(context.Background(), &filesystem.WriteRequest{FilePath: "/empty.txt", Content: ""})
+	assert.NoError(t, err)
+
+	readTool, err := newReadFileTool(backend, "", "")
+	assert.NoError(t, err)
+
+	out, err := invokeTool(t, readTool, `{"file_path": "/empty.txt"}`)
+	assert.NoError(t, err)
+	assert.NotEqual(t, "     1\t", out)
+	assert.Contains(t, out, "/empty.txt")
+}
+
+// TestMultiModalReadFileTool_OffsetBeyondEOF verifies the multimodal read tool
+// shares the out-of-range handling of the plain read tool.
+func TestMultiModalReadFileTool_OffsetBeyondEOF(t *testing.T) {
+	base := setupTestBackend()
+	eb := &multiModalBackend{
+		InMemoryBackend: base,
+		multiModalReadFunc: func(ctx context.Context, req *filesystem.MultiModalReadRequest) (*filesystem.MultiFileContent, error) {
+			fc, err := base.Read(ctx, &req.ReadRequest)
+			if err != nil {
+				return nil, err
+			}
+			return &filesystem.MultiFileContent{FileContent: fc}, nil
+		},
+	}
+
+	mmTool, err := newMultiModalReadFileTool(eb, "", "")
+	assert.NoError(t, err)
+
+	result, err := mmTool.(tool.EnhancedInvokableTool).InvokableRun(
+		context.Background(), &schema.ToolArgument{Text: `{"file_path": "/file1.txt", "offset": 300, "limit": 100}`})
+	assert.NoError(t, err)
+	assert.Len(t, result.Parts, 1)
+	assert.NotEqual(t, "   300\t", result.Parts[0].Text)
+	assert.Contains(t, result.Parts[0].Text, "offset 300")
+}
+
 func TestValidatePages(t *testing.T) {
 	tests := []struct {
 		name    string


### PR DESCRIPTION
## What

`read_file` returned the bare offset value as its output when `offset` exceeded the file's line count:

```
Input:  {"file_path": "/workspace/projects/src/app/page.tsx", "limit": 100, "offset": 300}
Output: 300
```

## Why

Two behaviours combined:

1. `InMemoryBackend.Read` reports an out-of-range offset as empty content with no error (`adk/filesystem/backend_inmemory.go:175`) — this is the intended contract.
2. `formatLineNumbers` ran `strings.Split("", "\n")`, which returns `[""]` (length 1, not 0), so it emitted one numbered blank line: `"   300\t"`. With the trailing tab trimmed for display, that reads as if the file contained `300`.

The same path made a legitimately empty file render as a phantom line 1 (`"     1\t"`).

## How

- `formatLineNumbers` short-circuits on empty content.
- New `formatReadResult` wraps it and, for empty content, returns a message the model can act on:
  ```
  No content read from /path/to/file: the file is empty, or offset 300 is past its last line
  ```
- Both `newReadFileTool` and `newMultiModalReadFileTool` use it.

Fixed at the tool layer rather than in `InMemoryBackend` so third-party backends following the same "offset out of range → empty content" contract are covered too.

## Note

The message merges "empty file" and "offset out of range" because the tool layer has no access to the file's total line count. Distinguishing them, or including the actual line count, would require extending `filesystem.FileContent` — a cross-package interface change left out of this fix.

## Tests

Added to `adk/middlewares/filesystem/filesystem_test.go`:

- `TestFormatLineNumbers_EmptyContent`
- `TestReadFileTool_OffsetBeyondEOF`
- `TestReadFileTool_EmptyFile`
- `TestMultiModalReadFileTool_OffsetBeyondEOF`

`go test -race ./adk/...` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
