### PR TITLE
fix(adk): scope tool result deduplication

### DIFF
--- a/adk/middlewares/patchtoolcalls/patchtoolcalls.go
+++ b/adk/middlewares/patchtoolcalls/patchtoolcalls.go
@@ -221,7 +221,7 @@ func buildMessageNormalizationPlan(ctx context.Context, cfg Config, messages []*
 			continue
 		}
 		for _, tc := range msg.ToolCalls {
-			if tc.ID == "" || hasCorrespondingToolMessage(messages[i+1:], tc.ID) {
+			if tc.ID == "" || hasCorrespondingKeptToolMessage(messages, keep, i+1, tc.ID) {
 				continue
 			}
 			toolMsg, err := createPatchedToolMessage(ctx, cfg, tc)
@@ -256,33 +256,52 @@ func buildMessageNormalizationPlan(ctx context.Context, cfg Config, messages []*
 
 func analyzeMessages(messages []*schema.Message) mismatchCounts {
 	var counts mismatchCounts
-	previousCalls := make(map[string]struct{})
-	seenResults := make(map[string]struct{})
+	var scope *toolResultScope
 
-	for i, msg := range messages {
-		if msg.Role == schema.Tool {
-			if _, ok := previousCalls[msg.ToolCallID]; !ok {
-				counts.orphan++
-			} else if _, ok := seenResults[msg.ToolCallID]; ok {
-				counts.duplicate++
-			} else {
-				seenResults[msg.ToolCallID] = struct{}{}
+	finishScope := func() {
+		if scope == nil {
+			return
+		}
+		for callID := range scope.callIDs {
+			if _, ok := scope.seen[callID]; !ok {
+				counts.missing++
 			}
 		}
+		scope = nil
+	}
+
+	for _, msg := range messages {
+		if msg.Role == schema.Tool {
+			if scope == nil {
+				counts.orphan++
+				continue
+			}
+			if _, ok := scope.callIDs[msg.ToolCallID]; !ok {
+				counts.orphan++
+			} else if _, ok := scope.seen[msg.ToolCallID]; ok {
+				counts.duplicate++
+			} else {
+				scope.seen[msg.ToolCallID] = struct{}{}
+			}
+			continue
+		}
+		finishScope()
 		if msg.Role != schema.Assistant {
 			continue
 		}
+		callIDs := make(map[string]struct{})
 		for _, tc := range msg.ToolCalls {
 			if tc.ID == "" {
 				counts.emptyID++
 				continue
 			}
-			previousCalls[tc.ID] = struct{}{}
-			if !hasCorrespondingToolMessage(messages[i+1:], tc.ID) {
-				counts.missing++
-			}
+			callIDs[tc.ID] = struct{}{}
+		}
+		if len(callIDs) > 0 {
+			scope = &toolResultScope{callIDs: callIDs, seen: make(map[string]struct{})}
 		}
 	}
+	finishScope()
 
 	return counts
 }
@@ -295,30 +314,39 @@ func ensureMessageIDs[M adk.MessageType](messages []M) {
 
 func keptMessages(messages []*schema.Message, cfg Config) []bool {
 	keep := make([]bool, len(messages))
-	previousCalls := make(map[string]struct{})
-	seenResults := make(map[string]struct{})
+	var scope *toolResultScope
 
 	for i, msg := range messages {
 		keep[i] = true
 		if msg.Role == schema.Tool {
-			_, valid := previousCalls[msg.ToolCallID]
-			_, duplicate := seenResults[msg.ToolCallID]
+			valid := false
+			duplicate := false
+			if scope != nil {
+				_, valid = scope.callIDs[msg.ToolCallID]
+				_, duplicate = scope.seen[msg.ToolCallID]
+			}
 			if !valid && cfg.RemoveOrphanResults {
 				keep[i] = false
 			} else if valid && duplicate && cfg.RemoveDuplicateResults {
 				keep[i] = false
 			}
 			if valid && !duplicate {
-				seenResults[msg.ToolCallID] = struct{}{}
+				scope.seen[msg.ToolCallID] = struct{}{}
 			}
+			continue
 		}
+		scope = nil
 		if msg.Role != schema.Assistant {
 			continue
 		}
+		callIDs := make(map[string]struct{})
 		for _, tc := range msg.ToolCalls {
 			if tc.ID != "" {
-				previousCalls[tc.ID] = struct{}{}
+				callIDs[tc.ID] = struct{}{}
 			}
+		}
+		if len(callIDs) > 0 {
+			scope = &toolResultScope{callIDs: callIDs, seen: make(map[string]struct{})}
 		}
 	}
 
@@ -356,7 +384,7 @@ func buildAgenticNormalizationPlan(ctx context.Context, cfg Config, messages []*
 			continue
 		}
 		for _, tc := range collectAgenticToolCalls(msg) {
-			if tc.callID == "" || hasCorrespondingAgenticToolResult(messages[i+1:], tc.callID) {
+			if tc.callID == "" || hasCorrespondingRewrittenAgenticToolResult(rewrites, i+1, tc.callID) {
 				continue
 			}
 			toolMsg, err := createPatchedAgenticToolMessage(ctx, cfg, tc.name, tc.callID, tc.args)
@@ -399,6 +427,13 @@ type agenticToolCall struct {
 	args   string
 }
 
+// toolResultScope is limited to one assistant tool-call message plus the
+// immediately following contiguous tool-result window.
+type toolResultScope struct {
+	callIDs map[string]struct{}
+	seen    map[string]struct{}
+}
+
 type agenticRewrite struct {
 	message *schema.AgenticMessage
 	keep    bool
@@ -407,94 +442,205 @@ type agenticRewrite struct {
 
 func analyzeAgenticMessages(messages []*schema.AgenticMessage) mismatchCounts {
 	var counts mismatchCounts
-	previousCalls := make(map[string]struct{})
-	seenResults := make(map[string]struct{})
+	var scope *toolResultScope
 
-	for i, msg := range messages {
-		for _, block := range msg.ContentBlocks {
-			callID, ok := agenticResultCallID(block)
-			if !ok {
-				continue
+	finishScope := func() {
+		if scope == nil {
+			return
+		}
+		for callID := range scope.callIDs {
+			if _, ok := scope.seen[callID]; !ok {
+				counts.missing++
 			}
-			if _, valid := previousCalls[callID]; !valid {
-				counts.orphan++
-			} else if _, duplicate := seenResults[callID]; duplicate {
-				counts.duplicate++
-			} else {
-				seenResults[callID] = struct{}{}
+		}
+		scope = nil
+	}
+
+	for _, msg := range messages {
+		hasToolResult := agenticMessageHasToolResult(msg)
+		if msg.Role == schema.AgenticRoleTypeUser && hasToolResult {
+			for _, block := range msg.ContentBlocks {
+				callID, ok := agenticResultCallID(block)
+				if !ok {
+					continue
+				}
+				if scope == nil {
+					counts.orphan++
+					continue
+				}
+				if _, valid := scope.callIDs[callID]; !valid {
+					counts.orphan++
+				} else if _, duplicate := scope.seen[callID]; duplicate {
+					counts.duplicate++
+				} else {
+					scope.seen[callID] = struct{}{}
+				}
+			}
+			continue
+		}
+
+		finishScope()
+		if hasToolResult {
+			for _, block := range msg.ContentBlocks {
+				if _, ok := agenticResultCallID(block); ok {
+					counts.orphan++
+				}
 			}
 		}
 		if msg.Role != schema.AgenticRoleTypeAssistant {
 			continue
 		}
+		callIDs := make(map[string]struct{})
 		for _, tc := range collectAgenticToolCalls(msg) {
 			if tc.callID == "" {
 				counts.emptyID++
 				continue
 			}
-			previousCalls[tc.callID] = struct{}{}
-			if !hasCorrespondingAgenticToolResult(messages[i+1:], tc.callID) {
-				counts.missing++
-			}
+			callIDs[tc.callID] = struct{}{}
+		}
+		if len(callIDs) > 0 {
+			scope = &toolResultScope{callIDs: callIDs, seen: make(map[string]struct{})}
 		}
 	}
+	finishScope()
 
 	return counts
 }
 
 func agenticMessageRewrites(messages []*schema.AgenticMessage, cfg Config) []agenticRewrite {
 	rewrites := make([]agenticRewrite, len(messages))
-	previousCalls := make(map[string]struct{})
-	seenResults := make(map[string]struct{})
+	var scope *toolResultScope
 
 	for i, msg := range messages {
 		rewrite := agenticRewrite{message: msg, keep: true}
-		blocks := make([]*schema.ContentBlock, 0, len(msg.ContentBlocks))
-		removedBlock := false
+		hasToolResult := agenticMessageHasToolResult(msg)
 
-		for _, block := range msg.ContentBlocks {
-			callID, ok := agenticResultCallID(block)
-			if !ok {
-				blocks = append(blocks, block)
-				continue
+		switch {
+		case msg.Role == schema.AgenticRoleTypeUser && hasToolResult:
+			rewrite = rewriteAgenticResultBlocks(msg, scope, cfg)
+			if scope != nil && rewrite.keep && !agenticMessageHasToolResult(rewrite.message) {
+				scope = nil
 			}
-			_, valid := previousCalls[callID]
-			_, duplicate := seenResults[callID]
-			remove := (!valid && cfg.RemoveOrphanResults) || (valid && duplicate && cfg.RemoveDuplicateResults)
-			if remove {
-				removedBlock = true
-			} else {
-				blocks = append(blocks, block)
+		default:
+			if hasToolResult {
+				rewrite = rewriteAgenticResultBlocks(msg, nil, cfg)
 			}
-			if valid && !duplicate {
-				seenResults[callID] = struct{}{}
+			if rewrite.keep {
+				scope = nil
 			}
-		}
-
-		if removedBlock {
-			if len(blocks) == 0 {
-				rewrite.keep = false
-			} else {
-				adk.EnsureMessageID(msg)
-				cp := *msg
-				cp.ContentBlocks = blocks
-				cp.Extra = copyStringAnyMap(msg.Extra)
-				rewrite.message = &cp
-				rewrite.updated = true
-			}
-		}
-
-		if msg.Role == schema.AgenticRoleTypeAssistant {
-			for _, tc := range collectAgenticToolCalls(msg) {
-				if tc.callID != "" {
-					previousCalls[tc.callID] = struct{}{}
+			if msg.Role == schema.AgenticRoleTypeAssistant && rewrite.keep {
+				callIDs := make(map[string]struct{})
+				for _, tc := range collectAgenticToolCalls(rewrite.message) {
+					if tc.callID != "" {
+						callIDs[tc.callID] = struct{}{}
+					}
+				}
+				if len(callIDs) > 0 {
+					scope = &toolResultScope{callIDs: callIDs, seen: make(map[string]struct{})}
 				}
 			}
 		}
+
 		rewrites[i] = rewrite
 	}
 
 	return rewrites
+}
+
+func rewriteAgenticResultBlocks(msg *schema.AgenticMessage, scope *toolResultScope, cfg Config) agenticRewrite {
+	rewrite := agenticRewrite{message: msg, keep: true}
+	blocks := make([]*schema.ContentBlock, 0, len(msg.ContentBlocks))
+	removedBlock := false
+
+	for _, block := range msg.ContentBlocks {
+		callID, ok := agenticResultCallID(block)
+		if !ok {
+			blocks = append(blocks, block)
+			continue
+		}
+		valid := false
+		duplicate := false
+		if scope != nil {
+			_, valid = scope.callIDs[callID]
+			_, duplicate = scope.seen[callID]
+		}
+		remove := (!valid && cfg.RemoveOrphanResults) || (valid && duplicate && cfg.RemoveDuplicateResults)
+		if remove {
+			removedBlock = true
+		} else {
+			blocks = append(blocks, block)
+		}
+		if valid && !duplicate {
+			scope.seen[callID] = struct{}{}
+		}
+	}
+
+	if removedBlock {
+		if len(blocks) == 0 {
+			rewrite.keep = false
+		} else {
+			adk.EnsureMessageID(msg)
+			cp := *msg
+			cp.ContentBlocks = blocks
+			cp.Extra = copyStringAnyMap(msg.Extra)
+			rewrite.message = &cp
+			rewrite.updated = true
+		}
+	}
+
+	return rewrite
+}
+
+func agenticMessageHasToolResult(msg *schema.AgenticMessage) bool {
+	for _, block := range msg.ContentBlocks {
+		if _, ok := agenticResultCallID(block); ok {
+			return true
+		}
+	}
+	return false
+}
+
+func hasCorrespondingKeptToolMessage(messages []*schema.Message, keep []bool, start int, toolCallID string) bool {
+	for i := start; i < len(messages); i++ {
+		if !keep[i] {
+			continue
+		}
+		msg := messages[i]
+		if msg.Role != schema.Tool {
+			return false
+		}
+		if msg.ToolCallID == toolCallID {
+			return true
+		}
+	}
+	return false
+}
+
+func hasCorrespondingRewrittenAgenticToolResult(rewrites []agenticRewrite, start int, toolCallID string) bool {
+	for i := start; i < len(rewrites); i++ {
+		rewrite := rewrites[i]
+		if !rewrite.keep {
+			continue
+		}
+		msg := rewrite.message
+		if msg.Role != schema.AgenticRoleTypeUser {
+			return false
+		}
+		hasToolResult := false
+		for _, block := range msg.ContentBlocks {
+			callID, ok := agenticResultCallID(block)
+			if ok {
+				hasToolResult = true
+				if callID == toolCallID {
+					return true
+				}
+			}
+		}
+		if !hasToolResult {
+			return false
+		}
+	}
+	return false
 }
 
 func collectAgenticToolCalls(msg *schema.AgenticMessage) []agenticToolCall {
@@ -522,42 +668,6 @@ func agenticResultCallID(block *schema.ContentBlock) (string, bool) {
 		return block.ToolSearchFunctionToolResult.CallID, true
 	}
 	return "", false
-}
-
-func hasCorrespondingToolMessage(messages []*schema.Message, toolCallID string) bool {
-	for _, msg := range messages {
-		// Only consider successive tool messages after the tool call message
-		if msg.Role != schema.Tool {
-			return false
-		}
-		if msg.ToolCallID == toolCallID {
-			return true
-		}
-	}
-	return false
-}
-
-func hasCorrespondingAgenticToolResult(messages []*schema.AgenticMessage, toolCallID string) bool {
-	for _, msg := range messages {
-		// Only consider successive tool messages after the tool call message
-		if msg.Role != schema.AgenticRoleTypeUser {
-			return false
-		}
-		hasToolResult := false
-		for _, block := range msg.ContentBlocks {
-			callID, ok := agenticResultCallID(block)
-			if ok {
-				hasToolResult = true
-				if callID == toolCallID {
-					return true
-				}
-			}
-		}
-		if !hasToolResult {
-			return false
-		}
-	}
-	return false
 }
 
 func firstKeptMessageID(messages []*schema.Message, keep []bool, start int) string {

--- a/adk/middlewares/patchtoolcalls/patchtoolcalls_test.go
+++ b/adk/middlewares/patchtoolcalls/patchtoolcalls_test.go
@@ -486,6 +486,31 @@ func TestPatchToolCallsRemoveDuplicateResults(t *testing.T) {
 	t.Run("AgenticMessage", testPatchToolCallsRemoveDuplicateResults[*schema.AgenticMessage])
 }
 
+func testAttackPatchToolCallsAllowsRepeatedCallIDAcrossWindows[M adk.MessageType](t *testing.T) {
+	ctx := context.Background()
+	mw, err := NewTyped[M](ctx, &Config{Strict: true, RemoveDuplicateResults: true})
+	require.NoError(t, err)
+
+	state := &adk.TypedChatModelAgentState[M]{Messages: []M{
+		makeAssistantMsgWithToolCalls[M]("", []testToolCall{{ID: "call_1", Name: "tool_a", Arguments: "{}"}}),
+		makeToolResultMsg[M]("result_a", "call_1", "tool_a"),
+		makeAssistantMsgWithToolCalls[M]("", []testToolCall{{ID: "call_1", Name: "tool_b", Arguments: "{}"}}),
+		makeToolResultMsg[M]("result_b", "call_1", "tool_b"),
+	}}
+	_, newState, err := mw.BeforeModelRewriteState(ctx, state, nil)
+	require.NoError(t, err)
+	require.Len(t, newState.Messages, 4)
+	assert.Equal(t, []string{"call_1", "call_1"}, collectToolResultIDs(newState.Messages))
+	assertMsgContent(t, newState.Messages[1], "result_a")
+	assertMsgContent(t, newState.Messages[3], "result_b")
+}
+
+func TestAttack_PatchToolCallsAllowsRepeatedCallIDAcrossWindows(t *testing.T) {
+	t.Log("reused provider call IDs must be scoped to each assistant tool-call message's contiguous result window")
+	t.Run("Message", testAttackPatchToolCallsAllowsRepeatedCallIDAcrossWindows[*schema.Message])
+	t.Run("AgenticMessage", testAttackPatchToolCallsAllowsRepeatedCallIDAcrossWindows[*schema.AgenticMessage])
+}
+
 func testPatchToolCallsSkipsEmptyIDInNonStrictMode[M adk.MessageType](t *testing.T) {
 	ctx := context.Background()
 	mw, err := NewTyped[M](ctx, nil)
@@ -590,6 +615,36 @@ func TestPatchToolCallsMixedAgenticBlockRemovalUpdatesMessage(t *testing.T) {
 	assert.Equal(t, adk.SessionEventMessageUpdated, plan.events[0].Kind)
 	assert.Equal(t, originalID, plan.events[0].MessageUpdated.MessageID)
 	assert.Equal(t, originalID, adk.GetMessageID(plan.events[0].MessageUpdated.Message))
+}
+
+func TestAttack_PatchToolCallsAgenticRechecksWindowAfterBlockRemoval(t *testing.T) {
+	t.Log("missing detection must use the rewritten result window after orphan blocks are removed")
+	ctx := context.Background()
+	assistant := makeAssistantMsgWithToolCalls[*schema.AgenticMessage]("", []testToolCall{{ID: "call_1", Name: "tool_a", Arguments: "{}"}})
+	mixed := &schema.AgenticMessage{
+		Role: schema.AgenticRoleTypeUser,
+		ContentBlocks: []*schema.ContentBlock{
+			schema.NewContentBlock(&schema.UserInputText{Text: "keep"}),
+			schema.NewContentBlock(&schema.FunctionToolResult{CallID: "call_orphan", Name: "tool_orphan"}),
+		},
+	}
+	delayed := makeToolResultMsg[*schema.AgenticMessage]("delayed", "call_1", "tool_a")
+
+	plan, err := buildAgenticNormalizationPlan(ctx, Config{RemoveOrphanResults: true}, []*schema.AgenticMessage{
+		assistant,
+		mixed,
+		delayed,
+	})
+	require.NoError(t, err)
+	require.Len(t, plan.messages, 3)
+	assert.Equal(t, []string{"call_1"}, collectToolResultIDs(plan.messages))
+	assertMsgContent(t, plan.messages[1], fmt.Sprintf(defaultPatchedToolMessageTemplate, "tool_a", "call_1"))
+	require.Len(t, plan.messages[2].ContentBlocks, 1)
+	assert.Equal(t, schema.ContentBlockTypeUserInputText, plan.messages[2].ContentBlocks[0].Type)
+	assert.Len(t, plan.events, 3)
+	assert.Equal(t, adk.SessionEventMessageInserted, plan.events[0].Kind)
+	assert.Equal(t, adk.SessionEventMessageUpdated, plan.events[1].Kind)
+	assert.Equal(t, adk.SessionEventMessagesDeleted, plan.events[2].Kind)
 }
 
 func TestPatchToolCallsInsertionEventAnchorsReplayOrder(t *testing.T) {


### PR DESCRIPTION
# Scope Tool Result Deduplication

## Problem

`patchtoolcalls` treated tool result duplication as a whole-history property. That is not the provider contract.

A provider requires each assistant message with `tool_calls` to be immediately followed by tool result messages for that assistant message's `tool_call_ids`. The same `call_id` can appear again in a later assistant tool-call message. That reuse is poor provider behavior, but it is still valid when each assistant message has its own contiguous result window.

Before this change:

```text
assistant A: tool_call write_file_26
user:      tool_result write_file_26
assistant B: tool_call write_file_26
user:      tool_result write_file_26
```

The second result could be removed as a duplicate because `seenResults` was global across history.

## Solution

`patchtoolcalls` now scopes result validation to one assistant tool-call message and the immediately following contiguous result window.

Within that window:

- missing call IDs are patched with synthetic tool results
- repeated result blocks/messages for the same call ID are duplicates
- result IDs outside the current assistant message are orphans

The patching path also checks missing results against the kept/rewritten message window, so removing orphan or duplicate results cannot leave a dangling assistant tool call.

## Key Insight

Tool result validity is not `call_id` uniqueness across the entire conversation. It is adjacency and completeness relative to the immediately preceding assistant tool-call message.

## Summary

| Problem | Solution |
|---------|----------|
| Reused `call_id` in a later assistant message was removed as duplicate | Reset duplicate tracking for each assistant result window |
| Removing invalid AgenticMessage result blocks could hide a newly missing result | Run missing detection against rewritten result windows |

---

# 修正 Tool Result 去重范围

## 问题

`patchtoolcalls` 之前把 tool result duplicate 当成全 history 维度的问题处理。这不符合 provider 协议语义。

provider 要求的是：带 `tool_calls` 的 assistant message 后面，紧跟该 assistant message 的 `tool_call_ids` 对应的 tool result messages。同一个 `call_id` 即使在后续 assistant tool-call message 中再次出现，只要各自窗口完整，仍然是合法历史。

修复前：

```text
assistant A: tool_call write_file_26
user:      tool_result write_file_26
assistant B: tool_call write_file_26
user:      tool_result write_file_26
```

第二个 result 可能因为全局 `seenResults` 被误删。

## 解决方案

`patchtoolcalls` 现在把 result 校验范围限定为：一个 assistant tool-call message，加上它后面连续的 result window。

在这个窗口内：

- 缺失的 call ID 会补 synthetic tool result
- 同一个 call ID 多次出现才是 duplicate
- 不属于当前 assistant message 的 result 作为 orphan 处理

补 missing 时也基于已保留/已重写后的窗口判断，避免删除 orphan 或 duplicate 后制造 dangling assistant tool call。

## 关键洞察

Tool result 的合法性不是整个 conversation 内 `call_id` 唯一，而是相对前一个 assistant tool-call message 的邻接性和完整性。

## 总结

| 问题 | 解决方案 |
|------|----------|
| 后续 assistant message 复用 `call_id` 时，合法 result 被当作 duplicate 删除 | 每个 assistant result window 单独维护 duplicate scope |
| 删除无效 AgenticMessage result block 后可能漏补 missing result | 基于 rewrite 后的 result window 重新判断 missing |
