### PR TITLE
fix(compose): copy map values before assigning nested fields

### DIFF
--- a/compose/field_mapping.go
+++ b/compose/field_mapping.go
@@ -332,6 +332,13 @@ func assignOne(destValue reflect.Value, taken any, to string) reflect.Value {
 			if !valueValue.IsValid() {
 				valueValue = newInstanceByType(destValue.Type().Elem())
 				destValue.SetMapIndex(keyValue, valueValue)
+			} else if !valueValue.CanAddr() {
+				// Values read back from a map are not addressable, so assigning
+				// to a nested field would panic. Copy into an addressable value;
+				// it is written back via SetMapIndex once the field is set.
+				addr := reflect.New(destValue.Type().Elem()).Elem()
+				addr.Set(valueValue)
+				valueValue = addr
 			}
 
 			if parentMap.IsValid() {

--- a/compose/field_mapping_test.go
+++ b/compose/field_mapping_test.go
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2024 CloudWeGo Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package compose
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestConvertToMapValueMultipleSubFields(t *testing.T) {
+	type sub struct {
+		X string
+		Y string
+	}
+
+	// Two mappings target sub-fields of the same map value. The second one
+	// reads the value back with MapIndex (which is not addressable), so
+	// assigning to its field used to panic with "reflect.Value.Set using
+	// unaddressable value".
+	aX, aY := FieldPath{"a", "X"}, FieldPath{"a", "Y"}
+	got := convertTo(map[string]any{
+		aX.join(): "x",
+		aY.join(): "y",
+	}, reflect.TypeOf(map[string]sub{}))
+
+	assert.Equal(t, map[string]sub{"a": {X: "x", Y: "y"}}, got)
+}


### PR DESCRIPTION
When two field mappings target sub-fields of the same map value (e.g. `a.X` and `a.Y` for a `map[string]struct{...}`), the second one panics with `reflect.Value.Set using unaddressable value`.

The first mapping creates the value through `newInstanceByType` (addressable) and stores it. The second mapping reads it back with `MapIndex`, which is never addressable, and then tries to `Set` a field on it. `assignOne` only handled the missing-key case, not the read-back case.

Fixed by copying the read-back value into an addressable value before descending into it; the existing `SetMapIndex` write-back at the end of the walk puts the updated struct back into the map, so the earlier field survives.

Added a test that maps two sub-fields into one map value — it panics on the current code and passes with the fix. `go test ./compose/` is green.
