### PR TITLE
fix(adk): bound subagent drain cancellation

### DIFF
--- a/adk/backgroundtask/subagent/subagent.go
+++ b/adk/backgroundtask/subagent/subagent.go
@@ -131,6 +131,11 @@ type ExecutorConfig[M adk.MessageType] struct {
 	CheckPointStore adk.CheckPointStore
 	// SessionConfig optionally customizes child-session persistence.
 	SessionConfig *adk.SessionConfig[M]
+	// DrainCancelTimeout bounds safe-point cancellation during ControlDrain. A
+	// positive value escalates the cancellation to checkpointable immediate
+	// cancellation when the safe point is not reached before the timeout.
+	// Zero preserves unbounded safe-point cancellation.
+	DrainCancelTimeout time.Duration
 }
 
 // Executor runs durable sub-agent tasks through ADK Runner checkpointing.
@@ -139,6 +144,7 @@ type Executor[M adk.MessageType] struct {
 	sessionStoreFactory SessionStoreFactory[M]
 	checkPointStore     adk.CheckPointStore
 	sessionConfig       *adk.SessionConfig[M]
+	drainCancelTimeout  time.Duration
 
 	mu            sync.RWMutex
 	registrations map[string]*AgentRegistration[M]
@@ -163,6 +169,7 @@ func NewExecutor[M adk.MessageType](config *ExecutorConfig[M]) (*Executor[M], er
 		sessionStoreFactory: config.SessionStoreFactory,
 		checkPointStore:     config.CheckPointStore,
 		sessionConfig:       sessionConfig,
+		drainCancelTimeout:  config.DrainCancelTimeout,
 	}, nil
 }
 
@@ -447,6 +454,10 @@ func (e *Executor[M]) Execute(
 			if control.Kind == backgroundtask.ControlDrain {
 				cancelOptions = append(cancelOptions,
 					adk.WithAgentCancelMode(adk.CancelAfterChatModel|adk.CancelAfterToolCalls))
+				if e.drainCancelTimeout > 0 {
+					cancelOptions = append(cancelOptions,
+						adk.WithAgentCancelTimeout(e.drainCancelTimeout))
+				}
 			} else {
 				cancelOptions = append(cancelOptions, adk.WithAgentCancelMode(adk.CancelImmediate))
 			}

--- a/adk/backgroundtask/subagent/subagent_test.go
+++ b/adk/backgroundtask/subagent/subagent_test.go
@@ -23,7 +23,9 @@ import (
 	"fmt"
 	"strconv"
 	"strings"
+	"sync/atomic"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -31,6 +33,9 @@ import (
 	"github.com/cloudwego/eino/adk"
 	"github.com/cloudwego/eino/adk/backgroundtask"
 	adksession "github.com/cloudwego/eino/adk/session"
+	"github.com/cloudwego/eino/components/model"
+	componenttool "github.com/cloudwego/eino/components/tool"
+	"github.com/cloudwego/eino/compose"
 	"github.com/cloudwego/eino/schema"
 )
 
@@ -79,6 +84,105 @@ type contextCaptureAgent struct {
 	name     string
 	contexts chan context.Context
 	release  chan struct{}
+}
+
+type drainTimeoutModel struct {
+	started chan struct{}
+	calls   int32
+}
+
+func (m *drainTimeoutModel) Generate(
+	ctx context.Context,
+	_ []*schema.Message,
+	_ ...model.Option,
+) (*schema.Message, error) {
+	if atomic.AddInt32(&m.calls, 1) == 1 {
+		close(m.started)
+		<-ctx.Done()
+		return nil, ctx.Err()
+	}
+	return schema.AssistantMessage("resumed", nil), nil
+}
+
+func (m *drainTimeoutModel) Stream(
+	ctx context.Context,
+	input []*schema.Message,
+	options ...model.Option,
+) (*schema.StreamReader[*schema.Message], error) {
+	message, err := m.Generate(ctx, input, options...)
+	if err != nil {
+		return nil, err
+	}
+	return schema.StreamReaderFromArray([]*schema.Message{message}), nil
+}
+
+func (*drainTimeoutModel) BindTools([]*schema.ToolInfo) error { return nil }
+
+type drainTimeoutToolModel struct {
+	calls int32
+}
+
+func (m *drainTimeoutToolModel) Generate(
+	_ context.Context,
+	_ []*schema.Message,
+	_ ...model.Option,
+) (*schema.Message, error) {
+	if atomic.AddInt32(&m.calls, 1) == 1 {
+		return &schema.Message{
+			Role: schema.Assistant,
+			ToolCalls: []schema.ToolCall{{
+				ID:   "call-1",
+				Type: "function",
+				Function: schema.FunctionCall{
+					Name:      "wait",
+					Arguments: `{"input":"work"}`,
+				},
+			}},
+		}, nil
+	}
+	return schema.AssistantMessage("resumed", nil), nil
+}
+
+func (m *drainTimeoutToolModel) Stream(
+	ctx context.Context,
+	input []*schema.Message,
+	options ...model.Option,
+) (*schema.StreamReader[*schema.Message], error) {
+	message, err := m.Generate(ctx, input, options...)
+	if err != nil {
+		return nil, err
+	}
+	return schema.StreamReaderFromArray([]*schema.Message{message}), nil
+}
+
+func (*drainTimeoutToolModel) BindTools([]*schema.ToolInfo) error { return nil }
+
+type drainTimeoutTool struct {
+	started chan struct{}
+	calls   int32
+}
+
+func (*drainTimeoutTool) Info(context.Context) (*schema.ToolInfo, error) {
+	return &schema.ToolInfo{
+		Name: "wait",
+		Desc: "waits for cancellation",
+		ParamsOneOf: schema.NewParamsOneOfByParams(map[string]*schema.ParameterInfo{
+			"input": {Type: schema.String},
+		}),
+	}, nil
+}
+
+func (t *drainTimeoutTool) InvokableRun(
+	ctx context.Context,
+	_ string,
+	_ ...componenttool.Option,
+) (string, error) {
+	if atomic.AddInt32(&t.calls, 1) == 1 {
+		close(t.started)
+		<-ctx.Done()
+		return "", ctx.Err()
+	}
+	return "resumed tool", nil
 }
 
 type historyCaptureAgent struct {
@@ -322,6 +426,96 @@ func (subagentContextSnapshotter) RestoreContext(ctx context.Context, snapshot [
 
 func textInput(query string) *adk.AgentInput {
 	return &adk.AgentInput{Messages: []*schema.Message{schema.UserMessage(query)}}
+}
+
+func executeDrainTimeout(
+	t *testing.T,
+	agent adk.ResumableAgent,
+	waitUntilRunning <-chan struct{},
+) (*backgroundtask.Task, *adksession.InMemoryStore[*schema.Message]) {
+	t.Helper()
+	store := adksession.NewInMemoryStore[*schema.Message](nil)
+	executor, err := NewExecutor(&ExecutorConfig[*schema.Message]{
+		SessionStore:       store,
+		CheckPointStore:    store,
+		DrainCancelTimeout: 20 * time.Millisecond,
+	})
+	require.NoError(t, err)
+	require.NoError(t, executor.Register("worker", &AgentRegistration[*schema.Message]{
+		Agent: agent,
+	}))
+	registry := backgroundtask.NewExecutorRegistry()
+	require.NoError(t, registry.Register(executor))
+	manager := mustNewBackgroundManager(t, context.Background(), &backgroundtask.Config{
+		Executors: registry,
+	})
+	task, err := Submit(context.Background(), manager, &SubmitRequest[*schema.Message]{
+		SubAgentName: "worker",
+		Input: &adk.AgentInput{
+			Messages:        []*schema.Message{schema.UserMessage("work")},
+			EnableStreaming: true,
+		},
+		SessionID: "parent",
+	})
+	require.NoError(t, err)
+
+	executeDone := make(chan error, 1)
+	go func() {
+		executeDone <- manager.Execute(context.Background(), task.Spec.ID)
+	}()
+	select {
+	case <-waitUntilRunning:
+	case <-time.After(time.Second):
+		t.Fatal("sub-agent did not reach the blocked operation")
+	}
+
+	closeCtx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+	require.NoError(t, manager.Close(closeCtx))
+	require.NoError(t, <-executeDone)
+
+	suspended, err := manager.Get(context.Background(), task.Spec.ID)
+	require.NoError(t, err)
+	require.Equal(t, backgroundtask.StatusSuspended, suspended.Status)
+	_, exists, err := store.Get(context.Background(), checkpointID(task.Spec.ID))
+	require.NoError(t, err)
+	require.True(t, exists)
+	return task, store
+}
+
+func requireDrainCheckpointResumes(
+	t *testing.T,
+	task *backgroundtask.Task,
+	store *adksession.InMemoryStore[*schema.Message],
+	agent adk.ResumableAgent,
+) {
+	t.Helper()
+	childSessionID, err := ChildSessionIDFromTask(task)
+	require.NoError(t, err)
+	runner := adk.NewRunner(context.Background(), adk.RunnerConfig{
+		Agent:           agent,
+		EnableStreaming: true,
+		CheckPointStore: store,
+		SessionID:       childSessionID,
+		SessionStore:    store,
+	})
+	iter, err := runner.Resume(context.Background(), checkpointID(task.Spec.ID))
+	require.NoError(t, err)
+	var final string
+	for {
+		event, open := iter.Next()
+		if !open {
+			break
+		}
+		require.NoError(t, event.Err)
+		if event.Output == nil || event.Output.MessageOutput == nil {
+			continue
+		}
+		message, messageErr := event.Output.MessageOutput.GetMessage()
+		require.NoError(t, messageErr)
+		final = message.Content
+	}
+	require.Equal(t, "resumed", final)
 }
 
 func TestNewExecutorRequiresDependencies_BitsUT(t *testing.T) {
@@ -1053,6 +1247,36 @@ func TestExecutorDrainUsesDurableRunnerCheckpoint_BitsUT(t *testing.T) {
 	result, err := manager.Get(context.Background(), task.Spec.ID)
 	require.NoError(t, err)
 	assert.Equal(t, backgroundtask.StatusWaitingInput, result.Status)
+}
+
+func TestExecutorDrainTimeoutEscalatesBlockedModelAndResumes_BitsUT(t *testing.T) {
+	model := &drainTimeoutModel{started: make(chan struct{})}
+	agent, err := adk.NewChatModelAgent(context.Background(), &adk.ChatModelAgentConfig{
+		Name: "worker", Description: "drain timeout test", Model: model,
+	})
+	require.NoError(t, err)
+
+	task, store := executeDrainTimeout(t, agent, model.started)
+	requireDrainCheckpointResumes(t, task, store, agent)
+	require.GreaterOrEqual(t, atomic.LoadInt32(&model.calls), int32(2))
+}
+
+func TestExecutorDrainTimeoutEscalatesBlockedToolAndResumes_BitsUT(t *testing.T) {
+	model := &drainTimeoutToolModel{}
+	tool := &drainTimeoutTool{started: make(chan struct{})}
+	agent, err := adk.NewChatModelAgent(context.Background(), &adk.ChatModelAgentConfig{
+		Name: "worker", Description: "drain timeout test", Model: model,
+		ToolsConfig: adk.ToolsConfig{
+			ToolsNodeConfig: compose.ToolsNodeConfig{
+				Tools: []componenttool.BaseTool{tool},
+			},
+		},
+	})
+	require.NoError(t, err)
+
+	task, store := executeDrainTimeout(t, agent, tool.started)
+	requireDrainCheckpointResumes(t, task, store, agent)
+	require.GreaterOrEqual(t, atomic.LoadInt32(&model.calls), int32(2))
 }
 
 func TestControlAndInterruptUseRunnerCheckpoint(t *testing.T) {


### PR DESCRIPTION
# Bound sub-agent drain cancellation

## Problem

A durable sub-agent receiving `ControlDrain` waited indefinitely for its next model or tool safe point. A long-running operation could outlive the pod shutdown deadline, leaving no Runner checkpoint for another worker to resume.

## Solution

`subagent.ExecutorConfig.DrainCancelTimeout` bounds that safe-point wait. When it is positive, drain requests use `WithAgentCancelTimeout`; Eino escalates to checkpointable immediate cancellation when the timeout expires. The executor only returns `Suspended` after the Runner checkpoint is available, and keeps returning `ErrDrainCheckpointUnavailable` when it is not.

Zero keeps the previous unbounded safe-point behavior.

## Key Insight

`ControlDrain` remains cooperative first: it still lets model and tool calls finish at their natural safe points. The timeout is only an escalation boundary, and it must go through the existing ADK cancellation path so the resulting interruption is recoverable by `Runner.Resume`.

## Summary

| Problem | Solution |
| --- | --- |
| A blocked model or tool can consume the shutdown window before a sub-agent checkpoint is saved. | Configure a drain cancel timeout that escalates to checkpointable cancellation and allows `Runner.Resume`. |


---

# 限制 sub-agent drain 取消等待

## 问题

durable sub-agent 收到 `ControlDrain` 后会无限等待下一处模型或工具安全点。长时间运行的调用可能先耗尽 Pod shutdown deadline，导致 Runner checkpoint 尚未保存，其他 worker 无法恢复任务。

## 方案

新增 `subagent.ExecutorConfig.DrainCancelTimeout`。其值大于零时，drain 请求会使用 `WithAgentCancelTimeout`；超时后 Eino 升级为可 checkpoint 的立即取消。Executor 只会在 Runner checkpoint 可用后返回 `Suspended`；若无法得到 checkpoint，仍明确返回 `ErrDrainCheckpointUnavailable`。

零值保持原有的无限期安全点等待行为。

## 关键认知

`ControlDrain` 仍然优先协作式执行：模型和工具调用可在自然安全点结束。timeout 只是升级边界，必须复用 ADK 已有取消链路，确保形成的中断可由 `Runner.Resume` 恢复。

## 总结

| 问题 | 方案 |
| --- | --- |
| 阻塞模型或工具可能在 sub-agent 保存 checkpoint 前耗尽 shutdown 时间。 | 配置 drain cancel timeout，升级为可 checkpoint 的取消，并支持 `Runner.Resume`。 |