### PR TITLE
fix(adk): prevent data races on synthetic agentic streams

### DIFF
--- a/adk/message_id_test.go
+++ b/adk/message_id_test.go
@@ -506,6 +506,10 @@ func TestMessageID_WrapModelSyntheticAgenticStreamGetsIDBeforeFanOut(t *testing.
 	chunk, err := event.Output.MessageOutput.MessageStream.Recv()
 	require.NoError(t, err)
 	assert.NotEmpty(t, GetMessageID(chunk), "synthetic stream output should have an ID before event fan-out")
+	// Reading the handler-owned message from this goroutine while the pipeline is
+	// still live is deliberate: it is the read the framework must not race with,
+	// so this assertion doubles as a race-detector canary under -race. Do not
+	// drop it as redundant.
 	assert.Empty(t, GetMessageID(synthetic), "assigning the framework ID should not mutate the handler-owned message")
 
 	close(release)
@@ -516,6 +520,154 @@ func TestMessageID_WrapModelSyntheticAgenticStreamGetsIDBeforeFanOut(t *testing.
 			break
 		}
 	}
+}
+
+// syntheticAgenticGenerateHandler short-circuits the inner model in non-streaming
+// mode and returns a message it keeps ownership of, mirroring
+// syntheticAgenticStreamHandler.
+type syntheticAgenticGenerateHandler struct {
+	*TypedBaseChatModelAgentMiddleware[*schema.AgenticMessage]
+	message *schema.AgenticMessage
+}
+
+func (h *syntheticAgenticGenerateHandler) WrapModel(
+	_ context.Context,
+	_ model.BaseModel[*schema.AgenticMessage],
+	_ *TypedModelContext[*schema.AgenticMessage],
+) (model.BaseModel[*schema.AgenticMessage], error) {
+	return &mockAgenticModel{
+		generateFn: func(context.Context, []*schema.AgenticMessage, ...model.Option) (*schema.AgenticMessage, error) {
+			return h.message, nil
+		},
+		streamFn: func(context.Context, []*schema.AgenticMessage, ...model.Option) (*schema.StreamReader[*schema.AgenticMessage], error) {
+			return nil, errors.New("unexpected Stream call")
+		},
+	}, nil
+}
+
+// A handler that short-circuits Generate bypasses the innermost ID assignment
+// layer just as the streaming case does. Without a stamp at the event sender
+// boundary the live event and the session event each lazily assign their own ID
+// to their own copy, so one logical message ends up with several identities --
+// and the outer state wrapper writes a third one into the handler's message in
+// place, racing with the handler.
+func TestMessageID_WrapModelSyntheticAgenticGenerateGetsSingleID(t *testing.T) {
+	ctx := context.Background()
+
+	synthetic := &schema.AgenticMessage{
+		Role: schema.AgenticRoleTypeAssistant,
+		ContentBlocks: []*schema.ContentBlock{
+			schema.NewContentBlock(&schema.AssistantGenText{Text: "synthetic"}),
+		},
+	}
+	inner := &mockAgenticModel{
+		generateFn: func(context.Context, []*schema.AgenticMessage, ...model.Option) (*schema.AgenticMessage, error) {
+			return nil, errors.New("inner model should not be called")
+		},
+		streamFn: func(context.Context, []*schema.AgenticMessage, ...model.Option) (*schema.StreamReader[*schema.AgenticMessage], error) {
+			return nil, errors.New("inner model should not be called")
+		},
+	}
+	handler := &syntheticAgenticGenerateHandler{
+		TypedBaseChatModelAgentMiddleware: &TypedBaseChatModelAgentMiddleware[*schema.AgenticMessage]{},
+		message:                           synthetic,
+	}
+	agent, err := NewTypedChatModelAgent(ctx, &TypedChatModelAgentConfig[*schema.AgenticMessage]{
+		Name:     "synthetic-generate-message-id",
+		Model:    inner,
+		Handlers: []TypedChatModelAgentMiddleware[*schema.AgenticMessage]{handler},
+	})
+	require.NoError(t, err)
+
+	iter := agent.Run(ctx, &TypedAgentInput[*schema.AgenticMessage]{
+		Messages:        []*schema.AgenticMessage{schema.UserAgenticMessage("hi")},
+		EnableStreaming: false,
+	})
+	event, ok := iter.Next()
+	require.True(t, ok)
+	require.NoError(t, event.Err)
+	require.NotNil(t, event.Output)
+	require.NotNil(t, event.Output.MessageOutput)
+
+	liveID := GetMessageID(event.Output.MessageOutput.Message)
+	assert.NotEmpty(t, liveID, "synthetic Generate output should have an ID on the live event")
+	require.NotNil(t, event.SessionEventVariant)
+	require.NotNil(t, event.SessionEventVariant.Event)
+	assert.Equal(t, liveID, GetMessageID(event.SessionEventVariant.Event.Message),
+		"live event and session event must agree on one message ID")
+	assert.Empty(t, GetMessageID(synthetic),
+		"assigning the framework ID should not mutate the handler-owned message")
+
+	for {
+		if _, ok = iter.Next(); !ok {
+			break
+		}
+	}
+}
+
+// The innermost ID assignment layer stamps the first chunk of the model's own
+// stream. That chunk belongs to the model implementation, which may retain it, so
+// the layer must copy before writing rather than stamping in place.
+func TestMessageID_StreamChunkIDDoesNotMutateModelOwnedChunk(t *testing.T) {
+	ctx := context.Background()
+
+	retained := &schema.AgenticMessage{
+		Role: schema.AgenticRoleTypeAssistant,
+		ContentBlocks: []*schema.ContentBlock{
+			schema.NewContentBlock(&schema.AssistantGenText{Text: "chunk"}),
+		},
+	}
+	inner := &mockAgenticModel{
+		generateFn: func(context.Context, []*schema.AgenticMessage, ...model.Option) (*schema.AgenticMessage, error) {
+			return nil, errors.New("unexpected Generate call")
+		},
+		streamFn: func(context.Context, []*schema.AgenticMessage, ...model.Option) (*schema.StreamReader[*schema.AgenticMessage], error) {
+			reader, writer := schema.Pipe[*schema.AgenticMessage](1)
+			go func() {
+				defer writer.Close()
+				writer.Send(retained, nil)
+			}()
+			return reader, nil
+		},
+	}
+	agent, err := NewTypedChatModelAgent(ctx, &TypedChatModelAgentConfig[*schema.AgenticMessage]{
+		Name:  "model-owned-chunk-message-id",
+		Model: inner,
+	})
+	require.NoError(t, err)
+
+	iter := agent.Run(ctx, &TypedAgentInput[*schema.AgenticMessage]{
+		Messages:        []*schema.AgenticMessage{schema.UserAgenticMessage("hi")},
+		EnableStreaming: true,
+	})
+
+	sawID := false
+	for {
+		event, ok := iter.Next()
+		if !ok {
+			break
+		}
+		require.NoError(t, event.Err)
+		if event.Output == nil || event.Output.MessageOutput == nil {
+			continue
+		}
+		if !event.Output.MessageOutput.IsStreaming {
+			continue
+		}
+		for {
+			chunk, recvErr := event.Output.MessageOutput.MessageStream.Recv()
+			if recvErr != nil {
+				break
+			}
+			if GetMessageID(chunk) != "" {
+				sawID = true
+			}
+		}
+	}
+
+	assert.True(t, sawID, "framework should assign an ID to the streamed model output")
+	assert.Empty(t, GetMessageID(retained),
+		"the innermost ID layer must copy rather than stamp the model-owned chunk in place")
 }
 
 // Scenario 7: User input messages do NOT get automatic IDs (they are external, not framework-created).

--- a/adk/message_id_test.go
+++ b/adk/message_id_test.go
@@ -427,6 +427,97 @@ func (w *idCheckModelWrapper) Stream(ctx context.Context, input []*schema.Messag
 	return w.inner.Stream(ctx, input, opts...)
 }
 
+type syntheticAgenticStreamHandler struct {
+	*TypedBaseChatModelAgentMiddleware[*schema.AgenticMessage]
+	message *schema.AgenticMessage
+	release <-chan struct{}
+}
+
+func (h *syntheticAgenticStreamHandler) WrapModel(
+	_ context.Context,
+	_ model.BaseModel[*schema.AgenticMessage],
+	_ *TypedModelContext[*schema.AgenticMessage],
+) (model.BaseModel[*schema.AgenticMessage], error) {
+	return &mockAgenticModel{
+		generateFn: func(context.Context, []*schema.AgenticMessage, ...model.Option) (*schema.AgenticMessage, error) {
+			return nil, errors.New("unexpected Generate call")
+		},
+		streamFn: func(context.Context, []*schema.AgenticMessage, ...model.Option) (*schema.StreamReader[*schema.AgenticMessage], error) {
+			reader, writer := schema.Pipe[*schema.AgenticMessage](1)
+			go func() {
+				defer writer.Close()
+				if writer.Send(h.message, nil) {
+					return
+				}
+				<-h.release
+			}()
+			return reader, nil
+		},
+	}, nil
+}
+
+func TestMessageID_WrapModelSyntheticAgenticStreamGetsIDBeforeFanOut(t *testing.T) {
+	ctx := context.Background()
+	release := make(chan struct{})
+	released := false
+	t.Cleanup(func() {
+		if !released {
+			close(release)
+		}
+	})
+
+	synthetic := &schema.AgenticMessage{
+		Role: schema.AgenticRoleTypeAssistant,
+		ContentBlocks: []*schema.ContentBlock{
+			schema.NewContentBlock(&schema.AssistantGenText{Text: "synthetic"}),
+		},
+	}
+	inner := &mockAgenticModel{
+		generateFn: func(context.Context, []*schema.AgenticMessage, ...model.Option) (*schema.AgenticMessage, error) {
+			return nil, errors.New("inner model should not be called")
+		},
+		streamFn: func(context.Context, []*schema.AgenticMessage, ...model.Option) (*schema.StreamReader[*schema.AgenticMessage], error) {
+			return nil, errors.New("inner model should not be called")
+		},
+	}
+	handler := &syntheticAgenticStreamHandler{
+		TypedBaseChatModelAgentMiddleware: &TypedBaseChatModelAgentMiddleware[*schema.AgenticMessage]{},
+		message:                           synthetic,
+		release:                           release,
+	}
+	agent, err := NewTypedChatModelAgent(ctx, &TypedChatModelAgentConfig[*schema.AgenticMessage]{
+		Name:     "synthetic-stream-message-id",
+		Model:    inner,
+		Handlers: []TypedChatModelAgentMiddleware[*schema.AgenticMessage]{handler},
+	})
+	require.NoError(t, err)
+
+	iter := agent.Run(ctx, &TypedAgentInput[*schema.AgenticMessage]{
+		Messages:        []*schema.AgenticMessage{schema.UserAgenticMessage("hi")},
+		EnableStreaming: true,
+	})
+	event, ok := iter.Next()
+	require.True(t, ok)
+	require.NoError(t, event.Err)
+	require.NotNil(t, event.Output)
+	require.NotNil(t, event.Output.MessageOutput)
+	require.True(t, event.Output.MessageOutput.IsStreaming)
+
+	chunk, err := event.Output.MessageOutput.MessageStream.Recv()
+	require.NoError(t, err)
+	assert.NotEmpty(t, GetMessageID(chunk), "synthetic stream output should have an ID before event fan-out")
+	assert.Empty(t, GetMessageID(synthetic), "assigning the framework ID should not mutate the handler-owned message")
+
+	close(release)
+	released = true
+	for {
+		_, ok = iter.Next()
+		if !ok {
+			break
+		}
+	}
+}
+
 // Scenario 7: User input messages do NOT get automatic IDs (they are external, not framework-created).
 // Only framework-created messages (model output, tool results, TypedSendEvent) get auto-assigned IDs.
 func TestMessageID_UserInputNoAutoID(t *testing.T) {

--- a/adk/wrappers.go
+++ b/adk/wrappers.go
@@ -547,6 +547,14 @@ func (m *typedEventSenderModel[M]) Generate(ctx context.Context, input []M, opts
 	startEvent := newModelSpanStartEvent[M](ctx, spanID, started, opts...)
 	sendSessionTimelineEvent(ctx, startEvent)
 	result, err := m.inner.Generate(ctx, input, opts...)
+	if err == nil {
+		// Symmetric with Stream below: a WrapModel handler may short-circuit the
+		// inner model and return a message that never passed through the innermost
+		// ID assignment layer. Stamp it here, before the span, draft, and live
+		// event each take an independent copy -- otherwise every consumer lazily
+		// assigns its own ID and one logical message ends up with several.
+		result = ensureMessageIDCOW(result)
+	}
 	ended := newEventTimestamp()
 	sendSessionTimelineEvent(ctx, newModelSpanEndEvent(ctx, modelSpanEndEventInput[M]{
 		spanID:       spanID,

--- a/adk/wrappers.go
+++ b/adk/wrappers.go
@@ -629,6 +629,23 @@ func (m *typedEventSenderModel[M]) Stream(ctx context.Context, input []M, opts .
 		return nil, errors.New("generator is nil when sending event in Stream: ensure agent state is properly initialized")
 	}
 
+	// A WrapModel handler may short-circuit the inner model and synthesize a
+	// stream that bypasses the framework's innermost ID assignment layer. Assign
+	// the ID before Copy fans the message out to event persistence, state, and
+	// tracing consumers. Copy the first chunk before mutation because the handler
+	// may retain or concurrently inspect the message it returned.
+	first := true
+	result = schema.StreamReaderWithConvert(result, func(msg M) (M, error) {
+		if first {
+			first = false
+			if GetMessageID(msg) == "" {
+				msg = copyMessage(msg)
+				typedSetMessageID(msg, uuid.NewString())
+			}
+		}
+		return msg, nil
+	})
+
 	streams := result.Copy(3)
 
 	eventStream := streams[0]

--- a/adk/wrappers.go
+++ b/adk/wrappers.go
@@ -632,19 +632,8 @@ func (m *typedEventSenderModel[M]) Stream(ctx context.Context, input []M, opts .
 	// A WrapModel handler may short-circuit the inner model and synthesize a
 	// stream that bypasses the framework's innermost ID assignment layer. Assign
 	// the ID before Copy fans the message out to event persistence, state, and
-	// tracing consumers. Copy the first chunk before mutation because the handler
-	// may retain or concurrently inspect the message it returned.
-	first := true
-	result = schema.StreamReaderWithConvert(result, func(msg M) (M, error) {
-		if first {
-			first = false
-			if GetMessageID(msg) == "" {
-				msg = copyMessage(msg)
-				typedSetMessageID(msg, uuid.NewString())
-			}
-		}
-		return msg, nil
-	})
+	// tracing consumers, so they only ever share an already-identified message.
+	result = stampFirstChunkMessageID(result)
 
 	streams := result.Copy(3)
 
@@ -666,7 +655,13 @@ func (m *typedEventSenderModel[M]) Stream(ctx context.Context, input []M, opts .
 	sc := sessionEventContextFromContext[M](ctx)
 	stampSessionEventTurnID(assistantDraft, sc.turnID)
 	if err := prepareSessionEventEnvelope(ctx, assistantDraft, sc.generator, sc.provider, sessionEventEnvelopeOptions{AllowPayloadlessDraft: true}); err != nil {
-		result.Close()
+		// result has already been fanned out, so it is the children that own the
+		// underlying stream now: parentStreamReader releases it once all of them
+		// close. Closing result directly would tear the stream down from under
+		// the children and leave the copies unclosed.
+		for _, s := range streams {
+			s.Close()
+		}
 		return nil, err
 	}
 	assistantMsgEventID := assistantDraft.EventID
@@ -940,6 +935,55 @@ func EnsureMessageID[M MessageType](msg M) {
 			v.Extra = internal.EnsureMessageID(v.Extra)
 		}
 	}
+}
+
+// ensureMessageIDCOW returns a message guaranteed to carry a framework message
+// ID, taking ownership of the struct before the ID is written. Callers must use
+// the returned value; msg itself is never modified.
+//
+// ID assignment is three layers, each adding exactly one thing:
+//
+//   - internal.SetMessageID builds a new Extra map, never touching the input map.
+//     That removes the map-level "concurrent map read and map write" panic.
+//   - EnsureMessageID assigns that map back into msg.Extra. This is an in-place
+//     field write, and it is safe only when the caller owns msg.
+//   - this function establishes that ownership by copying first, then delegates.
+//
+// In-place mutation is not the problem; mutating a struct someone else may read
+// is. The framework does not own model output -- it may be a pointer the user's
+// model implementation retains, or a message a WrapModel handler synthesized and
+// still inspects -- so it copies the struct and lets the field write land on
+// memory only this call can see. That closes the residual field-level race
+// documented on internal.SetMessageID, which cannot be fixed at the map layer.
+func ensureMessageIDCOW[M MessageType](msg M) M {
+	if isNilMessage(msg) || GetMessageID(msg) != "" {
+		return msg
+	}
+	cp := copyMessage(msg)
+	EnsureMessageID(cp)
+	return cp
+}
+
+// stampFirstChunkMessageID guarantees the first chunk of sr carries a framework
+// message ID, assigned before any downstream fan-out can hand that chunk to
+// concurrent consumers.
+//
+// Only the first chunk is stamped: ConcatMessages string-concatenates duplicate
+// Extra keys, so stamping every chunk would corrupt the ID on concat.
+//
+// The first flag needs no synchronization even when the returned reader is later
+// Copy'd: parentStreamReader.peek guards the parent Recv (and therefore this
+// convert) with a sync.Once, so it runs exactly once per element and the
+// happens-before edge covers every child reader.
+func stampFirstChunkMessageID[M MessageType](sr *schema.StreamReader[M]) *schema.StreamReader[M] {
+	first := true
+	return schema.StreamReaderWithConvert(sr, func(msg M) (M, error) {
+		if first {
+			first = false
+			return ensureMessageIDCOW(msg), nil
+		}
+		return msg, nil
+	})
 }
 
 func ensureTypedAgentEventMessageIDs[M MessageType](event *TypedAgentEvent[M]) {
@@ -1793,11 +1837,7 @@ func (w *typedStateModelWrapper[M]) wrapGenerateEndpoint(endpoint typedGenerateE
 			if err != nil {
 				return result, err
 			}
-			if GetMessageID(result) == "" {
-				result = copyMessage(result)
-				EnsureMessageID(result)
-			}
-			return result, nil
+			return ensureMessageIDCOW(result), nil
 		}
 	}
 
@@ -1865,9 +1905,9 @@ func (w *typedStateModelWrapper[M]) wrapGenerateEndpoint(endpoint typedGenerateE
 
 func (w *typedStateModelWrapper[M]) wrapStreamEndpoint(endpoint typedStreamEndpoint[M]) typedStreamEndpoint[M] {
 	// === ID Assignment layer (innermost, framework-controlled) ===
-	// Pre-allocates a UUID and injects it into the first chunk only.
-	// Only the first chunk carries the ID in Extra to avoid concatStrings corruption
-	// during ConcatMessages (which string-concatenates duplicate Extra keys).
+	// Ensures model output has a message ID before any WrapModel handler or event
+	// sender sees it. Copies the first chunk rather than writing the model's own
+	// chunk in place, matching the Generate layer above.
 	{
 		realInner := endpoint
 		endpoint = func(ctx context.Context, input []M, opts ...model.Option) (*schema.StreamReader[M], error) {
@@ -1875,17 +1915,7 @@ func (w *typedStateModelWrapper[M]) wrapStreamEndpoint(endpoint typedStreamEndpo
 			if err != nil {
 				return nil, err
 			}
-			msgID := uuid.NewString()
-			first := true
-			return schema.StreamReaderWithConvert(reader, func(msg M) (M, error) {
-				if first {
-					first = false
-					if GetMessageID(msg) == "" {
-						typedSetMessageID(msg, msgID)
-					}
-				}
-				return msg, nil
-			}), nil
+			return stampFirstChunkMessageID(reader), nil
 		}
 	}
 
@@ -2042,7 +2072,13 @@ func (w *typedStateModelWrapper[M]) Generate(ctx context.Context, _ []M, opts ..
 		})
 	}
 
-	EnsureMessageID(result)
+	// Normally a no-op: the innermost ID layer already stamped result. It is
+	// load-bearing when a WrapModel handler short-circuits the inner model from
+	// outside a user-supplied event sender (NewEventSenderModelWrapper is exported,
+	// so Handlers[0] can sit outside it) -- then result is a handler-owned message
+	// with no ID, and an in-place write here would mutate memory the handler still
+	// holds. Copy-on-write keeps that write on framework-owned memory.
+	result = ensureMessageIDCOW(result)
 	state.Messages = append(state.Messages, result)
 
 	for _, handler := range w.handlers {
@@ -2171,7 +2207,12 @@ func (w *typedStateModelWrapper[M]) Stream(ctx context.Context, _ []M, opts ...m
 		})
 	}
 
-	EnsureMessageID(result)
+	// Here the copy is provably redundant today -- result is a ConcatMessages
+	// product, which always allocates a fresh struct -- so this is the same
+	// no-op as an in-place write would be. Kept in the copy-on-write form so
+	// "the framework never writes a message it does not own" holds by reading,
+	// without depending on a concat implementation detail from another package.
+	result = ensureMessageIDCOW(result)
 	state.Messages = append(state.Messages, result)
 
 	for _, handler := range w.handlers {


### PR DESCRIPTION
#### What type of PR is this?

fix

#### Check the PR title.

- [x] This PR title match the format: \<type\>(optional scope): \<description\>
- [x] The description of this PR title is user-oriented and clear enough for others to understand.
- [x] Attach the PR updating the user documentation if the current PR requires user awareness at the usage level. [User docs repo](https://github.com/cloudwego/cloudwego.github.io)

No user documentation update is required because this only fixes an internal stream ownership race.

#### (Optional) Translate the PR title into Chinese.

fix(adk): 防止合成 AgenticMessage 流发生数据竞态

#### (Optional) More detailed description for this PR(en: English/zh: Chinese).

en:

A `WrapModel` handler can short-circuit the inner model and synthesize an agentic message stream. That stream bypasses the innermost message-ID assignment layer. Previously, `typedEventSenderModel.Stream` fanned the stream out with `Copy(3)` before another consumer assigned the missing ID, so event persistence could serialize a message while its shared `Extra` map was being mutated.

This change:

- assigns a missing ID to the first synthetic stream chunk before event, state, and tracing consumers are fanned out;
- copies the first message before mutation so a handler-owned message is not modified by the framework;
- adds a deterministic regression test that holds the synthetic stream open and checks the emitted chunk already has an ID before EOF.

Validation:

- `go test -race ./adk`
- `go test ./...`
- `golangci-lint run --timeout 5m ./adk/...`
- the downstream Base Agent regression case passed 100 times with `-race` against this local Eino change

zh(optional):

`WrapModel` handler 可以跳过内部模型并直接合成 AgenticMessage 流，这会绕过最内层的 Message ID 注入。此前 `typedEventSenderModel.Stream` 在 `Copy(3)` fan-out 后，另一个消费者才补写 ID，导致事件持久化序列化消息时可能与共享 `Extra` map 的写入并发。

本修改在 fan-out 前为首个合成消息补齐 ID，并先复制消息以避免修改 handler 持有的对象，同时新增可稳定复现该时序的回归测试。

#### (Optional) Which issue(s) this PR fixes:

N/A

#### (optional) The PR that updates user documentation:

N/A
