### PR TITLE
fix(adk): preserve subagent drain checkpoints

### DIFF
--- a/adk/backgroundtask/subagent/subagent.go
+++ b/adk/backgroundtask/subagent/subagent.go
@@ -604,6 +604,8 @@ func decodeResumeTargets(data []byte) (map[string]any, error) {
 	return targets, nil
 }
 
+// handleRunError translates agent event and output materialization errors into
+// durable task lifecycle outcomes when a control request is active.
 func (e *Executor[M]) handleRunError(
 	ctx context.Context,
 	iter *adk.AsyncIterator[*adk.TypedAgentEvent[M]],

--- a/adk/backgroundtask/subagent/subagent.go
+++ b/adk/backgroundtask/subagent/subagent.go
@@ -485,7 +485,7 @@ func (e *Executor[M]) Execute(
 			interrupted = event.Action.Interrupted
 		}
 		if event.Err != nil && interrupted == nil {
-			return e.handleEventError(ctx, iter, task, controlRequests, event.Err)
+			return e.handleRunError(ctx, iter, task, controlRequests, event.Err)
 		}
 		materialized := event
 		if event.Output != nil && event.Output.MessageOutput != nil {
@@ -495,7 +495,7 @@ func (e *Executor[M]) Execute(
 				if errors.As(messageErr, &retryErr) {
 					continue
 				}
-				return nil, messageErr
+				return e.handleRunError(ctx, iter, task, controlRequests, messageErr)
 			}
 			materialized = materializedEvent(event, message)
 			final = agenttool.ExtractTextContent(message)
@@ -604,7 +604,7 @@ func decodeResumeTargets(data []byte) (map[string]any, error) {
 	return targets, nil
 }
 
-func (e *Executor[M]) handleEventError(
+func (e *Executor[M]) handleRunError(
 	ctx context.Context,
 	iter *adk.AsyncIterator[*adk.TypedAgentEvent[M]],
 	task *backgroundtask.Task,
@@ -613,7 +613,10 @@ func (e *Executor[M]) handleEventError(
 ) (*backgroundtask.ExecutionResult, error) {
 	control := pollControl(controlRequests)
 	var cancelError *adk.CancelError
-	if control.Kind == "" && (errors.Is(err, context.Canceled) || errors.As(err, &cancelError)) {
+	if control.Kind == "" &&
+		(errors.Is(err, context.Canceled) ||
+			errors.As(err, &cancelError) ||
+			errors.Is(err, adk.ErrStreamCanceled)) {
 		control = waitForControl(ctx, controlRequests)
 	}
 	if control.Kind != "" {

--- a/adk/backgroundtask/subagent/subagent_test.go
+++ b/adk/backgroundtask/subagent/subagent_test.go
@@ -91,6 +91,45 @@ type drainTimeoutModel struct {
 	calls   int32
 }
 
+type drainTimeoutStreamingModel struct {
+	started chan struct{}
+	release chan struct{}
+	calls   int32
+}
+
+func (m *drainTimeoutStreamingModel) Generate(
+	_ context.Context,
+	_ []*schema.Message,
+	_ ...model.Option,
+) (*schema.Message, error) {
+	if atomic.AddInt32(&m.calls, 1) == 1 {
+		return schema.AssistantMessage("unreachable", nil), nil
+	}
+	return schema.AssistantMessage("resumed", nil), nil
+}
+
+func (m *drainTimeoutStreamingModel) Stream(
+	ctx context.Context,
+	input []*schema.Message,
+	options ...model.Option,
+) (*schema.StreamReader[*schema.Message], error) {
+	if atomic.LoadInt32(&m.calls) > 0 {
+		message, err := m.Generate(ctx, input, options...)
+		if err != nil {
+			return nil, err
+		}
+		return schema.StreamReaderFromArray([]*schema.Message{message}), nil
+	}
+	atomic.AddInt32(&m.calls, 1)
+	reader, writer := schema.Pipe[*schema.Message](1)
+	close(m.started)
+	go func() {
+		<-m.release
+		writer.Close()
+	}()
+	return reader, nil
+}
+
 func (m *drainTimeoutModel) Generate(
 	ctx context.Context,
 	_ []*schema.Message,
@@ -845,7 +884,7 @@ func TestResumeControlHelpers(t *testing.T) {
 	require.Nil(t, result)
 }
 
-func TestHandleEventErrorControlOutcomes(t *testing.T) {
+func TestHandleRunErrorControlOutcomes(t *testing.T) {
 	executor := newTestExecutor(t, nil)
 	task := &backgroundtask.Task{Spec: backgroundtask.Spec{ID: "task"}}
 
@@ -853,7 +892,7 @@ func TestHandleEventErrorControlOutcomes(t *testing.T) {
 		iter, generator := adk.NewAsyncIteratorPair[*adk.AgentEvent]()
 		generator.Close()
 		wantErr := errors.New("model failed")
-		result, err := executor.handleEventError(
+		result, err := executor.handleRunError(
 			context.Background(), iter, task,
 			make(chan backgroundtask.ControlRequest), wantErr,
 		)
@@ -864,7 +903,7 @@ func TestHandleEventErrorControlOutcomes(t *testing.T) {
 	t.Run("busy child session yields", func(t *testing.T) {
 		iter, generator := adk.NewAsyncIteratorPair[*adk.AgentEvent]()
 		generator.Close()
-		result, err := executor.handleEventError(
+		result, err := executor.handleRunError(
 			context.Background(),
 			iter,
 			task,
@@ -884,7 +923,7 @@ func TestHandleEventErrorControlOutcomes(t *testing.T) {
 		generator.Close()
 		controls := make(chan backgroundtask.ControlRequest, 1)
 		controls <- backgroundtask.ControlRequest{Kind: backgroundtask.ControlStop}
-		result, err := executor.handleEventError(
+		result, err := executor.handleRunError(
 			context.Background(), iter, task, controls, context.Canceled,
 		)
 		require.NoError(t, err)
@@ -898,7 +937,7 @@ func TestHandleEventErrorControlOutcomes(t *testing.T) {
 		controls <- backgroundtask.ControlRequest{
 			Kind: backgroundtask.ControlTimeout, Reason: "deadline",
 		}
-		result, err := executor.handleEventError(
+		result, err := executor.handleRunError(
 			context.Background(), iter, task, controls, context.Canceled,
 		)
 		require.NoError(t, err)
@@ -1253,6 +1292,22 @@ func TestExecutorDrainTimeoutEscalatesBlockedModelAndResumes_BitsUT(t *testing.T
 	model := &drainTimeoutModel{started: make(chan struct{})}
 	agent, err := adk.NewChatModelAgent(context.Background(), &adk.ChatModelAgentConfig{
 		Name: "worker", Description: "drain timeout test", Model: model,
+	})
+	require.NoError(t, err)
+
+	task, store := executeDrainTimeout(t, agent, model.started)
+	requireDrainCheckpointResumes(t, task, store, agent)
+	require.GreaterOrEqual(t, atomic.LoadInt32(&model.calls), int32(2))
+}
+
+func TestExecutorDrainTimeoutEscalatesBlockedModelStreamAndResumes(t *testing.T) {
+	model := &drainTimeoutStreamingModel{
+		started: make(chan struct{}),
+		release: make(chan struct{}),
+	}
+	defer close(model.release)
+	agent, err := adk.NewChatModelAgent(context.Background(), &adk.ChatModelAgentConfig{
+		Name: "worker", Description: "drain timeout stream test", Model: model,
 	})
 	require.NoError(t, err)
 

--- a/adk/backgroundtask/subagent/subagent_test.go
+++ b/adk/backgroundtask/subagent/subagent_test.go
@@ -946,6 +946,45 @@ func TestHandleRunErrorControlOutcomes(t *testing.T) {
 	})
 }
 
+func TestAttack_StreamCanceledWithoutControlRemainsFailure(t *testing.T) {
+	executor := newTestExecutor(t, nil)
+	task := &backgroundtask.Task{Spec: backgroundtask.Spec{ID: "task"}}
+	iter, generator := adk.NewAsyncIteratorPair[*adk.AgentEvent]()
+	generator.Close()
+
+	result, err := executor.handleRunError(
+		context.Background(), iter, task,
+		make(chan backgroundtask.ControlRequest), adk.ErrStreamCanceled,
+	)
+
+	require.Nil(t, result)
+	require.ErrorIs(t, err, adk.ErrStreamCanceled)
+}
+
+func TestAttack_DrainControlAfterStreamCancellationSuspends(t *testing.T) {
+	store := adksession.NewInMemoryStore[*schema.Message](nil)
+	executor := newTestExecutor(t, store)
+	task := &backgroundtask.Task{Spec: backgroundtask.Spec{ID: "task"}}
+	require.NoError(t, store.Set(
+		context.Background(), checkpointID(task.Spec.ID), []byte("runner checkpoint"),
+	))
+	iter, generator := adk.NewAsyncIteratorPair[*adk.AgentEvent]()
+	generator.Close()
+	controls := make(chan backgroundtask.ControlRequest)
+	go func() {
+		time.Sleep(10 * time.Millisecond)
+		controls <- backgroundtask.ControlRequest{Kind: backgroundtask.ControlDrain}
+	}()
+
+	result, err := executor.handleRunError(
+		context.Background(), iter, task, controls, adk.ErrStreamCanceled,
+	)
+
+	require.NoError(t, err)
+	require.Equal(t, backgroundtask.StatusSuspended, result.Status)
+	require.JSONEq(t, `{"sequence":1}`, string(result.Checkpoint))
+}
+
 func TestSubagentPayloadValidation_BitsUT(t *testing.T) {
 	executor, spec, _ := resumeFixture(t, "approval")
 	require.NoError(t, executor.ValidateSpec(spec))


### PR DESCRIPTION
# Preserve sub-agent checkpoints on drain timeout

## Problem

A graceful `ControlDrain` uses safe-point cancellation. When the configured timeout escalates an in-flight streaming model to immediate cancellation, materializing its output can return `adk.ErrStreamCanceled`. That consumer-side error bypassed the durable sub-agent control path, so the task became `failed` instead of `suspended`.

## Solution

Route both an `AgentEvent.Err` and a streaming `MessageOutput.GetMessage()` error through the same sub-agent run-error handler. When a drain control is pending, cancellation-shaped errors are translated to the existing durable drain result and require the runner checkpoint before returning `suspended`.

## Key Insight

`ChatModelAgent` owns agent cancellation and checkpoint semantics. The durable sub-agent executor owns the separate task lifecycle translation. A streaming output is consumed outside the agent run function, so its consumer-side error must re-enter the executor lifecycle handler rather than create a second cancellation state machine.

## Summary

| Problem | Solution |
| --- | --- |
| Drain timeout could terminally fail a resumable streaming sub-agent | Send event and stream-materialization errors through the same durable lifecycle handler |

---

# Drain timeout 下保留 sub-agent checkpoint

## 问题

`ControlDrain` 通过安全点取消执行。流式模型在超时后升级为立即取消时，物化其输出可能返回 `adk.ErrStreamCanceled`。这个消费侧错误绕过了 durable sub-agent 的 control 路径，导致任务被标记为 `failed`，而不是可恢复的 `suspended`。

## 解决方案

`AgentEvent.Err` 和流式 `MessageOutput.GetMessage()` 的错误现在统一进入 sub-agent 的 run-error handler。存在 drain control 时，取消类错误复用现有的 durable drain 结果；只有确认 Runner checkpoint 存在后才返回 `suspended`。

## 关键洞察

`ChatModelAgent` 负责 agent 内部的取消和 checkpoint 语义；durable sub-agent executor 负责把它翻译成 task 生命周期。流式 output 在 agent run function 外被消费，因此消费侧错误必须回到 executor 的同一生命周期出口，不能再建一套取消状态机。

## 总结

| 问题 | 方案 |
| --- | --- |
| drain timeout 会把可恢复的流式 sub-agent 终态化 | event 错误和 stream materialization 错误统一进入 durable 生命周期处理 |