### PR TITLE
ci: use the tracked Codecov config

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -46,7 +46,7 @@ jobs:
           env_vars: GOLANG,EINO
           files: ${{ env.COVERAGE_FILE }}
           token: ${{ secrets.CODECOV_TOKEN }}
-          codecov_yml_path: ./github/.codecov.yml
+          codecov_yml_path: ./.github/.codedev.yml
 
   benchmark-test:
     runs-on: ubuntu-latest


### PR DESCRIPTION
#### What type of PR is this?

ci

#### Check the PR title.

- [x] This PR title matches the format: `<type>(optional scope): <description>`.
- [x] The description of this PR title is user-oriented and clear enough for others to understand.
- [x] No user-documentation PR is required; this only corrects an existing CI input.

#### (Optional) Translate the PR title into Chinese.

`ci: 使用仓库中现有的 Codecov 配置`

#### (Optional) More detailed description for this PR(en: English/zh: Chinese).

en:

The unit-test job currently passes `./github/.codecov.yml` to the Codecov uploader, but that path does not exist. Its log reports that the config is ignored. The tracked configuration is `.github/.codedev.yml`.

This one-line functional change points the existing upload step at that file. It does not add or change an action, dependency, secret, permission, or job.

Validation:

- reproduced the `Config file github/.codecov.yml not found ... Ignoring config` diagnostic in current Actions job `95749550042`;
- verified `./.github/.codedev.yml` is a tracked regular file;
- parsed the workflow and Codecov configuration as YAML;
- `git diff --check` passes.

zh(optional): 当前上传步骤指向不存在的 `./github/.codecov.yml`，导致 Codecov 忽略配置。本 PR 将路径改为仓库中已有的 `.github/.codedev.yml`。

#### (Optional) Which issue(s) this PR fixes:

Fixes #1209

#### (optional) The PR that updates user documentation:

Not required; this is an internal CI correction.