### PR TITLE
Feat/filesystem tool args

### DIFF
--- a/adk/middlewares/filesystem/filesystem.go
+++ b/adk/middlewares/filesystem/filesystem.go
@@ -799,7 +799,7 @@ func newLsTool(fs filesystem.Backend, name string, desc string) (tool.BaseTool, 
 
 type readFileArgs struct {
 	// FilePath is the path to the file to read.
-	FilePath string `json:"file_path" jsonschema:"description=The path to the file to read"`
+	FilePath string `json:"file_path" jsonschema:"description=The absolute path to the file to read"`
 
 	// Offset is the line number to start reading from.
 	Offset int `json:"offset" jsonschema:"description=The line number to start reading from. Only provide if the file is too large to read at once"`
@@ -1009,7 +1009,7 @@ func newMultiModalReadFileTool(fs filesystem.Backend, name string, desc string) 
 
 type writeFileArgs struct {
 	// FilePath is the path to the file to write.
-	FilePath string `json:"file_path" jsonschema:"description=The path to the file to write"`
+	FilePath string `json:"file_path" jsonschema:"description=The absolute path to the file to write"`
 
 	// Content is the content to write to the file.
 	Content string `json:"content" jsonschema:"description=The content to write to the file"`
@@ -1035,7 +1035,7 @@ func newWriteFileTool(fs filesystem.Backend, name string, desc string) (tool.Bas
 
 type editFileArgs struct {
 	// FilePath is the path to the file to modify.
-	FilePath string `json:"file_path" jsonschema:"description=The path to the file to modify"`
+	FilePath string `json:"file_path" jsonschema:"description=The absolute path to the file to modify"`
 
 	// OldString is the text to replace.
 	OldString string `json:"old_string" jsonschema:"description=The text to replace"`


### PR DESCRIPTION
# PR Description

## English

Update the `FilePath` descriptions for read, write, and edit file tools to explicitly require an absolute path.

## 中文

更新文件读取、写入和编辑工具的 `FilePath` 描述，明确要求使用绝对路径。