### PR TITLE
fix(compose): apply middleware to unknown tools

### DIFF
--- a/adk/session_timeline_test.go
+++ b/adk/session_timeline_test.go
@@ -1529,6 +1529,105 @@ func TestToolSpan_PersistedAroundToolCallAndLinksToMessages(t *testing.T) {
 	assert.Equal(t, toolStart.Span.ParentSpanID, toolEnd.Span.ParentSpanID)
 }
 
+func TestAttack_UnknownToolResultPersistsSessionEvent(t *testing.T) {
+	for _, tt := range []struct {
+		name      string
+		streaming bool
+	}{
+		{name: "invoke"},
+		{name: "stream", streaming: true},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			ctx := context.Background()
+			const (
+				unknownToolName      = "missing_tool"
+				unknownToolResult    = `{"error":"unknown_tool"}`
+				toolResultBusinessID = "unknown-tool-result-id"
+			)
+			var handledToolNames []string
+
+			agent, err := NewChatModelAgent(ctx, &ChatModelAgentConfig{
+				Name:        "UnknownToolEventAgent",
+				Description: "unknown tool event agent",
+				Model:       &mockToolCallingModel{toolCallName: unknownToolName},
+				ToolsConfig: ToolsConfig{
+					ToolsNodeConfig: compose.ToolsNodeConfig{
+						Tools: []tool.BaseTool{
+							&invokableTestTool{name: "registered_tool", result: "unused"},
+						},
+						UnknownToolsHandler: func(_ context.Context, name, _ string) (string, error) {
+							handledToolNames = append(handledToolNames, name)
+							return unknownToolResult, nil
+						},
+					},
+				},
+			})
+			require.NoError(t, err)
+
+			gen := func(_ context.Context, event *SessionEvent[*schema.Message]) (string, error) {
+				if event != nil && event.Kind == SessionEventMessage &&
+					event.Message != nil && event.Message.Role == schema.Tool {
+					return toolResultBusinessID, nil
+				}
+				return DefaultSessionEventIDGenerator[*schema.Message](ctx, event)
+			}
+			store := newSessionHelperStore()
+			runner := NewRunner(ctx, RunnerConfig{
+				Agent:           agent,
+				EnableStreaming: tt.streaming,
+				SessionID:       "unknown-tool-event-" + tt.name,
+				SessionStore:    store,
+				SessionConfig: &SessionConfig[*schema.Message]{
+					EventIDGenerator: gen,
+				},
+			})
+
+			iter := runner.Query(ctx, "call a missing tool")
+			for {
+				event, ok := iter.Next()
+				if !ok {
+					break
+				}
+				require.NoError(t, event.Err)
+			}
+
+			stored := filterStoredSessionEvents(t, store.events, func(_ *SessionEvent[*schema.Message]) bool {
+				return true
+			})
+			var (
+				toolResults []*SessionEvent[*schema.Message]
+				toolStarts  []*SessionEvent[*schema.Message]
+				toolEnds    []*SessionEvent[*schema.Message]
+			)
+			for _, event := range stored {
+				switch {
+				case event.Kind == SessionEventMessage && event.Message != nil &&
+					event.Message.Role == schema.Tool && event.Message.ToolName == unknownToolName:
+					toolResults = append(toolResults, event)
+				case event.Kind == SessionEventSpanToolCallStart && event.Span != nil &&
+					event.Span.Tool != nil && event.Span.Tool.Name == unknownToolName:
+					toolStarts = append(toolStarts, event)
+				case event.Kind == SessionEventSpanToolCallEnd && event.Span != nil &&
+					event.Span.Tool != nil && event.Span.Tool.Name == unknownToolName:
+					toolEnds = append(toolEnds, event)
+				}
+			}
+
+			require.Equal(t, []string{unknownToolName}, handledToolNames)
+			require.Len(t, toolResults, 1, "expected exactly one durable unknown-tool result message")
+			require.Len(t, toolStarts, 1, "expected exactly one unknown-tool start span")
+			require.Len(t, toolEnds, 1, "expected exactly one unknown-tool end span")
+			toolResult := toolResults[0]
+			toolStart := toolStarts[0]
+			toolEnd := toolEnds[0]
+			assert.Equal(t, unknownToolResult, toolResult.Message.Content)
+			assert.Equal(t, toolResultBusinessID, toolResult.EventID)
+			assert.Equal(t, toolStart.EventID, toolEnd.Span.Tool.ToolCallStartEventID)
+			assert.Equal(t, toolResult.EventID, toolEnd.Span.Tool.ToolResultMessageEventID)
+		})
+	}
+}
+
 // TestSessionEventIDGenerator_CustomToolResultBusinessID 验证：configured
 // generator 看到 tool result message 草稿时返回业务 ID，持久化的 message
 // EventID 与对应 tool span end 的 ToolResultMessageEventID 必须等于该业务 ID

--- a/compose/tool_node.go
+++ b/compose/tool_node.go
@@ -238,6 +238,7 @@ type ToolsNodeConfig struct {
 	// This field is optional. When not set, calling a non-existent tool will result in an error.
 	// When provided, if the LLM attempts to call a tool that doesn't exist in the Tools list,
 	// this handler will be invoked instead of returning an error, allowing graceful handling of hallucinated tools.
+	// Its result is processed as an invokable tool call and passes through invokable ToolCallMiddlewares.
 	// Parameters:
 	//   - ctx: The context for the tool call
 	//   - name: The name of the non-existent tool
@@ -266,6 +267,7 @@ type ToolsNodeConfig struct {
 	// ToolCallMiddlewares configures middleware for tool calls.
 	// Each element can contain Invokable and/or Streamable middleware.
 	// Invokable middleware only applies to tools implementing InvokableTool interface.
+	// It also applies to UnknownToolsHandler, which is executed as an invokable tool call.
 	// Streamable middleware only applies to tools implementing StreamableTool interface.
 	ToolCallMiddlewares []ToolMiddleware
 }
@@ -946,7 +948,13 @@ func (tn *ToolsNode) genToolCallTasks(ctx context.Context, tuple *toolsTuple,
 			if tn.unknownToolHandler == nil {
 				return nil, fmt.Errorf("tool %s not found in toolsNode indexes", toolCall.Function.Name)
 			}
-			toolCallTasks[i] = newUnknownToolTask(toolCall.Function.Name, toolCall.Function.Arguments, toolCall.ID, tn.unknownToolHandler)
+			toolCallTasks[i] = newUnknownToolTask(
+				toolCall.Function.Name,
+				toolCall.Function.Arguments,
+				toolCall.ID,
+				tn.unknownToolHandler,
+				tn.toolCallMiddlewares,
+			)
 		} else {
 			toolCallTasks[i].meta = tuple.meta[index]
 			toolCallTasks[i].name = toolCall.Function.Name
@@ -990,7 +998,11 @@ func (tn *ToolsNode) genToolCallTasks(ctx context.Context, tuple *toolsTuple,
 	return toolCallTasks, nil
 }
 
-func newUnknownToolTask(name, arg, callID string, unknownToolHandler func(ctx context.Context, name, input string) (string, error)) toolCallTask {
+func newUnknownToolTask(
+	name, arg, callID string,
+	unknownToolHandler func(ctx context.Context, name, input string) (string, error),
+	middlewares []invokableToolMiddlewareSpec,
+) toolCallTask {
 	endpoint := func(ctx context.Context, input *ToolInput) (*ToolOutput, error) {
 		result, err := unknownToolHandler(ctx, input.Name, input.Arguments)
 		if err != nil {
@@ -999,6 +1011,9 @@ func newUnknownToolTask(name, arg, callID string, unknownToolHandler func(ctx co
 		return &ToolOutput{
 			Result: result,
 		}, nil
+	}
+	for i := len(middlewares) - 1; i >= 0; i-- {
+		endpoint = wrapInvokableToolMiddleware(middlewares[i], endpoint)
 	}
 	return toolCallTask{
 		endpoint:       endpoint,

--- a/compose/tool_node_test.go
+++ b/compose/tool_node_test.go
@@ -27,6 +27,7 @@ import (
 
 	"github.com/bytedance/sonic"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"github.com/cloudwego/eino/components/model"
 	"github.com/cloudwego/eino/components/tool"
@@ -746,6 +747,142 @@ func TestUnknownTool(t *testing.T) {
 		}
 	}
 	assert.Equal(t, expected, result)
+}
+
+func TestAttack_UnknownToolPreservesInvokableMiddlewareSemantics(t *testing.T) {
+	ctx := context.Background()
+	var calls []string
+	var inputs []*ToolInput
+	tn, err := NewToolNode(ctx, &ToolsNodeConfig{
+		UnknownToolsHandler: func(_ context.Context, _, _ string) (string, error) {
+			calls = append(calls, "handler")
+			return "unknown", nil
+		},
+		ToolCallMiddlewares: []ToolMiddleware{
+			{
+				Invokable: func(next InvokableToolEndpoint) InvokableToolEndpoint {
+					return func(ctx context.Context, input *ToolInput) (*ToolOutput, error) {
+						calls = append(calls, "outer-before")
+						inputs = append(inputs, input)
+						output, err := next(ctx, input)
+						if err != nil {
+							return nil, err
+						}
+						calls = append(calls, "outer-after")
+						output.Result = "outer:" + output.Result
+						return output, nil
+					}
+				},
+			},
+			{
+				Invokable: func(next InvokableToolEndpoint) InvokableToolEndpoint {
+					return func(ctx context.Context, input *ToolInput) (*ToolOutput, error) {
+						calls = append(calls, "inner-before")
+						output, err := next(ctx, input)
+						if err != nil {
+							return nil, err
+						}
+						calls = append(calls, "inner-after")
+						output.Result = "inner:" + output.Result
+						return output, nil
+					}
+				},
+			},
+		},
+	})
+	require.NoError(t, err)
+
+	input := schema.AssistantMessage("", []schema.ToolCall{{
+		ID: "call-1",
+		Function: schema.FunctionCall{
+			Name:      "missing_tool",
+			Arguments: `{"input":"test"}`,
+		},
+	}})
+
+	result, err := tn.Invoke(ctx, input)
+	require.NoError(t, err)
+	require.Len(t, result, 1)
+	assert.Equal(t, "outer:inner:unknown", result[0].Content)
+	assert.Equal(t, []string{"outer-before", "inner-before", "handler", "inner-after", "outer-after"}, calls)
+
+	calls = nil
+	streamResult, err := tn.Stream(ctx, input)
+	require.NoError(t, err)
+	var streamed []*schema.Message
+	for {
+		chunk, recvErr := streamResult.Recv()
+		if recvErr == io.EOF {
+			break
+		}
+		require.NoError(t, recvErr)
+		for i := range chunk {
+			if chunk[i] != nil {
+				streamed = append(streamed, chunk[i])
+			}
+		}
+	}
+	require.Len(t, streamed, 1)
+	assert.Equal(t, "outer:inner:unknown", streamed[0].Content)
+	assert.Equal(t, []string{"outer-before", "inner-before", "handler", "inner-after", "outer-after"}, calls)
+
+	require.Len(t, inputs, 2)
+	for _, got := range inputs {
+		assert.Equal(t, "missing_tool", got.Name)
+		assert.Equal(t, "call-1", got.CallID)
+		assert.Equal(t, `{"input":"test"}`, got.Arguments)
+	}
+	t.Log("unknown-tool endpoints preserve registered invokable middleware order in invoke and stream modes")
+}
+
+func TestAttack_UnknownToolMiddlewareErrorPropagates(t *testing.T) {
+	sentinel := errors.New("middleware rejected unknown tool")
+	for _, tt := range []struct {
+		name string
+		run  func(*ToolsNode, *schema.Message) error
+	}{
+		{
+			name: "invoke",
+			run: func(tn *ToolsNode, input *schema.Message) error {
+				_, err := tn.Invoke(context.Background(), input)
+				return err
+			},
+		},
+		{
+			name: "stream",
+			run: func(tn *ToolsNode, input *schema.Message) error {
+				_, err := tn.Stream(context.Background(), input)
+				return err
+			},
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			handlerCalled := false
+			tn, err := NewToolNode(context.Background(), &ToolsNodeConfig{
+				UnknownToolsHandler: func(_ context.Context, _, _ string) (string, error) {
+					handlerCalled = true
+					return "unexpected", nil
+				},
+				ToolCallMiddlewares: []ToolMiddleware{{
+					Invokable: func(InvokableToolEndpoint) InvokableToolEndpoint {
+						return func(context.Context, *ToolInput) (*ToolOutput, error) {
+							return nil, sentinel
+						}
+					},
+				}},
+			})
+			require.NoError(t, err)
+
+			input := schema.AssistantMessage("", []schema.ToolCall{{
+				ID:       "call-1",
+				Function: schema.FunctionCall{Name: "missing_tool", Arguments: `{}`},
+			}})
+			err = tt.run(tn, input)
+			require.ErrorIs(t, err, sentinel)
+			assert.False(t, handlerCalled)
+			t.Log("middleware errors stop the synthetic endpoint before it can enter conversation state")
+		})
+	}
 }
 
 func TestToolRerun(t *testing.T) {


### PR DESCRIPTION
## Problem

Registered tools pass through `ToolCallMiddlewares`, including ADK event-sender middleware that creates the durable `SessionEventMessage` for each tool result. Unknown tools are handled by a synthetic endpoint created after registered endpoints are wrapped, so their successful results entered conversation state without a durable base event or linked tool-call lifecycle.

## Solution

Treat `UnknownToolsHandler` as the invokable endpoint it already models. The synthetic endpoint now receives the same invokable middleware chain as registered invokable tools before `invokableToStreamable` derives its streaming form.

This keeps the policy generic in `compose`: ADK continues to own event persistence through middleware, while custom middleware observes identical metadata, ordering, and errors for registered and unknown tools.

## Key Insight

An unknown-tool fallback is not a separate execution category. It is an invokable tool endpoint created later in dispatch. Middleware must be applied at that construction boundary, before stream adaptation, so both `Invoke` and `Stream` preserve the same lifecycle and durability guarantees.

## Summary

| Problem | Solution |
|---|---|
| Unknown-tool results bypassed middleware and lacked durable session events | Apply invokable middleware when constructing the synthetic endpoint |
| Invoke and stream paths could diverge | Derive the stream endpoint from the wrapped invokable endpoint |
| Duplicate or unlinked durable events could go unnoticed | Enforce exactly-once result and span linkage invariants |