### PR TITLE
docs: fix README diagram links

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Eino provides:
 - **Composition**: connect components into graphs and workflows that can run standalone or be exposed as tools for agents.
 - **[Examples](https://github.com/cloudwego/eino-examples)**: working code for common patterns and real-world use cases.
 
-![](.github/static/img/eino/eino_concept.jpeg)
+![](.github/static/img/eino/eino_project_structure_and_modules.png)
 
 # Quick Start
 
@@ -157,7 +157,7 @@ Any agent or tool can pause execution for human input and resume from checkpoint
 
 # Framework Structure
 
-![](.github/static/img/eino/eino_framework.jpeg)
+![](.github/static/img/eino/eino_architecture_overview.png)
 
 The Eino framework consists of:
 

--- a/README.zh_CN.md
+++ b/README.zh_CN.md
@@ -22,7 +22,7 @@ Eino 提供：
 - **编排**：把组件组装成图或工作流，既能独立运行，也能作为工具给智能体调用
 - **[示例](https://github.com/cloudwego/eino-examples)**：常见模式和实际场景的可运行代码
 
-![](.github/static/img/eino/eino_concept.jpeg)
+![](.github/static/img/eino/eino_project_structure_and_modules.png)
 
 # 快速上手
 
@@ -157,7 +157,7 @@ Eino 在编排中自动处理流式：拼接、装箱、合并、复制。组件
 
 # 框架结构
 
-![](.github/static/img/eino/eino_framework.jpeg)
+![](.github/static/img/eino/eino_architecture_overview.png)
 
 Eino 框架包含：
 


### PR DESCRIPTION
#### What type of PR is this?

docs

#### Check the PR title.

- [x] This PR title matches the format: `<type>(optional scope): <description>`.
- [x] The description of this PR title is user-oriented and clear enough for others to understand.
- [x] No user-documentation PR is required; this change repairs repository README assets only.

#### (Optional) Translate the PR title into Chinese.

`docs: 修复 README 架构图链接`

#### (Optional) More detailed description for this PR(en: English/zh: Chinese).

en:

Both README variants still reference two JPEGs that were deleted when the current PNG diagrams were added. This updates the four references to tracked replacement assets:

- the project structure and modules diagram for the introductory concept section;
- the architecture overview diagram for the framework structure section.

Validation:

- verified every local Markdown image target in both README files exists;
- verified both deleted JPEG references are absent;
- `git diff --check` passes;
- confirmed the old raw-content URLs return 404 and the replacement URLs return 200.

zh(optional): 两份 README 仍引用已删除的 JPEG。本 PR 将 4 处链接更新为仓库中现有的项目结构图和架构总览图。

#### (Optional) Which issue(s) this PR fixes:

Fixes #1208

#### (optional) The PR that updates user documentation:

Not required; this only fixes repository README image references.