### PR TITLE
fix(adk): keep durable subagents alive during model retries

### DIFF
--- a/adk/backgroundtask/subagent/subagent.go
+++ b/adk/backgroundtask/subagent/subagent.go
@@ -480,6 +480,10 @@ func (e *Executor[M]) Execute(
 		if event.Output != nil && event.Output.MessageOutput != nil {
 			message, messageErr := event.Output.MessageOutput.GetMessage()
 			if messageErr != nil {
+				var retryErr *adk.WillRetryError
+				if errors.As(messageErr, &retryErr) {
+					continue
+				}
 				return nil, messageErr
 			}
 			materialized = materializedEvent(event, message)

--- a/adk/backgroundtask/subagent/typed_submit_test.go
+++ b/adk/backgroundtask/subagent/typed_submit_test.go
@@ -19,7 +19,10 @@ package subagent
 import (
 	"context"
 	"encoding/json"
+	"errors"
+	"sync/atomic"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/require"
 
@@ -27,8 +30,47 @@ import (
 	"github.com/cloudwego/eino/adk/backgroundtask"
 	"github.com/cloudwego/eino/adk/internal/agenttool"
 	adksession "github.com/cloudwego/eino/adk/session"
+	componentmodel "github.com/cloudwego/eino/components/model"
 	"github.com/cloudwego/eino/schema"
 )
+
+type retryingAgenticStreamModel struct {
+	calls atomic.Int32
+}
+
+func (*retryingAgenticStreamModel) Generate(
+	context.Context,
+	[]*schema.AgenticMessage,
+	...componentmodel.Option,
+) (*schema.AgenticMessage, error) {
+	return nil, errors.New("unexpected Generate call")
+}
+
+func (m *retryingAgenticStreamModel) Stream(
+	context.Context,
+	[]*schema.AgenticMessage,
+	...componentmodel.Option,
+) (*schema.StreamReader[*schema.AgenticMessage], error) {
+	if m.calls.Add(1) > 1 {
+		return schema.StreamReaderFromArray([]*schema.AgenticMessage{
+			{
+				Role: schema.AgenticRoleTypeAssistant,
+				ContentBlocks: []*schema.ContentBlock{
+					schema.NewContentBlock(&schema.AssistantGenText{Text: "retry succeeded"}),
+				},
+			},
+		}), nil
+	}
+	reader, writer := schema.Pipe[*schema.AgenticMessage](2)
+	writer.Send(&schema.AgenticMessage{
+		Role: schema.AgenticRoleTypeAssistant,
+		ContentBlocks: []*schema.ContentBlock{
+			schema.NewContentBlock(&schema.AssistantGenText{Text: "rejected partial output"}),
+		},
+	}, nil)
+	writer.Send(nil, errors.New("provider error: special token bracket mismatch"))
+	return reader, nil
+}
 
 type typedInputCaptureAgent struct {
 	name   string
@@ -244,6 +286,57 @@ func TestSubmitSupportsAgenticInput(t *testing.T) {
 	require.NotNil(t, agent.input)
 	require.Equal(t, input.Messages[0].ContentBlocks, agent.input.Messages[0].ContentBlocks)
 	require.Nil(t, input.Messages[0].Extra)
+}
+
+func TestAgenticModelStreamErrorRetriesWithinDurableAttempt(t *testing.T) {
+	ctx := context.Background()
+	store := adksession.NewInMemoryStore[*schema.AgenticMessage](nil)
+	executor, err := NewExecutor(&ExecutorConfig[*schema.AgenticMessage]{
+		SessionStore: store, CheckPointStore: store,
+	})
+	require.NoError(t, err)
+	model := &retryingAgenticStreamModel{}
+	agent, err := adk.NewTypedChatModelAgent(
+		ctx,
+		&adk.TypedChatModelAgentConfig[*schema.AgenticMessage]{
+			Name:  "worker",
+			Model: model,
+			ModelRetryConfig: &adk.TypedModelRetryConfig[*schema.AgenticMessage]{
+				MaxRetries: 1,
+				BackoffFunc: func(context.Context, int) time.Duration {
+					return time.Nanosecond
+				},
+			},
+		},
+	)
+	require.NoError(t, err)
+	require.NoError(t, executor.Register("worker", &AgentRegistration[*schema.AgenticMessage]{
+		Agent: agent,
+	}))
+	executors := backgroundtask.NewExecutorRegistry()
+	require.NoError(t, executors.Register(executor))
+	manager := mustNewBackgroundManager(
+		t,
+		ctx,
+		&backgroundtask.Config{Executors: executors},
+	)
+	defer manager.Close(context.Background())
+
+	task, err := Submit(ctx, manager, &SubmitRequest[*schema.AgenticMessage]{
+		SubAgentName: "worker",
+		Input: &adk.TypedAgentInput[*schema.AgenticMessage]{
+			Messages:        []*schema.AgenticMessage{schema.UserAgenticMessage("retry the model")},
+			EnableStreaming: true,
+		},
+		SessionID: "parent",
+	})
+	require.NoError(t, err)
+	require.NoError(t, manager.Execute(ctx, task.Spec.ID))
+	completed, err := manager.Get(ctx, task.Spec.ID)
+	require.NoError(t, err)
+	require.Equal(t, backgroundtask.StatusCompleted, completed.Status, completed.ResultError)
+	require.Equal(t, "retry succeeded", string(completed.ResultData))
+	require.Equal(t, int32(2), model.calls.Load())
 }
 
 func TestAttack_TypedInputRecoveryDoesNotReplayInitialInput(t *testing.T) {

--- a/adk/backgroundtask/subagent/typed_submit_test.go
+++ b/adk/backgroundtask/subagent/typed_submit_test.go
@@ -35,7 +35,7 @@ import (
 )
 
 type retryingAgenticStreamModel struct {
-	calls atomic.Int32
+	calls int32
 }
 
 func (*retryingAgenticStreamModel) Generate(
@@ -51,7 +51,7 @@ func (m *retryingAgenticStreamModel) Stream(
 	[]*schema.AgenticMessage,
 	...componentmodel.Option,
 ) (*schema.StreamReader[*schema.AgenticMessage], error) {
-	if m.calls.Add(1) > 1 {
+	if atomic.AddInt32(&m.calls, 1) > 1 {
 		return schema.StreamReaderFromArray([]*schema.AgenticMessage{
 			{
 				Role: schema.AgenticRoleTypeAssistant,
@@ -336,7 +336,7 @@ func TestAgenticModelStreamErrorRetriesWithinDurableAttempt(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, backgroundtask.StatusCompleted, completed.Status, completed.ResultError)
 	require.Equal(t, "retry succeeded", string(completed.ResultData))
-	require.Equal(t, int32(2), model.calls.Load())
+	require.Equal(t, int32(2), atomic.LoadInt32(&model.calls))
 }
 
 func TestAttack_TypedInputRecoveryDoesNotReplayInitialInput(t *testing.T) {

--- a/adk/middlewares/filesystem/bash_run_test.go
+++ b/adk/middlewares/filesystem/bash_run_test.go
@@ -83,12 +83,20 @@ func (r *outputRuntimeStub) ReportTranscriptFailure(context.Context, error) erro
 var testManagerStores sync.Map
 var testManagerExecutors sync.Map
 
-func newTestManager(t testing.TB, ctx context.Context) *backgroundtask.Manager {
+func newTestManager(
+	t testing.TB,
+	ctx context.Context,
+	configure ...func(*backgroundtask.Config),
+) *backgroundtask.Manager {
 	store := backgroundtask.NewInMemoryStore(nil)
 	executors := backgroundtask.NewExecutorRegistry()
-	manager := mustNewBackgroundManager(t, ctx, &backgroundtask.Config{
+	config := &backgroundtask.Config{
 		Tasks: store, Executors: executors,
-	})
+	}
+	for _, apply := range configure {
+		apply(config)
+	}
+	manager := mustNewBackgroundManager(t, ctx, config)
 	testManagerStores.Store(manager, store)
 	testManagerExecutors.Store(manager, executors)
 	return manager
@@ -312,7 +320,15 @@ func TestManagedExecuteTool_ForegroundWithoutNotificationSession(t *testing.T) {
 }
 
 func TestManagedExecuteTool_BackgroundWithoutNotificationSession(t *testing.T) {
-	mgr := newTestManager(t, context.Background())
+	const taskID = "background-without-notification-session"
+	mgr := newTestManager(t, context.Background(), func(config *backgroundtask.Config) {
+		config.IDGen = func(
+			context.Context,
+			*backgroundtask.AllocateTaskIDRequest,
+		) (string, error) {
+			return taskID, nil
+		}
+	})
 	defer func() {
 		ctx, cancel := context.WithTimeout(context.Background(), time.Second)
 		defer cancel()
@@ -339,13 +355,14 @@ func TestManagedExecuteTool_BackgroundWithoutNotificationSession(t *testing.T) {
 	assert.Contains(t, result, "Use task_output")
 	assert.NotContains(t, result, "You will be notified")
 
-	pending, err := mgr.ListPending(context.Background(), &backgroundtask.ListPendingRequest{
-		ExecutorKeys: []string{"eino.dev/process-local"},
-	})
+	task, err := mgr.Get(context.Background(), taskID)
 	require.NoError(t, err)
-	require.Len(t, pending.Tasks, 1)
-	assert.Empty(t, pending.Tasks[0].Spec.SessionID)
-	assert.False(t, pending.Tasks[0].Spec.NotifySession)
+	assert.Contains(t, []backgroundtask.Status{
+		backgroundtask.StatusPending,
+		backgroundtask.StatusRunning,
+	}, task.Status)
+	assert.Empty(t, task.Spec.SessionID)
+	assert.False(t, task.Spec.NotifySession)
 
 	store, ok := testManagerStores.Load(mgr)
 	require.True(t, ok)


### PR DESCRIPTION
#### What type of PR is this?

fix

#### Check the PR title.

- [x] This PR title matches the required format.
- [x] The title is user-oriented and describes the behavior change.
- [x] No user documentation update is required.

#### (Optional) Translate the PR title into Chinese.

fix(adk): 模型重试期间保持 durable subagent 继续运行

#### (Optional) More detailed description for this PR(en: English/zh: Chinese).

en:

The durable sub-agent executor materialized every streaming agent event and treated a `WillRetryError` from a rejected model attempt as a terminal task failure. This stopped the task before the retrying chat model could emit its next attempt.

Skip only `WillRetryError` events and continue consuming the same agent run. Non-retryable stream errors and exhausted retries still fail as before.

The regression test reproduces a streaming response that emits partial output and then a provider error, followed by a successful second model call. It verifies that the task completes with the accepted result and that the model is called twice.\n\nCI follow-ups keep test code compatible with the module's Go 1.18 baseline and stabilize an unrelated filesystem test that previously raced the transient pending-to-running transition.

Validation:
- `go test ./adk/backgroundtask/subagent -count=1`
- `go test -race ./adk/backgroundtask/subagent -count=1`
- `go test -race ./adk/... -count=1`
- `go test ./... -count=1`
- `go test -race ./adk/middlewares/filesystem -run '^TestManagedExecuteTool_BackgroundWithoutNotificationSession

zh(optional):

durable sub-agent executor 之前会把被拒绝模型尝试中的 `WillRetryError` 当成任务终态，导致模型第二次调用尚未开始，后台任务就被标记失败。本 PR 仅跳过“即将重试”事件并继续读取同一次 agent run；普通流错误和重试耗尽仍保持失败语义。

#### (Optional) Which issue(s) this PR fixes:

N/A

#### (optional) The PR that updates user documentation:

N/A -count=20`\n- `go test -race ./adk/middlewares/filesystem -count=1`\n- `golangci-lint run --timeout 5m`

zh(optional):

durable sub-agent executor 之前会把被拒绝模型尝试中的 `WillRetryError` 当成任务终态，导致模型第二次调用尚未开始，后台任务就被标记失败。本 PR 仅跳过“即将重试”事件并继续读取同一次 agent run；普通流错误和重试耗尽仍保持失败语义。

#### (Optional) Which issue(s) this PR fixes:

N/A

#### (optional) The PR that updates user documentation:

N/A