### PR TITLE
fix(adk): preserve background task context values

### DIFF
--- a/adk/backgroundtask/conformance_test.go
+++ b/adk/backgroundtask/conformance_test.go
@@ -120,7 +120,7 @@ func TestSimplifiedPublicModelHasNoOverlappingStateFields_BitsUT(t *testing.T) {
 	assertFieldsAbsent(t, reflect.TypeOf(Spec{}), "CreatedAt")
 	assertFieldsPresent(t, reflect.TypeOf(Task{}),
 		"Spec", "LeaseExpiryPolicy", "Status", "Checkpoint", "ResultData", "ResultError",
-		"PendingResume", "Version", "CreatedAt")
+		"PendingResume", "ContextSnapshot", "Version", "CreatedAt")
 	field, exists := reflect.TypeOf(Task{}).FieldByName("PendingResume")
 	require.True(t, exists)
 	assert.Equal(t, reflect.TypeOf([]byte(nil)), field.Type)
@@ -140,7 +140,7 @@ func TestSimplifiedPublicModelHasNoOverlappingStateFields_BitsUT(t *testing.T) {
 		"TaskID", "Cursor", "Limit", "NewestFirst")
 	assertFieldsPresent(t, reflect.TypeOf(ListTaskEventsResult{}), "Events", "NextCursor")
 	assertFieldsPresent(t, reflect.TypeOf(Config{}),
-		"Tasks", "TaskEvents", "Executors", "SendTaskCreatedEvent", "IDGen")
+		"Tasks", "TaskEvents", "Executors", "SendTaskCreatedEvent", "IDGen", "ContextSnapshotter")
 	assertFieldsAbsent(t, reflect.TypeOf(Config{}), "Store", "NotificationWriter")
 	assertMethodsAbsent(t, reflect.TypeOf((*TaskStore)(nil)).Elem(),
 		"AppendTaskEvent", "ListTaskEvents", "ReadRecentTaskEvents", "ReportOutputFailure",
@@ -162,7 +162,11 @@ func TestSimplifiedPublicModelHasNoOverlappingStateFields_BitsUT(t *testing.T) {
 		"Close")
 	assertFieldsPresent(t, reflect.TypeOf(SubmitRequest{}), "Spec", "InitialCheckpoint")
 	assertFieldsPresent(t, reflect.TypeOf(CreateTaskRequest{}),
-		"Spec", "LeaseExpiryPolicy", "Checkpoint")
+		"Spec", "LeaseExpiryPolicy", "Checkpoint", "ContextSnapshot")
+	assertFieldsPresent(t, reflect.TypeOf(ResumeRequest{}),
+		"TaskID", "ExpectedVersion", "Data", "ContextSnapshot")
+	assertFieldsPresent(t, reflect.TypeOf(ReleaseSuspensionRequest{}),
+		"TaskID", "ExpectedVersion", "ContextSnapshot")
 	assertMethodsPresent(t, reflect.TypeOf((*ExecutorRegistry)(nil)), "LoadOrRegister")
 	assertMethodsAbsent(t, reflect.TypeOf((*InMemoryStore)(nil)),
 		"CreateAndStart", "Cancel", "ReadRecentTaskEvents")

--- a/adk/backgroundtask/durable_store_test.go
+++ b/adk/backgroundtask/durable_store_test.go
@@ -88,6 +88,7 @@ func TestInMemoryStoreCreatePersistsPendingSnapshot_BitsUT(t *testing.T) {
 
 	created, err := store.Create(context.Background(), &CreateTaskRequest{
 		Spec: spec, LeaseExpiryPolicy: LeaseExpiryRetry,
+		ContextSnapshot: []byte("ctx-snapshot"),
 	})
 	require.NoError(t, err)
 	assert.Equal(t, StatusPending, created.Status)
@@ -95,11 +96,14 @@ func TestInMemoryStoreCreatePersistsPendingSnapshot_BitsUT(t *testing.T) {
 	assert.Empty(t, created.ResultData)
 	assert.Empty(t, created.ResultError)
 	assert.Nil(t, created.PendingResume)
+	assert.Equal(t, "ctx-snapshot", string(created.ContextSnapshot))
 
 	spec.Payload[0] = 'X'
+	created.ContextSnapshot[0] = 'X'
 	stored, err := store.Get(context.Background(), created.Spec.ID)
 	require.NoError(t, err)
 	assert.Equal(t, "payload", string(stored.Spec.Payload))
+	assert.Equal(t, "ctx-snapshot", string(stored.ContextSnapshot))
 	assert.True(t, stored.Spec.NotifySession)
 }
 
@@ -905,13 +909,14 @@ func TestInMemoryStoreResumePersistsPendingResumeBytes_BitsUT(t *testing.T) {
 
 	resumed, err := store.Resume(context.Background(), &ResumeRequest{
 		TaskID: "resume", ExpectedVersion: waiting.Version,
-		Data: []byte("answer"),
+		Data: []byte("answer"), ContextSnapshot: []byte("resume-context"),
 	})
 	require.NoError(t, err)
 	assert.Equal(t, StatusPending, resumed.Status)
 	assert.Equal(t, "checkpoint", string(resumed.Checkpoint))
 	require.NotNil(t, resumed.PendingResume)
 	assert.Equal(t, "answer", string(resumed.PendingResume))
+	assert.Equal(t, "resume-context", string(resumed.ContextSnapshot))
 }
 
 func TestInMemoryStoreResumeSurvivesRecoverableAttemptLoss_BitsUT(t *testing.T) {

--- a/adk/backgroundtask/executor.go
+++ b/adk/backgroundtask/executor.go
@@ -565,6 +565,39 @@ func (m *Manager) AllocateTaskID(ctx context.Context, request *AllocateTaskIDReq
 	return id, nil
 }
 
+func (m *Manager) captureContextSnapshot(ctx context.Context) ([]byte, bool, error) {
+	if m.contextSnapshotter == nil {
+		return nil, false, nil
+	}
+	snapshot, err := m.contextSnapshotter.CaptureContext(ctx)
+	if err != nil {
+		return nil, false, fmt.Errorf("backgroundtask: capture context snapshot: %w", err)
+	}
+	if snapshot == nil {
+		snapshot = []byte{}
+	}
+	return cloneBytes(snapshot), true, nil
+}
+
+func (m *Manager) restoreExecutionContext(ctx context.Context, task *Task) (context.Context, error) {
+	if task == nil || len(task.ContextSnapshot) == 0 {
+		return ctx, nil
+	}
+	if m.contextSnapshotter == nil {
+		return nil, errors.New(
+			"backgroundtask: context snapshotter is required to restore task context",
+		)
+	}
+	restored, err := m.contextSnapshotter.RestoreContext(ctx, cloneBytes(task.ContextSnapshot))
+	if err != nil {
+		return nil, fmt.Errorf("backgroundtask: restore context snapshot: %w", err)
+	}
+	if restored == nil {
+		return nil, errors.New("backgroundtask: restore context snapshot returned nil context")
+	}
+	return restored, nil
+}
+
 // Submit validates serialized intent, persists a pending background task, and
 // attempts to emit its low-latency TaskCreated parent-session event before
 // returning. Create atomically writes the durable TaskCreated outbox record; if
@@ -607,9 +640,14 @@ func (m *Manager) Submit(ctx context.Context, req *SubmitRequest) (*Task, error)
 	if err := executor.ValidateSpec(cloneSpec(spec)); err != nil {
 		return nil, fmt.Errorf("backgroundtask: validate spec: %w", err)
 	}
+	contextSnapshot, _, err := m.captureContextSnapshot(ctx)
+	if err != nil {
+		return nil, err
+	}
 	policy := executor.LeaseExpiryPolicy()
 	task, err := m.tasks.Create(ctx, &CreateTaskRequest{
 		Spec: spec, LeaseExpiryPolicy: policy, Checkpoint: cloneBytes(req.InitialCheckpoint),
+		ContextSnapshot: contextSnapshot,
 	})
 	if err != nil {
 		return nil, err
@@ -756,6 +794,10 @@ func (m *Manager) ReleaseSuspension(ctx context.Context, taskID string) (*Task, 
 	if taskID == "" {
 		return nil, errors.New("backgroundtask: release suspension task id is required")
 	}
+	contextSnapshot, capturedContextSnapshot, err := m.captureContextSnapshot(ctx)
+	if err != nil {
+		return nil, err
+	}
 	for retry := 0; ; retry++ {
 		task, err := m.tasks.Get(ctx, taskID)
 		if err != nil {
@@ -764,9 +806,13 @@ func (m *Manager) ReleaseSuspension(ctx context.Context, taskID string) (*Task, 
 		if task.Status != StatusSuspended {
 			return nil, ErrIllegalTransition
 		}
-		released, err := m.tasks.ReleaseSuspension(ctx, &ReleaseSuspensionRequest{
+		req := &ReleaseSuspensionRequest{
 			TaskID: taskID, ExpectedVersion: task.Version,
-		})
+		}
+		if capturedContextSnapshot {
+			req.ContextSnapshot = contextSnapshot
+		}
+		released, err := m.tasks.ReleaseSuspension(ctx, req)
 		if !errors.Is(err, ErrVersionConflict) {
 			return released, err
 		}
@@ -786,9 +832,17 @@ func (m *Manager) Resume(ctx context.Context, req *ResumeRequest) (*Task, error)
 	if req == nil {
 		return nil, errors.New("backgroundtask: resume request is required")
 	}
-	return m.tasks.Resume(ctx, &ResumeRequest{
+	contextSnapshot, capturedContextSnapshot, err := m.captureContextSnapshot(ctx)
+	if err != nil {
+		return nil, err
+	}
+	next := &ResumeRequest{
 		TaskID: req.TaskID, ExpectedVersion: req.ExpectedVersion, Data: cloneBytes(req.Data),
-	})
+	}
+	if capturedContextSnapshot {
+		next.ContextSnapshot = contextSnapshot
+	}
+	return m.tasks.Resume(ctx, next)
 }
 
 // Execute claims and runs one pending task attempt on the current worker.
@@ -832,6 +886,10 @@ func (m *Manager) execute(
 	}()
 
 	task, err := m.tasks.Get(ctx, taskID)
+	if err != nil {
+		return err
+	}
+	ctx, err = m.restoreExecutionContext(ctx, task)
 	if err != nil {
 		return err
 	}

--- a/adk/backgroundtask/in_memory_store.go
+++ b/adk/backgroundtask/in_memory_store.go
@@ -125,6 +125,9 @@ func (s *InMemoryStore) Create(_ context.Context, req *CreateTaskRequest) (*Task
 	if int64(len(req.Checkpoint)) > s.maxValue {
 		return nil, errors.New("backgroundtask: checkpoint exceeds configured bounds")
 	}
+	if int64(len(req.ContextSnapshot)) > s.maxValue {
+		return nil, errors.New("backgroundtask: context snapshot exceeds configured bounds")
+	}
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	if _, ok := s.tasks[req.Spec.ID]; ok {
@@ -137,6 +140,7 @@ func (s *InMemoryStore) Create(_ context.Context, req *CreateTaskRequest) (*Task
 		LeaseExpiryPolicy: req.LeaseExpiryPolicy,
 		Status:            StatusPending,
 		Checkpoint:        cloneBytes(req.Checkpoint),
+		ContextSnapshot:   cloneBytes(req.ContextSnapshot),
 		Version:           1,
 		CreatedAt:         now,
 		UpdatedAt:         now,
@@ -808,6 +812,9 @@ func (s *InMemoryStore) Resume(_ context.Context, req *ResumeRequest) (*Task, er
 	if int64(len(req.Data)) > s.maxValue {
 		return nil, errors.New("backgroundtask: resume data exceeds configured limit")
 	}
+	if int64(len(req.ContextSnapshot)) > s.maxValue {
+		return nil, errors.New("backgroundtask: context snapshot exceeds configured bounds")
+	}
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	t, err := s.taskVersionLocked(req.TaskID, req.ExpectedVersion)
@@ -818,6 +825,9 @@ func (s *InMemoryStore) Resume(_ context.Context, req *ResumeRequest) (*Task, er
 		return nil, ErrIllegalTransition
 	}
 	t.PendingResume = cloneBytes(req.Data)
+	if req.ContextSnapshot != nil {
+		t.ContextSnapshot = cloneBytes(req.ContextSnapshot)
+	}
 	t.Status = StatusPending
 	s.advanceLocked(t)
 	s.enqueueLocked(t, eventForStatus(t.Status))
@@ -830,6 +840,9 @@ func (s *InMemoryStore) ReleaseSuspension(_ context.Context, req *ReleaseSuspens
 	if req == nil {
 		return nil, errors.New("backgroundtask: release request is required")
 	}
+	if int64(len(req.ContextSnapshot)) > s.maxValue {
+		return nil, errors.New("backgroundtask: context snapshot exceeds configured bounds")
+	}
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	t, err := s.taskVersionLocked(req.TaskID, req.ExpectedVersion)
@@ -838,6 +851,9 @@ func (s *InMemoryStore) ReleaseSuspension(_ context.Context, req *ReleaseSuspens
 	}
 	if t.Status != StatusSuspended {
 		return nil, ErrIllegalTransition
+	}
+	if req.ContextSnapshot != nil {
+		t.ContextSnapshot = cloneBytes(req.ContextSnapshot)
 	}
 	t.Status = StatusPending
 	s.advanceLocked(t)

--- a/adk/backgroundtask/local/local.go
+++ b/adk/backgroundtask/local/local.go
@@ -148,7 +148,7 @@ func (r *Runner) Run(ctx context.Context, input *Input, work WorkFunc) (*backgro
 			return nil, err
 		}
 		go func() {
-			_ = r.manager.Execute(detachedContext{parent: context.Background()}, task.Spec.ID)
+			_ = r.manager.Execute(detachedContext{parent: ctx}, task.Spec.ID)
 		}()
 		return task, nil
 	}
@@ -243,7 +243,7 @@ func (r *Runner) adoptForeground(
 	if err != nil {
 		if errors.Is(err, backgroundtask.ErrTaskCreatedEventUndelivered) && task != nil {
 			go func() {
-				_ = r.manager.Execute(detachedContext{parent: context.Background()}, task.Spec.ID)
+				_ = r.manager.Execute(detachedContext{parent: ctx}, task.Spec.ID)
 			}()
 			return task, nil
 		}
@@ -251,7 +251,7 @@ func (r *Runner) adoptForeground(
 		return nil, err
 	}
 	go func() {
-		_ = r.manager.Execute(detachedContext{parent: context.Background()}, task.Spec.ID)
+		_ = r.manager.Execute(detachedContext{parent: ctx}, task.Spec.ID)
 	}()
 	return task, nil
 }
@@ -358,7 +358,7 @@ func (r *Runner) RunStream(
 	}
 	runDone := make(chan runResult, 1)
 	go func() {
-		runErr := r.manager.Execute(detachedContext{parent: context.Background()}, task.Spec.ID)
+		runErr := r.manager.Execute(detachedContext{parent: ctx}, task.Spec.ID)
 		current, getErr := r.manager.Get(context.Background(), task.Spec.ID)
 		if runErr == nil {
 			runErr = getErr

--- a/adk/backgroundtask/manager.go
+++ b/adk/backgroundtask/manager.go
@@ -85,6 +85,10 @@ type Task struct {
 	// subsequent wait-input or suspended checkpoint, or a terminal transition,
 	// consumes it.
 	PendingResume []byte
+	// ContextSnapshot is an opaque manager-owned snapshot used to restore
+	// deployment-selected context values for future execution attempts. It is
+	// captured only when Manager is configured with a ContextSnapshotter.
+	ContextSnapshot []byte
 	// Version is the CAS version of this durable record.
 	Version int64
 	// Attempt counts successful claims.
@@ -109,6 +113,17 @@ type Task struct {
 // business-side identifier. Manager does not add the task-type prefix when IDGen
 // is configured; callers that want one should include it in the returned ID.
 type IDGenerator func(ctx context.Context, request *AllocateTaskIDRequest) (string, error)
+
+// ContextSnapshotter captures deployment-owned context values into an opaque
+// byte snapshot and restores them for later execution attempts. Implementations
+// decide which values are serializable and stable enough to persist. Every
+// worker that may execute tasks carrying a snapshot must configure a
+// semantically equivalent snapshotter; otherwise execution fails instead of
+// silently dropping the snapshot.
+type ContextSnapshotter interface {
+	CaptureContext(context.Context) ([]byte, error)
+	RestoreContext(context.Context, []byte) (context.Context, error)
+}
 
 // Config configures a Manager.
 type Config struct {
@@ -135,6 +150,10 @@ type Config struct {
 	// must return a non-empty ID. The returned ID must be unique among this
 	// Manager's registered tasks; a duplicate fails task creation.
 	IDGen IDGenerator
+	// ContextSnapshotter optionally persists deployment-selected context values
+	// for background execution and later recovery. Snapshots are captured during
+	// Submit, Resume, and ReleaseSuspension, then restored before task execution.
+	ContextSnapshotter ContextSnapshotter
 }
 
 type closeOptions struct {
@@ -180,6 +199,7 @@ type Manager struct {
 	closed               bool
 	idGen                IDGenerator
 	sendTaskCreatedEvent func(context.Context, *Task) error
+	contextSnapshotter   ContextSnapshotter
 }
 
 // New creates a Manager. A nil Config installs the in-memory reference stores
@@ -216,6 +236,7 @@ func New(_ context.Context, conf *Config) (*Manager, error) {
 		}
 		m.sendTaskCreatedEvent = conf.SendTaskCreatedEvent
 		m.idGen = conf.IDGen
+		m.contextSnapshotter = conf.ContextSnapshotter
 	}
 	m.notificationWriter, _ = m.tasks.(NotificationWriter)
 	return m, nil
@@ -340,6 +361,7 @@ func cloneTask(t *Task) *Task {
 	clone.Checkpoint = cloneBytes(t.Checkpoint)
 	clone.ResultData = cloneBytes(t.ResultData)
 	clone.PendingResume = cloneBytes(t.PendingResume)
+	clone.ContextSnapshot = cloneBytes(t.ContextSnapshot)
 	clone.CancelRequestedAt = cloneTime(t.CancelRequestedAt)
 	clone.DoneAt = cloneTime(t.DoneAt)
 	return &clone

--- a/adk/backgroundtask/manager_test.go
+++ b/adk/backgroundtask/manager_test.go
@@ -34,6 +34,34 @@ func closeWithTimeout(manager *Manager) {
 	_ = manager.Close(ctx)
 }
 
+type managerContextSnapshotKey struct{}
+
+type testContextSnapshotter struct{}
+
+func (testContextSnapshotter) CaptureContext(ctx context.Context) ([]byte, error) {
+	value, _ := ctx.Value(managerContextSnapshotKey{}).(string)
+	if value == "" {
+		return nil, nil
+	}
+	return []byte(value), nil
+}
+
+func (testContextSnapshotter) RestoreContext(ctx context.Context, snapshot []byte) (context.Context, error) {
+	return context.WithValue(ctx, managerContextSnapshotKey{}, string(snapshot)), nil
+}
+
+type failingRestoreSnapshotter struct {
+	err error
+}
+
+func (f failingRestoreSnapshotter) CaptureContext(context.Context) ([]byte, error) {
+	return nil, nil
+}
+
+func (f failingRestoreSnapshotter) RestoreContext(context.Context, []byte) (context.Context, error) {
+	return nil, f.err
+}
+
 type firstReleaseConflictStore struct {
 	TaskStore
 	once sync.Once
@@ -417,6 +445,146 @@ func TestManagerReplaysCancellationReasonToRecoveryAttempt(t *testing.T) {
 	canceled, err := manager.Get(context.Background(), started.Spec.ID)
 	require.NoError(t, err)
 	require.Equal(t, "operator request", canceled.ResultError)
+}
+
+func TestManagerRestoresContextSnapshotAcrossRecoveryAndResume(t *testing.T) {
+	store := NewInMemoryStore(nil)
+	observed := make(chan string, 2)
+	attempt := 0
+	executor := &scriptedExecutor{execute: func(
+		ctx context.Context,
+		_ *Task,
+		_ ExecutionRuntime,
+	) (*ExecutionResult, error) {
+		attempt++
+		value, _ := ctx.Value(managerContextSnapshotKey{}).(string)
+		observed <- value
+		if attempt == 1 {
+			return &ExecutionResult{
+				Status:     StatusWaitingInput,
+				Checkpoint: []byte("checkpoint"),
+			}, nil
+		}
+		return &ExecutionResult{Status: StatusCompleted, Data: []byte("done")}, nil
+	}}
+	registry := NewExecutorRegistry()
+	require.NoError(t, registry.Register(executor))
+	manager := mustNewManager(t, context.Background(), &Config{
+		Tasks: store, Executors: registry,
+		ContextSnapshotter: testContextSnapshotter{},
+	})
+	defer closeWithTimeout(manager)
+
+	submitCtx := context.WithValue(
+		context.Background(), managerContextSnapshotKey{}, "submit-trace",
+	)
+	task, err := manager.Submit(submitCtx, &SubmitRequest{
+		Spec: validSpec("ctx-snapshot"),
+	})
+	require.NoError(t, err)
+	require.Equal(t, "submit-trace", string(task.ContextSnapshot))
+	require.NoError(t, manager.Execute(context.Background(), task.Spec.ID))
+	require.Equal(t, "submit-trace", <-observed)
+
+	waiting, err := manager.Get(context.Background(), task.Spec.ID)
+	require.NoError(t, err)
+	require.Equal(t, StatusWaitingInput, waiting.Status)
+	resumeCtx := context.WithValue(
+		context.Background(), managerContextSnapshotKey{}, "resume-trace",
+	)
+	resumed, err := manager.Resume(resumeCtx, &ResumeRequest{
+		TaskID: task.Spec.ID, ExpectedVersion: waiting.Version,
+		Data: []byte(`{"approval":true}`),
+	})
+	require.NoError(t, err)
+	require.Equal(t, "resume-trace", string(resumed.ContextSnapshot))
+	require.NoError(t, manager.Execute(context.Background(), task.Spec.ID))
+	require.Equal(t, "resume-trace", <-observed)
+
+	completed, err := manager.Get(context.Background(), task.Spec.ID)
+	require.NoError(t, err)
+	require.Equal(t, StatusCompleted, completed.Status)
+}
+
+func TestManagerExecuteRequiresContextSnapshotterForPersistedSnapshot(t *testing.T) {
+	store := NewInMemoryStore(nil)
+	created, err := store.Create(context.Background(), &CreateTaskRequest{
+		Spec: validSpec("missing-restorer"), LeaseExpiryPolicy: LeaseExpiryRetry,
+		ContextSnapshot: []byte("trace"),
+	})
+	require.NoError(t, err)
+	manager := managerWithExecutor(t, store, &scriptedExecutor{}, time.Minute)
+	defer closeWithTimeout(manager)
+
+	err = manager.Execute(context.Background(), created.Spec.ID)
+	require.EqualError(
+		t,
+		err,
+		"backgroundtask: context snapshotter is required to restore task context",
+	)
+	current, getErr := manager.Get(context.Background(), created.Spec.ID)
+	require.NoError(t, getErr)
+	require.Equal(t, StatusPending, current.Status)
+}
+
+func TestManagerResumeWithoutSnapshotterPreservesExistingContextSnapshot(t *testing.T) {
+	store := NewInMemoryStore(nil)
+	created, err := store.Create(context.Background(), &CreateTaskRequest{
+		Spec: validSpec("preserve-snapshot"), LeaseExpiryPolicy: LeaseExpiryRetry,
+		ContextSnapshot: []byte("submit-trace"),
+	})
+	require.NoError(t, err)
+	started, err := store.Start(context.Background(), &StartTaskRequest{
+		TaskID: created.Spec.ID, ExpectedVersion: created.Version,
+	})
+	require.NoError(t, err)
+	waiting, err := store.WaitInput(context.Background(), &WaitInputTaskRequest{
+		TaskID: created.Spec.ID, ExpectedVersion: started.Version,
+		Checkpoint: []byte("checkpoint"),
+	})
+	require.NoError(t, err)
+	manager := managerWithExecutor(t, store, &scriptedExecutor{}, time.Minute)
+	defer closeWithTimeout(manager)
+
+	resumed, err := manager.Resume(context.Background(), &ResumeRequest{
+		TaskID: created.Spec.ID, ExpectedVersion: waiting.Version,
+	})
+	require.NoError(t, err)
+	require.Equal(t, "submit-trace", string(resumed.ContextSnapshot))
+}
+
+func TestAttack_ContextSnapshotRestoreFailureDoesNotStartTask(t *testing.T) {
+	restoreErr := errors.New("restore failed")
+	store := NewInMemoryStore(nil)
+	created, err := store.Create(context.Background(), &CreateTaskRequest{
+		Spec: validSpec("restore-failure"), LeaseExpiryPolicy: LeaseExpiryRetry,
+		ContextSnapshot: []byte("trace"),
+	})
+	require.NoError(t, err)
+	executeCalled := false
+	executor := &scriptedExecutor{execute: func(
+		context.Context,
+		*Task,
+		ExecutionRuntime,
+	) (*ExecutionResult, error) {
+		executeCalled = true
+		return &ExecutionResult{Status: StatusCompleted, Data: []byte("unexpected")}, nil
+	}}
+	registry := NewExecutorRegistry()
+	require.NoError(t, registry.Register(executor))
+	manager := mustNewManager(t, context.Background(), &Config{
+		Tasks: store, Executors: registry,
+		ContextSnapshotter: failingRestoreSnapshotter{err: restoreErr},
+	})
+	defer closeWithTimeout(manager)
+
+	err = manager.Execute(context.Background(), created.Spec.ID)
+	require.ErrorIs(t, err, restoreErr)
+	require.False(t, executeCalled)
+	current, getErr := manager.Get(context.Background(), created.Spec.ID)
+	require.NoError(t, getErr)
+	require.Equal(t, StatusPending, current.Status)
+	require.Equal(t, int64(0), current.Attempt)
 }
 
 func TestManagerDispatchReadBoundaries(t *testing.T) {

--- a/adk/backgroundtask/subagent/subagent_test.go
+++ b/adk/backgroundtask/subagent/subagent_test.go
@@ -64,6 +64,11 @@ type interruptThenCompleteAgent struct {
 	name string
 }
 
+type resumeContextCaptureAgent struct {
+	name       string
+	resumeCtxs chan context.Context
+}
+
 type cancelThenMessageAgent struct {
 	name    string
 	started chan struct{}
@@ -225,6 +230,34 @@ func (a *interruptThenCompleteAgent) Resume(
 	return iter
 }
 
+func (a *resumeContextCaptureAgent) Name(context.Context) string { return a.name }
+func (a *resumeContextCaptureAgent) Description(context.Context) string {
+	return "capture resume context"
+}
+func (a *resumeContextCaptureAgent) Run(
+	ctx context.Context,
+	_ *adk.AgentInput,
+	_ ...adk.AgentRunOption,
+) *adk.AsyncIterator[*adk.AgentEvent] {
+	iter, generator := adk.NewAsyncIteratorPair[*adk.AgentEvent]()
+	generator.Send(adk.Interrupt(ctx, "approve"))
+	generator.Close()
+	return iter
+}
+func (a *resumeContextCaptureAgent) Resume(
+	ctx context.Context,
+	_ *adk.ResumeInfo,
+	_ ...adk.AgentRunOption,
+) *adk.AsyncIterator[*adk.AgentEvent] {
+	a.resumeCtxs <- ctx
+	iter, generator := adk.NewAsyncIteratorPair[*adk.AgentEvent]()
+	generator.Send(adk.EventFromMessage(
+		schema.AssistantMessage("resumed", nil), nil, schema.Assistant, a.name,
+	))
+	generator.Close()
+	return iter
+}
+
 func (a *resumableTestAgent) Name(context.Context) string        { return a.name }
 func (a *resumableTestAgent) Description(context.Context) string { return "test agent" }
 func (a *resumableTestAgent) Run(
@@ -269,6 +302,22 @@ func newTestExecutor(
 	})
 	require.NoError(t, err)
 	return executor
+}
+
+type subagentContextSnapshotKey struct{}
+
+type subagentContextSnapshotter struct{}
+
+func (subagentContextSnapshotter) CaptureContext(ctx context.Context) ([]byte, error) {
+	value, _ := ctx.Value(subagentContextSnapshotKey{}).(string)
+	if value == "" {
+		return nil, nil
+	}
+	return []byte(value), nil
+}
+
+func (subagentContextSnapshotter) RestoreContext(ctx context.Context, snapshot []byte) (context.Context, error) {
+	return context.WithValue(ctx, subagentContextSnapshotKey{}, string(snapshot)), nil
 }
 
 func textInput(query string) *adk.AgentInput {
@@ -1089,6 +1138,54 @@ func TestWaitForControlBoundaries(t *testing.T) {
 	require.Empty(t, waitForControl(
 		context.Background(), make(chan backgroundtask.ControlRequest),
 	).Kind)
+}
+
+func TestSubAgentTaskResumeRestoresLatestContextSnapshot(t *testing.T) {
+	sessionStore := adksession.NewInMemoryStore[*schema.Message](nil)
+	agent := &resumeContextCaptureAgent{
+		name: "worker", resumeCtxs: make(chan context.Context, 1),
+	}
+	executor := newTestExecutor(t, sessionStore)
+	require.NoError(t, executor.Register("worker", &AgentRegistration[*schema.Message]{
+		Agent: agent,
+	}))
+	executors := backgroundtask.NewExecutorRegistry()
+	require.NoError(t, executors.Register(executor))
+	manager := mustNewBackgroundManager(t, context.Background(), &backgroundtask.Config{
+		Executors:          executors,
+		ContextSnapshotter: subagentContextSnapshotter{},
+	})
+	defer manager.Close(context.Background())
+
+	submitCtx := context.WithValue(
+		context.Background(), subagentContextSnapshotKey{}, "submit-trace",
+	)
+	task, err := Submit(submitCtx, manager, &SubmitRequest[*schema.Message]{
+		SubAgentName: "worker", Input: textInput("do work"), Description: "durable child",
+		SessionID: "parent-session",
+	})
+	require.NoError(t, err)
+	require.Equal(t, "submit-trace", string(task.ContextSnapshot))
+	require.NoError(t, manager.Execute(context.Background(), task.Spec.ID))
+	waiting, err := manager.Get(context.Background(), task.Spec.ID)
+	require.NoError(t, err)
+	require.Equal(t, backgroundtask.StatusWaitingInput, waiting.Status)
+
+	resumeCtx := context.WithValue(
+		context.Background(), subagentContextSnapshotKey{}, "resume-trace",
+	)
+	pending, err := manager.Resume(resumeCtx, &backgroundtask.ResumeRequest{
+		TaskID: task.Spec.ID, ExpectedVersion: waiting.Version,
+	})
+	require.NoError(t, err)
+	require.Equal(t, "resume-trace", string(pending.ContextSnapshot))
+	require.NoError(t, manager.Execute(context.Background(), task.Spec.ID))
+
+	runCtx := <-agent.resumeCtxs
+	require.Equal(t, "resume-trace", runCtx.Value(subagentContextSnapshotKey{}))
+	completed, err := manager.Get(context.Background(), task.Spec.ID)
+	require.NoError(t, err)
+	require.Equal(t, backgroundtask.StatusCompleted, completed.Status)
 }
 
 func TestSubAgentTaskResumesAfterManagerReconstruction_BitsUT(t *testing.T) {

--- a/adk/backgroundtask/tool/managed_tool.go
+++ b/adk/backgroundtask/tool/managed_tool.go
@@ -218,13 +218,22 @@ type foregroundStart struct {
 	toolCheckpoint []byte
 }
 
+type detachedContext struct {
+	parent context.Context
+}
+
+func (detachedContext) Deadline() (time.Time, bool) { return time.Time{}, false }
+func (detachedContext) Done() <-chan struct{}       { return nil }
+func (detachedContext) Err() error                  { return nil }
+func (c detachedContext) Value(key any) any         { return c.parent.Value(key) }
+
 func (t *managedTool) executeBackgroundUntilStart(ctx context.Context, taskID string) {
 	_, window := t.startBackgroundExecution(ctx, taskID)
 	_ = window.Wait(ctx, t.startWindowTimeout())
 }
 
 func (t *managedTool) startBackgroundExecution(ctx context.Context, taskID string) (context.Context, *startwindow.Window) {
-	backgroundCtx, window := startwindow.Open(ctx)
+	backgroundCtx, window := startwindow.Open(detachedContext{parent: ctx})
 	go func() {
 		defer startwindow.Signal(backgroundCtx)
 		_ = t.manager.Execute(backgroundCtx, taskID)
@@ -750,7 +759,7 @@ func (t *managedTool) tryHandoff(
 		return nil, err
 	}
 	go func() {
-		_ = t.manager.Execute(context.Background(), task.Spec.ID)
+		_ = t.manager.Execute(detachedContext{parent: ctx}, task.Spec.ID)
 	}()
 	return task, nil
 }

--- a/adk/backgroundtask/types.go
+++ b/adk/backgroundtask/types.go
@@ -93,6 +93,9 @@ type CreateTaskRequest struct {
 	Spec              Spec
 	LeaseExpiryPolicy LeaseExpiryPolicy
 	Checkpoint        []byte
+	// ContextSnapshot is an opaque manager-owned snapshot of selected context
+	// values captured at submission time.
+	ContextSnapshot []byte
 }
 
 // ListPendingRequest lists pending task candidates for the given executor keys.
@@ -220,12 +223,22 @@ type ResumeRequest struct {
 	TaskID          string
 	ExpectedVersion int64
 	Data            []byte
+	// ContextSnapshot is Manager-owned. Manager callers should leave it empty;
+	// Manager captures it from Config.ContextSnapshotter. TaskStore
+	// implementations replace the task's stored context snapshot when this field
+	// is non-nil. An empty non-nil slice clears it.
+	ContextSnapshot []byte
 }
 
 // ReleaseSuspensionRequest returns a suspended task to pending.
 type ReleaseSuspensionRequest struct {
 	TaskID          string
 	ExpectedVersion int64
+	// ContextSnapshot is Manager-owned. Manager callers should leave it empty;
+	// Manager captures it from Config.ContextSnapshotter. TaskStore
+	// implementations replace the task's stored context snapshot when this field
+	// is non-nil. An empty non-nil slice clears it.
+	ContextSnapshot []byte
 }
 
 // WaitForTaskVersionRequest identifies a task and the latest snapshot version

--- a/adk/middlewares/subagent/agent_tool.go
+++ b/adk/middlewares/subagent/agent_tool.go
@@ -22,6 +22,7 @@ import (
 	"fmt"
 	"io"
 	"path/filepath"
+	"time"
 
 	"github.com/bytedance/sonic"
 	"github.com/google/uuid"
@@ -285,6 +286,15 @@ func signalClosed(done <-chan struct{}) bool {
 	}
 }
 
+type detachedExecutionContext struct {
+	parent context.Context
+}
+
+func (detachedExecutionContext) Deadline() (time.Time, bool) { return time.Time{}, false }
+func (detachedExecutionContext) Done() <-chan struct{}       { return nil }
+func (detachedExecutionContext) Err() error                  { return nil }
+func (c detachedExecutionContext) Value(key any) any         { return c.parent.Value(key) }
+
 type agentEventFileReceiver[M adk.MessageType] struct {
 	ctx       context.Context
 	writer    io.Writer
@@ -509,7 +519,7 @@ func newDurableAgentTool[M adk.MessageType](
 			return "", err
 		}
 		go func() {
-			_ = config.Manager.Execute(context.Background(), task.Spec.ID)
+			_ = config.Manager.Execute(detachedExecutionContext{parent: callCtx}, task.Spec.ID)
 		}()
 		return formatDurableAgentResult(in.SubagentType, task)
 	})

--- a/adk/middlewares/subagent/middleware_test.go
+++ b/adk/middlewares/subagent/middleware_test.go
@@ -425,6 +425,50 @@ func TestAttack_DurableTerminalResultPreservesChildSessionIdentity(t *testing.T)
 	}
 }
 
+func TestDurableAgentToolBackgroundPreservesParentContextValues(t *testing.T) {
+	type traceKey struct{}
+	const traceValue = "trace-123"
+
+	parentCtx := context.WithValue(runnerEnvironmentContext(t), traceKey{}, traceValue)
+	callCtx, cancelCall := context.WithCancel(parentCtx)
+	defer cancelCall()
+	manager := newTestManager(t, parentCtx)
+	seenValue := make(chan any, 1)
+	seenErr := make(chan error, 1)
+	started := make(chan struct{})
+	release := make(chan struct{})
+	agent := &mockAgent{name: "worker", run: func(ctx context.Context, _ *adk.AgentInput) string {
+		seenValue <- ctx.Value(traceKey{})
+		close(started)
+		<-release
+		seenErr <- ctx.Err()
+		return "done"
+	}}
+	middleware, err := New(parentCtx, &Config{
+		SubAgents:  []adk.Agent{agent},
+		Background: durableBackground(t, manager, agent),
+	})
+	require.NoError(t, err)
+	_, runCtx, err := middleware.BeforeAgent(
+		parentCtx,
+		&adk.ChatModelAgentContext[*schema.Message]{},
+	)
+	require.NoError(t, err)
+	_, err = runCtx.Tools[0].(tool.InvokableTool).InvokableRun(
+		callCtx,
+		`{"subagent_type":"worker","prompt":"work","description":"test","run_in_background":true}`,
+	)
+	require.NoError(t, err)
+	<-started
+	cancelCall()
+	close(release)
+	task := terminalTask(t, manager)
+	require.NotNil(t, task)
+	require.Equal(t, backgroundtask.StatusCompleted, task.Status)
+	require.Equal(t, traceValue, <-seenValue)
+	require.NoError(t, <-seenErr)
+}
+
 func TestFormatManagedAgentResultLifecycleStates(t *testing.T) {
 	task := &backgroundtask.Task{
 		Spec: backgroundtask.Spec{

--- a/test_tool_middleware_interrupt_state_comprehensive_review.md
+++ b/test_tool_middleware_interrupt_state_comprehensive_review.md
@@ -1,0 +1,89 @@
+# Comprehensive Review Summary: test/tool-middleware-interrupt-state
+
+## Overview
+- Base branch: `alpha/10`
+- Total iterations: Stage 1: 1, Stage 2: 1, Stage 3: 1
+- Files modified: 12
+- Scope: ADK background task context propagation, durable context snapshotting, and sub-agent background resume behavior
+
+## Pre-Flight
+- Changed files were enumerated with `git diff --stat` and `git diff --name-only`.
+- Baseline verification passed with `go test ./...`.
+
+## Stage 1: Design Review
+
+### Scorecard
+| Dimension | Rating | Notes |
+|---|---:|---|
+| Concept Coherence | 5/5 | `ContextSnapshotter` cleanly separates non-durable Go context values from explicit durable snapshots. |
+| API Usability | 4/5 | Manager-level configuration is explicit; request-field comments were tightened to avoid caller confusion. |
+| Minimum API Surface | 4/5 | One interface plus one task field is sufficient for cross-worker recovery. |
+| Backward Compatibility | 5/5 | Nil `ContextSnapshotter` preserves existing behavior. |
+| Module Separation | 5/5 | Capture/restore lives in `backgroundtask.Manager`, while executors remain payload-specific. |
+| Cohesion | 5/5 | Submit, resume, release, and execute all use one manager-owned snapshot path. |
+| Complexity | 4/5 | The snapshot lifecycle is explicit; nil/non-nil snapshot semantics are documented. |
+| Naming | 5/5 | Public names are direct: `ContextSnapshotter`, `ContextSnapshot`. |
+| Readability | 4/5 | `captureContextSnapshot` returns a captured flag to avoid accidental snapshot clearing. |
+| Duplication | 4/5 | Detached context wrappers remain package-local, matching existing package boundaries. |
+| Public API Docs | 5/5 | New exported identifiers and fields have comments. |
+| Internal Comments | 4/5 | Critical behavior is documented on public types and request fields. |
+
+### Finding Resolved
+| # | Dimension | Finding | Verdict | Fix |
+|---|---|---|---|---|
+| 1 | API Documentation | `ResumeRequest.ContextSnapshot` and `ReleaseSuspensionRequest.ContextSnapshot` could be mistaken as Manager caller inputs. | Fix | Clarified that these fields are Manager-owned and TaskStore-facing. |
+
+## Stage 2: Attack Review
+
+### Attack Results
+| # | Severity | Issue | Test | Status |
+|---|---|---|---|---|
+| 1 | High | Recovery restore failure must not claim or execute a task under the wrong context. | `TestAttack_ContextSnapshotRestoreFailureDoesNotStartTask` | Fixed and passing |
+
+### Attack Verification
+- Ran `go test ./adk/backgroundtask -run 'TestAttack_' -v -count=1`.
+- All attack tests passed.
+
+## Stage 3: Test Audit
+
+### Findings
+| Priority | Issue | Verdict |
+|---|---|---|
+| Medium | Selected package coverage is 80.3%, below the ideal 85% target. | Defer: low coverage is mostly from existing broad package code; changed critical paths meet the 70% hard floor. |
+
+### Coverage
+- `captureContextSnapshot`: 75.0%
+- `restoreExecutionContext`: 90.0%
+- `Resume`: 88.9%
+- `execute`: 87.5%
+- `subagent.Execute`: 83.8%
+- Selected packages total: 80.3%
+- Full repository total: 82.6%
+
+## Cumulative File Change List
+| File | Summary |
+|---|---|
+| `adk/backgroundtask/manager.go` | Added `Task.ContextSnapshot`, `ContextSnapshotter`, and manager config wiring. |
+| `adk/backgroundtask/executor.go` | Captures snapshots on submit/resume/release and restores before execution. |
+| `adk/backgroundtask/types.go` | Added store request snapshot fields and documented Manager-owned semantics. |
+| `adk/backgroundtask/in_memory_store.go` | Persists, clones, bounds, and conditionally replaces context snapshots. |
+| `adk/backgroundtask/local/local.go` | Preserves parent context values for process-local background execution. |
+| `adk/backgroundtask/tool/managed_tool.go` | Preserves parent context values for managed tool background execution. |
+| `adk/middlewares/subagent/agent_tool.go` | Preserves parent context values for durable sub-agent background launch. |
+| `adk/backgroundtask/*_test.go` | Added manager/store/conformance/attack coverage for context snapshots. |
+| `adk/backgroundtask/subagent/subagent_test.go` | Added sub-agent resume restoration coverage. |
+| `adk/middlewares/subagent/middleware_test.go` | Added pure background sub-agent context propagation coverage. |
+
+## Verification
+- `go build ./...`
+- `go test ./...`
+- `go test ./adk/backgroundtask -run 'TestAttack_' -v -count=1`
+- `go test ./adk/backgroundtask ./adk/backgroundtask/subagent ./adk/middlewares/subagent ./adk/backgroundtask/local ./adk/backgroundtask/tool`
+- `go test -coverprofile=/tmp/eino-context-review-cover.out ./adk/backgroundtask ./adk/backgroundtask/subagent ./adk/middlewares/subagent ./adk/backgroundtask/local ./adk/backgroundtask/tool`
+- `go test -race ./...`
+- `go test -coverprofile=/tmp/eino-pr-coverage.out ./...`
+- `git diff --check`
+
+## Remaining Items
+- No unresolved blockers.
+- Durable snapshot bytes are intentionally deployment-owned; deployments should avoid persisting secrets unless their task store access model permits it.


### PR DESCRIPTION
## Problem
Pure background ADK tasks could lose request-scoped context values such as log IDs or trace IDs. The immediate launch path detached execution with `context.Background()`, and recovery had no explicit way to reconstruct serializable context values.

## Solution
Background launches now detach cancellation while preserving parent context values for same-process execution. For durable recovery, `backgroundtask.Manager` can be configured with a `ContextSnapshotter` that captures deployment-selected context values on `Submit`, `Resume`, and `ReleaseSuspension`, then restores them before an execution attempt starts.

If a task has a persisted context snapshot but a recovery worker lacks a compatible snapshotter, execution fails before claim/executor side effects instead of silently running with the wrong context.

## Key Insight
Go `context.Value` is process-local behavior, not durable state. Foreground-to-background handoff can preserve values by using a detached context, but retry/recovery must persist an explicit, deployment-owned snapshot and restore it at the manager execution boundary.

## Summary
| Problem | Solution |
|---|---|
| Same-process background sub-agents lost parent ctx values | Use value-preserving detached execution contexts |
| Resumed/recovered background tasks had no durable ctx restoration path | Add manager-owned `ContextSnapshotter` capture/restore lifecycle |
| Restore failures could otherwise be masked | Fail before task claim/executor execution when snapshot restore is unavailable or invalid |

## Verification
- `go build ./...`
- `go test ./...`
- `go test -race ./...`
- `go test ./adk/backgroundtask -run 'TestAttack_' -v -count=1`\n- `go test -coverprofile=/tmp/eino-pr-coverage.out ./...`\n- `golangci-lint run --new-from-rev=alpha/10 ./...`\n\n---\n\n## 问题\n纯后台 ADK task 会丢失请求维度的 context values，例如 log ID 或 trace ID。立即后台启动路径使用 `context.Background()` 脱离执行；而跨进程 recovery 没有显式机制恢复可序列化的 context values。\n\n## 方案\n同进程后台启动现在使用保留 value、去掉取消和 deadline 的 detached context。对于 durable recovery，`backgroundtask.Manager` 新增可选 `ContextSnapshotter`，在 `Submit`、`Resume`、`ReleaseSuspension` 时捕获业务选择的 context values，并在执行 attempt 启动前恢复。\n\n如果 task 已持久化 context snapshot，但 recovery worker 没有配置兼容的 snapshotter，执行会在 claim / executor 副作用前失败，避免静默用错误 context 跑任务。\n\n## 关键认知\nGo 的 `context.Value` 是进程内调用链状态，不是 durable state。前台切后台的同进程 handoff 可以通过 detached context 保留 value；但 retry/recovery 必须显式持久化由部署方定义的 snapshot，并在 manager 执行边界恢复。\n\n## 总结\n| 问题 | 方案 |\n|---|---|\n| 同进程后台 sub-agent 丢失父 ctx values | 使用保留 value 的 detached execution context |\n| resume/recovery 缺少 durable ctx 恢复路径 | 增加 manager-owned `ContextSnapshotter` 生命周期 |\n| 恢复失败可能被静默掩盖 | snapshot 无法恢复时在 claim/executor 前失败 |\n\n## 验证\n- `go build ./...`\n- `go test ./...`\n- `go test -race ./...`\n- `go test ./adk/backgroundtask -run 'TestAttack_' -v -count=1`\n- `go test -coverprofile=/tmp/eino-pr-coverage.out ./...`\n- `golangci-lint run --new-from-rev=alpha/10 ./...`