### PR TITLE
fix(compose): preserve checkpoints after resumed stream timeout

### DIFF
--- a/adk/interrupt.go
+++ b/adk/interrupt.go
@@ -359,9 +359,7 @@ func newBridgeStore() *bridgeStore {
 func newResumeBridgeStore(checkPointID string, data []byte) *bridgeStore {
 	payload := append([]byte{}, data...)
 	return &bridgeStore{
-		data:        map[string][]byte{checkPointID: payload},
-		lastKey:     checkPointID,
-		lastPayload: payload,
+		data: map[string][]byte{checkPointID: payload},
 	}
 }
 

--- a/adk/interrupt_test.go
+++ b/adk/interrupt_test.go
@@ -59,6 +59,25 @@ func TestPreprocessADKCheckpoint(t *testing.T) {
 	})
 }
 
+func TestAttack_ResumeBridgeStoreRequiresFreshWrite(t *testing.T) {
+	store := newResumeBridgeStore("checkpoint", []byte("loaded"))
+	t.Log("a resume bridge must distinguish a loaded checkpoint from a replacement")
+
+	loaded, ok, err := store.Get(context.Background(), "checkpoint")
+	assert.NoError(t, err)
+	assert.True(t, ok)
+	assert.Equal(t, []byte("loaded"), loaded)
+
+	_, _, ok = store.LastCheckpoint()
+	assert.False(t, ok, "loaded checkpoints must not be reported as fresh writes")
+
+	assert.NoError(t, store.Set(context.Background(), "checkpoint", []byte("saved")))
+	key, saved, ok := store.LastCheckpoint()
+	assert.True(t, ok)
+	assert.Equal(t, "checkpoint", key)
+	assert.Equal(t, []byte("saved"), saved)
+}
+
 func (h *interruptTestToolsHandler) BeforeAgent(ctx context.Context, runCtx *ChatModelAgentContext[*schema.Message]) (context.Context, *ChatModelAgentContext[*schema.Message], error) {
 	runCtx.Tools = append(runCtx.Tools, h.tools...)
 	return ctx, runCtx, nil

--- a/adk/turn_loop_test.go
+++ b/adk/turn_loop_test.go
@@ -2841,6 +2841,215 @@ func TestTurnLoop_ResumeInterruptAgain_PreservesEnableStreamingCheckpoint(t *tes
 	}
 }
 
+type turnLoopTargetedResumeTimeoutModel struct {
+	calls         int32
+	secondStarted chan struct{}
+	thirdStarted  chan struct{}
+	release       chan struct{}
+}
+
+func (m *turnLoopTargetedResumeTimeoutModel) Generate(ctx context.Context, input []*schema.Message, opts ...model.Option) (*schema.Message, error) {
+	reader, err := m.Stream(ctx, input, opts...)
+	if err != nil {
+		return nil, err
+	}
+	defer reader.Close()
+	msg, err := reader.Recv()
+	if err != nil {
+		return nil, err
+	}
+	return msg, nil
+}
+
+func (m *turnLoopTargetedResumeTimeoutModel) Stream(_ context.Context, _ []*schema.Message, _ ...model.Option) (*schema.StreamReader[*schema.Message], error) {
+	switch atomic.AddInt32(&m.calls, 1) {
+	case 1:
+		return schema.StreamReaderFromArray([]*schema.Message{{
+			Role: schema.Assistant,
+			ToolCalls: []schema.ToolCall{{
+				ID:   "ask_1",
+				Type: "function",
+				Function: schema.FunctionCall{
+					Name:      "ask_user",
+					Arguments: `{"question":"continue?"}`,
+				},
+			}},
+		}}), nil
+	case 2:
+		reader, writer := schema.Pipe[*schema.Message](1)
+		go func() {
+			defer writer.Close()
+			writer.Send(schema.AssistantMessage("partial", nil), nil)
+			close(m.secondStarted)
+			<-m.release
+		}()
+		return reader, nil
+	default:
+		close(m.thirdStarted)
+		return schema.StreamReaderFromArray([]*schema.Message{schema.AssistantMessage("resumed", nil)}), nil
+	}
+}
+
+func (m *turnLoopTargetedResumeTimeoutModel) BindTools(_ []*schema.ToolInfo) error { return nil }
+
+type turnLoopTargetedResumeTool struct {
+	calls int32
+}
+
+func (t *turnLoopTargetedResumeTool) Info(_ context.Context) (*schema.ToolInfo, error) {
+	return &schema.ToolInfo{
+		Name: "ask_user",
+		ParamsOneOf: schema.NewParamsOneOfByParams(map[string]*schema.ParameterInfo{
+			"question": {Type: schema.String},
+		}),
+	}, nil
+}
+
+func (t *turnLoopTargetedResumeTool) InvokableRun(ctx context.Context, _ string, _ ...tool.Option) (string, error) {
+	atomic.AddInt32(&t.calls, 1)
+	wasInterrupted, _, _ := tool.GetInterruptState[string](ctx)
+	isTarget, hasAnswer, answer := tool.GetResumeContext[string](ctx)
+	if wasInterrupted && isTarget && hasAnswer {
+		return answer, nil
+	}
+	return "", tool.StatefulInterrupt(ctx, "answer required", "awaiting answer")
+}
+
+type recordingTurnLoopCheckpointStore struct {
+	mu sync.Mutex
+	m  map[string][]byte
+}
+
+func (s *recordingTurnLoopCheckpointStore) Set(_ context.Context, key string, value []byte) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.m[key] = append([]byte{}, value...)
+	return nil
+}
+
+func (s *recordingTurnLoopCheckpointStore) Get(_ context.Context, key string) ([]byte, bool, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	value, ok := s.m[key]
+	return append([]byte{}, value...), ok, nil
+}
+
+func TestTurnLoop_TargetedResume_TimeoutEscalationReplacesCheckpoint(t *testing.T) {
+	ctx := context.Background()
+	store := &recordingTurnLoopCheckpointStore{m: make(map[string][]byte)}
+	model := &turnLoopTargetedResumeTimeoutModel{
+		secondStarted: make(chan struct{}),
+		thirdStarted:  make(chan struct{}),
+		release:       make(chan struct{}),
+	}
+	t.Cleanup(func() { close(model.release) })
+	askUser := &turnLoopTargetedResumeTool{}
+
+	agent, err := NewChatModelAgent(ctx, &ChatModelAgentConfig{
+		Name:        "TargetedResumeTimeout",
+		Description: "test agent",
+		Model:       model,
+		ToolsConfig: ToolsConfig{
+			ToolsNodeConfig: compose.ToolsNodeConfig{Tools: []tool.BaseTool{askUser}},
+		},
+	})
+	require.NoError(t, err)
+
+	var interruptID string
+	observeInterrupt := func(_ context.Context, _ *TurnContext[string, *schema.Message], events *AsyncIterator[*AgentEvent]) error {
+		for {
+			event, ok := events.Next()
+			if !ok {
+				return nil
+			}
+			if event.Action != nil && event.Action.Interrupted != nil {
+				for _, interrupt := range event.Action.Interrupted.InterruptContexts {
+					if interrupt.IsRootCause {
+						interruptID = interrupt.ID
+					}
+				}
+			}
+			if event.Err != nil {
+				return event.Err
+			}
+		}
+	}
+	newLoop := func(genResume TurnLoopConfig[string, *schema.Message]) *TurnLoop[string, *schema.Message] {
+		genResume.Store = store
+		genResume.CheckpointID = "targeted-resume-timeout"
+		genResume.GenInput = func(_ context.Context, _ *TurnLoop[string, *schema.Message], items []string) (*GenInputResult[string, *schema.Message], error) {
+			return &GenInputResult[string, *schema.Message]{
+				Input: &AgentInput{
+					Messages:        []Message{schema.UserMessage(items[0])},
+					EnableStreaming: true,
+				},
+				Consumed: items,
+			}, nil
+		}
+		genResume.PrepareAgent = prepareAgent(agent)
+		genResume.OnAgentEvents = observeInterrupt
+		return NewTurnLoop(genResume)
+	}
+
+	owner1 := newLoop(TurnLoopConfig[string, *schema.Message]{})
+	owner1.Push("start")
+	owner1.Run(ctx)
+	exit1 := owner1.Wait()
+	require.ErrorAs(t, exit1.ExitReason, new(*InterruptError))
+	require.True(t, exit1.CheckpointAttempted)
+	require.NoError(t, exit1.CheckpointErr)
+	require.NotEmpty(t, interruptID)
+	firstCheckpoint, ok, err := store.Get(ctx, "targeted-resume-timeout")
+	require.NoError(t, err)
+	require.True(t, ok)
+	firstTurnLoopCheckpoint, err := unmarshalTurnLoopCheckpoint[string](firstCheckpoint)
+	require.NoError(t, err)
+
+	owner2 := newLoop(TurnLoopConfig[string, *schema.Message]{
+		GenResume: func(_ context.Context, _ *TurnLoop[string, *schema.Message], _, _, _ []string) (*GenResumeResult[string, *schema.Message], error) {
+			return &GenResumeResult[string, *schema.Message]{
+				ResumeParams: &ResumeParams{Targets: map[string]any{interruptID: "approved"}},
+			}, nil
+		},
+	})
+	owner2.Run(ctx)
+	select {
+	case <-model.secondStarted:
+	case <-time.After(5 * time.Second):
+		t.Fatal("resumed model call did not begin streaming")
+	}
+	owner2.Stop(WithGracefulTimeout(20 * time.Millisecond))
+	exit2 := owner2.Wait()
+	require.True(t, exit2.CheckpointAttempted)
+	require.NoError(t, exit2.CheckpointErr)
+
+	finalCheckpoint, ok, err := store.Get(ctx, "targeted-resume-timeout")
+	require.NoError(t, err)
+	require.True(t, ok)
+	finalTurnLoopCheckpoint, err := unmarshalTurnLoopCheckpoint[string](finalCheckpoint)
+	require.NoError(t, err)
+	require.NotEqual(t, firstTurnLoopCheckpoint.RunnerCheckpoint, finalTurnLoopCheckpoint.RunnerCheckpoint,
+		"timeout escalation must replace the resumed runner checkpoint")
+
+	owner3 := newLoop(TurnLoopConfig[string, *schema.Message]{
+		GenResume: func(_ context.Context, _ *TurnLoop[string, *schema.Message], _, _, _ []string) (*GenResumeResult[string, *schema.Message], error) {
+			return &GenResumeResult[string, *schema.Message]{}, nil
+		},
+	})
+	owner3.Run(ctx)
+	select {
+	case <-model.thirdStarted:
+		owner3.Stop()
+		exit3 := owner3.Wait()
+		require.NotErrorAs(t, exit3.ExitReason, new(*InterruptError))
+	case <-owner3.done:
+		require.NotErrorAs(t, owner3.Wait().ExitReason, new(*InterruptError))
+	case <-time.After(5 * time.Second):
+		t.Fatal("targetless resume did not continue from the replacement checkpoint")
+	}
+	assert.Equal(t, int32(2), atomic.LoadInt32(&askUser.calls), "resolved tool interrupt must not be replayed")
+}
+
 func TestTurnLoop_Stop_EscalatesCancelMode(t *testing.T) {
 	ctx := context.Background()
 	agentStarted := make(chan *cancelContext, 1)

--- a/compose/checkpoint.go
+++ b/compose/checkpoint.go
@@ -118,6 +118,29 @@ type checkpoint struct {
 type stateModifierKey struct{}
 type checkPointKey struct{} // *checkpoint
 
+func withSubGraphCheckpointPublisher(opts []any) (
+	[]any,
+	<-chan *subGraphInterruptError,
+) {
+	ready := make(chan *subGraphInterruptError, 1)
+	childOpts := append([]any(nil), opts...)
+	childOpts = append(childOpts, Option{
+		subGraphCheckpointPublisher: func(checkpoint *subGraphInterruptError) {
+			ready <- checkpoint
+		},
+	})
+	return childOpts, ready
+}
+
+func getSubGraphCheckpointPublisher(opts ...Option) func(*subGraphInterruptError) {
+	for _, opt := range opts {
+		if opt.subGraphCheckpointPublisher != nil {
+			return opt.subGraphCheckpointPublisher
+		}
+	}
+	return nil
+}
+
 func getStateModifier(ctx context.Context) StateModifier {
 	if sm, ok := ctx.Value(stateModifierKey{}).(StateModifier); ok {
 		return sm

--- a/compose/graph_call_options.go
+++ b/compose/graph_call_options.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"fmt"
 	"reflect"
+	"sync"
 	"time"
 
 	"github.com/cloudwego/eino/callbacks"
@@ -31,9 +32,14 @@ import (
 	"github.com/cloudwego/eino/components/retriever"
 )
 
-type graphCancelChanKey struct{}
-type graphCancelChanVal struct {
-	ch chan *time.Duration
+type graphCancelSignalKey struct{}
+type graphCancelSignal struct {
+	done chan struct{}
+
+	mu        sync.RWMutex
+	triggered bool
+	timeout   *time.Duration
+	deadline  *time.Time
 }
 
 type graphInterruptOptions struct {
@@ -70,22 +76,40 @@ func WithGraphInterruptTimeout(timeout time.Duration) GraphInterruptOption {
 // or resuming from an interrupt. The recommended approach is to use compose.GetInterruptState() to explicitly
 // determine whether the current execution is a first run or a resume.
 func WithGraphInterrupt(parent context.Context) (ctx context.Context, interrupt func(opts ...GraphInterruptOption)) {
-	ch := make(chan *time.Duration, 1)
-	ctx = context.WithValue(parent, graphCancelChanKey{}, &graphCancelChanVal{
-		ch: ch,
-	})
+	cancel := &graphCancelSignal{done: make(chan struct{})}
+	ctx = context.WithValue(parent, graphCancelSignalKey{}, cancel)
 	return ctx, func(opts ...GraphInterruptOption) {
 		o := &graphInterruptOptions{}
 		for _, opt := range opts {
 			opt(o)
 		}
-		ch <- o.timeout
-		close(ch)
+		cancel.trigger(o.timeout)
 	}
 }
 
-func getGraphCancel(ctx context.Context) *graphCancelChanVal {
-	val, ok := ctx.Value(graphCancelChanKey{}).(*graphCancelChanVal)
+func (c *graphCancelSignal) trigger(timeout *time.Duration) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if c.triggered {
+		panic("compose: graph interrupt called more than once")
+	}
+	c.triggered = true
+	c.timeout = timeout
+	if timeout != nil && *timeout > 0 {
+		deadline := time.Now().Add(*timeout)
+		c.deadline = &deadline
+	}
+	close(c.done)
+}
+
+func (c *graphCancelSignal) request() (timeout *time.Duration, deadline *time.Time) {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+	return c.timeout, c.deadline
+}
+
+func getGraphCancel(ctx context.Context) *graphCancelSignal {
+	val, ok := ctx.Value(graphCancelSignalKey{}).(*graphCancelSignal)
 	if !ok {
 		return nil
 	}
@@ -104,6 +128,11 @@ type Option struct {
 	writeToCheckPointID *string
 	forceNewRun         bool
 	stateModifier       StateModifier
+
+	// subGraphCheckpointPublisher is a one-hop parent-child execution option.
+	// It is injected after option extraction and intentionally omitted from
+	// deepCopy so a child graph cannot forward its parent's publisher.
+	subGraphCheckpointPublisher func(*subGraphInterruptError)
 }
 
 func (o Option) deepCopy() Option {

--- a/compose/graph_manager.go
+++ b/compose/graph_manager.go
@@ -255,16 +255,18 @@ func appendIfNotExist(s []string, elem string) []string {
 }
 
 type task struct {
-	ctx                 context.Context
-	nodeKey             string
-	call                *chanCall
-	input               any
-	originalInput       any
-	output              any
-	option              []any
-	err                 error
-	skipPreHandler      bool
-	syntheticRerunInput bool
+	ctx                     context.Context
+	nodeKey                 string
+	call                    *chanCall
+	input                   any
+	originalInput           any
+	output                  any
+	option                  []any
+	err                     error
+	skipPreHandler          bool
+	syntheticRerunInput     bool
+	subGraphCheckpointReady <-chan *subGraphInterruptError
+	finished                chan struct{}
 }
 
 type taskManager struct {
@@ -276,7 +278,7 @@ type taskManager struct {
 	done         *internal.UnboundedChan[*task]
 	runningTasks map[string]*task
 
-	cancelCh chan *time.Duration
+	cancel   *graphCancelSignal
 	canceled bool
 	deadline *time.Time
 
@@ -291,6 +293,7 @@ func (t *taskManager) execute(currentTask *task) {
 			currentTask.err = safe.NewPanicErr(panicInfo, debug.Stack())
 		}
 
+		close(currentTask.finished)
 		t.done.Send(currentTask)
 	}()
 
@@ -308,6 +311,9 @@ func (t *taskManager) submit(tasks []*task) error {
 	// 2. the task manager mode is set to needAll
 	for i := 0; i < len(tasks); i++ {
 		currentTask := tasks[i]
+		if currentTask.finished == nil {
+			currentTask.finished = make(chan struct{})
+		}
 
 		if t.persistRerunInput && !currentTask.syntheticRerunInput {
 			if sr, ok := currentTask.input.(streamReader); ok {
@@ -325,6 +331,7 @@ func (t *taskManager) submit(tasks []*task) error {
 			tasks = append(tasks[:i], tasks[i+1:]...)
 			i--
 			t.num++
+			close(currentTask.finished)
 			t.done.Send(currentTask)
 		}
 
@@ -336,7 +343,7 @@ func (t *taskManager) submit(tasks []*task) error {
 	}
 
 	var syncTask *task
-	if t.num == 0 && (len(tasks) == 1 || t.needAll) && t.cancelCh == nil /*if graph can be interrupted by user, shouldn't sync run task*/ {
+	if t.num == 0 && (len(tasks) == 1 || t.needAll) && t.cancel == nil /*if graph can be interrupted by user, shouldn't sync run task*/ {
 		syncTask = tasks[0]
 		tasks = tasks[1:]
 	}
@@ -359,13 +366,13 @@ func (t *taskManager) wait() (tasks []*task, canceled bool, canceledTasks []*tas
 
 	ta, success, canceled := t.waitOne()
 	if canceled {
-		// has canceled and timeout, return canceled tasks
-		for _, rta := range t.runningTasks {
-			canceledTasks = append(canceledTasks, rta)
-		}
+		// A framework-owned subgraph can always observe the same graph
+		// interrupt and produce its own stable checkpoint. Wait for that
+		// handoff before the parent snapshots its state.
+		tasks, canceledTasks = t.settleCanceledSubgraphs()
 		t.runningTasks = make(map[string]*task)
 		t.num = 0
-		return nil, true, canceledTasks
+		return tasks, true, canceledTasks
 	}
 	if t.canceled {
 		// has canceled, but not timeout, wait all
@@ -384,20 +391,23 @@ func (t *taskManager) waitOne() (ta *task, success bool, canceled bool) {
 		return nil, false, false
 	}
 
-	if t.cancelCh == nil {
+	if t.cancel == nil {
 		ta, _ = t.done.Receive()
 	} else {
 		ta, _, canceled = t.receive(t.done.Receive)
 	}
 
-	t.num--
-
 	if canceled {
 		return nil, false, true
 	}
 
+	t.num--
 	delete(t.runningTasks, ta.nodeKey)
+	t.finishTask(ta)
+	return ta, true, false
+}
 
+func (t *taskManager) finishTask(ta *task) {
 	if ta.originalInput != nil && (ta.err == nil || !isInterruptError(ta.err)) {
 		if sr, ok := ta.originalInput.(streamReader); ok {
 			sr.close()
@@ -407,10 +417,47 @@ func (t *taskManager) waitOne() (ta *task, success bool, canceled bool) {
 
 	if ta.err != nil {
 		// biz error, jump post processor
-		return ta, true, false
+		return
 	}
 	runPostHandler(ta, t.runWrapper)
-	return ta, true, false
+}
+
+func (t *taskManager) settleCanceledSubgraphs() (completedTasks, canceledTasks []*task) {
+	for key, runningTask := range t.runningTasks {
+		if runningTask.subGraphCheckpointReady == nil {
+			continue
+		}
+
+		var completedTask *task
+		select {
+		case subGraphCheckpoint := <-runningTask.subGraphCheckpointReady:
+			completedTask = &task{
+				ctx:                     runningTask.ctx,
+				nodeKey:                 runningTask.nodeKey,
+				call:                    runningTask.call,
+				input:                   runningTask.input,
+				originalInput:           runningTask.originalInput,
+				option:                  runningTask.option,
+				err:                     subGraphCheckpoint,
+				skipPreHandler:          runningTask.skipPreHandler,
+				syntheticRerunInput:     runningTask.syntheticRerunInput,
+				subGraphCheckpointReady: runningTask.subGraphCheckpointReady,
+				finished:                runningTask.finished,
+			}
+		case <-runningTask.finished:
+			completedTask = runningTask
+		}
+
+		t.num--
+		delete(t.runningTasks, key)
+		t.finishTask(completedTask)
+		completedTasks = append(completedTasks, completedTask)
+	}
+
+	for _, runningTask := range t.runningTasks {
+		canceledTasks = append(canceledTasks, runningTask)
+	}
+	return completedTasks, canceledTasks
 }
 
 func (t *taskManager) waitAll() (successTasks []*task, canceledTasks []*task) {
@@ -418,12 +465,11 @@ func (t *taskManager) waitAll() (successTasks []*task, canceledTasks []*task) {
 	for {
 		ta, success, canceled := t.waitOne()
 		if canceled {
-			for _, rt := range t.runningTasks {
-				canceledTasks = append(canceledTasks, rt)
-			}
+			settledTasks, remainingTasks := t.settleCanceledSubgraphs()
+			result = append(result, settledTasks...)
 			t.runningTasks = make(map[string]*task)
 			t.num = 0
-			return result, canceledTasks
+			return result, remainingTasks
 		}
 		if !success {
 			return result, nil
@@ -442,9 +488,9 @@ func (t *taskManager) receive(recv func() (*task, bool)) (ta *task, closed bool,
 		ta, closed = recv()
 		return ta, closed, false
 	}
-	if t.cancelCh != nil {
+	if t.cancel != nil {
 		// have not canceled, receive while listening
-		ta, closed, canceled, t.canceled, t.deadline = receiveWithListening(recv, t.cancelCh)
+		ta, closed, canceled, t.canceled, t.deadline = receiveWithListening(recv, t.cancel)
 		return ta, closed, canceled
 	}
 	// won't cancel
@@ -477,7 +523,10 @@ func receiveWithDeadline(recv func() (*task, bool), deadline time.Time) (ta *tas
 	}
 }
 
-func receiveWithListening(recv func() (*task, bool), cancel chan *time.Duration) (*task, bool, bool, bool, *time.Time) {
+func receiveWithListening(
+	recv func() (*task, bool),
+	cancel *graphCancelSignal,
+) (*task, bool, bool, bool, *time.Time) {
 	type pair struct {
 		ta     *task
 		closed bool
@@ -504,10 +553,8 @@ func receiveWithListening(recv func() (*task, bool), cancel chan *time.Duration)
 		// cancel call — that residual race is inherent to unsynchronized
 		// concurrent channel signals.
 		select {
-		case timeout, ok := <-cancel:
-			if !ok {
-				return nil, false, true, true, nil
-			}
+		case <-cancel.done:
+			timeout, requestedDeadline := cancel.request()
 			if timeout == nil {
 				// Unlimited grace period: the task's real result is authoritative.
 				return p.ta, p.closed, false, true, nil
@@ -516,20 +563,12 @@ func receiveWithListening(recv func() (*task, bool), cancel chan *time.Duration)
 				now := time.Now()
 				return nil, false, true, true, &now
 			}
-			dt := time.Now().Add(*timeout)
-			return p.ta, p.closed, false, true, &dt
+			return p.ta, p.closed, false, true, requestedDeadline
 		default:
 			return p.ta, p.closed, false, false, nil
 		}
-	case timeout, ok := <-cancel:
-		if !ok {
-			// The cancel channel has been closed — this means a previous call to
-			// receiveWithListening already consumed the cancel signal (task completed
-			// at the same time as cancel, and select picked the task result). Since
-			// cancel was already issued, treat this as an immediate cancel rather than
-			// blocking forever on resultCh.
-			return nil, false, true, true, nil
-		}
+	case <-cancel.done:
+		timeout, requestedDeadline := cancel.request()
 		canceled = true
 		if timeout == nil {
 			break
@@ -547,9 +586,12 @@ func receiveWithListening(recv func() (*task, bool), cancel chan *time.Duration)
 			now := time.Now()
 			return nil, false, true, true, &now
 		}
-		timeoutCh = time.After(*timeout)
-		dt := time.Now().Add(*timeout)
-		deadline = &dt
+		deadline = requestedDeadline
+		remaining := time.Until(*deadline)
+		if remaining <= 0 {
+			return nil, false, true, true, deadline
+		}
+		timeoutCh = time.After(remaining)
 	}
 
 	if timeoutCh != nil {

--- a/compose/graph_manager_test.go
+++ b/compose/graph_manager_test.go
@@ -17,11 +17,115 @@
 package compose
 
 import (
+	"context"
+	"errors"
 	"testing"
 	"time"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/cloudwego/eino/internal"
 )
+
+func triggeredGraphCancel(timeout *time.Duration) *graphCancelSignal {
+	cancel := &graphCancelSignal{done: make(chan struct{})}
+	cancel.trigger(timeout)
+	return cancel
+}
+
+func TestGraphCancelBroadcast(t *testing.T) {
+	timeout := 100 * time.Millisecond
+	cancel := triggeredGraphCancel(&timeout)
+
+	for i := 0; i < 3; i++ {
+		select {
+		case <-cancel.done:
+			gotTimeout, deadline := cancel.request()
+			require.NotNil(t, gotTimeout)
+			assert.Equal(t, timeout, *gotTimeout)
+			assert.NotNil(t, deadline)
+		case <-time.After(time.Second):
+			t.Fatalf("listener %d did not observe graph cancellation", i)
+		}
+	}
+}
+
+func TestTaskManagerSettleCanceledSubgraphUsesPublishedCheckpoint(t *testing.T) {
+	ready := make(chan *subGraphInterruptError, 1)
+	published := &subGraphInterruptError{CheckPoint: &checkpoint{}}
+	ready <- published
+
+	subGraphTask := &task{
+		nodeKey:                 "subgraph",
+		subGraphCheckpointReady: ready,
+		finished:                make(chan struct{}),
+	}
+	manager := &taskManager{
+		num:          1,
+		runningTasks: map[string]*task{"subgraph": subGraphTask},
+	}
+
+	completed, canceled := manager.settleCanceledSubgraphs()
+
+	require.Len(t, completed, 1)
+	assert.Same(t, published, completed[0].err)
+	assert.Empty(t, canceled)
+}
+
+func TestAttack_SubGraphCheckpointPublisherIsOneHop(t *testing.T) {
+	rawOpts, ready := withSubGraphCheckpointPublisher(nil)
+	opts, err := convertOption[Option](rawOpts...)
+	require.NoError(t, err)
+
+	publish := getSubGraphCheckpointPublisher(opts...)
+	require.NotNil(t, publish)
+	want := &subGraphInterruptError{CheckPoint: &checkpoint{}}
+	publish(want)
+	assert.Same(t, want, <-ready)
+
+	nodes := map[string]*chanCall{
+		"nested": {action: &composableRunnable{optionType: nil}},
+	}
+	forwarded, err := extractOption(nodes, opts...)
+	assert.NoError(t, err)
+	assert.Empty(t, forwarded, "the parent publisher must not propagate into a grandchild graph")
+}
+
+func TestTaskManagerPreHandlerFailureClosesFinished(t *testing.T) {
+	wantErr := errors.New("pre-handler failed")
+	preProcessor := &composableRunnable{}
+	failedTask := &task{
+		nodeKey: "subgraph",
+		call: &chanCall{
+			action:       &composableRunnable{},
+			preProcessor: preProcessor,
+		},
+		subGraphCheckpointReady: make(chan *subGraphInterruptError),
+	}
+	manager := &taskManager{
+		runWrapper: func(_ context.Context, runnable *composableRunnable, _ any, _ ...any) (any, error) {
+			if runnable == preProcessor {
+				return nil, wantErr
+			}
+			return nil, nil
+		},
+		done:         internal.NewUnboundedChan[*task](),
+		runningTasks: make(map[string]*task),
+	}
+
+	require.NoError(t, manager.submit([]*task{failedTask}))
+	select {
+	case <-failedTask.finished:
+	case <-time.After(time.Second):
+		t.Fatal("pre-handler failure did not mark task as finished")
+	}
+
+	completed, canceled := manager.settleCanceledSubgraphs()
+	require.Len(t, completed, 1)
+	assert.ErrorIs(t, completed[0].err, wantErr)
+	assert.Empty(t, canceled)
+}
 
 // TestReceiveWithListening_ZeroTimeout_WinsAgainstDelayedTaskCompletion
 // covers https://github.com/cloudwego/eino/issues/1148 at the compose level.
@@ -49,16 +153,13 @@ func TestReceiveWithListening_ZeroTimeout_WinsAgainstDelayedTaskCompletion(t *te
 			return &task{nodeKey: "n"}, true
 		}
 
-		cancelCh := make(chan *time.Duration, 1)
-
 		go func() {
 			time.Sleep(time.Microsecond)
 			close(recvReleased)
 		}()
 		zero := time.Duration(0)
-		cancelCh <- &zero
 
-		ta, _, immediateCanceled, canceled, _ := receiveWithListening(recv, cancelCh)
+		ta, _, immediateCanceled, canceled, _ := receiveWithListening(recv, triggeredGraphCancel(&zero))
 
 		assert.True(t, canceled, "iteration %d", i)
 		assert.True(t, immediateCanceled, "iteration %d: zero-timeout cancel must win against a slightly-delayed task completion", i)
@@ -78,15 +179,12 @@ func TestReceiveWithListening_UnlimitedGrace_UsesRealTaskResult(t *testing.T) {
 		return want, true
 	}
 
-	cancelCh := make(chan *time.Duration, 1)
-	cancelCh <- nil // unlimited grace: no timeout
-
 	go func() {
 		time.Sleep(20 * time.Millisecond)
 		close(recvReleased)
 	}()
 
-	ta, _, immediateCanceled, canceled, deadline := receiveWithListening(recv, cancelCh)
+	ta, _, immediateCanceled, canceled, deadline := receiveWithListening(recv, triggeredGraphCancel(nil))
 
 	assert.True(t, canceled)
 	assert.False(t, immediateCanceled)
@@ -105,16 +203,14 @@ func TestReceiveWithListening_PositiveTimeout_TaskFinishesWithinGrace(t *testing
 		return want, true
 	}
 
-	cancelCh := make(chan *time.Duration, 1)
 	timeout := 200 * time.Millisecond
-	cancelCh <- &timeout
 
 	go func() {
 		time.Sleep(20 * time.Millisecond)
 		close(recvReleased)
 	}()
 
-	ta, _, immediateCanceled, canceled, deadline := receiveWithListening(recv, cancelCh)
+	ta, _, immediateCanceled, canceled, deadline := receiveWithListening(recv, triggeredGraphCancel(&timeout))
 
 	assert.True(t, canceled)
 	assert.False(t, immediateCanceled)
@@ -133,11 +229,9 @@ func TestReceiveWithListening_PositiveTimeout_DeadlineExpiresFirst(t *testing.T)
 	}
 	defer close(recvReleased)
 
-	cancelCh := make(chan *time.Duration, 1)
 	timeout := 20 * time.Millisecond
-	cancelCh <- &timeout
 
-	ta, _, immediateCanceled, canceled, deadline := receiveWithListening(recv, cancelCh)
+	ta, _, immediateCanceled, canceled, deadline := receiveWithListening(recv, triggeredGraphCancel(&timeout))
 
 	assert.True(t, canceled)
 	assert.True(t, immediateCanceled)

--- a/compose/graph_run.go
+++ b/compose/graph_run.go
@@ -145,6 +145,7 @@ func (r *runner) run(ctx context.Context, isStream bool, input any, opts ...Opti
 
 	// Extract CheckPointID
 	checkPointID, writeToCheckPointID, stateModifier, forceNewRun := getCheckPointInfo(opts...)
+	subGraphCheckpointPublisher := getSubGraphCheckpointPublisher(opts...)
 	if checkPointID != nil && r.checkPointer.store == nil {
 		return nil, newGraphRunError(fmt.Errorf("receive checkpoint id but have not set checkpoint store"))
 	}
@@ -238,6 +239,7 @@ func (r *runner) run(ctx context.Context, isStream bool, input any, opts ...Opti
 				isStream,
 				isSubGraph,
 				writeToCheckPointID,
+				subGraphCheckpointPublisher,
 			)
 		}
 	}
@@ -305,6 +307,7 @@ func (r *runner) run(ctx context.Context, isStream bool, input any, opts ...Opti
 				isSubGraph,
 				cm,
 				isStream,
+				subGraphCheckpointPublisher,
 			)
 		}
 
@@ -346,6 +349,7 @@ func (r *runner) run(ctx context.Context, isStream bool, input any, opts ...Opti
 					isSubGraph,
 					cm,
 					isStream,
+					subGraphCheckpointPublisher,
 				)
 			}
 
@@ -362,7 +366,16 @@ func (r *runner) run(ctx context.Context, isStream bool, input any, opts ...Opti
 			tempInfo.interruptBeforeNodes = append(tempInfo.interruptBeforeNodes, getHitKey(newNextTasks, r.interruptBeforeNodes)...)
 
 			// simple interrupt
-			return nil, r.handleInterrupt(ctx, tempInfo, append(nextTasks, newNextTasks...), cm.channels, isStream, isSubGraph, writeToCheckPointID)
+			return nil, r.handleInterrupt(
+				ctx,
+				tempInfo,
+				append(nextTasks, newNextTasks...),
+				cm.channels,
+				isStream,
+				isSubGraph,
+				writeToCheckPointID,
+				subGraphCheckpointPublisher,
+			)
 		}
 	}
 }
@@ -553,6 +566,7 @@ func (r *runner) handleInterrupt(
 	isStream bool,
 	isSubGraph bool,
 	checkPointID *string,
+	publishSubGraphCheckpoint func(*subGraphInterruptError),
 ) error {
 	cp := &checkpoint{
 		Channels:       channels,
@@ -598,11 +612,15 @@ func (r *runner) handleInterrupt(
 		return fmt.Errorf("failed to convert checkpoint: %w", err)
 	}
 	if isSubGraph {
-		return &subGraphInterruptError{
+		subGraphInterrupt := &subGraphInterruptError{
 			Info:       intInfo,
 			CheckPoint: cp,
 			signal:     is,
 		}
+		if publishSubGraphCheckpoint != nil {
+			publishSubGraphCheckpoint(subGraphInterrupt)
+		}
+		return subGraphInterrupt
 	} else if checkPointID != nil {
 		err := r.checkPointer.set(ctx, *checkPointID, cp)
 		if err != nil {
@@ -649,6 +667,7 @@ func (r *runner) handleInterruptWithSubGraphAndRerunNodes(
 	isSubGraph bool,
 	cm *channelManager,
 	isStream bool,
+	publishSubGraphCheckpoint func(*subGraphInterruptError),
 ) error {
 	var rerunTasks, subgraphTasks, otherTasks []*task
 	skipPreHandler := map[string]bool{}
@@ -750,11 +769,15 @@ func (r *runner) handleInterruptWithSubGraphAndRerunNodes(
 		return fmt.Errorf("failed to convert checkpoint: %w", err)
 	}
 	if isSubGraph {
-		return &subGraphInterruptError{
+		subGraphInterrupt := &subGraphInterruptError{
 			Info:       intInfo,
 			CheckPoint: cp,
 			signal:     is,
 		}
+		if publishSubGraphCheckpoint != nil {
+			publishSubGraphCheckpoint(subGraphInterrupt)
+		}
+		return subGraphInterrupt
 	} else if checkPointID != nil {
 		err = r.checkPointer.set(ctx, *checkPointID, cp)
 		if err != nil {
@@ -923,16 +946,23 @@ func (r *runner) createTasks(ctx context.Context, nodeMap map[string]any, optMap
 			return nil, fmt.Errorf("node[%s] has not been registered", nodeKey)
 		}
 
+		taskCtx := ctx
+		var subGraphCheckpointReady <-chan *subGraphInterruptError
+		taskOpts := optMap[nodeKey]
 		if call.action.nodeInfo != nil && call.action.nodeInfo.compileOption != nil {
-			ctx = forwardCheckPoint(ctx, nodeKey)
+			taskCtx = forwardCheckPoint(taskCtx, nodeKey)
+		}
+		if isSubGraphCall(call) {
+			taskOpts, subGraphCheckpointReady = withSubGraphCheckpointPublisher(taskOpts)
 		}
 
 		nextTasks = append(nextTasks, &task{
-			ctx:     AppendAddressSegment(ctx, AddressSegmentNode, nodeKey),
-			nodeKey: nodeKey,
-			call:    call,
-			input:   nodeInput,
-			option:  optMap[nodeKey],
+			ctx:                     AppendAddressSegment(taskCtx, AddressSegmentNode, nodeKey),
+			nodeKey:                 nodeKey,
+			call:                    call,
+			input:                   nodeInput,
+			option:                  taskOpts,
+			subGraphCheckpointReady: subGraphCheckpointReady,
 		})
 	}
 	return nextTasks, nil
@@ -988,26 +1018,29 @@ func (r *runner) restoreTasks(
 			return nil, fmt.Errorf("channel[%s] from checkpoint is not registered", key)
 		}
 
+		taskCtx := ctx
+		var subGraphCheckpointReady <-chan *subGraphInterruptError
+		taskOpts := optMap[key]
 		if call.action.nodeInfo != nil && call.action.nodeInfo.compileOption != nil {
 			// sub graph
-			ctx = forwardCheckPoint(ctx, key)
+			taskCtx = forwardCheckPoint(taskCtx, key)
+		}
+		if isSubGraphCall(call) {
+			taskOpts, subGraphCheckpointReady = withSubGraphCheckpointPublisher(taskOpts)
 		}
 
 		newTask := &task{
-			ctx:            AppendAddressSegment(ctx, AddressSegmentNode, key),
-			nodeKey:        key,
-			call:           call,
-			input:          input,
-			option:         nil,
-			skipPreHandler: skipPreHandler[key],
+			ctx:                     AppendAddressSegment(taskCtx, AddressSegmentNode, key),
+			nodeKey:                 key,
+			call:                    call,
+			input:                   input,
+			option:                  taskOpts,
+			skipPreHandler:          skipPreHandler[key],
+			subGraphCheckpointReady: subGraphCheckpointReady,
 		}
 		if _, ok := syntheticInputs[key]; ok {
 			newTask.syntheticRerunInput = true
 		}
-		if opt, ok := optMap[key]; ok {
-			newTask.option = opt
-		}
-
 		ret = append(ret, newTask)
 	}
 	return ret, nil
@@ -1016,11 +1049,7 @@ func (r *runner) restoreTasks(
 func (r *runner) validateCheckpointIntegrity(cp *checkpoint) error {
 	for _, key := range cp.RerunNodes {
 		call, ok := r.chanSubscribeTo[key]
-		if !ok || call.action.meta == nil {
-			continue
-		}
-		cmp := call.action.meta.component
-		if cmp != ComponentOfGraph && cmp != ComponentOfChain && cmp != ComponentOfWorkflow {
+		if !ok || !isSubGraphCall(call) {
 			continue
 		}
 		if subCP, hasSubGraph := cp.SubGraphs[key]; hasSubGraph && subCP != nil {
@@ -1032,6 +1061,14 @@ func (r *runner) validateCheckpointIntegrity(cp *checkpoint) error {
 		return fmt.Errorf("subgraph node %q is marked for rerun without a nested checkpoint or persisted input", key)
 	}
 	return nil
+}
+
+func isSubGraphCall(call *chanCall) bool {
+	if call == nil || call.action == nil || call.action.meta == nil {
+		return false
+	}
+	cmp := call.action.meta.component
+	return cmp == ComponentOfGraph || cmp == ComponentOfChain || cmp == ComponentOfWorkflow
 }
 
 func (r *runner) resolveCompletedTasks(ctx context.Context, completedTasks []*task, isStream bool, cm *channelManager) (map[string]map[string]any, map[string][]string, error) {
@@ -1139,7 +1176,7 @@ func (r *runner) calculateBranch(ctx context.Context, curNodeKey string, startCh
 	return ret, nil
 }
 
-func (r *runner) initTaskManager(runWrapper runnableCallWrapper, cancelVal *graphCancelChanVal, opts ...Option) *taskManager {
+func (r *runner) initTaskManager(runWrapper runnableCallWrapper, cancelVal *graphCancelSignal, opts ...Option) *taskManager {
 	tm := &taskManager{
 		runWrapper:        runWrapper,
 		opts:              opts,
@@ -1149,7 +1186,7 @@ func (r *runner) initTaskManager(runWrapper runnableCallWrapper, cancelVal *grap
 		persistRerunInput: cancelVal != nil,
 	}
 	if cancelVal != nil {
-		tm.cancelCh = cancelVal.ch
+		tm.cancel = cancelVal
 	}
 	return tm
 }


### PR DESCRIPTION
# Preserve checkpoints after resumed stream timeout

## Problem

After a stateful tool interrupt was resolved with `ResumeWithParams`, timeout escalation during the next streaming model call could not replace the checkpoint. The parent graph marked its child graph for rerun while holding neither the child's input nor a stable nested checkpoint.

The TurnLoop bridge then exposed the checkpoint loaded for resume as if it had been written by the resumed run. A later owner therefore restored the old business-interrupt checkpoint and replayed an already resolved tool call.

## Solution

Graph interruption is now a broadcast request with one shared absolute deadline, so every nested graph observes the same cancellation instead of competing to consume one channel value.

When timeout escalation abandons running work, framework-owned child graphs publish their completed checkpoint before returning. The parent waits for this checkpoint handoff, not for the child goroutine or blocked provider, and persists only the stable child snapshot.

The resume bridge now reports a last checkpoint only after `Set` is called, keeping loaded state distinct from newly persisted state.

## Key Insight

A nested checkpoint is owned by the child graph while that graph is running. The parent may persist it only after the child publishes a completed checkpoint. Cancellation delivery and checkpoint ownership therefore need explicit broadcast and handoff semantics.

## Summary

| Problem | Solution |
|---|---|
| Only one graph level reliably observed timeout escalation | Broadcast one cancellation request and deadline to every nested graph |
| Parent serialized child state while it was still changing | Child publishes a stable checkpoint before parent persistence |
| Loaded checkpoint looked like a fresh replacement | `LastCheckpoint` changes only after a real bridge `Set` |

---

# 修复恢复后流式超时场景的 checkpoint 替换

## 问题

有状态工具中断通过 `ResumeWithParams` 解决后，如果下一次流式模型调用发生超时升级，父图会把子图标记为 rerun，但此时既没有子图输入，也没有稳定的嵌套 checkpoint，因此无法写入新的 checkpoint。

同时，TurnLoop bridge 会把本次恢复时加载的旧 checkpoint 当成本轮新写入结果。后续 owner 因此再次恢复旧的业务中断 checkpoint，重放已经解决的工具调用。

## 方案

Graph interrupt 改为广播同一份取消请求和绝对 deadline，所有嵌套 graph 都能观察到相同的取消，而不是竞争消费一个 channel 值。

超时升级放弃运行中任务时，由框架管理的子图在返回前主动发布已经构造完成的 checkpoint。父图只等待 checkpoint 交接，不等待子图 goroutine 或卡住的 provider，并且只持久化稳定快照。

Resume bridge 只有在实际调用 `Set` 后才更新 `LastCheckpoint`，从语义上区分“恢复时加载的数据”和“本轮新写入的数据”。

## 核心认知

子图运行期间，嵌套 checkpoint 的所有权属于子图。父图只能在子图发布完成态 checkpoint 后持久化它。因此，取消传播需要广播语义，checkpoint 需要明确的父子交接语义。

## 总结

| 问题 | 方案 |
|---|---|
| 超时升级只有一层 graph 能可靠收到 | 向所有嵌套 graph 广播同一取消请求和 deadline |
| 父图序列化仍在变化的子图状态 | 子图先发布稳定 checkpoint，父图再持久化 |
| 加载的旧 checkpoint 被误认为新替换结果 | 只有真实 bridge `Set` 才更新 `LastCheckpoint` |
