### PR TITLE
fix(adk): avoid racing on shared react config when concurrent Run reuses one ChatModelAgent

### DIFF
--- a/adk/chatmodel.go
+++ b/adk/chatmodel.go
@@ -1142,13 +1142,23 @@ func (a *TypedChatModelAgent[M]) buildMessageReActRunFunc(_ context.Context, bc 
 	return func(ctx context.Context, p *typedRunParams[M]) {
 		mp := any(p).(*typedRunParams[*schema.Message])
 		cancelCtx := mp.cancelCtx
-		msgConf.cancelCtx = cancelCtx
-		if msgConf.modelWrapperConf != nil {
-			msgConf.modelWrapperConf.cancelContext = cancelCtx
-		}
 		ctx = withCancelContext(ctx, cancelCtx)
 
-		g, err := newReact(ctx, msgConf)
+		// msgConf is built once per agent and shared by every concurrent Run.
+		// Shallow-copy it so the per-run cancel scope stays run-local instead
+		// of racing across runs. The copied fields are read-only after
+		// construction (buildModelWrappers snapshots the wrapper config at
+		// build time), so a copy of the struct plus the wrapper config is
+		// enough. See https://github.com/cloudwego/eino/issues/1177.
+		runConf := *msgConf
+		if msgConf.modelWrapperConf != nil {
+			mw := *msgConf.modelWrapperConf
+			mw.cancelContext = cancelCtx
+			runConf.modelWrapperConf = &mw
+		}
+		runConf.cancelCtx = cancelCtx
+
+		g, err := newReact(ctx, &runConf)
 		if err != nil {
 			mp.generator.Send(&AgentEvent{Err: err})
 			return
@@ -1272,13 +1282,21 @@ func (a *TypedChatModelAgent[M]) buildAgenticReActRunFunc(_ context.Context, bc 
 	return func(ctx context.Context, p *typedRunParams[M]) {
 		ap := any(p).(*typedRunParams[*schema.AgenticMessage])
 		cancelCtx := ap.cancelCtx
-		agenticConf.cancelCtx = cancelCtx
-		if agenticConf.modelWrapperConf != nil {
-			agenticConf.modelWrapperConf.cancelContext = cancelCtx
-		}
 		ctx = withCancelContext(ctx, cancelCtx)
 
-		g, err := newAgenticReact(ctx, agenticConf)
+		// agenticConf is built once per agent and shared by every concurrent
+		// Run. Shallow-copy it so the per-run cancel scope stays run-local
+		// instead of racing across runs. See
+		// https://github.com/cloudwego/eino/issues/1177.
+		runConf := *agenticConf
+		if agenticConf.modelWrapperConf != nil {
+			mw := *agenticConf.modelWrapperConf
+			mw.cancelContext = cancelCtx
+			runConf.modelWrapperConf = &mw
+		}
+		runConf.cancelCtx = cancelCtx
+
+		g, err := newAgenticReact(ctx, &runConf)
 		if err != nil {
 			ap.generator.Send(&TypedAgentEvent[*schema.AgenticMessage]{Err: err})
 			return

--- a/adk/chatmodel_react_race_test.go
+++ b/adk/chatmodel_react_race_test.go
@@ -1,0 +1,106 @@
+/*
+ * Copyright 2026 CloudWeGo Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package adk
+
+import (
+	"context"
+	"sync"
+	"testing"
+
+	"github.com/cloudwego/eino/components/model"
+	"github.com/cloudwego/eino/components/tool"
+	"github.com/cloudwego/eino/compose"
+	"github.com/cloudwego/eino/schema"
+)
+
+// reactRaceChatModel is a minimal ToolCallingChatModel that immediately returns
+// a final assistant message. It keeps the race report focused on the agent
+// config mutation instead of mock-internal synchronization.
+type reactRaceChatModel struct{}
+
+func (reactRaceChatModel) WithTools(_ []*schema.ToolInfo) (model.ToolCallingChatModel, error) {
+	return reactRaceChatModel{}, nil
+}
+
+func (reactRaceChatModel) Generate(_ context.Context, _ []*schema.Message, _ ...model.Option) (*schema.Message, error) {
+	return schema.AssistantMessage("ok", nil), nil
+}
+
+func (reactRaceChatModel) Stream(_ context.Context, _ []*schema.Message, _ ...model.Option) (*schema.StreamReader[*schema.Message], error) {
+	return schema.StreamReaderFromArray([]*schema.Message{schema.AssistantMessage("ok", nil)}), nil
+}
+
+// reactRaceNoopTool forces the ReAct (tools) run path: the no-tools path never
+// mutates the shared reactConfig, so it cannot reproduce this race.
+type reactRaceNoopTool struct{}
+
+func (reactRaceNoopTool) Info(_ context.Context) (*schema.ToolInfo, error) {
+	return &schema.ToolInfo{Name: "ping", Desc: "noop"}, nil
+}
+
+func (reactRaceNoopTool) InvokableRun(_ context.Context, _ string, _ ...tool.Option) (string, error) {
+	return "pong", nil
+}
+
+// TestConcurrentRunSharedAgentWithTools_Race reproduces
+// https://github.com/cloudwego/eino/issues/1177: the ReAct run func writes the
+// per-run cancel scope into the once-built shared reactConfig, so concurrent
+// Run calls on one long-lived ChatModelAgent race on reactConfig.cancelCtx and
+// modelWrapperConfig.cancelContext.
+func TestConcurrentRunSharedAgentWithTools_Race(t *testing.T) {
+	ctx := context.Background()
+	agent, err := NewChatModelAgent(ctx, &ChatModelAgentConfig{
+		Name:        "shared",
+		Description: "race repro",
+		Instruction: "hi",
+		Model:       reactRaceChatModel{},
+		ToolsConfig: ToolsConfig{
+			ToolsNodeConfig: compose.ToolsNodeConfig{
+				Tools: []tool.BaseTool{reactRaceNoopTool{}},
+			},
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	const runners = 4
+	start := make(chan struct{})
+	var wg sync.WaitGroup
+	for i := 0; i < runners; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			<-start
+			iter := agent.Run(context.Background(), &AgentInput{
+				Messages:        []*schema.Message{schema.UserMessage("q")},
+				EnableStreaming: false,
+			})
+			for {
+				ev, ok := iter.Next()
+				if !ok {
+					return
+				}
+				if ev != nil && ev.Err != nil {
+					t.Errorf("run err: %v", ev.Err)
+				}
+			}
+		}()
+	}
+	close(start)
+	wg.Wait()
+}


### PR DESCRIPTION
## What

`buildMessageReActRunFunc` and `buildAgenticReActRunFunc` build the react config
(`reactConfig` / `agenticReactConfig`) once per agent and then write the per-run
cancel scope into it on every `Run`:

```go
msgConf.cancelCtx = cancelCtx
msgConf.modelWrapperConf.cancelContext = cancelCtx
```

When one long-lived `ChatModelAgent` is reused across concurrent `Run` calls
(e.g. a multi-tenant gateway), these writes race with `newReact` /
`newAgenticReact` reading the same fields, and two runs can observe each other's
cancel pointer — so a plain run can be cancelled by another run's cancel scope.
Fixes #1177.

## How

Inside the run closure, shallow-copy the once-built config before assigning the
cancel fields and hand the copy to `newReact` / `newAgenticReact`:

```go
runConf := *msgConf
if msgConf.modelWrapperConf != nil {
    mw := *msgConf.modelWrapperConf
    mw.cancelContext = cancelCtx
    runConf.modelWrapperConf = &mw
}
runConf.cancelCtx = cancelCtx
g, err := newReact(ctx, &runConf)
```

All other fields are read-only after construction, and `buildModelWrappers`
snapshots the wrapper config fields at build time, so a struct copy is
sufficient. The per-run cancel injection points (ReAct cancel safe-points, model
wrapper stack, graph interrupt wiring) are preserved unchanged.

## Tests

- New `TestConcurrentRunSharedAgentWithTools_Race`: 4 concurrent runs on one
  shared agent with a start barrier. Fails reliably under `go test -race`
  before this change and passes after.
- `go test -race ./adk/` passes; `golangci-lint run ./adk/...` reports 0 issues.
