### PR TITLE
feat(adk): make subagent child session ids opaque

### DIFF
--- a/adk/backgroundtask/subagent/subagent.go
+++ b/adk/backgroundtask/subagent/subagent.go
@@ -20,12 +20,13 @@ package subagent
 import (
 	"bytes"
 	"context"
-	"encoding/base64"
+	"crypto/rand"
+	"encoding/binary"
 	"encoding/json"
 	"errors"
 	"fmt"
 	"io"
-	"strings"
+	"strconv"
 	"sync"
 	"time"
 
@@ -44,6 +45,29 @@ const (
 	maxChildSessionIDLength = 1024
 	taskIDEventExtraKey     = "eino.background_task.id"
 )
+
+type taskContextKey struct{}
+
+// TaskContext describes the durable task currently executing a sub-agent. The
+// child session ID is opaque; use TaskID for task-owned metadata lookups.
+type TaskContext struct {
+	TaskID          string
+	ParentSessionID string
+	SubAgentName    string
+	ChildSessionID  string
+	Attempt         int64
+}
+
+// TaskContextFromContext returns durable sub-agent task metadata for the current
+// execution attempt.
+func TaskContextFromContext(ctx context.Context) (TaskContext, bool) {
+	taskCtx, ok := ctx.Value(taskContextKey{}).(TaskContext)
+	return taskCtx, ok && taskCtx.TaskID != "" && taskCtx.ChildSessionID != ""
+}
+
+func contextWithTaskContext(ctx context.Context, taskCtx TaskContext) context.Context {
+	return context.WithValue(ctx, taskContextKey{}, taskCtx)
+}
 
 type taskPayload struct {
 	Version        int                   `json:"version"`
@@ -259,39 +283,19 @@ func validateSpecPayload(spec backgroundtask.Spec) (*taskPayload, error) {
 			"backgroundtask/subagent: child session id exceeds configured bounds",
 		)
 	}
-	if err := validateChildSessionOwner(
-		payload.ChildSessionID,
-		spec.SessionID,
-		payload.SubAgentName,
-	); err != nil {
-		return nil, err
-	}
 	return payload, nil
 }
 
-func childSessionPrefix(parentSessionID, subAgentName string) string {
-	return "subagent-session/" +
-		base64.RawURLEncoding.EncodeToString([]byte(parentSessionID)) + "/" +
-		base64.RawURLEncoding.EncodeToString([]byte(subAgentName)) + "/"
-}
-
-func defaultChildSessionID(parentSessionID, subAgentName, taskID string) string {
-	return childSessionPrefix(parentSessionID, subAgentName) + taskID
-}
-
-func validateChildSessionOwner(
-	childSessionID,
-	parentSessionID,
-	subAgentName string,
-) error {
-	prefix := childSessionPrefix(parentSessionID, subAgentName)
-	if !strings.HasPrefix(childSessionID, prefix) ||
-		len(childSessionID) == len(prefix) {
-		return errors.New(
-			"backgroundtask/subagent: child session does not belong to the parent session and sub-agent",
-		)
+func defaultChildSessionID() (string, error) {
+	var entropy [8]byte
+	if _, err := rand.Read(entropy[:]); err != nil {
+		return "", err
 	}
-	return nil
+	value := binary.BigEndian.Uint64(entropy[:]) & ((uint64(1) << 63) - 1)
+	if value == 0 {
+		value = 1
+	}
+	return strconv.FormatInt(int64(value), 10), nil
 }
 
 func checkpointID(taskID string) string {
@@ -423,6 +427,13 @@ func (e *Executor[M]) Execute(
 		CheckPointStore: e.checkPointStore,
 		SessionID:       payload.ChildSessionID, SessionStore: sessionStore,
 		SessionConfig: e.sessionConfigForTask(task.Spec.ID),
+	})
+	ctx = contextWithTaskContext(ctx, TaskContext{
+		TaskID:          task.Spec.ID,
+		ParentSessionID: task.Spec.SessionID,
+		SubAgentName:    payload.SubAgentName,
+		ChildSessionID:  payload.ChildSessionID,
+		Attempt:         task.Attempt,
 	})
 	cancelOption, cancelRun := adk.WithCancel()
 	controlRequests := make(chan backgroundtask.ControlRequest, 1)
@@ -791,10 +802,10 @@ func nextCheckpointSequence(previous []byte) int64 {
 // concrete values stored in interface fields must be registered with schema.
 // Empty TaskID asks Manager to allocate one. SessionID identifies the parent
 // session notified when the child waits for input or terminates. Empty
-// ChildSessionID creates a new child session derived from the allocated task
-// ID; a non-empty value continues that existing child session and inherits its
-// committed history. DisableLifecycleNotifications suppresses automatic
-// waiting and terminal notifications without suppressing TaskCreated recovery.
+// ChildSessionID creates a new opaque child session when empty; a non-empty
+// value is used as-is and continues that existing child session with its
+// committed history. DisableLifecycleNotifications suppresses automatic waiting
+// and terminal notifications without suppressing TaskCreated recovery.
 type SubmitRequest[M adk.MessageType] struct {
 	TaskID                        string
 	SubAgentName                  string
@@ -839,24 +850,15 @@ func Submit[M adk.MessageType](
 	}
 	payload.ChildSessionID = req.ChildSessionID
 	if payload.ChildSessionID == "" {
-		payload.ChildSessionID = defaultChildSessionID(
-			req.SessionID,
-			req.SubAgentName,
-			id,
-		)
+		payload.ChildSessionID, err = defaultChildSessionID()
+		if err != nil {
+			return nil, err
+		}
 	}
 	if len(payload.ChildSessionID) > maxChildSessionIDLength {
 		return nil, errors.New(
 			"backgroundtask/subagent: child session id exceeds configured bounds",
 		)
-	}
-	err = validateChildSessionOwner(
-		payload.ChildSessionID,
-		req.SessionID,
-		req.SubAgentName,
-	)
-	if err != nil {
-		return nil, err
 	}
 	data, err := json.Marshal(payload)
 	if err != nil {

--- a/adk/backgroundtask/subagent/subagent_test.go
+++ b/adk/backgroundtask/subagent/subagent_test.go
@@ -21,6 +21,8 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"strconv"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -449,7 +451,7 @@ func resumeFixture(
 	require.NoError(t, err)
 	payload, err := json.Marshal(taskPayload{
 		Version: payloadVersion, SubAgentName: "worker", Input: input,
-		ChildSessionID: defaultChildSessionID("parent", "worker", "task"),
+		ChildSessionID: "42",
 	})
 	require.NoError(t, err)
 	return executor, backgroundtask.Spec{
@@ -711,19 +713,19 @@ func TestSubmitPersistsChildSessionIdentity_BitsUT(t *testing.T) {
 	require.NoError(t, err)
 	payload, err := decodePayload(task.Spec)
 	require.NoError(t, err)
-	expectedChildSessionID := defaultChildSessionID(
-		"parent-session",
-		"worker",
-		task.Spec.ID,
-	)
 	assert.Equal(t, payloadVersion, payload.Version)
-	assert.Equal(t, expectedChildSessionID, payload.ChildSessionID)
+	parsedChildSessionID, err := strconv.ParseInt(payload.ChildSessionID, 10, 64)
+	require.NoError(t, err)
+	assert.Positive(t, parsedChildSessionID)
+	assert.False(t, strings.Contains(payload.ChildSessionID, "parent-session"))
+	assert.False(t, strings.Contains(payload.ChildSessionID, "worker"))
+	assert.False(t, strings.Contains(payload.ChildSessionID, task.Spec.ID))
 	persistedInput, err := decodeTypedInput[*schema.Message](payload.Input)
 	require.NoError(t, err)
 	require.Equal(t, "work", persistedInput.Messages[0].Content)
 	childSessionID, err := ChildSessionIDFromTask(task)
 	require.NoError(t, err)
-	assert.Equal(t, expectedChildSessionID, childSessionID)
+	assert.Equal(t, payload.ChildSessionID, childSessionID)
 	assert.Equal(t, task.Spec.ID+"/checkpoint", checkpointID(task.Spec.ID))
 	assert.Equal(t, "parent-session", task.Spec.SessionID)
 	assert.True(t, task.Spec.NotifySession)
@@ -734,6 +736,42 @@ func TestSubmitPersistsChildSessionIdentity_BitsUT(t *testing.T) {
 	})
 	require.NoError(t, err)
 	assert.False(t, disabled.Spec.NotifySession)
+}
+
+func TestAttack_DefaultChildSessionIDIsOpaqueAndFresh_BitsUT(t *testing.T) {
+	executor := newTestExecutor(t, nil)
+	require.NoError(t, executor.Register("worker", &AgentRegistration[*schema.Message]{
+		Agent: &resumableTestAgent{name: "worker"},
+	}))
+	executors := backgroundtask.NewExecutorRegistry()
+	require.NoError(t, executors.Register(executor))
+	var sequence int
+	manager := mustNewBackgroundManager(t, context.Background(), &backgroundtask.Config{
+		Executors: executors,
+		IDGen: func(context.Context, *backgroundtask.AllocateTaskIDRequest) (string, error) {
+			sequence++
+			return "task_same", nil
+		},
+	})
+	defer manager.Close(context.Background())
+
+	first, err := Submit(context.Background(), manager, &SubmitRequest[*schema.Message]{
+		SubAgentName: "worker", Input: textInput("first"), SessionID: "parent",
+	})
+	require.NoError(t, err)
+	firstPayload, err := decodePayload(first.Spec)
+	require.NoError(t, err)
+	_, err = Submit(context.Background(), manager, &SubmitRequest[*schema.Message]{
+		SubAgentName: "worker", Input: textInput("second"), SessionID: "parent",
+	})
+	require.ErrorIs(t, err, backgroundtask.ErrAlreadyExists)
+	assert.Equal(t, 2, sequence)
+	secondID, err := defaultChildSessionID()
+	require.NoError(t, err)
+	assert.NotEqual(t, firstPayload.ChildSessionID, secondID)
+	assert.NotContains(t, firstPayload.ChildSessionID, first.Spec.ID)
+	assert.NotContains(t, firstPayload.ChildSessionID, "parent")
+	assert.NotContains(t, firstPayload.ChildSessionID, "worker")
 }
 
 func TestTasksCanReusePersistentChildSessionHistory_BitsUT(t *testing.T) {
@@ -752,11 +790,7 @@ func TestTasksCanReusePersistentChildSessionHistory_BitsUT(t *testing.T) {
 	)
 	defer manager.Close(context.Background())
 
-	childSessionID := defaultChildSessionID(
-		"parent",
-		"worker",
-		"persistent-child",
-	)
+	childSessionID := "1234567890"
 	first, err := Submit(context.Background(), manager, &SubmitRequest[*schema.Message]{
 		SubAgentName: "worker", Input: textInput("first request"),
 		SessionID: "parent", ChildSessionID: childSessionID,
@@ -802,7 +836,7 @@ func TestTasksCanReusePersistentChildSessionHistory_BitsUT(t *testing.T) {
 	require.NotContains(t, secondProgress, "reply-1")
 }
 
-func TestSubmitRejectsChildSessionFromAnotherOwner_BitsUT(t *testing.T) {
+func TestSubmitAcceptsOpaqueUserProvidedChildSessionID_BitsUT(t *testing.T) {
 	executor := newTestExecutor(t, nil)
 	require.NoError(t, executor.Register("worker", &AgentRegistration[*schema.Message]{
 		Agent: &resumableTestAgent{name: "worker"},
@@ -815,16 +849,19 @@ func TestSubmitRejectsChildSessionFromAnotherOwner_BitsUT(t *testing.T) {
 		&backgroundtask.Config{Executors: executors},
 	)
 
-	_, err := Submit(context.Background(), manager, &SubmitRequest[*schema.Message]{
+	task, err := Submit(context.Background(), manager, &SubmitRequest[*schema.Message]{
 		SubAgentName: "worker", Input: textInput("work"), SessionID: "parent",
-		ChildSessionID: defaultChildSessionID("other-parent", "worker", "child"),
+		ChildSessionID: "42",
 	})
-	require.ErrorContains(t, err, "does not belong")
+	require.NoError(t, err)
+	childSessionID, err := ChildSessionIDFromTask(task)
+	require.NoError(t, err)
+	require.Equal(t, "42", childSessionID)
 	_, err = Submit(context.Background(), manager, &SubmitRequest[*schema.Message]{
 		SubAgentName: "worker", Input: textInput("work"), SessionID: "parent",
-		ChildSessionID: defaultChildSessionID("parent", "other-agent", "child"),
+		ChildSessionID: "43",
 	})
-	require.ErrorContains(t, err, "does not belong")
+	require.NoError(t, err)
 }
 
 func executionFixture(
@@ -993,6 +1030,13 @@ func TestControlAndInterruptUseRunnerCheckpoint(t *testing.T) {
 		executeDone <- manager.Execute(context.Background(), task.Spec.ID)
 	}()
 	runCtx := <-agent.contexts
+	taskCtx, ok := TaskContextFromContext(runCtx)
+	require.True(t, ok)
+	assert.Equal(t, task.Spec.ID, taskCtx.TaskID)
+	assert.Equal(t, "parent", taskCtx.ParentSessionID)
+	assert.Equal(t, agent.name, taskCtx.SubAgentName)
+	assert.Equal(t, int64(1), taskCtx.Attempt)
+	assert.NotEmpty(t, taskCtx.ChildSessionID)
 
 	result, controlErr, controlled := executor.controlResult(
 		runCtx, task, backgroundtask.ControlRequest{Kind: backgroundtask.ControlDrain},
@@ -1104,10 +1148,8 @@ func TestSubAgentTaskResumesAfterManagerReconstruction_BitsUT(t *testing.T) {
 	persistedInput, err := decodeTypedInput[*schema.Message](persisted.Input)
 	require.NoError(t, err)
 	assert.Equal(t, "do work", persistedInput.Messages[0].Content)
-	assert.Equal(
-		t,
-		defaultChildSessionID("parent-session", "worker", task.Spec.ID),
-		persisted.ChildSessionID,
-	)
+	parsedChildSessionID, err := strconv.ParseInt(persisted.ChildSessionID, 10, 64)
+	require.NoError(t, err)
+	assert.Positive(t, parsedChildSessionID)
 	assert.Equal(t, checkpointID(task.Spec.ID), completed.Spec.ID+"/checkpoint")
 }

--- a/adk/backgroundtask/subagent/typed_submit_test.go
+++ b/adk/backgroundtask/subagent/typed_submit_test.go
@@ -358,7 +358,7 @@ func TestAttack_TypedPayloadRejectsMismatchedExecutorMessageType(t *testing.T) {
 	require.NoError(t, err)
 	payload, err := json.Marshal(taskPayload{
 		Version: payloadVersion, SubAgentName: "worker", Input: input,
-		ChildSessionID: defaultChildSessionID("parent", "worker", "task"),
+		ChildSessionID: "42",
 	})
 	require.NoError(t, err)
 

--- a/adk/middlewares/backgroundtask/middleware_test.go
+++ b/adk/middlewares/backgroundtask/middleware_test.go
@@ -464,7 +464,7 @@ func TestTaskOutputNonBlockingReturnsCurrentSnapshot(t *testing.T) {
 	task, err := runWork(submitter, "racing task", true, completedWork("done"))
 	require.NoError(t, err)
 	task = waitUntilTerminal(t, context.Background(), submitter, task.Spec.ID)
-	require.NoError(t, submitter.Close(context.Background()))
+	closeWithTimeout(submitter)
 
 	racingStore := &staleFirstGetStore{TaskStore: store, first: true}
 	reader := newBackgroundManager(t, context.Background(), &bgtask.Config{

--- a/adk/middlewares/filesystem/bash_run_test.go
+++ b/adk/middlewares/filesystem/bash_run_test.go
@@ -424,9 +424,9 @@ func TestManagedExecuteTool_StreamingForeground(t *testing.T) {
 	assert.Contains(t, got, "chunk3")
 }
 
-// An explicit background launch on a streaming managed tool exposes startup
-// output. This quick command completes inside the preview window, so its complete
-// output reaches the caller without a stale background notice.
+// An explicit background launch on a streaming managed tool exposes the bounded
+// startup preview when available, then drains the complete output in the
+// background.
 func TestManagedExecuteTool_StreamingExplicitBackground(t *testing.T) {
 	backend := setupTestBackend()
 	mgr := newTestManager(t, context.Background())
@@ -446,7 +446,6 @@ func TestManagedExecuteTool_StreamingExplicitBackground(t *testing.T) {
 	sr, err := st.StreamableRun(context.Background(), `{"command":"echo hi","run_in_background":true}`)
 	require.NoError(t, err)
 	got := drainToolStream(t, sr)
-	assert.Contains(t, got, "chunk1")
 	assert.Contains(t, got, "is running in the background")
 
 	task := waitTerminalTask(t, mgr)


### PR DESCRIPTION
# Opaque Durable Sub-Agent Child Sessions

## Problem
Durable sub-agent `child_session_id` encoded parent session, sub-agent name, and task ID in a fixed string format. That made the ID carry ownership metadata and prevented callers from using arbitrary opaque child session IDs.

A child session ID should identify the child transcript only. Task ownership and task metadata should come from the durable task record and execution context, not from parsing the session ID string.

## Solution
`ChildSessionID` is now opaque:

```go
ChildSessionID: "42"
```

When callers provide a value, Eino stores and uses it as-is. When omitted, Eino allocates a random positive `int64` decimal string. Durable execution now exposes `TaskContextFromContext`, so task-owned code can read `TaskID`, parent session, sub-agent name, child session ID, and attempt without decoding the child session ID.

## Key Insight
A durable sub-agent has two independent identities: the durable task owns execution and recovery, while the child session owns transcript history. Encoding task ownership into `child_session_id` couples those identities and makes user-provided child sessions impossible.

## Summary
| Problem | Solution |
|---------|----------|
| `child_session_id` required a fixed `subagent-session/...` format | Treat it as an opaque string and remove owner-format validation |
| Default child IDs embedded task/parent/sub-agent information | Allocate random positive `int64` decimal IDs |
| Consumers needed task metadata but parsed it from session ID | Expose `TaskContextFromContext` during durable sub-agent execution |

---

# 不再把 durable sub-agent 的 child session ID 作为信息载体

## Problem
Durable sub-agent 的 `child_session_id` 之前使用固定格式编码 parent session、sub-agent name 和 task ID。这让 session ID 同时承担了 transcript 标识和 task ownership 元数据两种职责，也阻止调用方传入任意 opaque child session ID。

`child_session_id` 应该只标识子会话历史；task 归属和执行元数据应来自 durable task 记录和执行上下文，而不是解析 session ID 字符串。

## Solution
`ChildSessionID` 现在是 opaque ID：

```go
ChildSessionID: "42"
```

调用方传入时 Eino 原样持久化并使用；未传时 Eino 分配随机正 `int64` 十进制字符串。durable 执行期间新增 `TaskContextFromContext`，让 task-owned 代码显式读取 `TaskID`、parent session、sub-agent name、child session ID 和 attempt，不再依赖解析 `child_session_id`。

## Key Insight
durable sub-agent 有两个独立身份：durable task 负责执行和恢复，child session 负责 transcript history。把 task ownership 编进 `child_session_id` 会把两者耦合在一起，并让用户指定 child session 变得不可行。

## Summary
| Problem | Solution |
|---------|----------|
| `child_session_id` 依赖固定 `subagent-session/...` 格式 | 改成 opaque string，移除 owner-format 校验 |
| 默认 child ID 泄漏 task/parent/sub-agent 信息 | 默认分配随机正 `int64` 十进制 ID |
| 消费方需要 task metadata 时只能解析 session ID | durable sub-agent 执行期间通过 `TaskContextFromContext` 暴露元数据 |
