### PR TITLE
fix(multiquery): forward retrieve options to the underlying retriever

### DIFF
--- a/flow/retriever/multiquery/multi_query.go
+++ b/flow/retriever/multiquery/multi_query.go
@@ -171,7 +171,8 @@ func (m *multiQueryRetriever) Retrieve(ctx context.Context, query string, opts .
 	// retrieve
 	tasks := make([]*utils.RetrieveTask, len(queries))
 	for i := range queries {
-		tasks[i] = &utils.RetrieveTask{Retriever: m.origRetriever, Query: queries[i]}
+		// forward caller options to the underlying retriever, same as router.go does
+		tasks[i] = &utils.RetrieveTask{Retriever: m.origRetriever, Query: queries[i], RetrieveOptions: opts}
 	}
 	utils.ConcurrentRetrieveWithCallback(ctx, tasks)
 	result := make([][]*schema.Document, len(queries))

--- a/flow/retriever/multiquery/multi_query_test.go
+++ b/flow/retriever/multiquery/multi_query_test.go
@@ -19,6 +19,7 @@ package multiquery
 import (
 	"context"
 	"strings"
+	"sync"
 	"testing"
 
 	"github.com/cloudwego/eino/components/model"
@@ -114,5 +115,44 @@ func TestMultiQueryRetriever(t *testing.T) {
 	}
 	if len(result) != 3 {
 		t.Fatal("default llm retrieve result is unexpected")
+	}
+}
+
+type optionCapturingRetriever struct {
+	mu   sync.Mutex
+	topK *int
+}
+
+func (m *optionCapturingRetriever) Retrieve(ctx context.Context, query string, opts ...retriever.Option) ([]*schema.Document, error) {
+	options := retriever.GetCommonOptions(&retriever.Options{}, opts...)
+	m.mu.Lock()
+	m.topK = options.TopK
+	m.mu.Unlock()
+	return []*schema.Document{{ID: query}}, nil
+}
+
+func TestMultiQueryRetrieverForwardsOptions(t *testing.T) {
+	ctx := context.Background()
+	orig := &optionCapturingRetriever{}
+
+	mqr, err := NewRetriever(ctx, &Config{
+		RewriteHandler: func(ctx context.Context, query string) ([]string, error) {
+			return []string{"1"}, nil
+		},
+		OrigRetriever: orig,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if _, err = mqr.Retrieve(ctx, "query", retriever.WithTopK(7)); err != nil {
+		t.Fatal(err)
+	}
+
+	if orig.topK == nil {
+		t.Fatal("retrieve options were not forwarded to the underlying retriever")
+	}
+	if *orig.topK != 7 {
+		t.Fatalf("expected forwarded TopK 7, got %d", *orig.topK)
 	}
 }


### PR DESCRIPTION
The multi-query retriever drops any options passed to `Retrieve`. In `multiQueryRetriever.Retrieve` each `RetrieveTask` is built without `RetrieveOptions`, so `WithTopK`, `WithScoreThreshold`, `WithEmbedding`, `WithDSLInfo` etc. never reach the underlying retriever — the per-call knobs silently do nothing and you're stuck with whatever defaults the wrapped retriever was constructed with.

The router retriever handles the same fan-out correctly (`flow/retriever/router/router.go` sets `RetrieveOptions: opts` on its tasks), so this is just a missed forward on the multiquery path. Fixed by passing `opts` through, matching the router.

Added a test that calls `Retrieve` with `WithTopK(7)` and asserts the underlying retriever actually receives it. `go test ./flow/retriever/multiquery/ -race` passes; without the one-line change the new test fails.
