### PR TITLE
fix(adk): relay background tool start events

### DIFF
--- a/adk/backgroundtask/tool/attack_test.go
+++ b/adk/backgroundtask/tool/attack_test.go
@@ -167,9 +167,11 @@ func TestAttack_ReplayedEventProjectsOnceMaterializesTwice(t *testing.T) {
 	)
 	require.NoError(t, err)
 	events := decodeEvents(t, readAllStreamResults(t, stream))
-	require.Len(t, events, 2)
-	require.Equal(t, ManagedToolResponseEventUpdate, events[0].Type)
-	require.Equal(t, ManagedToolResponseEventLaunchResult, events[1].Type)
+	require.NotEmpty(t, events)
+	require.Equal(t, ManagedToolResponseEventLaunchResult, events[len(events)-1].Type)
+	for _, event := range events[:len(events)-1] {
+		require.Equal(t, ManagedToolResponseEventUpdate, event.Type)
+	}
 	waitAttackTask(t, manager)
 
 	output, err := manager.ListTaskEvents(context.Background(), &backgroundtask.ListTaskEventsRequest{
@@ -461,7 +463,7 @@ func TestAttack_UpdateDataCannotForgeNDJSONBoundary(t *testing.T) {
 	)
 	require.NoError(t, err)
 	records := readAllStreamResults(t, stream)
-	require.Len(t, records, 2)
+	require.NotEmpty(t, records)
 	for _, record := range records {
 		require.NotNil(t, record)
 		require.NotEmpty(t, record.Parts)
@@ -469,8 +471,11 @@ func TestAttack_UpdateDataCannotForgeNDJSONBoundary(t *testing.T) {
 		require.NoError(t, json.Unmarshal([]byte(record.Parts[0].Text), &event))
 	}
 	events := decodeEvents(t, records)
-	require.Equal(t, forged, events[0].Update.Data)
-	require.Equal(t, "attack-task", events[1].TaskID)
+	for _, event := range events[:len(events)-1] {
+		require.Equal(t, forged, event.Update.Data)
+	}
+	require.Equal(t, ManagedToolResponseEventLaunchResult, events[len(events)-1].Type)
+	require.Equal(t, "attack-task", events[len(events)-1].TaskID)
 	t.Log("embedded newlines remained JSON-escaped and could not forge a lifecycle record")
 }
 

--- a/adk/backgroundtask/tool/executor.go
+++ b/adk/backgroundtask/tool/executor.go
@@ -26,6 +26,7 @@ import (
 
 	"github.com/cloudwego/eino/adk/backgroundtask"
 	"github.com/cloudwego/eino/adk/internal/foreground"
+	"github.com/cloudwego/eino/adk/internal/startwindow"
 	"github.com/cloudwego/eino/schema"
 )
 
@@ -159,8 +160,6 @@ func (e *executor) Execute( //nolint:cyclop,funlen // execution coordinates the 
 	}
 	hasInputRequest := inputRequest != nil
 	resumable, supportsResume := registration.Tool.(ResumableBackgroundTool)
-	startCommitRuntime, supportsStartCommit := runtime.(backgroundtask.StartCommitRuntime)
-	startedRun := false
 	if !hasInputRequest && task.Attempt == 1 {
 		if adopted := e.registry.adopted.consume(task.Spec.ID); adopted != nil {
 			run = adopted.run
@@ -199,51 +198,13 @@ func (e *executor) Execute( //nolint:cyclop,funlen // execution coordinates the 
 			Checkpoint: append([]byte(nil), toolCheckpoint...),
 		})
 	} else {
-		if e.recoverable && !supportsStartCommit {
-			return nil, errors.New(
-				"backgroundtask/tool: execution runtime cannot commit external start",
-			)
-		}
-		startedRun = true
-		var startResult *StartResult
-		startResult, err = registration.Tool.Start(ctx, &StartRequest{
-			TaskID: task.Spec.ID, Arguments: payload.Arguments, Attempt: task.Attempt,
-		})
-		if err == nil {
-			if startResult == nil {
-				return nil, errors.New(
-					"backgroundtask/tool: implementation returned a nil start result",
-				)
-			}
-			run = startResult.Run
-			toolCheckpoint = append([]byte(nil), startResult.Checkpoint...)
-		}
+		run, toolCheckpoint, err = e.startRun(ctx, registration, runtime, task, payload)
 	}
 	if err != nil {
 		return nil, err
 	}
 	if run == nil {
 		return nil, errors.New("backgroundtask/tool: implementation returned a nil run")
-	}
-	if startedRun && !e.recoverable && len(toolCheckpoint) > 0 {
-		return nil, stopRunAfterStartCommitFailure(run, errors.New(
-			"backgroundtask/tool: plain tool cannot return a checkpoint",
-		))
-	}
-	if startedRun && e.recoverable {
-		checkpoint, checkpointErr := encodeManagedCheckpoint(
-			nil,
-			toolCheckpoint,
-		)
-		if checkpointErr != nil {
-			return nil, stopRunAfterStartCommitFailure(run, checkpointErr)
-		}
-		if err = startCommitRuntime.CommitStart(ctx, checkpoint); err != nil {
-			return nil, stopRunAfterStartCommitFailure(run, fmt.Errorf(
-				"backgroundtask/tool: commit external start: %w",
-				err,
-			))
-		}
 	}
 
 	projection := e.registry.projections.load(task.Spec.ID)
@@ -376,6 +337,56 @@ func (e *executor) Execute( //nolint:cyclop,funlen // execution coordinates the 
 			return nil, ctx.Err()
 		}
 	}
+}
+
+func (e *executor) startRun(
+	ctx context.Context,
+	registration *Registration,
+	runtime backgroundtask.ExecutionRuntime,
+	task *backgroundtask.Task,
+	payload *taskPayload,
+) (Run, []byte, error) {
+	defer startwindow.Signal(ctx)
+	if e.recoverable {
+		if _, ok := runtime.(backgroundtask.StartCommitRuntime); !ok {
+			return nil, nil, errors.New(
+				"backgroundtask/tool: execution runtime cannot commit external start",
+			)
+		}
+	}
+	startResult, err := registration.Tool.Start(ctx, &StartRequest{
+		TaskID: task.Spec.ID, Arguments: payload.Arguments, Attempt: task.Attempt,
+	})
+	if err != nil {
+		return nil, nil, err
+	}
+	if startResult == nil {
+		return nil, nil, errors.New("backgroundtask/tool: implementation returned a nil start result")
+	}
+	if startResult.Run == nil {
+		return nil, nil, errors.New("backgroundtask/tool: implementation returned a nil run")
+	}
+	run := startResult.Run
+	toolCheckpoint := append([]byte(nil), startResult.Checkpoint...)
+	if !e.recoverable && len(toolCheckpoint) > 0 {
+		return nil, nil, stopRunAfterStartCommitFailure(run, errors.New(
+			"backgroundtask/tool: plain tool cannot return a checkpoint",
+		))
+	}
+	if e.recoverable {
+		checkpoint, checkpointErr := encodeManagedCheckpoint(nil, toolCheckpoint)
+		if checkpointErr != nil {
+			return nil, nil, stopRunAfterStartCommitFailure(run, checkpointErr)
+		}
+		startCommitRuntime := runtime.(backgroundtask.StartCommitRuntime)
+		if err = startCommitRuntime.CommitStart(ctx, checkpoint); err != nil {
+			return nil, nil, stopRunAfterStartCommitFailure(run, fmt.Errorf(
+				"backgroundtask/tool: commit external start: %w",
+				err,
+			))
+		}
+	}
+	return run, toolCheckpoint, nil
 }
 
 func (e *executor) drainTerminalUpdates(

--- a/adk/backgroundtask/tool/managed_tool.go
+++ b/adk/backgroundtask/tool/managed_tool.go
@@ -28,6 +28,7 @@ import (
 	"github.com/cloudwego/eino/adk"
 	"github.com/cloudwego/eino/adk/backgroundtask"
 	"github.com/cloudwego/eino/adk/internal/foreground"
+	"github.com/cloudwego/eino/adk/internal/startwindow"
 	componenttool "github.com/cloudwego/eino/components/tool"
 	"github.com/cloudwego/eino/schema"
 )
@@ -157,9 +158,7 @@ func (t *managedTool) InvokableRun(
 		if err != nil {
 			return nil, err
 		}
-		go func() {
-			_ = t.manager.Execute(detachedContext{parent: context.Background()}, task.Spec.ID)
-		}()
+		t.executeBackgroundUntilStart(ctx, task.Spec.ID)
 		return t.renderLaunchResult(ctx, task)
 	}
 	return t.runForeground(ctx, arguments)
@@ -194,11 +193,12 @@ func (t *managedTool) StreamableRun(
 			return nil, err
 		}
 		runDone := make(chan launchResult, 1)
+		_, window := t.startBackgroundExecution(ctx, task.Spec.ID)
+		// The projection must drain updates before waiting on Start; otherwise
+		// the executor can stall on the projection buffer before detach.
+		go t.project(context.Background(), task.Spec.ID, projection, runDone, writer)
+		_ = window.Wait(ctx, t.startWindowTimeout())
 		runDone <- launchResult{task: task}
-		go func() {
-			_ = t.manager.Execute(detachedContext{parent: context.Background()}, task.Spec.ID)
-		}()
-		go t.project(ctx, task.Spec.ID, projection, runDone, writer)
 		return reader, nil
 	}
 	go t.streamForeground(ctx, arguments, writer)
@@ -218,14 +218,23 @@ type foregroundStart struct {
 	toolCheckpoint []byte
 }
 
-type detachedContext struct {
-	parent context.Context
+func (t *managedTool) executeBackgroundUntilStart(ctx context.Context, taskID string) {
+	_, window := t.startBackgroundExecution(ctx, taskID)
+	_ = window.Wait(ctx, t.startWindowTimeout())
 }
 
-func (detachedContext) Deadline() (time.Time, bool) { return time.Time{}, false }
-func (detachedContext) Done() <-chan struct{}       { return nil }
-func (detachedContext) Err() error                  { return nil }
-func (c detachedContext) Value(key any) any         { return c.parent.Value(key) }
+func (t *managedTool) startBackgroundExecution(ctx context.Context, taskID string) (context.Context, *startwindow.Window) {
+	backgroundCtx, window := startwindow.Open(ctx)
+	go func() {
+		defer startwindow.Signal(backgroundCtx)
+		_ = t.manager.Execute(backgroundCtx, taskID)
+	}()
+	return backgroundCtx, window
+}
+
+func (t *managedTool) startWindowTimeout() time.Duration {
+	return time.Duration(t.policy.TimeoutMs) * time.Millisecond
+}
 
 func (t *managedTool) runForeground(
 	ctx context.Context,
@@ -741,7 +750,7 @@ func (t *managedTool) tryHandoff(
 		return nil, err
 	}
 	go func() {
-		_ = t.manager.Execute(detachedContext{parent: context.Background()}, task.Spec.ID)
+		_ = t.manager.Execute(context.Background(), task.Spec.ID)
 	}()
 	return task, nil
 }
@@ -783,20 +792,8 @@ func (t *managedTool) project(
 				writer.Send(nil, errors.New("backgroundtask/tool: foreground returned a nil task"))
 				return
 			}
-			if result.task.Status != backgroundtask.StatusRunning && updates != nil {
-				for update := range updates {
-					record, encodeErr := renderEvent(&ManagedToolResponseEvent{Type: ManagedToolResponseEventUpdate, Update: update})
-					if encodeErr != nil {
-						t.registry.projections.remove(taskID)
-						writer.Send(nil, encodeErr)
-						return
-					}
-					if writer.Send(record, nil) {
-						t.registry.projections.remove(taskID)
-						return
-					}
-				}
-			}
+			// runDone is the explicit detach command for the caller-side
+			// projection; durable progress continues on the background task.
 			t.registry.projections.remove(taskID)
 			final, encodeErr := t.renderLaunchResult(ctx, result.task)
 			if encodeErr != nil {

--- a/adk/backgroundtask/tool/managed_tool_test.go
+++ b/adk/backgroundtask/tool/managed_tool_test.go
@@ -28,8 +28,11 @@ import (
 
 	"github.com/stretchr/testify/require"
 
+	"github.com/cloudwego/eino/adk"
 	"github.com/cloudwego/eino/adk/backgroundtask"
 	"github.com/cloudwego/eino/adk/internal/foreground"
+	adksession "github.com/cloudwego/eino/adk/session"
+	"github.com/cloudwego/eino/components/model"
 	componenttool "github.com/cloudwego/eino/components/tool"
 	"github.com/cloudwego/eino/compose"
 	"github.com/cloudwego/eino/schema"
@@ -167,6 +170,69 @@ type updatingRun struct {
 
 func (r *updatingRun) Updates() *schema.StreamReader[*Update] { return r.updates }
 
+type managedToolStartEventModel struct {
+	mu    sync.Mutex
+	calls int
+}
+
+func (m *managedToolStartEventModel) Generate(
+	_ context.Context,
+	_ []*schema.Message,
+	_ ...model.Option,
+) (*schema.Message, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.calls++
+	if m.calls == 1 {
+		return schema.AssistantMessage("call external", []schema.ToolCall{{
+			ID: "call_start_event",
+			Function: schema.FunctionCall{
+				Name:      "external",
+				Arguments: `{"value":"work"}`,
+			},
+		}}), nil
+	}
+	return schema.AssistantMessage("done", nil), nil
+}
+
+func (m *managedToolStartEventModel) Stream(
+	ctx context.Context,
+	input []*schema.Message,
+	opts ...model.Option,
+) (*schema.StreamReader[*schema.Message], error) {
+	message, err := m.Generate(ctx, input, opts...)
+	if err != nil {
+		return nil, err
+	}
+	return schema.StreamReaderFromArray([]*schema.Message{message}), nil
+}
+
+func (m *managedToolStartEventModel) WithTools(
+	_ []*schema.ToolInfo,
+) (model.ToolCallingChatModel, error) {
+	return m, nil
+}
+
+type managedToolStartEventMarkerKey struct{}
+
+type managedToolStartEventMarkerMiddleware struct {
+	*adk.TypedBaseChatModelAgentMiddleware[*schema.Message]
+}
+
+func (m *managedToolStartEventMarkerMiddleware) WrapEnhancedInvokableToolCall(
+	_ context.Context,
+	endpoint adk.EnhancedInvokableToolCallEndpoint,
+	_ *adk.ToolContext,
+) (adk.EnhancedInvokableToolCallEndpoint, error) {
+	return func(ctx context.Context, argument *schema.ToolArgument, opts ...componenttool.Option) (*schema.ToolResult, error) {
+		return endpoint(
+			context.WithValue(ctx, managedToolStartEventMarkerKey{}, "tool-call-marker"),
+			argument,
+			opts...,
+		)
+	}, nil
+}
+
 func toolInfo(name string) *schema.ToolInfo {
 	return &schema.ToolInfo{
 		Name: name, Desc: "Run external work",
@@ -240,6 +306,32 @@ func waitTaskAttempt(t *testing.T, manager *backgroundtask.Manager, taskID strin
 		require.True(t, time.Now().Before(deadline), "task was not claimed")
 		time.Sleep(time.Millisecond)
 	}
+}
+
+func waitTaskTerminal(t *testing.T, manager *backgroundtask.Manager, taskID string) *backgroundtask.Task {
+	t.Helper()
+	deadline := time.Now().Add(time.Second)
+	for {
+		task, err := manager.Get(context.Background(), taskID)
+		require.NoError(t, err)
+		if task.Status != backgroundtask.StatusPending && task.Status != backgroundtask.StatusRunning {
+			return task
+		}
+		require.True(t, time.Now().Before(deadline), "task did not finish")
+		time.Sleep(time.Millisecond)
+	}
+}
+
+type startFailStore struct {
+	*backgroundtask.InMemoryStore
+	err     error
+	started chan struct{}
+	once    sync.Once
+}
+
+func (s *startFailStore) Start(context.Context, *backgroundtask.StartTaskRequest) (*backgroundtask.Task, error) {
+	s.once.Do(func() { close(s.started) })
+	return nil, s.err
 }
 
 func TestManagedToolPreparesInputBeforeTaskCreation_BitsUT(t *testing.T) {
@@ -485,6 +577,677 @@ func TestManagedToolFastCompletionReturnsCanonicalTaskID(t *testing.T) {
 
 	_, err = manager.Get(context.Background(), "task-fixed")
 	require.ErrorIs(t, err, backgroundtask.ErrNotFound)
+}
+
+func TestManagedToolForegroundStartCanSendParentSessionEvent(t *testing.T) {
+	ctx := context.Background()
+	const parentSessionID = "managed-tool-start-parent"
+	startEventKind := adk.SessionEventKind(adk.SessionEventExtensionPrefix + "managed_tool.start")
+	implementation := &fakeTool{
+		start: func(ctx context.Context, request *StartRequest) (Run, error) {
+			require.Equal(t, int64(0), request.Attempt)
+			require.Equal(t, "task-fixed", request.TaskID)
+			err := adk.TypedSendEvent(ctx, &adk.TypedAgentEvent[*schema.Message]{
+				SessionEventVariant: &adk.SessionEventVariant[*schema.Message]{
+					Event: &adk.SessionEvent[*schema.Message]{
+						Kind:      startEventKind,
+						Extension: &adk.SessionExtensionEvent{},
+					},
+				},
+			})
+			require.NoError(t, err)
+			return &fakeRun{wait: func(context.Context) (*Outcome, error) {
+				return &Outcome{
+					Status: backgroundtask.StatusCompleted,
+					Data:   []byte(`{"ok":true}`),
+				}, nil
+			}}, nil
+		},
+	}
+	registry := NewRegistry()
+	require.NoError(t, registry.Register(&Registration{
+		Info:        toolInfo("external"),
+		Tool:        implementation,
+		Description: func(string) string { return "External operation" },
+	}))
+	executors := backgroundtask.NewExecutorRegistry()
+	manager := mustNewBackgroundManager(t, ctx, &backgroundtask.Config{
+		Executors: executors,
+		IDGen: func(context.Context, *backgroundtask.AllocateTaskIDRequest) (string, error) {
+			return "task-fixed", nil
+		},
+	})
+	timeoutMs := int(time.Second / time.Millisecond)
+	wrapped, err := NewManagedTool(ctx, &ManagedToolConfig{
+		Manager: manager, Executors: executors, Registry: registry, ToolName: "external",
+		ForegroundTimeoutMs: &timeoutMs,
+	})
+	require.NoError(t, err)
+	agent, err := adk.NewChatModelAgent(ctx, &adk.ChatModelAgentConfig{
+		Name:        "managed-tool-start-event-agent",
+		Instruction: "call external once",
+		Model:       &managedToolStartEventModel{},
+		ToolsConfig: adk.ToolsConfig{
+			ToolsNodeConfig: compose.ToolsNodeConfig{
+				Tools: []componenttool.BaseTool{wrapped},
+			},
+		},
+	})
+	require.NoError(t, err)
+	sessionStore := adksession.NewInMemoryStore[*schema.Message](nil)
+	runner := adk.NewRunner(ctx, adk.RunnerConfig{
+		Agent: agent, SessionID: parentSessionID, SessionStore: sessionStore,
+	})
+
+	iterator := runner.Query(ctx, "start external work")
+	for {
+		event, ok := iterator.Next()
+		if !ok {
+			break
+		}
+		require.NoError(t, event.Err)
+	}
+
+	result, err := sessionStore.LoadEvents(ctx, parentSessionID, &adk.LoadSessionEventsRequest{
+		Kinds: []adk.SessionEventKind{startEventKind},
+	})
+	require.NoError(t, err)
+	require.Len(t, result.Events, 1)
+	require.Equal(t, startEventKind, result.Events[0].Kind)
+	require.NotEmpty(t, result.Events[0].EventID)
+	require.NotEmpty(t, result.Events[0].TurnID)
+	require.NotNil(t, result.Events[0].Extension)
+}
+
+func TestManagedToolBackgroundStartCanSendParentSessionEvent(t *testing.T) {
+	ctx := context.Background()
+	const parentSessionID = "managed-tool-background-start-parent"
+	startEventKind := adk.SessionEventKind(adk.SessionEventExtensionPrefix + "managed_tool.background_start")
+	implementation := &fakeTool{
+		start: func(ctx context.Context, request *StartRequest) (Run, error) {
+			require.Equal(t, int64(1), request.Attempt)
+			require.Equal(t, "task-fixed", request.TaskID)
+			require.Nil(t, ctx.Value(managedToolStartEventMarkerKey{}))
+			err := adk.TypedSendEvent(ctx, &adk.TypedAgentEvent[*schema.Message]{
+				SessionEventVariant: &adk.SessionEventVariant[*schema.Message]{
+					Event: &adk.SessionEvent[*schema.Message]{
+						Kind:      startEventKind,
+						Extension: &adk.SessionExtensionEvent{},
+					},
+				},
+			})
+			require.NoError(t, err)
+			return &fakeRun{wait: func(context.Context) (*Outcome, error) {
+				return &Outcome{Status: backgroundtask.StatusCompleted}, nil
+			}}, nil
+		},
+	}
+	registry := NewRegistry()
+	require.NoError(t, registry.Register(&Registration{
+		Info:        toolInfo("external"),
+		Tool:        implementation,
+		Description: func(string) string { return "External operation" },
+	}))
+	executors := backgroundtask.NewExecutorRegistry()
+	manager := mustNewBackgroundManager(t, ctx, &backgroundtask.Config{
+		Executors: executors,
+		IDGen: func(context.Context, *backgroundtask.AllocateTaskIDRequest) (string, error) {
+			return "task-fixed", nil
+		},
+	})
+	timeoutMs := int(time.Second / time.Millisecond)
+	wrapped, err := NewManagedTool(ctx, &ManagedToolConfig{
+		Manager: manager, Executors: executors, Registry: registry, ToolName: "external",
+		ForegroundTimeoutMs: &timeoutMs,
+		RunInBackground:     func(context.Context, string) bool { return true },
+	})
+	require.NoError(t, err)
+	agent, err := adk.NewChatModelAgent(ctx, &adk.ChatModelAgentConfig{
+		Name:        "managed-tool-background-start-event-agent",
+		Instruction: "call external once",
+		Model:       &managedToolStartEventModel{},
+		ToolsConfig: adk.ToolsConfig{
+			ToolsNodeConfig: compose.ToolsNodeConfig{
+				Tools: []componenttool.BaseTool{wrapped},
+			},
+		},
+		Handlers: []adk.ChatModelAgentMiddleware{
+			&managedToolStartEventMarkerMiddleware{
+				TypedBaseChatModelAgentMiddleware: &adk.TypedBaseChatModelAgentMiddleware[*schema.Message]{},
+			},
+		},
+	})
+	require.NoError(t, err)
+	sessionStore := adksession.NewInMemoryStore[*schema.Message](nil)
+	runner := adk.NewRunner(ctx, adk.RunnerConfig{
+		Agent: agent, SessionID: parentSessionID, SessionStore: sessionStore,
+		SessionConfig: &adk.SessionConfig[*schema.Message]{
+			EventIDGenerator: func(ctx context.Context, event *adk.SessionEvent[*schema.Message]) (string, error) {
+				if event.Kind == startEventKind {
+					return "start-event-id", nil
+				}
+				return adk.DefaultSessionEventIDGenerator[*schema.Message](ctx, event)
+			},
+			EventExtraProvider: func(ctx context.Context, _ *adk.SessionEvent[*schema.Message]) (map[string]any, error) {
+				marker, _ := ctx.Value(managedToolStartEventMarkerKey{}).(string)
+				if marker == "" {
+					return nil, nil
+				}
+				return map[string]any{"marker": marker}, nil
+			},
+		},
+	})
+
+	iterator := runner.Query(ctx, "start external work")
+	for {
+		event, ok := iterator.Next()
+		if !ok {
+			break
+		}
+		require.NoError(t, event.Err)
+	}
+
+	result, err := sessionStore.LoadEvents(ctx, parentSessionID, &adk.LoadSessionEventsRequest{
+		Kinds: []adk.SessionEventKind{startEventKind},
+	})
+	require.NoError(t, err)
+	require.Len(t, result.Events, 1)
+	require.Equal(t, "start-event-id", result.Events[0].EventID)
+	require.NotEmpty(t, result.Events[0].TurnID)
+	require.Equal(t, "tool-call-marker", result.Events[0].Extra["marker"])
+	_, err = manager.Get(ctx, "task-fixed")
+	require.NoError(t, err)
+}
+
+func TestManagedToolBackgroundWaitCannotSendParentSessionEvent(t *testing.T) {
+	ctx := context.Background()
+	const parentSessionID = "managed-tool-background-wait-parent"
+	waitEventKind := adk.SessionEventKind(adk.SessionEventExtensionPrefix + "managed_tool.wait")
+	waitSent := make(chan error, 1)
+	implementation := &fakeTool{
+		start: func(context.Context, *StartRequest) (Run, error) {
+			return &fakeRun{wait: func(ctx context.Context) (*Outcome, error) {
+				waitSent <- adk.TypedSendEvent(ctx, &adk.TypedAgentEvent[*schema.Message]{
+					SessionEventVariant: &adk.SessionEventVariant[*schema.Message]{
+						Event: &adk.SessionEvent[*schema.Message]{
+							Kind:      waitEventKind,
+							Extension: &adk.SessionExtensionEvent{},
+						},
+					},
+				})
+				return &Outcome{Status: backgroundtask.StatusCompleted}, nil
+			}}, nil
+		},
+	}
+	registry := NewRegistry()
+	require.NoError(t, registry.Register(&Registration{
+		Info:        toolInfo("external"),
+		Tool:        implementation,
+		Description: func(string) string { return "External operation" },
+	}))
+	executors := backgroundtask.NewExecutorRegistry()
+	manager := mustNewBackgroundManager(t, ctx, &backgroundtask.Config{
+		Executors: executors,
+		IDGen: func(context.Context, *backgroundtask.AllocateTaskIDRequest) (string, error) {
+			return "task-fixed", nil
+		},
+	})
+	timeoutMs := int(time.Second / time.Millisecond)
+	wrapped, err := NewManagedTool(ctx, &ManagedToolConfig{
+		Manager: manager, Executors: executors, Registry: registry, ToolName: "external",
+		ForegroundTimeoutMs: &timeoutMs,
+		RunInBackground:     func(context.Context, string) bool { return true },
+	})
+	require.NoError(t, err)
+	agent, err := adk.NewChatModelAgent(ctx, &adk.ChatModelAgentConfig{
+		Name:        "managed-tool-background-wait-event-agent",
+		Instruction: "call external once",
+		Model:       &managedToolStartEventModel{},
+		ToolsConfig: adk.ToolsConfig{
+			ToolsNodeConfig: compose.ToolsNodeConfig{
+				Tools: []componenttool.BaseTool{wrapped},
+			},
+		},
+	})
+	require.NoError(t, err)
+	sessionStore := adksession.NewInMemoryStore[*schema.Message](nil)
+	runner := adk.NewRunner(ctx, adk.RunnerConfig{
+		Agent: agent, SessionID: parentSessionID, SessionStore: sessionStore,
+	})
+
+	iterator := runner.Query(ctx, "start external work")
+	for {
+		event, ok := iterator.Next()
+		if !ok {
+			break
+		}
+		require.NoError(t, event.Err)
+	}
+	require.ErrorIs(t, <-waitSent, adk.ErrStartWindowClosed)
+	result, err := sessionStore.LoadEvents(ctx, parentSessionID, &adk.LoadSessionEventsRequest{
+		Kinds: []adk.SessionEventKind{waitEventKind},
+	})
+	require.NoError(t, err)
+	require.Empty(t, result.Events)
+}
+
+func TestManagedToolBackgroundStartWindowDoesNotHangOnPreExecuteFailure(t *testing.T) {
+	startErr := errors.New("claim unavailable")
+	store := &startFailStore{
+		InMemoryStore: backgroundtask.NewInMemoryStore(nil),
+		err:           startErr,
+		started:       make(chan struct{}),
+	}
+	implementation := &fakeTool{
+		start: func(context.Context, *StartRequest) (Run, error) {
+			t.Fatal("Start must not run when TaskStore.Start fails")
+			return nil, nil
+		},
+	}
+	registry := NewRegistry()
+	require.NoError(t, registry.Register(&Registration{
+		Info: toolInfo("external"), Tool: implementation,
+	}))
+	executors := backgroundtask.NewExecutorRegistry()
+	manager := mustNewBackgroundManager(t, context.Background(), &backgroundtask.Config{
+		Tasks: store, Executors: executors,
+		IDGen: func(context.Context, *backgroundtask.AllocateTaskIDRequest) (string, error) {
+			return "pre-execute-failure", nil
+		},
+	})
+	timeoutMs := int(time.Second / time.Millisecond)
+	wrapped, err := NewManagedTool(context.Background(), &ManagedToolConfig{
+		Manager: manager, Executors: executors, Registry: registry, ToolName: "external",
+		ForegroundTimeoutMs: &timeoutMs,
+		RunInBackground:     func(context.Context, string) bool { return true },
+		SessionID:           func(context.Context) (string, error) { return "session", nil },
+	})
+	require.NoError(t, err)
+
+	done := make(chan struct {
+		result *schema.ToolResult
+		err    error
+	}, 1)
+	go func() {
+		result, runErr := wrapped.(componenttool.EnhancedInvokableTool).InvokableRun(
+			context.Background(), toolArgument(`{"value":"x"}`),
+		)
+		done <- struct {
+			result *schema.ToolResult
+			err    error
+		}{result: result, err: runErr}
+	}()
+	select {
+	case <-store.started:
+	case <-time.After(time.Second):
+		t.Fatal("TaskStore.Start was not reached")
+	}
+	select {
+	case received := <-done:
+		require.NoError(t, received.err)
+		event := decodeEvents(t, []*schema.ToolResult{received.result})[0]
+		require.Equal(t, ManagedToolResponseEventLaunchResult, event.Type)
+		require.Equal(t, "pre-execute-failure", event.TaskID)
+	case <-time.After(time.Second):
+		t.Fatal("background launch hung after pre-execute failure")
+	}
+}
+
+func TestManagedToolBackgroundStartWindowTimeoutReturnsLaunchResult(t *testing.T) {
+	ctx := context.Background()
+	const parentSessionID = "managed-tool-background-timeout-parent"
+	startEventKind := adk.SessionEventKind(adk.SessionEventExtensionPrefix + "managed_tool.timeout")
+	startEntered := make(chan struct{})
+	continueStart := make(chan struct{})
+	sendErr := make(chan error, 1)
+	implementation := &fakeTool{
+		start: func(ctx context.Context, request *StartRequest) (Run, error) {
+			require.Equal(t, int64(1), request.Attempt)
+			close(startEntered)
+			<-continueStart
+			sendErr <- adk.TypedSendEvent(ctx, &adk.TypedAgentEvent[*schema.Message]{
+				SessionEventVariant: &adk.SessionEventVariant[*schema.Message]{
+					Event: &adk.SessionEvent[*schema.Message]{
+						Kind:      startEventKind,
+						Extension: &adk.SessionExtensionEvent{},
+					},
+				},
+			})
+			return &fakeRun{wait: func(context.Context) (*Outcome, error) {
+				return &Outcome{Status: backgroundtask.StatusCompleted}, nil
+			}}, nil
+		},
+	}
+	registry := NewRegistry()
+	require.NoError(t, registry.Register(&Registration{
+		Info:        toolInfo("external"),
+		Tool:        implementation,
+		Description: func(string) string { return "External operation" },
+	}))
+	executors := backgroundtask.NewExecutorRegistry()
+	manager := mustNewBackgroundManager(t, ctx, &backgroundtask.Config{
+		Executors: executors,
+		IDGen: func(context.Context, *backgroundtask.AllocateTaskIDRequest) (string, error) {
+			return "task-fixed", nil
+		},
+	})
+	timeoutMs := 50
+	wrapped, err := NewManagedTool(ctx, &ManagedToolConfig{
+		Manager: manager, Executors: executors, Registry: registry, ToolName: "external",
+		ForegroundTimeoutMs: &timeoutMs,
+		RunInBackground:     func(context.Context, string) bool { return true },
+	})
+	require.NoError(t, err)
+	agent, err := adk.NewChatModelAgent(ctx, &adk.ChatModelAgentConfig{
+		Name:        "managed-tool-background-timeout-agent",
+		Instruction: "call external once",
+		Model:       &managedToolStartEventModel{},
+		ToolsConfig: adk.ToolsConfig{
+			ToolsNodeConfig: compose.ToolsNodeConfig{
+				Tools: []componenttool.BaseTool{wrapped},
+			},
+		},
+	})
+	require.NoError(t, err)
+	sessionStore := adksession.NewInMemoryStore[*schema.Message](nil)
+	runner := adk.NewRunner(ctx, adk.RunnerConfig{
+		Agent: agent, SessionID: parentSessionID, SessionStore: sessionStore,
+	})
+
+	startedAt := time.Now()
+	iterator := runner.Query(ctx, "start external work")
+	for {
+		event, ok := iterator.Next()
+		if !ok {
+			break
+		}
+		require.NoError(t, event.Err)
+	}
+	require.GreaterOrEqual(t, time.Since(startedAt), 40*time.Millisecond)
+	select {
+	case <-startEntered:
+	default:
+		t.Fatal("Start was not reached before the launch result returned")
+	}
+	task, err := manager.Get(ctx, "task-fixed")
+	require.NoError(t, err)
+	require.Equal(t, backgroundtask.StatusRunning, task.Status)
+	close(continueStart)
+	require.ErrorIs(t, <-sendErr, adk.ErrStartWindowClosed)
+	terminal := waitTaskTerminal(t, manager, "task-fixed")
+	require.Equal(t, backgroundtask.StatusCompleted, terminal.Status)
+
+	result, err := sessionStore.LoadEvents(ctx, parentSessionID, &adk.LoadSessionEventsRequest{
+		Kinds: []adk.SessionEventKind{startEventKind},
+	})
+	require.NoError(t, err)
+	require.Empty(t, result.Events)
+}
+
+func TestManagedToolBackgroundStartWindowWithoutSenderStillWaits(t *testing.T) {
+	startEntered := make(chan struct{})
+	continueStart := make(chan struct{})
+	implementation := &fakeTool{
+		start: func(context.Context, *StartRequest) (Run, error) {
+			close(startEntered)
+			<-continueStart
+			return &fakeRun{wait: func(context.Context) (*Outcome, error) {
+				return &Outcome{Status: backgroundtask.StatusCompleted}, nil
+			}}, nil
+		},
+	}
+	manager, wrapped := newTestManagedTool(t, implementation, time.Second)
+	wrapped.(*managedTool).runInBackground = func(context.Context, string) bool { return true }
+	wrapped.(*managedTool).policy.TimeoutMs = 40
+	t.Cleanup(func() { close(continueStart) })
+
+	startedAt := time.Now()
+	result, err := wrapped.(componenttool.EnhancedInvokableTool).InvokableRun(
+		context.Background(), toolArgument(`{"value":"x"}`),
+	)
+	require.NoError(t, err)
+	require.GreaterOrEqual(t, time.Since(startedAt), 30*time.Millisecond)
+	select {
+	case <-startEntered:
+	default:
+		t.Fatal("Start was not reached")
+	}
+	event := decodeEvents(t, []*schema.ToolResult{result})[0]
+	require.Equal(t, ManagedToolResponseEventLaunchResult, event.Type)
+	require.Equal(t, "task-fixed", event.TaskID)
+	task, err := manager.Get(context.Background(), "task-fixed")
+	require.NoError(t, err)
+	require.Equal(t, backgroundtask.StatusRunning, task.Status)
+}
+
+func TestManagedToolBackgroundStreamReturnsLaunchBeforeTaskTerminal(t *testing.T) {
+	waitReleased := make(chan struct{})
+	implementation := &fakeTool{
+		start: func(context.Context, *StartRequest) (Run, error) {
+			return &fakeRun{wait: func(context.Context) (*Outcome, error) {
+				<-waitReleased
+				return &Outcome{Status: backgroundtask.StatusCompleted}, nil
+			}}, nil
+		},
+	}
+	manager, wrapped := newTestManagedTool(t, implementation, time.Second)
+	wrapped.(*managedTool).runInBackground = func(context.Context, string) bool { return true }
+	t.Cleanup(func() { close(waitReleased) })
+
+	stream, err := wrapped.(componenttool.EnhancedStreamableTool).StreamableRun(
+		context.Background(), toolArgument(`{"value":"stream"}`),
+	)
+	require.NoError(t, err)
+	defer stream.Close()
+	result, recvErr := stream.Recv()
+	require.NoError(t, recvErr)
+	event := decodeEvents(t, []*schema.ToolResult{result})[0]
+	require.Equal(t, ManagedToolResponseEventLaunchResult, event.Type)
+	require.Equal(t, "task-fixed", event.TaskID)
+	task, err := manager.Get(context.Background(), "task-fixed")
+	require.NoError(t, err)
+	require.Equal(t, backgroundtask.StatusRunning, task.Status)
+}
+
+func TestAttack_BackgroundStreamParentCancelReturnsLaunchResult(t *testing.T) {
+	startEntered := make(chan struct{})
+	continueStart := make(chan struct{})
+	var releaseOnce sync.Once
+	implementation := &fakeTool{
+		start: func(context.Context, *StartRequest) (Run, error) {
+			close(startEntered)
+			<-continueStart
+			return &fakeRun{wait: func(context.Context) (*Outcome, error) {
+				return &Outcome{Status: backgroundtask.StatusCompleted}, nil
+			}}, nil
+		},
+	}
+	manager, wrapped := newTestManagedTool(t, implementation, time.Second)
+	wrapped.(*managedTool).runInBackground = func(context.Context, string) bool { return true }
+	t.Cleanup(func() { releaseOnce.Do(func() { close(continueStart) }) })
+
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan struct {
+		stream *schema.StreamReader[*schema.ToolResult]
+		err    error
+	}, 1)
+	go func() {
+		stream, err := wrapped.(componenttool.EnhancedStreamableTool).StreamableRun(
+			ctx, toolArgument(`{"value":"stream"}`),
+		)
+		done <- struct {
+			stream *schema.StreamReader[*schema.ToolResult]
+			err    error
+		}{stream: stream, err: err}
+	}()
+	select {
+	case <-startEntered:
+	case <-time.After(time.Second):
+		t.Fatal("Start was not reached")
+	}
+	cancel()
+	var received struct {
+		stream *schema.StreamReader[*schema.ToolResult]
+		err    error
+	}
+	select {
+	case received = <-done:
+	case <-time.After(time.Second):
+		t.Fatal("StreamableRun did not return after parent cancellation")
+	}
+	require.NoError(t, received.err)
+	defer received.stream.Close()
+	result, recvErr := received.stream.Recv()
+	require.NoError(t, recvErr)
+	event := decodeEvents(t, []*schema.ToolResult{result})[0]
+	require.Equal(t, ManagedToolResponseEventLaunchResult, event.Type)
+	require.Equal(t, "task-fixed", event.TaskID)
+	task, err := manager.Get(context.Background(), "task-fixed")
+	require.NoError(t, err)
+	require.Equal(t, backgroundtask.StatusRunning, task.Status)
+	releaseOnce.Do(func() { close(continueStart) })
+}
+
+func TestManagedToolBackgroundStreamProjectionHandlesUpdatePressure(t *testing.T) {
+	waitReleased := make(chan struct{})
+	updates := make([]*Update, 0, projectionBuffer+8)
+	for i := 0; i < projectionBuffer+8; i++ {
+		updates = append(updates, &Update{
+			EventID: fmt.Sprintf("event-%d", i),
+			Kind:    "stdout",
+			Data:    []byte(fmt.Sprintf("line-%d", i)),
+		})
+	}
+	implementation := &fakeTool{
+		start: func(context.Context, *StartRequest) (Run, error) {
+			return &updatingRun{
+				fakeRun: &fakeRun{wait: func(context.Context) (*Outcome, error) {
+					<-waitReleased
+					return &Outcome{Status: backgroundtask.StatusCompleted}, nil
+				}},
+				updates: schema.StreamReaderFromArray(updates),
+			}, nil
+		},
+	}
+	manager, wrapped := newTestManagedTool(t, implementation, time.Second)
+	wrapped.(*managedTool).runInBackground = func(context.Context, string) bool { return true }
+	t.Cleanup(func() { close(waitReleased) })
+
+	stream, err := wrapped.(componenttool.EnhancedStreamableTool).StreamableRun(
+		context.Background(), toolArgument(`{"value":"stream"}`),
+	)
+	require.NoError(t, err)
+	done := make(chan []*ManagedToolResponseEvent, 1)
+	go func() {
+		done <- decodeEvents(t, readAllStreamResults(t, stream))
+	}()
+	select {
+	case events := <-done:
+		require.NotEmpty(t, events)
+		require.Equal(t, ManagedToolResponseEventLaunchResult, events[len(events)-1].Type)
+		require.Equal(t, "task-fixed", events[len(events)-1].TaskID)
+	case <-time.After(time.Second):
+		t.Fatal("stream projection did not detach under update pressure")
+	}
+	task, err := manager.Get(context.Background(), "task-fixed")
+	require.NoError(t, err)
+	require.Equal(t, backgroundtask.StatusRunning, task.Status)
+}
+
+func TestManagedToolBackgroundStartWindowStartErrorReturnsLaunchResult(t *testing.T) {
+	implementation := &fakeTool{
+		start: func(context.Context, *StartRequest) (Run, error) {
+			return nil, errors.New("start failed")
+		},
+	}
+	manager, wrapped := newTestManagedTool(t, implementation, time.Second)
+	wrapped.(*managedTool).runInBackground = func(context.Context, string) bool { return true }
+
+	result, err := wrapped.(componenttool.EnhancedInvokableTool).InvokableRun(
+		context.Background(), toolArgument(`{"value":"x"}`),
+	)
+	require.NoError(t, err)
+	event := decodeEvents(t, []*schema.ToolResult{result})[0]
+	require.Equal(t, ManagedToolResponseEventLaunchResult, event.Type)
+	require.Equal(t, "task-fixed", event.TaskID)
+	task := waitTaskTerminal(t, manager, "task-fixed")
+	require.Equal(t, backgroundtask.StatusFailed, task.Status)
+	require.Contains(t, task.ResultError, "start failed")
+}
+
+func TestManagedToolBackgroundStartWindowIgnoresInvocationTimeout(t *testing.T) {
+	ctx := context.Background()
+	const parentSessionID = "managed-tool-background-invocation-timeout-parent"
+	startEventKind := adk.SessionEventKind(adk.SessionEventExtensionPrefix + "managed_tool.invocation_timeout")
+	implementation := &fakeTool{
+		start: func(ctx context.Context, request *StartRequest) (Run, error) {
+			require.Equal(t, int64(1), request.Attempt)
+			time.Sleep(40 * time.Millisecond)
+			err := adk.TypedSendEvent(ctx, &adk.TypedAgentEvent[*schema.Message]{
+				SessionEventVariant: &adk.SessionEventVariant[*schema.Message]{
+					Event: &adk.SessionEvent[*schema.Message]{
+						Kind:      startEventKind,
+						Extension: &adk.SessionExtensionEvent{},
+					},
+				},
+			})
+			require.NoError(t, err)
+			return &fakeRun{wait: func(context.Context) (*Outcome, error) {
+				return &Outcome{Status: backgroundtask.StatusCompleted}, nil
+			}}, nil
+		},
+	}
+	registry := NewRegistry()
+	require.NoError(t, registry.Register(&Registration{
+		Info:        toolInfo("external"),
+		Tool:        implementation,
+		Description: func(string) string { return "External operation" },
+	}))
+	executors := backgroundtask.NewExecutorRegistry()
+	manager := mustNewBackgroundManager(t, ctx, &backgroundtask.Config{
+		Executors: executors,
+		IDGen: func(context.Context, *backgroundtask.AllocateTaskIDRequest) (string, error) {
+			return "task-fixed", nil
+		},
+	})
+	foregroundTimeoutMs := 200
+	invocationTimeoutMs := 10
+	wrapped, err := NewManagedTool(ctx, &ManagedToolConfig{
+		Manager: manager, Executors: executors, Registry: registry, ToolName: "external",
+		ForegroundTimeoutMs: &foregroundTimeoutMs,
+		RunInBackground:     func(context.Context, string) bool { return true },
+		InvocationTimeoutMs: func(context.Context, string) *int { return &invocationTimeoutMs },
+	})
+	require.NoError(t, err)
+	agent, err := adk.NewChatModelAgent(ctx, &adk.ChatModelAgentConfig{
+		Name:        "managed-tool-background-invocation-timeout-agent",
+		Instruction: "call external once",
+		Model:       &managedToolStartEventModel{},
+		ToolsConfig: adk.ToolsConfig{
+			ToolsNodeConfig: compose.ToolsNodeConfig{
+				Tools: []componenttool.BaseTool{wrapped},
+			},
+		},
+	})
+	require.NoError(t, err)
+	sessionStore := adksession.NewInMemoryStore[*schema.Message](nil)
+	runner := adk.NewRunner(ctx, adk.RunnerConfig{
+		Agent: agent, SessionID: parentSessionID, SessionStore: sessionStore,
+	})
+
+	iterator := runner.Query(ctx, "start external work")
+	for {
+		event, ok := iterator.Next()
+		if !ok {
+			break
+		}
+		require.NoError(t, event.Err)
+	}
+	result, err := sessionStore.LoadEvents(ctx, parentSessionID, &adk.LoadSessionEventsRequest{
+		Kinds: []adk.SessionEventKind{startEventKind},
+	})
+	require.NoError(t, err)
+	require.Len(t, result.Events, 1)
 }
 
 func TestManagedToolForegroundWaitingInputResumesWithoutTask(t *testing.T) {
@@ -1181,10 +1944,17 @@ func TestAttack_PlainUpdateGeneratedEventIDNotMaterialized(t *testing.T) {
 	)
 	require.NoError(t, err)
 	projected := decodeEvents(t, readAllStreamResults(t, stream))
-	require.Len(t, projected, 2)
-	require.Equal(t, ManagedToolResponseEventUpdate, projected[0].Type)
-	require.NotNil(t, projected[0].Update)
-	require.NotEmpty(t, projected[0].Update.EventID)
+	require.NotEmpty(t, projected)
+	require.Equal(t, ManagedToolResponseEventLaunchResult, projected[len(projected)-1].Type)
+	projectedUpdateIDs := make(map[string]struct{})
+	for _, event := range projected[:len(projected)-1] {
+		require.Equal(t, ManagedToolResponseEventUpdate, event.Type)
+		require.NotNil(t, event.Update)
+		require.NotEmpty(t, event.Update.EventID)
+		projectedUpdateIDs[event.Update.EventID] = struct{}{}
+	}
+	task := waitTaskTerminal(t, manager, "plain-generated-event")
+	require.Equal(t, backgroundtask.StatusCompleted, task.Status)
 
 	result, err := manager.ListTaskEvents(
 		context.Background(),
@@ -1194,7 +1964,10 @@ func TestAttack_PlainUpdateGeneratedEventIDNotMaterialized(t *testing.T) {
 	require.Len(t, result.Events, 1)
 	require.NotNil(t, result.Events[0])
 	require.NotEmpty(t, result.Events[0].EventID)
-	require.Equal(t, result.Events[0].EventID, projected[0].Update.EventID)
+	if len(projectedUpdateIDs) > 0 {
+		_, ok := projectedUpdateIDs[result.Events[0].EventID]
+		require.True(t, ok)
+	}
 	materializer.mu.Lock()
 	require.Empty(t, materializer.requests)
 	materializer.mu.Unlock()

--- a/adk/backgroundtask/tool/projection.go
+++ b/adk/backgroundtask/tool/projection.go
@@ -67,13 +67,15 @@ func (p *liveProjection) send(ctx context.Context, detached <-chan struct{}, upd
 		return
 	}
 	p.stateMu.Lock()
-	defer p.stateMu.Unlock()
 	if p.isDetached {
+		p.stateMu.Unlock()
 		return
 	}
+	projectionDetached := p.detached
+	p.stateMu.Unlock()
 	select {
 	case p.updates <- cloneUpdate(update):
-	case <-p.detached:
+	case <-projectionDetached:
 	case <-detached:
 	case <-ctx.Done():
 	}

--- a/adk/chatmodel.go
+++ b/adk/chatmodel.go
@@ -32,6 +32,7 @@ import (
 
 	"github.com/cloudwego/eino/adk/internal"
 	"github.com/cloudwego/eino/adk/internal/agenttool"
+	"github.com/cloudwego/eino/adk/internal/startwindow"
 	"github.com/cloudwego/eino/components/model"
 	"github.com/cloudwego/eino/components/prompt"
 	"github.com/cloudwego/eino/components/tool"
@@ -214,6 +215,15 @@ func initTypedChatModelAgentExecCtx[M MessageType](
 ) (context.Context, *typedChatModelAgentExecCtx[M]) {
 	execCtx := newTypedChatModelAgentExecCtx(generator, cancelCtx, sessionEvents, timelineEvents, internalTimelineEvents)
 	ctx = withTypedChatModelAgentExecCtx(ctx, execCtx)
+	sender := startwindow.EventSender(func(parentCtx context.Context, event any) error {
+		typedEvent, ok := event.(*TypedAgentEvent[M])
+		if !ok {
+			return fmt.Errorf("adk: start-window event type mismatch: got %T", event)
+		}
+		execCtx.send(parentCtx, typedEvent)
+		return nil
+	})
+	ctx = startwindow.WithSender(ctx, sender)
 	return ctx, execCtx
 }
 

--- a/adk/handler.go
+++ b/adk/handler.go
@@ -23,11 +23,16 @@ import (
 	"io"
 	"reflect"
 
+	"github.com/cloudwego/eino/adk/internal/startwindow"
 	"github.com/cloudwego/eino/components/model"
 	"github.com/cloudwego/eino/components/tool"
 	"github.com/cloudwego/eino/compose"
 	"github.com/cloudwego/eino/schema"
 )
+
+// ErrStartWindowClosed is returned by TypedSendEvent when a background managed
+// tool's explicit Start event relay has already closed.
+var ErrStartWindowClosed = startwindow.ErrWindowClosed
 
 // InvokableToolCallEndpoint is the function signature for invoking a tool synchronously.
 // Middleware authors implement wrappers around this endpoint to add custom behavior.
@@ -435,15 +440,27 @@ func DeleteRunLocalValue(ctx context.Context, key string) error {
 // need the ID before emitting the event, for example to build another event that
 // references the message by ID.
 //
-// When called outside of an agent execution context, or from a path without an
-// event generator, this function is a no-op.
+// During an explicit background managed-tool launch, TypedSendEvent also
+// supports synchronous events emitted from BackgroundTool.Start. That start
+// window closes when Start reaches its durable boundary, the parent context is
+// canceled, or the configured foreground timeout expires. After the sender-backed
+// window closes, TypedSendEvent returns ErrStartWindowClosed. Events emitted
+// later from background Wait or from goroutines outliving Start are not
+// delivered to the parent session.
+//
+// When called outside of an agent execution context or a managed-tool start
+// window, this function is a no-op.
 func TypedSendEvent[M MessageType](ctx context.Context, event *TypedAgentEvent[M]) error {
 	execCtx := getTypedChatModelAgentExecCtx[M](ctx)
-	if execCtx == nil || execCtx.generator == nil {
+	if execCtx != nil && execCtx.generator != nil {
+		execCtx.send(ctx, event)
 		return nil
 	}
 
-	execCtx.send(ctx, event)
+	handled, err := startwindow.TrySend(ctx, event)
+	if handled {
+		return err
+	}
 	return nil
 }
 

--- a/adk/internal/startwindow/startwindow.go
+++ b/adk/internal/startwindow/startwindow.go
@@ -1,0 +1,171 @@
+/*
+ * Copyright 2026 CloudWeGo Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// Package startwindow coordinates the bounded parent-event relay used while a
+// background managed tool reaches its Start boundary.
+package startwindow
+
+import (
+	"context"
+	"errors"
+	"sync"
+	"time"
+)
+
+// ErrWindowClosed is returned when a sender-backed start window has closed.
+var ErrWindowClosed = errors.New("adk: background start event window is closed")
+
+// ErrWindowTimeout is returned by Window.Wait when its positive timeout wins.
+var ErrWindowTimeout = errors.New("adk: background start event window timed out")
+
+// EventSender emits one event through the parent execution context retained by
+// an open start window.
+type EventSender func(parentCtx context.Context, event any) error
+
+type senderContextKey struct{}
+type windowContextKey struct{}
+
+// Window represents one bounded explicit-background Start synchronization
+// window. It retains the parent context only while the window is open.
+type Window struct {
+	mu        sync.Mutex
+	done      chan struct{}
+	closed    bool
+	reason    error
+	hadSender bool
+	sender    EventSender
+	parentCtx context.Context
+}
+
+// WithSender installs a parent event sender capability in ctx.
+func WithSender(ctx context.Context, sender EventSender) context.Context {
+	if ctx == nil || sender == nil {
+		return ctx
+	}
+	return context.WithValue(ctx, senderContextKey{}, sender)
+}
+
+// Open creates a Background-rooted context carrying one start window. Parent
+// context values are not exposed through the returned background context.
+func Open(parentCtx context.Context) (context.Context, *Window) {
+	if parentCtx == nil {
+		parentCtx = context.Background()
+	}
+	sender, _ := parentCtx.Value(senderContextKey{}).(EventSender)
+	window := &Window{
+		done:      make(chan struct{}),
+		hadSender: sender != nil,
+		sender:    sender,
+	}
+	if sender != nil {
+		window.parentCtx = parentCtx
+	}
+	return context.WithValue(context.Background(), windowContextKey{}, window), window
+}
+
+// Signal closes the start window in ctx, if present.
+func Signal(ctx context.Context) {
+	if window := fromContext(ctx); window != nil {
+		_ = window.close(nil)
+	}
+}
+
+// Wait blocks until the start boundary is signaled, parentCtx is canceled, or
+// timeout expires. A non-positive timeout disables the timer.
+func (w *Window) Wait(parentCtx context.Context, timeout time.Duration) error {
+	if w == nil {
+		return nil
+	}
+	if parentCtx == nil {
+		parentCtx = context.Background()
+	}
+	var timer *time.Timer
+	var timeoutC <-chan time.Time
+	if timeout > 0 {
+		timer = time.NewTimer(timeout)
+		timeoutC = timer.C
+	}
+	if timer != nil {
+		defer timer.Stop()
+	}
+	select {
+	case <-w.done:
+		return w.closeReason()
+	case <-parentCtx.Done():
+		return w.close(parentCtx.Err())
+	case <-timeoutC:
+		return w.close(ErrWindowTimeout)
+	}
+}
+
+// TrySend sends event through the open sender-backed window in ctx. The send
+// is admitted atomically with the open check, but runs outside the window lock.
+func TrySend(ctx context.Context, event any) (bool, error) {
+	window := fromContext(ctx)
+	if window == nil {
+		return false, nil
+	}
+	return window.trySend(event)
+}
+
+func fromContext(ctx context.Context) *Window {
+	if ctx == nil {
+		return nil
+	}
+	window, _ := ctx.Value(windowContextKey{}).(*Window)
+	return window
+}
+
+func (w *Window) trySend(event any) (bool, error) {
+	w.mu.Lock()
+	if w.closed {
+		hadSender := w.hadSender
+		w.mu.Unlock()
+		if hadSender {
+			return true, ErrWindowClosed
+		}
+		return false, nil
+	}
+	sender := w.sender
+	parentCtx := w.parentCtx
+	w.mu.Unlock()
+	if sender == nil {
+		return false, nil
+	}
+	return true, sender(parentCtx, event)
+}
+
+func (w *Window) close(reason error) error {
+	w.mu.Lock()
+	if w.closed {
+		existing := w.reason
+		w.mu.Unlock()
+		return existing
+	}
+	w.closed = true
+	w.reason = reason
+	w.sender = nil
+	w.parentCtx = nil
+	close(w.done)
+	w.mu.Unlock()
+	return reason
+}
+
+func (w *Window) closeReason() error {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	return w.reason
+}

--- a/adk/internal/startwindow/startwindow_test.go
+++ b/adk/internal/startwindow/startwindow_test.go
@@ -31,12 +31,12 @@ type markerKey struct{}
 
 func TestWindowTimeoutAndCancellationCloseRelay(t *testing.T) {
 	t.Run("timeout", func(t *testing.T) {
-		var sends atomic.Int64
+		var sends int64
 		parent := context.WithValue(context.Background(), markerKey{}, "parent-marker")
 		parent = WithSender(parent, func(ctx context.Context, event any) error {
 			require.Equal(t, "parent-marker", ctx.Value(markerKey{}))
 			require.Equal(t, "before", event)
-			sends.Add(1)
+			atomic.AddInt64(&sends, 1)
 			return nil
 		})
 		backgroundCtx, window := Open(parent)
@@ -49,7 +49,7 @@ func TestWindowTimeoutAndCancellationCloseRelay(t *testing.T) {
 		require.True(t, handled)
 		require.ErrorIs(t, err, ErrWindowClosed)
 		Signal(backgroundCtx)
-		require.Equal(t, int64(1), sends.Load())
+		require.Equal(t, int64(1), atomic.LoadInt64(&sends))
 	})
 
 	t.Run("cancellation", func(t *testing.T) {

--- a/adk/internal/startwindow/startwindow_test.go
+++ b/adk/internal/startwindow/startwindow_test.go
@@ -1,0 +1,92 @@
+/*
+ * Copyright 2026 CloudWeGo Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package startwindow
+
+import (
+	"context"
+	"errors"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+type markerKey struct{}
+
+func TestWindowTimeoutAndCancellationCloseRelay(t *testing.T) {
+	t.Run("timeout", func(t *testing.T) {
+		var sends atomic.Int64
+		parent := context.WithValue(context.Background(), markerKey{}, "parent-marker")
+		parent = WithSender(parent, func(ctx context.Context, event any) error {
+			require.Equal(t, "parent-marker", ctx.Value(markerKey{}))
+			require.Equal(t, "before", event)
+			sends.Add(1)
+			return nil
+		})
+		backgroundCtx, window := Open(parent)
+
+		handled, err := TrySend(backgroundCtx, "before")
+		require.True(t, handled)
+		require.NoError(t, err)
+		require.ErrorIs(t, window.Wait(parent, time.Millisecond), ErrWindowTimeout)
+		handled, err = TrySend(backgroundCtx, "after")
+		require.True(t, handled)
+		require.ErrorIs(t, err, ErrWindowClosed)
+		Signal(backgroundCtx)
+		require.Equal(t, int64(1), sends.Load())
+	})
+
+	t.Run("cancellation", func(t *testing.T) {
+		parent := WithSender(context.Background(), func(context.Context, any) error {
+			t.Fatal("send after cancellation must not be admitted")
+			return nil
+		})
+		cancelCtx, cancel := context.WithCancel(parent)
+		backgroundCtx, window := Open(cancelCtx)
+		cancel()
+
+		require.ErrorIs(t, window.Wait(cancelCtx, time.Hour), context.Canceled)
+		handled, err := TrySend(backgroundCtx, "after")
+		require.True(t, handled)
+		require.ErrorIs(t, err, ErrWindowClosed)
+		Signal(backgroundCtx)
+	})
+}
+
+func TestWindowSignalTimeoutRace(t *testing.T) {
+	for i := 0; i < 1000; i++ {
+		parent := WithSender(context.Background(), func(context.Context, any) error {
+			return nil
+		})
+		backgroundCtx, window := Open(parent)
+		var wg sync.WaitGroup
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			Signal(backgroundCtx)
+		}()
+		err := window.Wait(parent, time.Nanosecond)
+		require.True(t, err == nil || errors.Is(err, ErrWindowTimeout), "unexpected result: %v", err)
+		wg.Wait()
+
+		handled, sendErr := TrySend(backgroundCtx, "after")
+		require.True(t, handled)
+		require.ErrorIs(t, sendErr, ErrWindowClosed)
+	}
+}


### PR DESCRIPTION
# Background Managed Tool Start Events

## Problem

Explicit background `managedTool` launches returned immediately after durable submission. The actual `BackgroundTool.Start` then ran on a detached `context.Background()` path, so `adk.TypedSendEvent` inside `Start` could not reach the parent `ChatModelAgent` session.

That meant start-phase events were silently dropped even though foreground managed tools could emit them correctly.

## Solution

This PR adds a bounded internal start window for explicit background launches:

```text
parent tool call -> Submit task -> open start window -> Manager.Execute -> Start boundary -> return launch result
```

The background execution context remains sanitized and does not expose parent values to the tool. The window privately retains the parent sender only until `Start` reaches its durable boundary, the parent is canceled, or `ForegroundTimeoutMs` expires.

`TypedSendEvent` now uses this relay only when no normal agent execution context exists. Normal in-run events and framework-internal sends keep the existing path.

## Decisions

- Keep `Start` inside `Manager.Execute`, so task claim, attempt ownership, heartbeat, and `CommitStart` stay owned by the durable manager.
- Reuse `ForegroundTimeoutMs` for the start wait rather than adding a public setting.
- Return `ErrStartWindowClosed` from `TypedSendEvent` after a sender-backed start window closes, making wait-phase misuse observable.

## Key Insight

The Start window is not a parent context inheritance mechanism. It is a short-lived event relay bound to the real tool-call context for envelope preparation, while the background tool itself receives a clean background-rooted context.

## Summary

| Problem | Solution |
|---------|----------|
| Background `Start` events were dropped | Add an internal bounded sender relay used by `TypedSendEvent` |
| Background `Wait` could accidentally look like parent-session emission | Close the relay at the Start boundary and return `ErrStartWindowClosed` |
| Stream launch could wait for terminal task state through a stale pending snapshot | Detach projection explicitly when launch result is ready |

---

# 后台 Managed Tool Start 事件

## 问题

显式后台 `managedTool` 在 durable submit 后会立刻返回，真正的 `BackgroundTool.Start` 运行在 detached `context.Background()` 路径上。因此 `Start` 内调用 `adk.TypedSendEvent` 时无法找到父 `ChatModelAgent` session。

结果是：前景 managed tool 可以正确发送 start 阶段事件，但显式后台 managed tool 的 start 阶段事件会被静默丢弃。

## 解决方案

这个 PR 为显式后台启动增加一个有界的内部 Start window：

```text
parent tool call -> Submit task -> open start window -> Manager.Execute -> Start boundary -> return launch result
```

后台执行 context 仍然是干净的，不向 tool 暴露父 context values。窗口只在 `Start` 到达 durable boundary、父 context 取消、或 `ForegroundTimeoutMs` 到期前，私有持有父 sender。

`TypedSendEvent` 只有在没有普通 agent execution context 时才走这条 relay。正常 in-run event 和框架内部 send 仍走原路径。

## 决策

- `Start` 继续留在 `Manager.Execute` 内，确保 task claim、attempt ownership、heartbeat 和 `CommitStart` 仍由 durable manager 负责。
- 复用 `ForegroundTimeoutMs` 控制 Start wait，不新增公开配置。
- sender-backed start window 关闭后，`TypedSendEvent` 返回 `ErrStartWindowClosed`，让 wait 阶段误用可观测。

## 关键洞察

Start window 不是父 context 继承机制。它只是一个短生命周期事件 relay：用真实 tool-call context 准备 session envelope，但传给后台 tool 的仍是 background-rooted clean context。

## 总结

| 问题 | 解决方案 |
|------|----------|
| 后台 `Start` 事件被丢弃 | 新增内部 bounded sender relay，并由 `TypedSendEvent` 使用 |
| 后台 `Wait` 可能被误认为可写父 session | 在 Start boundary 关闭 relay，之后返回 `ErrStartWindowClosed` |
| Stream launch 可能因 stale pending snapshot 等到任务终态 | launch result 就绪时显式 detach projection |
