### PR TITLE
feat(adk): expose descriptions in task-created events

### DIFF
--- a/adk/backgroundtask/session_event.go
+++ b/adk/backgroundtask/session_event.go
@@ -33,7 +33,8 @@ const SessionEventTaskCreated adk.SessionEventKind = "x.eino.background_task.cre
 // TaskCreatedSessionEvent is the extension payload for
 // SessionEventTaskCreated.
 type TaskCreatedSessionEvent struct {
-	TaskID string `json:"task_id"`
+	TaskID      string `json:"task_id"`
+	Description string `json:"description"`
 }
 
 var taskCreatedSessionEventNamespace = uuid.MustParse("fddebb92-8d8a-4ae4-a652-7a49bbb4de2e")
@@ -75,7 +76,9 @@ func TaskCreatedSessionEventSender[M adk.MessageType]() func(context.Context, *T
 					Timestamp: task.CreatedAt,
 					Kind:      SessionEventTaskCreated,
 					Extension: &adk.SessionExtensionEvent{
-						Data: &TaskCreatedSessionEvent{TaskID: task.Spec.ID},
+						Data: &TaskCreatedSessionEvent{
+							TaskID: task.Spec.ID, Description: task.Spec.Description,
+						},
 					},
 				},
 			},

--- a/adk/backgroundtask/session_event_test.go
+++ b/adk/backgroundtask/session_event_test.go
@@ -83,6 +83,7 @@ func TestManagerSubmitAppendsTaskCreatedSessionEvent_BitsUT(t *testing.T) {
 				spec := validSpec("task-created")
 				spec.SessionID = sessionID
 				spec.NotifySession = false
+				spec.Description = "Research task creation"
 				var submitErr error
 				task, submitErr = manager.Submit(runCtx, &SubmitRequest{Spec: spec})
 				return submitErr
@@ -118,6 +119,7 @@ func TestManagerSubmitAppendsTaskCreatedSessionEvent_BitsUT(t *testing.T) {
 	payload, ok := event.Extension.Data.(*TaskCreatedSessionEvent)
 	require.True(t, ok)
 	require.Equal(t, task.Spec.ID, payload.TaskID)
+	require.Equal(t, "Research task creation", payload.Description)
 }
 
 func TestManagerSubmitReturnsUndeliveredSentinelAfterCreate_BitsUT(t *testing.T) {


### PR DESCRIPTION
#### What type of PR is this?

feat

#### Check the PR title.

- [x] This PR title matches the format: `<type>(optional scope): <description>`
- [x] The description is user-oriented and clear enough for others to understand.
- [x] User documentation is not required for this event payload extension.

#### (Optional) Translate the PR title into Chinese.

feat(adk): 在任务创建事件中暴露任务描述

#### (Optional) More detailed description for this PR(en: English/zh: Chinese).

en:

`TaskCreatedSessionEvent` now carries the immutable task description alongside the task ID. `TaskCreatedSessionEventSender` copies the value from `Task.Spec.Description`, allowing session event consumers to display a task immediately without querying the task store.

The focused background-task test verifies that the submitted description survives event emission and session persistence.

Validation: `go test ./adk/backgroundtask -count=1`.

zh(optional):

`TaskCreatedSessionEvent` 新增任务描述，并由通用 sender 从 `Task.Spec.Description` 透传。会话事件消费者可直接展示任务信息，无需额外查询 task store。