### PR TITLE
fix(adk/filesystem): use seconds for execute timeout

### DIFF
--- a/adk/middlewares/filesystem/bash_run.go
+++ b/adk/middlewares/filesystem/bash_run.go
@@ -400,11 +400,11 @@ func managedRunInput(
 		SessionID:       sessionID,
 		NotifySession:   sessionID != "",
 	}
-	// A positive timeout overrides the Manager's default foreground timeout for
-	// this command. When the deadline expires, the Manager's policy decides
-	// whether to move the task to the background or stop it.
-	if input.TimeoutMS > 0 {
-		runInput.ForegroundTimeoutMs = &input.TimeoutMS
+	// A positive timeout in seconds overrides the Manager's default foreground
+	// timeout for this command. When the deadline expires, the Manager's policy
+	// decides whether to move the task to the background or stop it.
+	if timeoutMs := foregroundTimeoutMsForToolArgument(input.TimeoutSeconds); timeoutMs != nil {
+		runInput.ForegroundTimeoutMs = timeoutMs
 	}
 	return runInput, nil
 }

--- a/adk/middlewares/filesystem/bash_run_test.go
+++ b/adk/middlewares/filesystem/bash_run_test.go
@@ -508,8 +508,8 @@ func TestForegroundTimeoutMsForToolArgument(t *testing.T) {
 	}{
 		{name: "omitted", seconds: 0},
 		{name: "one second", seconds: 1, want: 1000},
-		{name: "maximum", seconds: 600, want: 600000},
-		{name: "clamped", seconds: 601, want: 600000},
+		{name: "maximum", seconds: 3 * 24 * 60 * 60, want: 3 * 24 * 60 * 60 * 1000},
+		{name: "clamped", seconds: 3*24*60*60 + 1, want: 3 * 24 * 60 * 60 * 1000},
 	}
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {

--- a/adk/middlewares/filesystem/bash_run_test.go
+++ b/adk/middlewares/filesystem/bash_run_test.go
@@ -427,7 +427,7 @@ func TestManagedExecuteTool_TimeoutMovesToBackground(t *testing.T) {
 	}()
 
 	tools, err := getFilesystemTools(context.Background(), &MiddlewareConfig{
-		Shell: &slowShell{delay: 200 * time.Millisecond, out: "slow done"},
+		Shell: &slowShell{delay: 1200 * time.Millisecond, out: "slow done"},
 		Background: &BackgroundConfig{
 			Local: &LocalBackgroundConfig{
 				Runner: mustLocalRunner(t, mgr, func(config *backgroundlocal.Config) {
@@ -441,8 +441,8 @@ func TestManagedExecuteTool_TimeoutMovesToBackground(t *testing.T) {
 	})
 	require.NoError(t, err)
 
-	// timeout=50ms < 200ms command → moved to background.
-	result, err := invokeTool(t, tools[0], `{"command":"sleep","timeout":50}`)
+	// timeout=1s < 1.2s command → moved to background.
+	result, err := invokeTool(t, tools[0], `{"command":"sleep","timeout":1}`)
 	require.NoError(t, err)
 	assert.Contains(t, result, "Command running in background with ID:")
 
@@ -462,7 +462,7 @@ func TestManagedExecuteTool_TimeoutKills(t *testing.T) {
 	}()
 
 	tools, err := getFilesystemTools(context.Background(), &MiddlewareConfig{
-		Shell: &slowShell{delay: time.Second, out: "never"},
+		Shell: &slowShell{delay: 2 * time.Second, out: "never"},
 		Background: &BackgroundConfig{
 			Local: &LocalBackgroundConfig{Runner: mustLocalRunner(t, mgr)},
 		},
@@ -470,8 +470,8 @@ func TestManagedExecuteTool_TimeoutKills(t *testing.T) {
 	})
 	require.NoError(t, err)
 
-	_, err = invokeTool(t, tools[0], `{"command":"sleep","timeout":50}`)
-	require.ErrorContains(t, err, "timed out after 50ms")
+	_, err = invokeTool(t, tools[0], `{"command":"sleep","timeout":1}`)
+	require.ErrorContains(t, err, "timed out after 1000ms")
 }
 
 func TestShellPayloadV1AndCommandFromTask(t *testing.T) {
@@ -484,12 +484,44 @@ func TestShellPayloadV1AndCommandFromTask(t *testing.T) {
 	}}
 	assert.Equal(t, "echo hello", CommandFromTask(task))
 
+	input, err = managedRunInput(executeManagedArgs{
+		executeArgs:    executeArgs{Command: "echo hello"},
+		TimeoutSeconds: 2,
+	}, &bashOutputWriter{}, "test-session")
+	require.NoError(t, err)
+	require.NotNil(t, input.ForegroundTimeoutMs)
+	assert.Equal(t, 2000, *input.ForegroundTimeoutMs)
+
 	payload := shellPayloadV1{Version: 2, Command: "echo hello"}
 	task.Spec.Payload, err = json.Marshal(payload)
 	require.NoError(t, err)
 	assert.Empty(t, CommandFromTask(task))
 	_, err = decodeShellPayload(task.Spec.Payload)
 	assert.ErrorIs(t, err, backgroundtask.ErrUnsupportedExecutorPayloadVersion)
+}
+
+func TestForegroundTimeoutMsForToolArgument(t *testing.T) {
+	tests := []struct {
+		name    string
+		seconds int
+		want    int
+	}{
+		{name: "omitted", seconds: 0},
+		{name: "one second", seconds: 1, want: 1000},
+		{name: "maximum", seconds: 600, want: 600000},
+		{name: "clamped", seconds: 601, want: 600000},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			timeout := foregroundTimeoutMsForToolArgument(test.seconds)
+			if test.seconds <= 0 {
+				assert.Nil(t, timeout)
+				return
+			}
+			require.NotNil(t, timeout)
+			assert.Equal(t, test.want, *timeout)
+		})
+	}
 }
 
 // With a Manager, the execute tool schema gains run_in_background and timeout fields.
@@ -668,8 +700,9 @@ func TestManagedExecuteTool_Schema(t *testing.T) {
 	assert.True(t, ok)
 	_, ok = js.Properties.Get("run_in_background")
 	assert.True(t, ok)
-	_, ok = js.Properties.Get("timeout")
+	timeout, ok := js.Properties.Get("timeout")
 	assert.True(t, ok)
+	assert.Contains(t, timeout.Description, "seconds")
 }
 
 // Without a Manager, the execute tool is command-only and untracked.

--- a/adk/middlewares/filesystem/bash_run_test.go
+++ b/adk/middlewares/filesystem/bash_run_test.go
@@ -703,6 +703,7 @@ func TestManagedExecuteTool_Schema(t *testing.T) {
 	timeout, ok := js.Properties.Get("timeout")
 	assert.True(t, ok)
 	assert.Contains(t, timeout.Description, "seconds")
+	assert.Contains(t, timeout.Description, "stops unless the host allows automatic backgrounding")
 }
 
 // Without a Manager, the execute tool is command-only and untracked.

--- a/adk/middlewares/filesystem/filesystem.go
+++ b/adk/middlewares/filesystem/filesystem.go
@@ -28,6 +28,7 @@ import (
 	"sort"
 	"strconv"
 	"strings"
+	"time"
 
 	"github.com/slongfield/pyfmt"
 
@@ -706,7 +707,7 @@ func newRecoverableExecuteTool(
 				},
 				"timeout": {
 					Type: schema.Integer,
-					Desc: "Optional foreground timeout in milliseconds; ignored when run_in_background is true",
+					Desc: "Optional foreground timeout in seconds, up to 600; ignored when run_in_background is true",
 				},
 			}),
 		},
@@ -730,10 +731,10 @@ func newRecoverableExecuteTool(
 		},
 		InvocationTimeoutMs: func(_ context.Context, arguments string) *int {
 			var input executeManagedArgs
-			if json.Unmarshal([]byte(arguments), &input) != nil || input.TimeoutMS <= 0 {
+			if json.Unmarshal([]byte(arguments), &input) != nil {
 				return nil
 			}
-			return &input.TimeoutMS
+			return foregroundTimeoutMsForToolArgument(input.TimeoutSeconds)
 		},
 	})
 }
@@ -1236,11 +1237,24 @@ type executeArgs struct {
 type executeManagedArgs struct {
 	executeArgs
 	RunInBackground bool `json:"run_in_background,omitempty" jsonschema_description:"Set to true to run the command in the background. Use task_output to query it and task_stop to cancel it."`
-	// TimeoutMS is the foreground timeout in milliseconds. When omitted, the configured
+	// TimeoutSeconds is the foreground timeout in seconds. When omitted, the configured
 	// default applies. Ignored when run_in_background is true. What happens at the
 	// deadline (move to background vs. stop) is decided by the Manager's
 	// ShouldAutoBackground policy and is intentionally not surfaced to the model.
-	TimeoutMS int `json:"timeout,omitempty" jsonschema_description:"Optional foreground wait in milliseconds. Ignored when run_in_background is true. At expiry, host policy either detaches the command or stops it. Omit to use the configured default."`
+	TimeoutSeconds int `json:"timeout,omitempty" jsonschema_description:"Optional foreground wait in seconds, up to 600. Ignored when run_in_background is true. At expiry, host policy either detaches the command or stops it. Omit to use the configured default."`
+}
+
+const maxToolArgumentTimeoutSeconds = 600
+
+func foregroundTimeoutMsForToolArgument(seconds int) *int {
+	if seconds <= 0 {
+		return nil
+	}
+	if seconds > maxToolArgumentTimeoutSeconds {
+		seconds = maxToolArgumentTimeoutSeconds
+	}
+	timeoutMs := seconds * int(time.Second/time.Millisecond)
+	return &timeoutMs
 }
 
 func newExecuteTool(sb filesystem.Shell, name string, desc string) (tool.BaseTool, error) {

--- a/adk/middlewares/filesystem/filesystem.go
+++ b/adk/middlewares/filesystem/filesystem.go
@@ -707,7 +707,7 @@ func newRecoverableExecuteTool(
 				},
 				"timeout": {
 					Type: schema.Integer,
-					Desc: "Optional foreground timeout in seconds, up to 3 days; ignored when run_in_background is true",
+					Desc: "Optional foreground timeout in seconds, up to 3 days. Ignored when run_in_background is true. At expiry, the command stops unless the host allows automatic backgrounding for this command; then it continues as a background task.",
 				},
 			}),
 		},
@@ -1238,10 +1238,10 @@ type executeManagedArgs struct {
 	executeArgs
 	RunInBackground bool `json:"run_in_background,omitempty" jsonschema_description:"Set to true to run the command in the background. Use task_output to query it and task_stop to cancel it."`
 	// TimeoutSeconds is the foreground timeout in seconds. When omitted, the configured
-	// default applies. Ignored when run_in_background is true. What happens at the
-	// deadline (move to background vs. stop) is decided by the Manager's
-	// ShouldAutoBackground policy and is intentionally not surfaced to the model.
-	TimeoutSeconds int `json:"timeout,omitempty" jsonschema_description:"Optional foreground wait in seconds, up to 3 days. Ignored when run_in_background is true. At expiry, host policy either detaches the command or stops it. Omit to use the configured default."`
+	// default applies. Ignored when run_in_background is true. At expiry, the
+	// command stops unless the Manager's ShouldAutoBackground policy allows
+	// automatic backgrounding for this command.
+	TimeoutSeconds int `json:"timeout,omitempty" jsonschema_description:"Optional foreground wait in seconds, up to 3 days. Ignored when run_in_background is true. At expiry, the command stops unless the host allows automatic backgrounding for this command; then it continues as a background task. Omit to use the configured default."`
 }
 
 const maxToolArgumentTimeoutSeconds = 3 * 24 * 60 * 60

--- a/adk/middlewares/filesystem/filesystem.go
+++ b/adk/middlewares/filesystem/filesystem.go
@@ -707,7 +707,7 @@ func newRecoverableExecuteTool(
 				},
 				"timeout": {
 					Type: schema.Integer,
-					Desc: "Optional foreground timeout in seconds, up to 600; ignored when run_in_background is true",
+					Desc: "Optional foreground timeout in seconds, up to 3 days; ignored when run_in_background is true",
 				},
 			}),
 		},
@@ -1241,10 +1241,10 @@ type executeManagedArgs struct {
 	// default applies. Ignored when run_in_background is true. What happens at the
 	// deadline (move to background vs. stop) is decided by the Manager's
 	// ShouldAutoBackground policy and is intentionally not surfaced to the model.
-	TimeoutSeconds int `json:"timeout,omitempty" jsonschema_description:"Optional foreground wait in seconds, up to 600. Ignored when run_in_background is true. At expiry, host policy either detaches the command or stops it. Omit to use the configured default."`
+	TimeoutSeconds int `json:"timeout,omitempty" jsonschema_description:"Optional foreground wait in seconds, up to 3 days. Ignored when run_in_background is true. At expiry, host policy either detaches the command or stops it. Omit to use the configured default."`
 }
 
-const maxToolArgumentTimeoutSeconds = 600
+const maxToolArgumentTimeoutSeconds = 3 * 24 * 60 * 60
 
 func foregroundTimeoutMsForToolArgument(seconds int) *int {
 	if seconds <= 0 {

--- a/adk/middlewares/filesystem/prompt.go
+++ b/adk/middlewares/filesystem/prompt.go
@@ -149,13 +149,13 @@ When to use: creating a new file, or fully replacing one you've already Read. Ov
 
 - Working directory persists between calls, but prefer absolute paths — ` + "`" + `cd` + "`" + ` in a compound command can trigger a permission prompt. Shell state (env vars, functions) does not persist; the shell is initialized from the user's profile.
 - IMPORTANT: Avoid using this tool to run ` + "`" + `cat` + "`" + `, ` + "`" + `head` + "`" + `, ` + "`" + `tail` + "`" + `, ` + "`" + `sed` + "`" + `, ` + "`" + `awk` + "`" + `, or ` + "`" + `echo` + "`" + ` commands, unless explicitly instructed or after you have verified that a dedicated tool cannot accomplish your task. Instead, use the appropriate dedicated tool as this will provide a much better experience for the user.
-- ` + "`" + `timeout` + "`" + ` is in milliseconds: default 120000, max 600000.
+- ` + "`" + `timeout` + "`" + ` is in seconds: default 120, max 600.
 - ` + "`" + `run_in_background` + "`" + ` starts a background task immediately: the tool result returns a task_id/startup preview. Use task_output to check status and read the terminal result; the host may also deliver a completion notification when configured. No ` + "`" + `&` + "`" + ` needed. Foreground runs are synchronous and do not create a task unless the host supports safe auto-background handoff. Foreground ` + "`" + `sleep` + "`" + ` is blocked; use Monitor with an until-loop to wait on a condition.`
 
 	ManagedExecuteToolDescChinese = `执行一条 bash 命令并返回其输出。
 
 - 工作目录在多次调用间保持，但优先使用绝对路径 —— 复合命令中的 ` + "`" + `cd` + "`" + ` 可能触发权限确认。Shell 状态（环境变量、函数）不会保留；shell 以用户的 profile 初始化。
 - 重要：除非明确要求，或你已确认没有专用工具能完成任务，否则避免用本工具运行 ` + "`" + `cat` + "`" + `、` + "`" + `head` + "`" + `、` + "`" + `tail` + "`" + `、` + "`" + `sed` + "`" + `、` + "`" + `awk` + "`" + `、` + "`" + `echo` + "`" + ` 命令。请改用相应的专用工具，这会带来更好的体验。
-- ` + "`" + `timeout` + "`" + ` 单位为毫秒：默认 120000，最大 600000。
+- ` + "`" + `timeout` + "`" + ` 单位为秒：默认 120，最大 600。
 - ` + "`" + `run_in_background` + "`" + ` 会立即创建后台任务：工具结果返回 task_id/启动预览。使用 task_output 查询状态并读取终态结果；宿主配置了完成通知时也可能主动投递通知。无需 ` + "`" + `&` + "`" + `。前台运行是同步执行，除非宿主支持安全 auto-background handoff，否则不会创建 task。前台 ` + "`" + `sleep` + "`" + ` 被禁止；用 Monitor 配合 until 循环来等待某个条件。`
 )

--- a/adk/middlewares/filesystem/prompt.go
+++ b/adk/middlewares/filesystem/prompt.go
@@ -149,13 +149,13 @@ When to use: creating a new file, or fully replacing one you've already Read. Ov
 
 - Working directory persists between calls, but prefer absolute paths — ` + "`" + `cd` + "`" + ` in a compound command can trigger a permission prompt. Shell state (env vars, functions) does not persist; the shell is initialized from the user's profile.
 - IMPORTANT: Avoid using this tool to run ` + "`" + `cat` + "`" + `, ` + "`" + `head` + "`" + `, ` + "`" + `tail` + "`" + `, ` + "`" + `sed` + "`" + `, ` + "`" + `awk` + "`" + `, or ` + "`" + `echo` + "`" + ` commands, unless explicitly instructed or after you have verified that a dedicated tool cannot accomplish your task. Instead, use the appropriate dedicated tool as this will provide a much better experience for the user.
-- ` + "`" + `timeout` + "`" + ` is in seconds: default 120, max 600.
+- ` + "`" + `timeout` + "`" + ` is in seconds: default 120, max 3 days.
 - ` + "`" + `run_in_background` + "`" + ` starts a background task immediately: the tool result returns a task_id/startup preview. Use task_output to check status and read the terminal result; the host may also deliver a completion notification when configured. No ` + "`" + `&` + "`" + ` needed. Foreground runs are synchronous and do not create a task unless the host supports safe auto-background handoff. Foreground ` + "`" + `sleep` + "`" + ` is blocked; use Monitor with an until-loop to wait on a condition.`
 
 	ManagedExecuteToolDescChinese = `执行一条 bash 命令并返回其输出。
 
 - 工作目录在多次调用间保持，但优先使用绝对路径 —— 复合命令中的 ` + "`" + `cd` + "`" + ` 可能触发权限确认。Shell 状态（环境变量、函数）不会保留；shell 以用户的 profile 初始化。
 - 重要：除非明确要求，或你已确认没有专用工具能完成任务，否则避免用本工具运行 ` + "`" + `cat` + "`" + `、` + "`" + `head` + "`" + `、` + "`" + `tail` + "`" + `、` + "`" + `sed` + "`" + `、` + "`" + `awk` + "`" + `、` + "`" + `echo` + "`" + ` 命令。请改用相应的专用工具，这会带来更好的体验。
-- ` + "`" + `timeout` + "`" + ` 单位为秒：默认 120，最大 600。
+- ` + "`" + `timeout` + "`" + ` 单位为秒：默认 120，最大 3 天。
 - ` + "`" + `run_in_background` + "`" + ` 会立即创建后台任务：工具结果返回 task_id/启动预览。使用 task_output 查询状态并读取终态结果；宿主配置了完成通知时也可能主动投递通知。无需 ` + "`" + `&` + "`" + `。前台运行是同步执行，除非宿主支持安全 auto-background handoff，否则不会创建 task。前台 ` + "`" + `sleep` + "`" + ` 被禁止；用 Monitor 配合 until 循环来等待某个条件。`
 )

--- a/adk/middlewares/filesystem/recoverable_shell_test.go
+++ b/adk/middlewares/filesystem/recoverable_shell_test.go
@@ -107,6 +107,7 @@ func TestRecoverableShellUsesManagedToolLifecycle(t *testing.T) {
 	timeout, ok := js.Properties.Get("timeout")
 	require.True(t, ok)
 	require.Contains(t, timeout.Description, "seconds")
+	require.Contains(t, timeout.Description, "stops unless the host allows automatic backgrounding")
 	result, err := tools[0].(componenttool.EnhancedInvokableTool).InvokableRun(
 		context.Background(), &schema.ToolArgument{Text: `{"command":"echo hello"}`},
 	)

--- a/adk/middlewares/filesystem/recoverable_shell_test.go
+++ b/adk/middlewares/filesystem/recoverable_shell_test.go
@@ -100,6 +100,13 @@ func TestRecoverableShellUsesManagedToolLifecycle(t *testing.T) {
 	tools, err := getFilesystemTools(context.Background(), config)
 	require.NoError(t, err)
 	require.Len(t, tools, 1)
+	info, err := tools[0].Info(context.Background())
+	require.NoError(t, err)
+	js, err := info.ParamsOneOf.ToJSONSchema()
+	require.NoError(t, err)
+	timeout, ok := js.Properties.Get("timeout")
+	require.True(t, ok)
+	require.Contains(t, timeout.Description, "seconds")
 	result, err := tools[0].(componenttool.EnhancedInvokableTool).InvokableRun(
 		context.Background(), &schema.ToolArgument{Text: `{"command":"echo hello"}`},
 	)


### PR DESCRIPTION
## Problem
The managed `execute` tool documented `timeout` in milliseconds, making ordinary foreground limits hard to read and easy to over-specify.

## Solution
Keep the JSON field name as `timeout`, but interpret its value as seconds. `timeout: 120` now represents the default two-minute foreground wait; values above three days are capped before the existing runtime receives the equivalent milliseconds. Both Local and Recoverable shell schemas, English/Chinese tool prompts, and the per-invocation adapter use the same conversion.

## Decision
The runtime configuration APIs remain millisecond-based. They are internal host configuration, while this PR changes only the model-facing Tool argument. A three-day upper bound preserves a practical long-running-command option while preventing overflow during the seconds-to-milliseconds conversion.

## Key Insight
Foreground timeout decides whether a managed command remains observable, is handed off, or fails. The Tool argument must use one unit consistently across the schema, prompt, Local adapter, and Recoverable adapter; converting only one path would make the same tool call behave differently by shell backend.

## Summary
| Problem | Solution |
| --- | --- |
| `execute.timeout` required millisecond values | Accept seconds, cap at three days, then convert once at the adapter boundary |

## Verification
- `go test ./adk/middlewares/filesystem -run ...`
- `golangci-lint run --new-from-rev=alpha/10 ./...`

---

## 问题
托管 `execute` 工具的 `timeout` 原先以毫秒为单位，前台等待时长不直观，且容易传入过大的值。

## 方案
保留 JSON 字段名 `timeout`，将其值解释为秒。`timeout: 120` 表示默认两分钟的前台等待；超过 3 天的值按上限处理，再在进入既有运行时前转换为毫秒。Local 与 Recoverable shell 的 schema、英文/中文提示词和单次调用适配逻辑统一使用该转换。

## 决策
运行时配置 API 仍以毫秒为单位。它们是宿主内部配置；本 PR 只改变面向模型的 Tool argument。3 天上限既能覆盖实用的长命令，又能避免秒转毫秒时发生溢出。

## 关键洞察
前台 timeout 决定托管命令是继续前台观察、转交后台还是失败。Tool argument 必须在 schema、提示词、Local adapter 和 Recoverable adapter 中保持同一单位；只改其中一条路径会让相同工具调用因 shell 后端不同而产生不同语义。

## 总结
| 问题 | 方案 |
| --- | --- |
| `execute.timeout` 需要毫秒值 | 接受秒值、上限 3 天，并在适配边界统一转换 |

## 验证
- `go test ./adk/middlewares/filesystem -run ...`
- `golangci-lint run --new-from-rev=alpha/10 ./...