### PR TITLE
fix(adk): make background session notification optional

### DIFF
--- a/adk/backgroundtask/local/local.go
+++ b/adk/backgroundtask/local/local.go
@@ -645,12 +645,14 @@ func (e *executor) remove(taskID string) {
 
 func defaultBackgroundNotice(_ context.Context, info NoticeInfo) string {
 	id, kind, outputFile := "", "", ""
+	notifySession := false
 	if info.Task != nil {
 		id = info.Task.Spec.ID
 		if info.Task.Spec.Kind != "" {
 			kind = " (" + info.Task.Spec.Kind + ")"
 		}
 		outputFile = info.Task.Spec.OutputFile
+		notifySession = info.Task.Spec.NotifySession
 	}
 	state := "is running in the background"
 	if info.AutoBackgrounded {
@@ -663,8 +665,9 @@ func defaultBackgroundNotice(_ context.Context, info NoticeInfo) string {
 			outputFile,
 		)
 	}
-	return fmt.Sprintf(
-		"\n[task %s%s %s; you will be notified when it completes.%s]",
-		id, kind, state, output,
-	)
+	completion := "; use task_output to check status and retrieve the result."
+	if notifySession {
+		completion = "; you will be notified when it completes."
+	}
+	return fmt.Sprintf("\n[task %s%s %s%s%s]", id, kind, state, completion, output)
 }

--- a/adk/backgroundtask/local/local_test.go
+++ b/adk/backgroundtask/local/local_test.go
@@ -449,10 +449,14 @@ func TestRunnerLocalContracts(t *testing.T) {
 	notice := defaultBackgroundNotice(context.Background(), NoticeInfo{Task: task})
 	require.Contains(t, notice, "is running in the background")
 	require.Contains(t, notice, "/tasks/output")
+	require.Contains(t, notice, "task_output")
+	require.NotContains(t, notice, "you will be notified")
+	task.Spec.NotifySession = true
 	notice = defaultBackgroundNotice(context.Background(), NoticeInfo{
 		Task: task, AutoBackgrounded: true,
 	})
 	require.Contains(t, notice, "moved to the background")
+	require.Contains(t, notice, "you will be notified")
 
 	work := func(context.Context, backgroundtask.ExecutionRuntime) (string, error) {
 		return "done", nil

--- a/adk/backgroundtask/tool/managed_tool.go
+++ b/adk/backgroundtask/tool/managed_tool.go
@@ -61,8 +61,9 @@ type ManagedToolConfig struct {
 	// InvocationTimeoutMs returns an optional operation timeout in milliseconds.
 	// Nil or a nil result means no operation timeout.
 	InvocationTimeoutMs func(context.Context, string) *int
-	// SessionID resolves the parent session for notification. Nil reads request
-	// identity from context.
+	// SessionID resolves the optional session notification target. An empty
+	// result disables session-routed lifecycle notifications. Nil uses the
+	// current Runner session when one exists and otherwise disables notification.
 	SessionID func(context.Context) (string, error)
 }
 
@@ -859,9 +860,6 @@ func (t *managedTool) newSpec(ctx context.Context, arguments string) (string, ba
 	if err != nil {
 		return "", backgroundtask.Spec{}, err
 	}
-	if sessionID == "" {
-		return "", backgroundtask.Spec{}, errors.New("backgroundtask/tool: parent session is required")
-	}
 	taskID, err := t.manager.AllocateTaskID(ctx, &backgroundtask.AllocateTaskIDRequest{
 		Kind: "background_tool",
 	})
@@ -886,7 +884,7 @@ func (t *managedTool) newSpec(ctx context.Context, arguments string) (string, ba
 		t.recoverable,
 		&taskSpecInput{
 			taskID: taskID, arguments: arguments, outputFile: outputFile,
-			sessionID: sessionID, notifySession: true,
+			sessionID: sessionID, notifySession: sessionID != "",
 		},
 	)
 	if err != nil {
@@ -905,16 +903,13 @@ func (t *managedTool) specForTaskID(
 	if err != nil {
 		return "", backgroundtask.Spec{}, err
 	}
-	if sessionID == "" {
-		return "", backgroundtask.Spec{}, errors.New("backgroundtask/tool: parent session is required")
-	}
 	spec, err := buildTaskSpec(
 		ctx,
 		t.registration,
 		t.recoverable,
 		&taskSpecInput{
 			taskID: taskID, arguments: arguments, outputFile: outputFile,
-			sessionID: sessionID, notifySession: true,
+			sessionID: sessionID, notifySession: sessionID != "",
 		},
 	)
 	if err != nil {
@@ -1196,7 +1191,7 @@ func sessionIDFromContext(ctx context.Context) (string, error) {
 	if sessionID, ok := adk.RunnerSessionID(ctx); ok {
 		return sessionID, nil
 	}
-	return "", errors.New("backgroundtask/tool: runner session is required")
+	return "", nil
 }
 
 var (

--- a/adk/backgroundtask/tool/session_context_test.go
+++ b/adk/backgroundtask/tool/session_context_test.go
@@ -54,10 +54,10 @@ func (m *sessionContextModel) Stream(
 	return schema.StreamReaderFromArray([]*schema.Message{message}), nil
 }
 
-func TestSessionIDFromContextRequiresRunnerAndReadsSession_BitsUT(t *testing.T) {
+func TestSessionIDFromContextIsOptionalAndReadsRunnerSession_BitsUT(t *testing.T) {
 	sessionID, err := sessionIDFromContext(context.Background())
 	require.Empty(t, sessionID)
-	require.EqualError(t, err, "backgroundtask/tool: runner session is required")
+	require.NoError(t, err)
 
 	const expectedSessionID = "managed-tool-parent"
 	chatModel := &sessionContextModel{}

--- a/adk/backgroundtask/tool/submit.go
+++ b/adk/backgroundtask/tool/submit.go
@@ -27,9 +27,9 @@ import (
 )
 
 // SubmitRequest describes a registered managed tool submitted directly as a
-// durable task. Empty TaskID asks Manager to allocate one. SessionID identifies
-// the immutable parent session. DisableLifecycleNotifications suppresses only
-// automatic waiting and terminal notifications.
+// durable task. Empty TaskID asks Manager to allocate one. SessionID optionally
+// identifies the session notification target. It may be empty only when
+// DisableLifecycleNotifications is true.
 type SubmitRequest struct {
 	TaskID      string
 	ToolName    string
@@ -56,9 +56,14 @@ func Submit(
 			"backgroundtask/tool: manager, tool registry, and submit request are required",
 		)
 	}
-	if req.ToolName == "" || req.SessionID == "" {
+	if req.ToolName == "" {
 		return nil, errors.New(
-			"backgroundtask/tool: tool name and parent session are required",
+			"backgroundtask/tool: tool name is required",
+		)
+	}
+	if req.SessionID == "" && !req.DisableLifecycleNotifications {
+		return nil, errors.New(
+			"backgroundtask/tool: notification session is required when lifecycle notifications are enabled",
 		)
 	}
 	registration, recoverable, ok := registry.resolveAny(req.ToolName)

--- a/adk/backgroundtask/tool/submit_test.go
+++ b/adk/backgroundtask/tool/submit_test.go
@@ -129,6 +129,30 @@ func TestSubmitBuildsManagedToolSpecWithoutInputPreparer_BitsUT(t *testing.T) {
 	}, payload)
 }
 
+func TestSubmitWithoutNotificationSession_BitsUT(t *testing.T) {
+	registry := NewRegistry()
+	require.NoError(t, registry.Register(&Registration{
+		Info: toolInfo("direct"),
+		Tool: &submitValidationTool{},
+	}))
+	executors := backgroundtask.NewExecutorRegistry()
+	require.NoError(t, RegisterExecutors(executors, registry))
+	manager := mustNewBackgroundManager(t, context.Background(), &backgroundtask.Config{
+		Executors: executors,
+		IDGen: func(context.Context, *backgroundtask.AllocateTaskIDRequest) (string, error) {
+			return "task-without-notification", nil
+		},
+	})
+
+	task, err := Submit(context.Background(), manager, registry, &SubmitRequest{
+		ToolName: "direct", Arguments: `{"value":"input"}`,
+		DisableLifecycleNotifications: true,
+	})
+	require.NoError(t, err)
+	require.Empty(t, task.Spec.SessionID)
+	require.False(t, task.Spec.NotifySession)
+}
+
 func TestSubmitValidatesBeforeAllocationAndReservation_BitsUT(t *testing.T) {
 	validationErr := errors.New("invalid arguments")
 	materializer := &countingMaterializer{}
@@ -197,12 +221,12 @@ func TestSubmitRejectsInvalidRequestsAndDependencyFailures_BitsUT(t *testing.T) 
 		{
 			name: "empty tool name", manager: manager, registry: registry,
 			req: &SubmitRequest{Arguments: "{}", SessionID: "parent"},
-			err: "backgroundtask/tool: tool name and parent session are required",
+			err: "backgroundtask/tool: tool name is required",
 		},
 		{
 			name: "empty parent session", manager: manager, registry: registry,
 			req: &SubmitRequest{ToolName: "direct", Arguments: "{}"},
-			err: "backgroundtask/tool: tool name and parent session are required",
+			err: "backgroundtask/tool: notification session is required when lifecycle notifications are enabled",
 		},
 		{
 			name: "unregistered tool", manager: manager, registry: registry,

--- a/adk/backgroundtask/types.go
+++ b/adk/backgroundtask/types.go
@@ -39,9 +39,14 @@ type Spec struct {
 	Kind        string
 	Payload     []byte
 
-	Description   string
-	OutputFile    string
-	SessionID     string
+	Description string
+	OutputFile  string
+	// SessionID is an optional session notification target. It is routing
+	// metadata, not the task's execution identity and not necessarily the
+	// session of an agent executing the task.
+	SessionID string
+	// NotifySession enables waiting and terminal lifecycle notifications when
+	// SessionID is non-empty. Tasks do not otherwise require a session.
 	NotifySession bool
 }
 

--- a/adk/middlewares/filesystem/bash_run.go
+++ b/adk/middlewares/filesystem/bash_run.go
@@ -19,7 +19,6 @@ package filesystem
 import (
 	"context"
 	"encoding/json"
-	"errors"
 	"fmt"
 	"io"
 	"path/filepath"
@@ -364,7 +363,7 @@ func newManagedExecuteTool(
 	definition toolDefinition,
 ) (tool.BaseTool, error) {
 	if sessionID == nil {
-		return nil, errors.New("filesystem: notification session resolver is required")
+		sessionID = noNotificationSessionID
 	}
 	toolName := selectToolName(definition.name, ToolNameExecute)
 	d, err := selectToolDesc(
@@ -399,7 +398,7 @@ func managedRunInput(
 		OutputFile:      writer.path,
 		RunInBackground: input.RunInBackground,
 		SessionID:       sessionID,
-		NotifySession:   true,
+		NotifySession:   sessionID != "",
 	}
 	// A positive timeout overrides the Manager's default foreground timeout for
 	// this command. When the deadline expires, the Manager's policy decides
@@ -445,7 +444,11 @@ func newManagedBufferedExecuteTool(
 			if w.path != "" {
 				msg += fmt.Sprintf(" Output is being written to: %s.", w.path)
 			}
-			msg += " You will be notified when it completes."
+			if result.Spec.NotifySession {
+				msg += " You will be notified when it completes."
+			} else {
+				msg += " Use task_output to check status and retrieve the result."
+			}
 			if w.path != "" {
 				msg += " To check interim output, use Read on that file path."
 			}
@@ -458,6 +461,10 @@ func newManagedBufferedExecuteTool(
 			return "", fmt.Errorf("execute task %q has unknown status %q", result.Spec.ID, result.Status)
 		}
 	})
+}
+
+func noNotificationSessionID(context.Context) (string, error) {
+	return "", nil
 }
 
 func newManagedStreamingExecuteTool(

--- a/adk/middlewares/filesystem/bash_run_test.go
+++ b/adk/middlewares/filesystem/bash_run_test.go
@@ -125,9 +125,11 @@ func TestManagedExecuteAcceptsBackgroundRunner(t *testing.T) {
 	require.NoError(t, err)
 }
 
-func TestManagedExecutePromptPreservesCompletionNotification(t *testing.T) {
-	assert.Contains(t, ManagedExecuteToolDesc, "You will be notified when the command completes")
-	assert.Contains(t, ManagedExecuteToolDescChinese, "命令完成时你会收到通知")
+func TestManagedExecutePromptDoesNotPromiseCompletionNotification(t *testing.T) {
+	assert.NotContains(t, ManagedExecuteToolDesc, "You will be notified")
+	assert.NotContains(t, ManagedExecuteToolDescChinese, "你会收到通知")
+	assert.Contains(t, ManagedExecuteToolDesc, "task_output")
+	assert.Contains(t, ManagedExecuteToolDescChinese, "task_output")
 }
 
 // findExecuteTool returns the execute tool from a tool set (which, when a Backend
@@ -284,6 +286,78 @@ func TestManagedExecuteTool_Foreground(t *testing.T) {
 	require.NoError(t, err)
 }
 
+func TestManagedExecuteTool_ForegroundWithoutNotificationSession(t *testing.T) {
+	mgr := newTestManager(t, context.Background())
+	defer func() {
+		ctx, cancel := context.WithTimeout(context.Background(), 100*time.Millisecond)
+		defer cancel()
+		_ = mgr.Close(ctx)
+	}()
+
+	middleware, err := New(context.Background(), &MiddlewareConfig{
+		Shell: &mockShellBackend{resp: &filesystem.ExecuteResponse{Output: "ok"}},
+		Background: &BackgroundConfig{
+			Local: &LocalBackgroundConfig{Runner: mustLocalRunner(t, mgr)},
+		},
+	})
+	require.NoError(t, err)
+	typed, ok := middleware.(*typedFilesystemMiddleware[*schema.Message])
+	require.True(t, ok)
+
+	result, err := invokeTool(
+		t, findExecuteTool(t, typed.additionalTools), `{"command":"echo hi"}`,
+	)
+	require.NoError(t, err)
+	assert.Equal(t, "ok", result)
+}
+
+func TestManagedExecuteTool_BackgroundWithoutNotificationSession(t *testing.T) {
+	mgr := newTestManager(t, context.Background())
+	defer func() {
+		ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+		defer cancel()
+		_ = mgr.Close(ctx)
+	}()
+
+	release := make(chan struct{})
+	middleware, err := New(context.Background(), &MiddlewareConfig{
+		Shell: &gatedShell{release: release, out: "done"},
+		Background: &BackgroundConfig{
+			Local: &LocalBackgroundConfig{Runner: mustLocalRunner(t, mgr)},
+		},
+	})
+	require.NoError(t, err)
+	typed, ok := middleware.(*typedFilesystemMiddleware[*schema.Message])
+	require.True(t, ok)
+
+	result, err := invokeTool(
+		t,
+		findExecuteTool(t, typed.additionalTools),
+		`{"command":"sleep 1","run_in_background":true}`,
+	)
+	require.NoError(t, err)
+	assert.Contains(t, result, "Use task_output")
+	assert.NotContains(t, result, "You will be notified")
+
+	pending, err := mgr.ListPending(context.Background(), &backgroundtask.ListPendingRequest{
+		ExecutorKeys: []string{"eino.dev/process-local"},
+	})
+	require.NoError(t, err)
+	require.Len(t, pending.Tasks, 1)
+	assert.Empty(t, pending.Tasks[0].Spec.SessionID)
+	assert.False(t, pending.Tasks[0].Spec.NotifySession)
+
+	store, ok := testManagerStores.Load(mgr)
+	require.True(t, ok)
+	deliveries, err := store.(backgroundtask.NotificationOutbox).Receive(
+		context.Background(),
+		&backgroundtask.ReceiveNotificationsRequest{Limit: 10, LeaseDuration: time.Second},
+	)
+	require.NoError(t, err)
+	assert.Empty(t, deliveries.Deliveries)
+	close(release)
+}
+
 func TestManagedExecuteTool_Background(t *testing.T) {
 	mgr := newTestManager(t, context.Background())
 	defer func() {
@@ -294,25 +368,29 @@ func TestManagedExecuteTool_Background(t *testing.T) {
 
 	backend := setupTestBackend() // so a background launch reports an output path
 	release := make(chan struct{})
-	tools, err := getFilesystemTools(context.Background(), &MiddlewareConfig{
+	middleware, err := New(context.Background(), &MiddlewareConfig{
 		Backend: backend,
 		Shell:   &gatedShell{release: release, out: "done"},
 		Background: &BackgroundConfig{
+			NotificationSessionID: testNotificationSessionID,
 			Local: &LocalBackgroundConfig{
 				Runner: mustLocalRunner(t, mgr), OutputStore: backend, OutputDir: "/tasks",
 			},
 		},
-		notificationSessionID: testNotificationSessionID,
 	})
 	require.NoError(t, err)
+	typed, ok := middleware.(*typedFilesystemMiddleware[*schema.Message])
+	require.True(t, ok)
 
-	result, err := invokeTool(t, findExecuteTool(t, tools), `{"command":"sleep 1","run_in_background":true}`)
+	result, err := invokeTool(t, findExecuteTool(t, typed.additionalTools), `{"command":"sleep 1","run_in_background":true}`)
 	require.NoError(t, err)
 	assert.Contains(t, result, "Command running in background with ID:")
 
 	close(release)
 	task := waitTerminalTask(t, mgr)
 	assert.Equal(t, backgroundtask.StatusCompleted, task.Status)
+	assert.Equal(t, "test-session", task.Spec.SessionID)
+	assert.True(t, task.Spec.NotifySession)
 
 	// The background-launch message reports the (reserved) output-file path so the
 	// agent can read it once the task completes.

--- a/adk/middlewares/filesystem/filesystem.go
+++ b/adk/middlewares/filesystem/filesystem.go
@@ -94,6 +94,10 @@ type ExecuteToolConfig struct {
 type BackgroundConfig struct {
 	Local       *LocalBackgroundConfig
 	Recoverable *RecoverableBackgroundConfig
+	// NotificationSessionID resolves the optional session that receives task
+	// lifecycle notifications. An empty result disables session-routed
+	// notifications. Nil does not infer a session from the current Runner.
+	NotificationSessionID func(context.Context) (string, error)
 }
 
 // LocalBackgroundConfig configures process-local background execution for the
@@ -246,15 +250,7 @@ func NewMiddleware(ctx context.Context, config *Config) (adk.AgentMiddleware, er
 		CustomGlobToolDesc:      config.CustomGlobToolDesc,
 		CustomWriteFileToolDesc: config.CustomWriteFileToolDesc,
 		CustomEditToolDesc:      config.CustomEditToolDesc,
-		notificationSessionID: func(ctx context.Context) (string, error) {
-			sessionID, ok := adk.RunnerSessionID(ctx)
-			if !ok {
-				return "", errors.New(
-					"filesystem: runner session is required for background notification",
-				)
-			}
-			return sessionID, nil
-		},
+		notificationSessionID:   noNotificationSessionID,
 	}
 	ts, err := getFilesystemTools(ctx, middlewareConfig)
 	if err != nil {
@@ -471,14 +467,9 @@ func NewTyped[M adk.MessageType](ctx context.Context, config *MiddlewareConfig) 
 		return nil, err
 	}
 	typedConfig := *config
-	typedConfig.notificationSessionID = func(ctx context.Context) (string, error) {
-		sessionID, ok := adk.RunnerSessionID(ctx)
-		if !ok {
-			return "", errors.New(
-				"filesystem: runner session is required for background notification",
-			)
-		}
-		return sessionID, nil
+	typedConfig.notificationSessionID = noNotificationSessionID
+	if typedConfig.Background != nil && typedConfig.Background.NotificationSessionID != nil {
+		typedConfig.notificationSessionID = typedConfig.Background.NotificationSessionID
 	}
 	ts, err := getFilesystemTools(ctx, &typedConfig)
 	if err != nil {

--- a/adk/middlewares/filesystem/prompt.go
+++ b/adk/middlewares/filesystem/prompt.go
@@ -150,12 +150,12 @@ When to use: creating a new file, or fully replacing one you've already Read. Ov
 - Working directory persists between calls, but prefer absolute paths — ` + "`" + `cd` + "`" + ` in a compound command can trigger a permission prompt. Shell state (env vars, functions) does not persist; the shell is initialized from the user's profile.
 - IMPORTANT: Avoid using this tool to run ` + "`" + `cat` + "`" + `, ` + "`" + `head` + "`" + `, ` + "`" + `tail` + "`" + `, ` + "`" + `sed` + "`" + `, ` + "`" + `awk` + "`" + `, or ` + "`" + `echo` + "`" + ` commands, unless explicitly instructed or after you have verified that a dedicated tool cannot accomplish your task. Instead, use the appropriate dedicated tool as this will provide a much better experience for the user.
 - ` + "`" + `timeout` + "`" + ` is in milliseconds: default 120000, max 600000.
-- ` + "`" + `run_in_background` + "`" + ` starts a background task immediately: the tool result returns a task_id/startup preview, and completion arrives through notification even if the command finishes quickly. You will be notified when the command completes. Use task_output after notification to read the terminal result. No ` + "`" + `&` + "`" + ` needed. Foreground runs are synchronous and do not create a task unless the host supports safe auto-background handoff. Foreground ` + "`" + `sleep` + "`" + ` is blocked; use Monitor with an until-loop to wait on a condition.`
+- ` + "`" + `run_in_background` + "`" + ` starts a background task immediately: the tool result returns a task_id/startup preview. Use task_output to check status and read the terminal result; the host may also deliver a completion notification when configured. No ` + "`" + `&` + "`" + ` needed. Foreground runs are synchronous and do not create a task unless the host supports safe auto-background handoff. Foreground ` + "`" + `sleep` + "`" + ` is blocked; use Monitor with an until-loop to wait on a condition.`
 
 	ManagedExecuteToolDescChinese = `执行一条 bash 命令并返回其输出。
 
 - 工作目录在多次调用间保持，但优先使用绝对路径 —— 复合命令中的 ` + "`" + `cd` + "`" + ` 可能触发权限确认。Shell 状态（环境变量、函数）不会保留；shell 以用户的 profile 初始化。
 - 重要：除非明确要求，或你已确认没有专用工具能完成任务，否则避免用本工具运行 ` + "`" + `cat` + "`" + `、` + "`" + `head` + "`" + `、` + "`" + `tail` + "`" + `、` + "`" + `sed` + "`" + `、` + "`" + `awk` + "`" + `、` + "`" + `echo` + "`" + ` 命令。请改用相应的专用工具，这会带来更好的体验。
 - ` + "`" + `timeout` + "`" + ` 单位为毫秒：默认 120000，最大 600000。
-- ` + "`" + `run_in_background` + "`" + ` 会立即创建后台任务：工具结果返回 task_id/启动预览，即使命令很快完成，最终结果也通过完成通知到达。命令完成时你会收到通知。收到通知后用 task_output 读取终态结果。无需 ` + "`" + `&` + "`" + `。前台运行是同步执行，除非宿主支持安全 auto-background handoff，否则不会创建 task。前台 ` + "`" + `sleep` + "`" + ` 被禁止；用 Monitor 配合 until 循环来等待某个条件。`
+- ` + "`" + `run_in_background` + "`" + ` 会立即创建后台任务：工具结果返回 task_id/启动预览。使用 task_output 查询状态并读取终态结果；宿主配置了完成通知时也可能主动投递通知。无需 ` + "`" + `&` + "`" + `。前台运行是同步执行，除非宿主支持安全 auto-background handoff，否则不会创建 task。前台 ` + "`" + `sleep` + "`" + ` 被禁止；用 Monitor 配合 until 循环来等待某个条件。`
 )

--- a/adk/middlewares/filesystem/recoverable_shell_test.go
+++ b/adk/middlewares/filesystem/recoverable_shell_test.go
@@ -39,7 +39,7 @@ type recoverableShellStub struct {
 
 func TestBackgroundConfigSeparatesExecutionModes_BitsUT(t *testing.T) {
 	configType := reflect.TypeOf(BackgroundConfig{})
-	for _, field := range []string{"Local", "Recoverable"} {
+	for _, field := range []string{"Local", "Recoverable", "NotificationSessionID"} {
 		_, ok := configType.FieldByName(field)
 		require.True(t, ok)
 	}

--- a/adk/prebuilt/deep/deep.go
+++ b/adk/prebuilt/deep/deep.go
@@ -445,6 +445,7 @@ func buildTypedBuiltinAgentMiddlewares[M adk.MessageType](ctx context.Context, c
 		if deepFilesystemBackgroundEnabled(background) {
 			if background.RecoverableShell != nil {
 				mwCfg.Background = &filesystem2.BackgroundConfig{
+					NotificationSessionID: deepNotificationSessionID,
 					Recoverable: &filesystem2.RecoverableBackgroundConfig{
 						Shell: recoverableShell, Manager: background.Manager,
 						Executors:            background.Executors,
@@ -459,6 +460,7 @@ func buildTypedBuiltinAgentMiddlewares[M adk.MessageType](ctx context.Context, c
 					return nil, err
 				}
 				mwCfg.Background = &filesystem2.BackgroundConfig{
+					NotificationSessionID: deepNotificationSessionID,
 					Local: &filesystem2.LocalBackgroundConfig{
 						Runner: runner, OutputStore: backendAppendOpener(cfg.Backend),
 						OutputDir: deepShellOutputDir(background),
@@ -474,6 +476,11 @@ func buildTypedBuiltinAgentMiddlewares[M adk.MessageType](ctx context.Context, c
 	}
 
 	return ms, nil
+}
+
+func deepNotificationSessionID(ctx context.Context) (string, error) {
+	sessionID, _ := adk.RunnerSessionID(ctx)
+	return sessionID, nil
 }
 
 func deepBackgroundManager[M adk.MessageType](background *TypedBackgroundConfig[M]) *backgroundtask.Manager {


### PR DESCRIPTION
## Summary

- keep background task execution independent from AgentTool and Runner session identity
- make filesystem session notifications explicit and optional through `BackgroundConfig.NotificationSessionID`
- allow managed tools to run without a session when lifecycle notifications are disabled
- make background notices fall back to `task_output` instead of promising notification

## Problem

Background task execution does not inherently belong to a sub-agent or session. The filesystem middleware nevertheless resolved `RunnerSessionID` for every managed Bash invocation, including commands that completed entirely in the foreground, and always set `NotifySession=true`.

An inline AgentTool has no independent child session log. Its internal Runner intentionally has an empty session ID, so Bash failed before execution with:

`filesystem: runner session is required for background notification`

Copying the parent Runner session into AgentTool removes the error but conflates execution identity with an optional notification target.

## Fix

- leave AgentTool session behavior unchanged
- add an optional notification-session resolver to filesystem background configuration; nil or empty disables session-routed notifications
- set `NotifySession` only when an explicit notification target exists
- keep Deep notification behavior explicit at the prebuilt integration layer
- allow managed-tool specs and direct submissions to omit a session when lifecycle notifications are disabled
- clarify that `Spec.SessionID` is routing metadata, not task execution identity

Without a notification target, tasks remain fully manageable by task ID through `task_output` and `task_stop`.

## Testing

- exact standalone reproduction against `alpha/10`: fails with the filesystem runner-session error
- same reproduction with this branch: passes
- `go test ./adk/... -count=1`