### PR TITLE
perf(adk): stop session replay at replacement boundary

### DIFF
--- a/adk/session.go
+++ b/adk/session.go
@@ -1617,7 +1617,7 @@ func reconstructSessionState[M MessageType](
 	sessionID string,
 	pageSize int,
 ) (*sessionReconstructResult[M], error) {
-	allEvents, err := loadActiveSessionEventsReverse[M](ctx, handle, sessionID, pageSize)
+	allEvents, err := loadSessionEventsForReconstructionReverse[M](ctx, handle, pageSize)
 	if err != nil {
 		return nil, err
 	}
@@ -1632,17 +1632,35 @@ func reconstructSessionState[M MessageType](
 	return &sessionReconstructResult[M]{state: state}, nil
 }
 
+func loadSessionEventsForReconstructionReverse[M MessageType](
+	ctx context.Context,
+	handle sessionHandle[M],
+	pageSize int,
+) ([]*SessionEvent[M], error) {
+	return loadProjectedSessionEventsReverse(ctx, handle, pageSize, true)
+}
+
 func loadActiveSessionEventsReverse[M MessageType](
 	ctx context.Context,
 	handle sessionHandle[M],
 	sessionID string,
 	pageSize int,
 ) ([]*SessionEvent[M], error) {
+	return loadProjectedSessionEventsReverse(ctx, handle, pageSize, false)
+}
+
+func loadProjectedSessionEventsReverse[M MessageType](
+	ctx context.Context,
+	handle sessionHandle[M],
+	pageSize int,
+	stopAtMessagesReplaced bool,
+) ([]*SessionEvent[M], error) {
 	if pageSize <= 0 {
 		pageSize = defaultLoadPageSize
 	}
 	var physicalReverse []*SessionEvent[M]
 	var after string
+	var sawRollback bool
 	for {
 		result, err := handle.loadEvents(ctx, &LoadSessionEventsRequest{
 			After:   after,
@@ -1656,7 +1674,28 @@ func loadActiveSessionEventsReverse[M MessageType](
 		if result == nil || len(result.Events) == 0 {
 			break
 		}
-		physicalReverse = append(physicalReverse, result.Events...)
+
+		stopAt := len(result.Events)
+		foundBoundary := false
+		if stopAtMessagesReplaced && !sawRollback {
+			for i, event := range result.Events {
+				// A newer rollback may project the active head before this replacement,
+				// so reconstruction needs the complete physical history.
+				if event.Kind == SessionEventRollback {
+					sawRollback = true
+					break
+				}
+				if event.MessagesReplaced != nil {
+					stopAt = i + 1
+					foundBoundary = true
+					break
+				}
+			}
+		}
+		physicalReverse = append(physicalReverse, result.Events[:stopAt]...)
+		if foundBoundary {
+			break
+		}
 		if result.Next == "" {
 			break
 		}

--- a/adk/session_test.go
+++ b/adk/session_test.go
@@ -539,6 +539,18 @@ type testSessionHandle struct {
 	sessionID string
 }
 
+type recordingSessionHandle struct {
+	sessionHandle[*schema.Message]
+	loadRequests []*LoadSessionEventsRequest
+}
+
+func (h *recordingSessionHandle) loadEvents(ctx context.Context, req *LoadSessionEventsRequest) (*LoadSessionEventsResult[*schema.Message], error) {
+	recorded := *req
+	recorded.Kinds = append([]SessionEventKind(nil), req.Kinds...)
+	h.loadRequests = append(h.loadRequests, &recorded)
+	return h.sessionHandle.loadEvents(ctx, req)
+}
+
 func (h *testSessionHandle) loadEvents(ctx context.Context, req *LoadSessionEventsRequest) (*LoadSessionEventsResult[*schema.Message], error) {
 	if req == nil {
 		req = &LoadSessionEventsRequest{}
@@ -2358,41 +2370,256 @@ func TestReconstructFromEventLog_CorruptEventReturnsError(t *testing.T) {
 	require.Error(t, err, "corrupt event must cause reconstruction failure")
 }
 
-// TestReconstructFromEventLog_WithSummarizationBoundary: events before
-// MessagesReplaced are ignored; reconstruction starts from boundary.
-func TestReconstructFromEventLog_WithSummarizationBoundary(t *testing.T) {
-	store := newSessionHelperStore()
+func TestReconstructSessionStateStopsAtMessagesReplaced(t *testing.T) {
 	ctx := context.Background()
-	sid := "with-boundary"
 
-	// Pre-boundary events (should be ignored).
-	for i := 0; i < 3; i++ {
-		m := schema.UserMessage("pre")
-		EnsureMessageID(m)
-		se := withTestEventID(&SessionEvent[*schema.Message]{Message: m})
-		require.NoError(t, store.AppendEventsForSession(ctx, sid, []*SessionEvent[*schema.Message]{se}))
+	appendEvents := func(t *testing.T, store *sessionHelperStore, sid string, events ...*SessionEvent[*schema.Message]) {
+		t.Helper()
+		for _, event := range events {
+			appendTestSessionEvent(t, ctx, store, sid, event)
+		}
+	}
+	messageEvent := func(content string) *SessionEvent[*schema.Message] {
+		return &SessionEvent[*schema.Message]{
+			Kind:    SessionEventMessage,
+			Message: testMessageWithID(content, schema.User),
+		}
+	}
+	replacementEvent := func(messages []*schema.Message) *SessionEvent[*schema.Message] {
+		return &SessionEvent[*schema.Message]{
+			Kind:             SessionEventMessagesReplaced,
+			MessagesReplaced: &messages,
+		}
+	}
+	reconstruct := func(t *testing.T, store *sessionHelperStore, sid string, pageSize int) (*sessionReconstructResult[*schema.Message], *recordingSessionHandle) {
+		t.Helper()
+		handle := &recordingSessionHandle{sessionHandle: store}
+		result, err := reconstructSessionState[*schema.Message](ctx, handle, sid, pageSize)
+		require.NoError(t, err)
+		require.NotNil(t, result)
+		require.NotNil(t, result.state)
+		return result, handle
 	}
 
-	// Boundary: summary of all messages.
-	summary := schema.UserMessage("summary")
-	EnsureMessageID(summary)
-	repl := []*schema.Message{summary}
-	se := withTestEventID(&SessionEvent[*schema.Message]{MessagesReplaced: &repl})
-	require.NoError(t, store.AppendEventsForSession(ctx, sid, []*SessionEvent[*schema.Message]{se}))
+	for _, tc := range []struct {
+		name      string
+		preCount  int
+		postCount int
+		pageSize  int
+		wantLoads int
+	}{
+		{name: "replacement in first page middle", preCount: 2, postCount: 1, pageSize: 3, wantLoads: 1},
+		{name: "replacement in later page middle", preCount: 2, postCount: 4, pageSize: 3, wantLoads: 2},
+		{name: "replacement at page boundary", preCount: 2, postCount: 2, pageSize: 2, wantLoads: 2},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			store := newSessionHelperStore()
+			sid := tc.name
+			for i := 0; i < tc.preCount; i++ {
+				appendEvents(t, store, sid, messageEvent(fmt.Sprintf("pre-%d", i)))
+			}
+			summary := testMessageWithID("summary", schema.User)
+			appendEvents(t, store, sid, replacementEvent([]*schema.Message{summary}))
+			for i := 0; i < tc.postCount; i++ {
+				appendEvents(t, store, sid, messageEvent(fmt.Sprintf("post-%d", i)))
+			}
 
-	// Post-boundary events.
-	post := schema.AssistantMessage("post", nil)
-	EnsureMessageID(post)
-	se = withTestEventID(&SessionEvent[*schema.Message]{Message: post})
-	require.NoError(t, store.AppendEventsForSession(ctx, sid, []*SessionEvent[*schema.Message]{se}))
+			result, handle := reconstruct(t, store, sid, tc.pageSize)
 
-	result, err := reconstructSessionState[*schema.Message](ctx, store, sid, defaultLoadPageSize)
-	require.NoError(t, err)
-	require.NotNil(t, result)
-	require.NotNil(t, result.state)
-	require.Len(t, result.state.Messages, 2)
-	assert.Equal(t, "summary", result.state.Messages[0].Content)
-	assert.Equal(t, "post", result.state.Messages[1].Content)
+			require.Len(t, handle.loadRequests, tc.wantLoads)
+			require.Len(t, result.state.Messages, tc.postCount+1)
+			assert.Equal(t, "summary", result.state.Messages[0].Content)
+			for i := 0; i < tc.postCount; i++ {
+				assert.Equal(t, fmt.Sprintf("post-%d", i), result.state.Messages[i+1].Content)
+			}
+		})
+	}
+
+	t.Run("empty replacement is a boundary", func(t *testing.T) {
+		store := newSessionHelperStore()
+		sid := "empty-replacement"
+		empty := []*schema.Message{}
+		appendEvents(t, store, sid,
+			messageEvent("pre-0"),
+			messageEvent("pre-1"),
+			replacementEvent(empty),
+			messageEvent("post"),
+		)
+
+		result, handle := reconstruct(t, store, sid, 3)
+
+		require.Len(t, handle.loadRequests, 1)
+		require.Len(t, result.state.Messages, 1)
+		assert.Equal(t, "post", result.state.Messages[0].Content)
+	})
+
+	t.Run("message mutations and model context after replacement", func(t *testing.T) {
+		store := newSessionHelperStore()
+		sid := "replacement-increments"
+		first := testMessageWithID("first", schema.User)
+		second := testMessageWithID("second", schema.User)
+		deleted := testMessageWithID("deleted", schema.User)
+		updated := testMessageWithID("first-updated", schema.Assistant)
+		setMessageIDForTest(updated, GetMessageID(first))
+		inserted := testMessageWithID("inserted", schema.User)
+		tools := []*schema.ToolInfo{{Name: "tool"}}
+		deferredTools := []*schema.ToolInfo{{Name: "deferred-tool"}}
+		boundary := replacementEvent([]*schema.Message{first, second, deleted})
+		boundary.Extra = map[string]any{"reason": "opaque-to-eino"}
+		appendEvents(t, store, sid,
+			messageEvent("pre"),
+			boundary,
+			&SessionEvent[*schema.Message]{
+				Kind: SessionEventMessageUpdated,
+				MessageUpdated: &MessageUpdatedEvent[*schema.Message]{
+					MessageID: GetMessageID(first),
+					Message:   updated,
+				},
+			},
+			&SessionEvent[*schema.Message]{
+				Kind: SessionEventMessageInserted,
+				MessageInserted: &MessageInsertedEvent[*schema.Message]{
+					Message:         inserted,
+					BeforeMessageID: GetMessageID(second),
+				},
+			},
+			&SessionEvent[*schema.Message]{
+				Kind:            SessionEventMessagesDeleted,
+				MessagesDeleted: &MessagesDeletedEvent{MessageIDs: []string{GetMessageID(deleted)}},
+			},
+			&SessionEvent[*schema.Message]{
+				Kind: SessionEventModelContext,
+				ModelContext: &ModelContextEvent{
+					ToolInfos:         tools,
+					DeferredToolInfos: deferredTools,
+				},
+			},
+		)
+
+		result, _ := reconstruct(t, store, sid, 10)
+
+		assert.Equal(t, []*schema.Message{updated, inserted, second}, result.state.Messages)
+		assert.Equal(t, tools, result.state.ToolInfos)
+		assert.Equal(t, deferredTools, result.state.DeferredToolInfos)
+		assert.True(t, result.state.sawModelContext)
+
+		fullEvents, err := loadActiveSessionEventsReverse[*schema.Message](ctx, store, sid, 2)
+		require.NoError(t, err)
+		fullState, err := replayDurableContextEvents(fullEvents)
+		require.NoError(t, err)
+		assert.Equal(t, fullState, result.state)
+	})
+
+	t.Run("rollback after replacement falls back to full history", func(t *testing.T) {
+		store := newSessionHelperStore()
+		sid := "rollback-after-replacement"
+		appendEvents(t, store, sid,
+			messageEvent("Q1"),
+			messageEvent("A1"),
+		)
+		firstIdle := withTestCommittedIdle[*schema.Message]("turn-1")
+		require.NoError(t, store.AppendEventsForSession(ctx, sid, []*SessionEvent[*schema.Message]{firstIdle}))
+		appendEvents(t, store, sid,
+			replacementEvent([]*schema.Message{testMessageWithID("summary", schema.User)}),
+			messageEvent("post"),
+		)
+		secondIdle := withTestCommittedIdle[*schema.Message]("turn-2")
+		require.NoError(t, store.AppendEventsForSession(ctx, sid, []*SessionEvent[*schema.Message]{secondIdle}))
+		appendEvents(t, store, sid, &SessionEvent[*schema.Message]{
+			Kind: SessionEventRollback,
+			Rollback: &SessionRollbackEvent{
+				ToEventID:                 firstIdle.EventID,
+				PreviousHeadCommitEventID: secondIdle.EventID,
+			},
+		})
+
+		result, handle := reconstruct(t, store, sid, 4)
+
+		require.Len(t, handle.loadRequests, 2)
+		require.Len(t, result.state.Messages, 2)
+		assert.Equal(t, "Q1", result.state.Messages[0].Content)
+		assert.Equal(t, "A1", result.state.Messages[1].Content)
+	})
+
+	t.Run("session without replacement loads all pages unchanged", func(t *testing.T) {
+		store := newSessionHelperStore()
+		sid := "without-replacement"
+		for i := 0; i < 5; i++ {
+			appendEvents(t, store, sid, messageEvent(fmt.Sprintf("message-%d", i)))
+		}
+
+		result, handle := reconstruct(t, store, sid, 2)
+
+		require.Len(t, handle.loadRequests, 3)
+		require.Len(t, result.state.Messages, 5)
+		fullEvents, err := loadActiveSessionEventsReverse[*schema.Message](ctx, store, sid, 2)
+		require.NoError(t, err)
+		fullState, err := replayDurableContextEvents(fullEvents)
+		require.NoError(t, err)
+		assert.Equal(t, fullState, result.state)
+	})
+}
+
+func TestAttack_ReconstructionReplacementBoundaryOrdering(t *testing.T) {
+	ctx := context.Background()
+
+	t.Run("older rollback does not suppress newer replacement", func(t *testing.T) {
+		store := newSessionHelperStore()
+		sid := "older-rollback"
+		appendCommittedTestTurn(t, ctx, store, sid, "turn-1", "Q1", "A1")
+		appendCommittedTestTurn(t, ctx, store, sid, "turn-2", "Q2", "A2")
+		require.NoError(t, RollbackSession[*schema.Message](ctx, store, sid, "turn-1"))
+
+		summary := testMessageWithID("summary", schema.User)
+		replacement := []*schema.Message{summary}
+		appendTestSessionEvent(t, ctx, store, sid, &SessionEvent[*schema.Message]{
+			Kind:             SessionEventMessagesReplaced,
+			MessagesReplaced: &replacement,
+		})
+		post := testMessageWithID("post", schema.Assistant)
+		appendTestSessionEvent(t, ctx, store, sid, &SessionEvent[*schema.Message]{
+			Kind:    SessionEventMessage,
+			Message: post,
+		})
+
+		handle := &recordingSessionHandle{sessionHandle: store}
+		result, err := reconstructSessionState[*schema.Message](ctx, handle, sid, 4)
+		require.NoError(t, err)
+		require.NotNil(t, result)
+		require.NotNil(t, result.state)
+		assert.Equal(t, []*schema.Message{summary, post}, result.state.Messages)
+		assert.Len(t, handle.loadRequests, 1)
+		t.Log("a rollback older than the latest replacement remains outside the replay window")
+	})
+
+	t.Run("latest replacement wins", func(t *testing.T) {
+		store := newSessionHelperStore()
+		sid := "latest-replacement"
+		firstSummary := testMessageWithID("first-summary", schema.User)
+		firstReplacement := []*schema.Message{firstSummary}
+		secondSummary := testMessageWithID("second-summary", schema.User)
+		secondReplacement := []*schema.Message{secondSummary}
+		for _, event := range []*SessionEvent[*schema.Message]{
+			{Kind: SessionEventMessage, Message: testMessageWithID("pre", schema.User)},
+			{Kind: SessionEventMessagesReplaced, MessagesReplaced: &firstReplacement},
+			{Kind: SessionEventMessage, Message: testMessageWithID("between", schema.Assistant)},
+			{Kind: SessionEventMessagesReplaced, MessagesReplaced: &secondReplacement},
+			{Kind: SessionEventMessage, Message: testMessageWithID("post", schema.Assistant)},
+		} {
+			appendTestSessionEvent(t, ctx, store, sid, event)
+		}
+
+		handle := &recordingSessionHandle{sessionHandle: store}
+		result, err := reconstructSessionState[*schema.Message](ctx, handle, sid, 4)
+		require.NoError(t, err)
+		require.NotNil(t, result)
+		require.NotNil(t, result.state)
+		require.Len(t, result.state.Messages, 2)
+		assert.Equal(t, "second-summary", result.state.Messages[0].Content)
+		assert.Equal(t, "post", result.state.Messages[1].Content)
+		assert.Len(t, handle.loadRequests, 1)
+		t.Log("the newest replacement is selected without reading through an older replacement")
+	})
 }
 
 func TestSessionRollbackEventRoundTrip(t *testing.T) {


### PR DESCRIPTION
# Stop Session Replay at the Latest Replacement Boundary

## Problem

Session reconstruction reads the complete event history in reverse before
`replayDurableContextEvents` selects the latest `MessagesReplaced` snapshot.
Events older than that snapshot cannot affect the reconstructed model context,
so long sessions repeatedly perform unnecessary database reads.

## Solution

Stop reverse pagination at the first non-nil `MessagesReplaced` event and retain
only that event plus its physical suffix. The existing replay implementation
then uses the snapshot as its initial message state and applies subsequent
message mutations and model context events in chronological order.

If a rollback is encountered before the replacement during the reverse scan,
the loader conservatively reads the full history. That preserves the existing
active-log projection because the rollback may move the active head to an event
older than the replacement.

## Decisions

- Keep `SessionEventStore` and its cursor protocol unchanged.
- Treat a non-nil pointer to an empty message slice as a valid boundary.
- Do not inspect `SessionEvent.Extra`; every replacement has identical semantics.
- Keep rollback target loading on the unconditional full-history path.

## Key Insight

A `MessagesReplaced` snapshot makes the earlier physical prefix irrelevant only
when no newer rollback can reactivate that prefix. Reverse scanning reveals this
condition before the boundary is accepted.

## Summary

| Problem | Solution |
| --- | --- |
| Reconstruction reads all historical event pages | Stop at the latest effective `MessagesReplaced` boundary |
| A newer rollback may invalidate that shortcut | Fall back to the existing full active-log projection |

---

# Session 重建从最新 Replacement 边界停止

## 问题

Session 重建会先逆向读取完整事件历史，再由 `replayDurableContextEvents`
选择最新的 `MessagesReplaced` 快照。该快照之前的事件无法影响最终模型上下文，
因此长 Session 会在每轮重建时产生大量无效数据库读取。

## 解决方案

逆向分页遇到首个非 nil 的 `MessagesReplaced` 后停止，仅保留该事件及其物理后缀。
现有 replay 逻辑继续以快照作为初始消息状态，并按时间顺序应用后续消息变更和
model context 事件。

如果逆向扫描在 replacement 之前先遇到 rollback，则保守地读取完整历史。
rollback 可能把 active head 移动到 replacement 之前，因此必须继续使用现有
active-log projection 才能保证重建结果不变。

## 决策

- 不修改 `SessionEventStore` 及其 cursor 协议。
- 非 nil 的空消息 slice 仍是有效 replacement 边界。
- 不读取或解释 `SessionEvent.Extra`，所有 replacement 语义一致。
- rollback target 加载继续无条件读取完整历史。

## 关键洞察

只有在 replacement 之后不存在 rollback 时，`MessagesReplaced` 才能证明更早的
物理事件前缀与当前重建无关。逆向扫描恰好可以在接受边界前确认这一条件。

## 总结

| 问题 | 解决方案 |
| --- | --- |
| 重建读取全部历史事件页 | 在最新有效 `MessagesReplaced` 边界停止 |
| 较新的 rollback 可能使截断失效 | 回退到现有完整 active-log projection |
