### PR TITLE
fix: handle nil values in concatMaps to prevent SIGSEGV

### DIFF
--- a/internal/concat.go
+++ b/internal/concat.go
@@ -205,18 +205,30 @@ func ConcatSliceValue(val reflect.Value) (reflect.Value, error) {
 }
 
 func toSliceValue(vs []any) (reflect.Value, error) {
-	typ := reflect.TypeOf(vs[0])
+	// Filter out nil elements and find the first non-nil element's type.
+	var nonNil []any
+	for _, v := range vs {
+		if v != nil {
+			nonNil = append(nonNil, v)
+		}
+	}
 
-	ret := reflect.MakeSlice(reflect.SliceOf(typ), len(vs), len(vs))
-	ret.Index(0).Set(reflect.ValueOf(vs[0]))
+	if len(nonNil) == 0 {
+		// All elements are nil; return an empty []any slice.
+		return reflect.ValueOf([]any{}), nil
+	}
 
-	for i := 1; i < len(vs); i++ {
-		v := vs[i]
+	typ := reflect.TypeOf(nonNil[0])
+	for i, v := range nonNil {
 		vt := reflect.TypeOf(v)
 		if typ != vt {
 			return reflect.Value{}, fmt.Errorf("unexpected slice element type. Got %v, expected %v", typ, vt)
 		}
+		_ = i
+	}
 
+	ret := reflect.MakeSlice(reflect.SliceOf(typ), len(nonNil), len(nonNil))
+	for i, v := range nonNil {
 		ret.Index(i).Set(reflect.ValueOf(v))
 	}
 

--- a/internal/concat_test.go
+++ b/internal/concat_test.go
@@ -49,4 +49,28 @@ func TestConcat(t *testing.T) {
 			},
 		}, m)
 	})
+
+	t.Run("concat map with nil value in first chunk and non-nil in second", func(t *testing.T) {
+		c1 := map[string]any{"key": nil}
+		c2 := map[string]any{"key": "value"}
+		m, err := ConcatItems([]map[string]any{c1, c2})
+		assert.Nil(t, err)
+		assert.Equal(t, map[string]any{"key": "value"}, m)
+	})
+
+	t.Run("concat map with non-nil value in first chunk and nil in second", func(t *testing.T) {
+		c1 := map[string]any{"key": "value"}
+		c2 := map[string]any{"key": nil}
+		m, err := ConcatItems([]map[string]any{c1, c2})
+		assert.Nil(t, err)
+		assert.Equal(t, map[string]any{"key": "value"}, m)
+	})
+
+	t.Run("concat flat map with mixed nil values", func(t *testing.T) {
+		c1 := map[string]any{"a": nil, "b": "hello"}
+		c2 := map[string]any{"a": "world", "b": "hello2"}
+		m, err := ConcatItems([]map[string]any{c1, c2})
+		assert.Nil(t, err)
+		assert.Equal(t, map[string]any{"a": "world", "b": "hellohello2"}, m)
+	})
 }


### PR DESCRIPTION
## Description

Fix a nil pointer dereference (SIGSEGV) panic in `concatMaps` when merging `map[string]any` stream chunks where a key is `nil` in an earlier chunk and set in a later chunk.

### Root Cause

`toSliceValue` calls `reflect.TypeOf(vs[0])` where `vs` is a `[]any`. When the first element is `nil`, `reflect.TypeOf` returns `nil`, causing `reflect.SliceOf(nil)` to panic with SIGSEGV.

This happens in `concatMaps` at line 151 when collecting per-key values across chunks — nil values from map entries get appended to the `[]any` slice via `reflect.Append`, and `toSliceValue` doesn't handle nil elements.

### Fix

In `toSliceValue`, filter out nil elements before processing. If all elements are nil, return an empty `[]any` slice. Otherwise, use the first non-nil element's type for the slice type. This makes concat behavior symmetric regardless of whether nil values appear before or after non-nil values.

### Changes

- `internal/concat.go`: Handle nil elements in `toSliceValue`
- `internal/concat_test.go`: Add test cases for nil-first, nil-last, and mixed-nil scenarios

### Testing

- `go test ./internal/... -count=1` — all pass
- Reproducer from issue: `ConcatItems([]map[string]any{{"key": nil}, {"key": "value"}})` no longer panics

### Related

- Fixes #1181
