### PR TITLE
feat(adk): return reader immediately when RunInBackground is true

### DIFF
--- a/adk/backgroundtask/local/local.go
+++ b/adk/backgroundtask/local/local.go
@@ -365,48 +365,11 @@ func (r *Runner) RunStream(
 		}
 		runDone <- runResult{task: current, err: runErr}
 	}()
-	var (
-		readyErr    error
-		earlyResult *runResult
-	)
-waitReady:
-	for {
-		select {
-		case readyErr = <-ready:
-			break waitReady
-		case result := <-runDone:
-			select {
-			case readyErr = <-ready:
-				earlyResult = &result
-				break waitReady
-			default:
-			}
-			if result.err != nil {
-				r.removeUnstarted(task.Spec.ID)
-				return nil, result.err
-			}
-			if result.task == nil || result.task.Status != backgroundtask.StatusRunning {
-				r.removeUnstarted(task.Spec.ID)
-				return nil, errors.New("backgroundtask/local: task ended before stream construction")
-			}
-			earlyResult = &result
-			runDone = nil
-		}
-	}
-	if readyErr != nil {
-		if earlyResult == nil {
-			result := <-runDone
-			if result.err != nil {
-				return nil, result.err
-			}
-		}
-		return nil, readyErr
-	}
-	if earlyResult != nil {
-		runDone = make(chan runResult, 1)
-		runDone <- *earlyResult
-	}
 	reader, writer := schema.Pipe[string](streamBufferCap)
+	// A successful submission is the acknowledgement boundary for an explicit
+	// background run. In particular, a StreamingShell may block while creating
+	// its reader (for example, when adapting a synchronous RPC), but that must
+	// not delay returning the persisted task to the caller.
 	go r.projectStream(ctx, input, task.Spec.ID, chunks, runDone, writer)
 	return reader, nil
 }

--- a/adk/backgroundtask/local/local_test.go
+++ b/adk/backgroundtask/local/local_test.go
@@ -434,6 +434,54 @@ func TestRunnerStreamBackgroundNotices(t *testing.T) {
 	})
 }
 
+func TestRunnerStreamExplicitBackgroundReturnsBeforeStreamConstruction_BitsUT(t *testing.T) {
+	runner, manager := newTestRunner(t)
+	entered := make(chan struct{})
+	release := make(chan struct{})
+	released := false
+	defer func() {
+		if !released {
+			close(release)
+		}
+	}()
+
+	type result struct {
+		stream *schema.StreamReader[string]
+		err    error
+	}
+	returned := make(chan result, 1)
+	go func() {
+		stream, err := runner.RunStream(context.Background(), &Input{
+			Description: "blocking construction", RunInBackground: true,
+			BackgroundStartupPreviewMs: 1,
+		}, func(context.Context, backgroundtask.ExecutionRuntime) (*schema.StreamReader[string], error) {
+			close(entered)
+			<-release
+			return streamWork("done")(context.Background(), nil)
+		})
+		returned <- result{stream: stream, err: err}
+	}()
+
+	select {
+	case <-entered:
+	case <-time.After(time.Second):
+		t.Fatal("background work did not begin")
+	}
+	select {
+	case got := <-returned:
+		require.NoError(t, got.err)
+		require.NotNil(t, got.stream)
+		require.Contains(t, drain(t, got.stream), "running in the background")
+	case <-time.After(time.Second):
+		t.Fatal("explicit background run waited for stream construction")
+	}
+
+	close(release)
+	released = true
+	require.Equal(t, backgroundtask.StatusCompleted,
+		waitTerminal(t, manager, onlyTask(t, manager)).Status)
+}
+
 func TestRunnerLocalContracts(t *testing.T) {
 	runner, manager := newTestRunner(t)
 	require.Same(t, manager, runner.Manager())


### PR DESCRIPTION
#### What type of PR is this?
<!--
Add one of the following kinds:

build: Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)
ci: Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
docs: Documentation only changes
feat: A new feature
optimize: A new optimization
fix: A bug fix
perf: A code change that improves performance
refactor: A code change that neither fixes a bug nor adds a feature
style: Changes that do not affect the meaning of the code (white space, formatting, missing semi-colons, etc)
test: Adding missing tests or correcting existing tests
chore: Changes to the build process or auxiliary tools and libraries such as documentation generation
-->

#### Check the PR title.
<!--
The description of the title will be attached in Release Notes, 
so please describe it from user-oriented, what this PR does / why we need it.
Please check your PR title with the below requirements:
-->
- [ ] This PR title match the format: \<type\>(optional scope): \<description\>
- [ ] The description of this PR title is user-oriented and clear enough for others to understand.
- [ ] Attach the PR updating the user documentation if the current PR requires user awareness at the usage level. [User docs repo](https://github.com/cloudwego/cloudwego.github.io)


#### (Optional) Translate the PR title into Chinese.


#### (Optional) More detailed description for this PR(en: English/zh: Chinese).
<!--
Provide more detailed info for review(e.g., it's recommended to provide perf data if this is a perf type PR).
-->
en:
zh(optional): 


#### (Optional) Which issue(s) this PR fixes:
<!--
Automatically closes linked issue when PR is merged.
Eg: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

#### (optional) The PR that updates user documentation:
<!--
If the current PR requires user awareness at the usage level, please submit a PR to update user docs. [User docs repo](https://github.com/cloudwego/cloudwego.github.io)
-->
