### PR TITLE
fix(compose): backport nested stream checkpoint fixes to v0.9

### DIFF
--- a/adk/agentic_react_test.go
+++ b/adk/agentic_react_test.go
@@ -103,6 +103,86 @@ func (t *agenticInterruptTool) InvokableRun(ctx context.Context, _ string, _ ...
 	return "resumed_no_data", nil
 }
 
+var errAgenticSandboxEscapeRequired = errors.New("sandbox escape required")
+
+type agenticLateErrorTool struct {
+	name            string
+	callCount       int32
+	sideEffectCount int32
+}
+
+func (t *agenticLateErrorTool) Info(_ context.Context) (*schema.ToolInfo, error) {
+	return &schema.ToolInfo{Name: t.name, Desc: "returns a late stream error before completing"}, nil
+}
+
+func (t *agenticLateErrorTool) StreamableRun(_ context.Context, _ string, _ ...tool.Option) (*schema.StreamReader[string], error) {
+	switch atomic.AddInt32(&t.callCount, 1) {
+	case 1:
+		r, w := schema.Pipe[string](2)
+		go func() {
+			defer w.Close()
+			w.Send("partial", nil)
+			w.Send("", errAgenticSandboxEscapeRequired)
+		}()
+		return r, nil
+	case 2:
+		atomic.AddInt32(&t.sideEffectCount, 1)
+		return schema.StreamReaderFromArray([]string{"completed"}), nil
+	default:
+		return nil, errors.New("late error tool called more than twice")
+	}
+}
+
+func agenticLateInterruptMiddleware() compose.ToolMiddleware {
+	return compose.ToolMiddleware{
+		Name: "permission",
+		Streamable: func(next compose.StreamableToolEndpoint) compose.StreamableToolEndpoint {
+			return func(ctx context.Context, input *compose.ToolInput) (*compose.StreamToolOutput, error) {
+				wasInterrupted, hasState, state := tool.GetInterruptState[string](ctx)
+				if !wasInterrupted {
+					return nil, tool.StatefulInterrupt(ctx, "first approval", "awaiting_first_approval")
+				}
+				if !hasState {
+					return nil, errors.New("permission middleware: missing interrupt state")
+				}
+				isResume, hasData, resumeData := tool.GetResumeContext[string](ctx)
+				if !isResume || !hasData {
+					return nil, errors.New("permission middleware: missing resume data")
+				}
+				expectedResumeData := map[string]string{
+					"awaiting_first_approval":  "approved_1",
+					"awaiting_second_approval": "approved_2",
+				}
+				expected, ok := expectedResumeData[state]
+				if !ok {
+					return nil, fmt.Errorf("permission middleware: unexpected interrupt state %q", state)
+				}
+				if resumeData != expected {
+					return nil, fmt.Errorf("permission middleware: state %q received resume data %q, want %q", state, resumeData, expected)
+				}
+
+				output, err := next(ctx, input)
+				if err != nil {
+					return nil, err
+				}
+				output.Result = schema.StreamReaderWithConvert(
+					output.Result,
+					func(chunk string) (string, error) {
+						return chunk, nil
+					},
+					schema.WithErrWrapper(func(streamErr error) error {
+						if errors.Is(streamErr, errAgenticSandboxEscapeRequired) {
+							return tool.StatefulInterrupt(ctx, "second approval", "awaiting_second_approval")
+						}
+						return streamErr
+					}),
+				)
+				return output, nil
+			}
+		},
+	}
+}
+
 type agenticArgCaptureTool struct {
 	name     string
 	onInvoke func(args string) string
@@ -617,6 +697,220 @@ func TestAgenticReact_DoubleInterruptResume(t *testing.T) {
 	require.NotNil(t, last.Output)
 	require.NotNil(t, last.Output.MessageOutput)
 	assert.Contains(t, agenticTextContent(last.Output.MessageOutput.Message), "all approved")
+}
+
+func TestAgenticReact_LateStreamInterruptResume(t *testing.T) {
+	for _, useTurnLoop := range []bool{false, true} {
+		for _, enableStreaming := range []bool{false, true} {
+			name := fmt.Sprintf("turn_loop_%t/streaming_%t", useTurnLoop, enableStreaming)
+			t.Run(name, func(t *testing.T) {
+				if useTurnLoop {
+					testAgenticLateStreamInterruptWithTurnLoop(t, enableStreaming)
+					return
+				}
+				testAgenticLateStreamInterruptWithRunner(t, enableStreaming)
+			})
+		}
+	}
+}
+
+func newAgenticLateStreamInterruptFixture(t *testing.T) (TypedAgent[*schema.AgenticMessage], *agenticLateErrorTool, *int32) {
+	t.Helper()
+	ctx := context.Background()
+
+	var modelCallCount int32
+	mdl := &mockAgenticModel{
+		generateFn: func(ctx context.Context, input []*schema.AgenticMessage, opts ...model.Option) (*schema.AgenticMessage, error) {
+			switch atomic.AddInt32(&modelCallCount, 1) {
+			case 1:
+				return agenticToolCallMsg("approval_tool", "c1", `"run"`), nil
+			case 2:
+				return agenticMsg("operation completed"), nil
+			default:
+				return nil, errors.New("model called more than twice")
+			}
+		},
+	}
+
+	lateErrorTool := &agenticLateErrorTool{name: "approval_tool"}
+	agent, err := NewTypedChatModelAgent(ctx, &TypedChatModelAgentConfig[*schema.AgenticMessage]{
+		Name:        t.Name(),
+		Description: "late stream interrupt test agent",
+		Model:       mdl,
+		ToolsConfig: ToolsConfig{
+			ToolsNodeConfig: compose.ToolsNodeConfig{
+				Tools:               []tool.BaseTool{lateErrorTool},
+				ToolCallMiddlewares: []compose.ToolMiddleware{agenticLateInterruptMiddleware()},
+			},
+		},
+	})
+	require.NoError(t, err)
+	return agent, lateErrorTool, &modelCallCount
+}
+
+func testAgenticLateStreamInterruptWithRunner(t *testing.T, enableStreaming bool) {
+	t.Helper()
+	ctx := context.Background()
+	agent, lateErrorTool, modelCallCount := newAgenticLateStreamInterruptFixture(t)
+	store := &agenticReactTestStore{m: map[string][]byte{}}
+	runner := NewTypedRunner(TypedRunnerConfig[*schema.AgenticMessage]{
+		Agent:           agent,
+		CheckPointStore: store,
+		EnableStreaming: enableStreaming,
+	})
+
+	checkpointID := "late-stream-runner"
+	events1 := drainAgenticEvents(runner.Query(ctx, "run once", WithCheckPointID(checkpointID)))
+	require.NoError(t, firstAgenticEventError(events1))
+	int1Event := findInterruptEvent(events1)
+	require.NotNil(t, int1Event, "expected first interrupt")
+	int1ID := int1Event.Action.Interrupted.InterruptContexts[0].ID
+
+	iter2, err := runner.ResumeWithParams(ctx, checkpointID, &ResumeParams{
+		Targets: map[string]any{int1ID: "approved_1"},
+	})
+	require.NoError(t, err)
+	events2 := drainAgenticEvents(iter2)
+	require.NoError(t, firstAgenticEventError(events2))
+	int2Event := findInterruptEvent(events2)
+	require.NotNil(t, int2Event, "expected second interrupt")
+	int2ID := int2Event.Action.Interrupted.InterruptContexts[0].ID
+
+	iter3, err := runner.ResumeWithParams(ctx, checkpointID, &ResumeParams{
+		Targets: map[string]any{int2ID: "approved_2"},
+	})
+	require.NoError(t, err)
+	events3 := drainAgenticEvents(iter3)
+	require.NoError(t, firstAgenticEventError(events3))
+	last := lastAgenticEvent(events3)
+	require.NotNil(t, last)
+	require.NotNil(t, last.Output)
+	require.NotNil(t, last.Output.MessageOutput)
+	finalMessage, err := last.Output.MessageOutput.GetMessage()
+	require.NoError(t, err)
+	assert.Equal(t, "operation completed", agenticTextContent(finalMessage))
+	assert.Equal(t, int32(1), atomic.LoadInt32(&lateErrorTool.sideEffectCount))
+	assert.Equal(t, int32(2), atomic.LoadInt32(modelCallCount))
+}
+
+func testAgenticLateStreamInterruptWithTurnLoop(t *testing.T, enableStreaming bool) {
+	t.Helper()
+	ctx := context.Background()
+	agent, lateErrorTool, modelCallCount := newAgenticLateStreamInterruptFixture(t)
+	store := newTestStore()
+	checkpointID := "late-stream-turn-loop"
+
+	loop1 := NewTurnLoop(TurnLoopConfig[string, *schema.AgenticMessage]{
+		Store:        store,
+		CheckpointID: checkpointID,
+		GenInput: func(_ context.Context, _ *TurnLoop[string, *schema.AgenticMessage], items []string) (*GenInputResult[string, *schema.AgenticMessage], error) {
+			return &GenInputResult[string, *schema.AgenticMessage]{
+				Input: &TypedAgentInput[*schema.AgenticMessage]{
+					Messages:        []*schema.AgenticMessage{schema.UserAgenticMessage(items[0])},
+					EnableStreaming: enableStreaming,
+				},
+				Consumed: items,
+			}, nil
+		},
+		PrepareAgent: func(_ context.Context, _ *TurnLoop[string, *schema.AgenticMessage], _ []string) (TypedAgent[*schema.AgenticMessage], error) {
+			return agent, nil
+		},
+	})
+	ok, _ := loop1.Push("run once")
+	require.True(t, ok)
+	loop1.Run(ctx)
+	firstID := requireTurnLoopInterruptID(t, loop1.Wait())
+
+	loop2 := newAgenticResumeTurnLoop(t, store, checkpointID, agent, firstID, "approved_1", nil)
+	loop2.Run(ctx)
+	secondID := requireTurnLoopInterruptID(t, loop2.Wait())
+
+	var finalEvents []*agenticAgentEvent
+	loop3 := newAgenticResumeTurnLoop(t, store, checkpointID, agent, secondID, "approved_2",
+		func(_ context.Context, tc *TurnContext[string, *schema.AgenticMessage], events *AsyncIterator[*agenticAgentEvent]) error {
+			finalEvents = drainAgenticEvents(events)
+			tc.Loop.Stop()
+			return firstAgenticEventError(finalEvents)
+		})
+	loop3.Run(ctx)
+	exit3 := loop3.Wait()
+	require.NoError(t, exit3.ExitReason)
+	require.NoError(t, exit3.CheckpointErr)
+
+	last := lastAgenticEvent(finalEvents)
+	require.NotNil(t, last)
+	require.NotNil(t, last.Output)
+	require.NotNil(t, last.Output.MessageOutput)
+	finalMessage, err := last.Output.MessageOutput.GetMessage()
+	require.NoError(t, err)
+	assert.Equal(t, "operation completed", agenticTextContent(finalMessage))
+	assert.Equal(t, int32(1), atomic.LoadInt32(&lateErrorTool.sideEffectCount))
+	assert.Equal(t, int32(2), atomic.LoadInt32(modelCallCount))
+}
+
+func newAgenticResumeTurnLoop(
+	t *testing.T,
+	store CheckPointStore,
+	checkpointID string,
+	agent TypedAgent[*schema.AgenticMessage],
+	interruptID string,
+	resumeData string,
+	onEvents func(context.Context, *TurnContext[string, *schema.AgenticMessage], *AsyncIterator[*agenticAgentEvent]) error,
+) *TurnLoop[string, *schema.AgenticMessage] {
+	t.Helper()
+	loop := NewTurnLoop(TurnLoopConfig[string, *schema.AgenticMessage]{
+		Store:        store,
+		CheckpointID: checkpointID,
+		GenInput: func(_ context.Context, _ *TurnLoop[string, *schema.AgenticMessage], items []string) (*GenInputResult[string, *schema.AgenticMessage], error) {
+			return &GenInputResult[string, *schema.AgenticMessage]{
+				Input:    &TypedAgentInput[*schema.AgenticMessage]{},
+				Consumed: items,
+			}, nil
+		},
+		GenResume: func(_ context.Context, _ *TurnLoop[string, *schema.AgenticMessage], interrupted, unhandled, newItems []string) (*GenResumeResult[string, *schema.AgenticMessage], error) {
+			return &GenResumeResult[string, *schema.AgenticMessage]{
+				ResumeParams: &ResumeParams{Targets: map[string]any{interruptID: resumeData}},
+				Consumed:     append(append([]string{}, interrupted...), newItems...),
+				Remaining:    unhandled,
+			}, nil
+		},
+		PrepareAgent: func(_ context.Context, _ *TurnLoop[string, *schema.AgenticMessage], _ []string) (TypedAgent[*schema.AgenticMessage], error) {
+			return agent, nil
+		},
+		OnAgentEvents: onEvents,
+	})
+	ok, _ := loop.Push(resumeData)
+	require.True(t, ok)
+	return loop
+}
+
+func requireTurnLoopInterruptID(t *testing.T, exit *TurnLoopExitState[string, *schema.AgenticMessage]) string {
+	t.Helper()
+	require.NoError(t, exit.CheckpointErr)
+	var interruptErr *InterruptError
+	require.ErrorAs(t, exit.ExitReason, &interruptErr)
+	require.Len(t, interruptErr.InterruptContexts, 1)
+	return interruptErr.InterruptContexts[0].ID
+}
+
+func TestAgenticReact_NilInitInputReturnsError(t *testing.T) {
+	ctx := context.Background()
+	mdl := &mockAgenticModel{
+		generateFn: func(_ context.Context, _ []*schema.AgenticMessage, _ ...model.Option) (*schema.AgenticMessage, error) {
+			return agenticMsg("unexpected"), nil
+		},
+	}
+
+	graph, err := newAgenticReact(ctx, &agenticReactConfig{
+		model:       mdl,
+		toolsConfig: &compose.ToolsNodeConfig{},
+	})
+	require.NoError(t, err)
+	runnable, err := graph.Compile(ctx)
+	require.NoError(t, err)
+
+	_, err = runnable.Invoke(ctx, nil)
+	require.ErrorContains(t, err, "agentic react: init input is nil")
 }
 
 func TestAgenticReact_ResumeThenCancelAfterChatModelCheckpoint(t *testing.T) {

--- a/adk/agentic_react_test.go
+++ b/adk/agentic_react_test.go
@@ -135,7 +135,6 @@ func (t *agenticLateErrorTool) StreamableRun(_ context.Context, _ string, _ ...t
 
 func agenticLateInterruptMiddleware() compose.ToolMiddleware {
 	return compose.ToolMiddleware{
-		Name: "permission",
 		Streamable: func(next compose.StreamableToolEndpoint) compose.StreamableToolEndpoint {
 			return func(ctx context.Context, input *compose.ToolInput) (*compose.StreamToolOutput, error) {
 				wasInterrupted, hasState, state := tool.GetInterruptState[string](ctx)

--- a/adk/interrupt.go
+++ b/adk/interrupt.go
@@ -317,21 +317,24 @@ func newBridgeStore() *bridgeStore {
 }
 
 func newResumeBridgeStore(checkPointID string, data []byte) *bridgeStore {
+	payload := append([]byte{}, data...)
 	return &bridgeStore{
-		data: map[string][]byte{checkPointID: data},
+		data: map[string][]byte{checkPointID: payload},
 	}
 }
 
 type bridgeStore struct {
-	mu   sync.Mutex
-	data map[string][]byte
+	mu          sync.Mutex
+	data        map[string][]byte
+	lastKey     string
+	lastPayload []byte
 }
 
 func (m *bridgeStore) Get(_ context.Context, key string) ([]byte, bool, error) {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 	if v, ok := m.data[key]; ok {
-		return v, true, nil
+		return append([]byte{}, v...), true, nil
 	}
 	return nil, false, nil
 }
@@ -342,8 +345,20 @@ func (m *bridgeStore) Set(_ context.Context, key string, checkPoint []byte) erro
 	if m.data == nil {
 		m.data = make(map[string][]byte)
 	}
-	m.data[key] = checkPoint
+	payload := append([]byte{}, checkPoint...)
+	m.data[key] = payload
+	m.lastKey = key
+	m.lastPayload = payload
 	return nil
+}
+
+func (m *bridgeStore) LastCheckpoint() (key string, payload []byte, ok bool) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if m.lastKey == "" {
+		return "", nil, false
+	}
+	return m.lastKey, append([]byte{}, m.lastPayload...), true
 }
 
 func getNextResumeAgent(ctx context.Context, _ *ResumeInfo) (string, error) {

--- a/adk/interrupt_test.go
+++ b/adk/interrupt_test.go
@@ -59,6 +59,25 @@ func TestPreprocessADKCheckpoint(t *testing.T) {
 	})
 }
 
+func TestAttack_ResumeBridgeStoreRequiresFreshWrite(t *testing.T) {
+	store := newResumeBridgeStore("checkpoint", []byte("loaded"))
+	t.Log("a resume bridge must distinguish a loaded checkpoint from a replacement")
+
+	loaded, ok, err := store.Get(context.Background(), "checkpoint")
+	assert.NoError(t, err)
+	assert.True(t, ok)
+	assert.Equal(t, []byte("loaded"), loaded)
+
+	_, _, ok = store.LastCheckpoint()
+	assert.False(t, ok, "loaded checkpoints must not be reported as fresh writes")
+
+	assert.NoError(t, store.Set(context.Background(), "checkpoint", []byte("saved")))
+	key, saved, ok := store.LastCheckpoint()
+	assert.True(t, ok)
+	assert.Equal(t, "checkpoint", key)
+	assert.Equal(t, []byte("saved"), saved)
+}
+
 func (h *interruptTestToolsHandler) BeforeAgent(ctx context.Context, runCtx *ChatModelAgentContext) (context.Context, *ChatModelAgentContext, error) {
 	runCtx.Tools = append(runCtx.Tools, h.tools...)
 	return ctx, runCtx, nil

--- a/adk/react.go
+++ b/adk/react.go
@@ -365,6 +365,9 @@ func newReact(ctx context.Context, config *reactConfig) (reactGraph, error) {
 	cancelCtx := config.cancelCtx
 	g := compose.NewGraph[*reactInput, Message](compose.WithGenLocalState(genReactState(config)))
 	_ = g.AddLambdaNode(initNode_, compose.InvokableLambda(func(ctx context.Context, input *reactInput) ([]Message, error) {
+		if input == nil {
+			return nil, errors.New("react: init input is nil")
+		}
 		_ = compose.ProcessState(ctx, func(_ context.Context, st *State) error {
 			st.Messages = append(st.Messages, input.Messages...)
 			return nil
@@ -616,6 +619,9 @@ func newAgenticReact(ctx context.Context, config *agenticReactConfig) (agenticRe
 	g := compose.NewGraph[*agenticReactInput, *schema.AgenticMessage](
 		compose.WithGenLocalState(genAgenticReactState(config)))
 	_ = g.AddLambdaNode(initNode_, compose.InvokableLambda(func(ctx context.Context, input *agenticReactInput) ([]*schema.AgenticMessage, error) {
+		if input == nil {
+			return nil, errors.New("agentic react: init input is nil")
+		}
 		_ = compose.ProcessState(ctx, func(_ context.Context, st *agenticState) error {
 			st.Messages = append(st.Messages, input.Messages...)
 			return nil

--- a/adk/react_test.go
+++ b/adk/react_test.go
@@ -98,6 +98,23 @@ func (w *testModelWrapper) WithTools(tools []*schema.ToolInfo) (model.ToolCallin
 
 // TestReact tests the newReact function with different scenarios
 func TestReact(t *testing.T) {
+	t.Run("NilInput", func(t *testing.T) {
+		ctx := context.Background()
+		ctrl := gomock.NewController(t)
+		cm := mockModel.NewMockToolCallingChatModel(ctrl)
+
+		graph, err := newReact(ctx, &reactConfig{
+			model:       cm,
+			toolsConfig: &compose.ToolsNodeConfig{},
+		})
+		require.NoError(t, err)
+		compiled, err := graph.Compile(ctx)
+		require.NoError(t, err)
+
+		_, err = compiled.Invoke(ctx, nil)
+		require.ErrorContains(t, err, "react: init input is nil")
+	})
+
 	// Basic test for newReact function
 	t.Run("Invoke", func(t *testing.T) {
 		ctx := context.Background()

--- a/adk/turn_loop.go
+++ b/adk/turn_loop.go
@@ -1920,10 +1920,7 @@ func (l *TurnLoop[T, M]) runAgentAndHandleEvents(
 
 	finalizeCheckpoint := func() error {
 		if store != nil && ms != nil {
-			data, ok, err := ms.Get(ctx, bridgeCheckpointID)
-			if err != nil {
-				return fmt.Errorf("failed to read runner checkpoint: %w", err)
-			}
+			_, data, ok := ms.LastCheckpoint()
 			if ok {
 				l.checkPointRunnerBytes = append([]byte{}, data...)
 			}

--- a/adk/turn_loop_test.go
+++ b/adk/turn_loop_test.go
@@ -28,6 +28,9 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"github.com/cloudwego/eino/components/model"
+	"github.com/cloudwego/eino/components/tool"
+	"github.com/cloudwego/eino/compose"
 	"github.com/cloudwego/eino/schema"
 )
 
@@ -2600,6 +2603,215 @@ func TestTurnLoop_ResumeInterruptAgain_PreservesEnableStreamingCheckpoint(t *tes
 			assert.Equal(t, enableStreaming, info2.EnableStreaming)
 		})
 	}
+}
+
+type turnLoopTargetedResumeTimeoutModel struct {
+	calls         int32
+	secondStarted chan struct{}
+	thirdStarted  chan struct{}
+	release       chan struct{}
+}
+
+func (m *turnLoopTargetedResumeTimeoutModel) Generate(ctx context.Context, input []*schema.Message, opts ...model.Option) (*schema.Message, error) {
+	reader, err := m.Stream(ctx, input, opts...)
+	if err != nil {
+		return nil, err
+	}
+	defer reader.Close()
+	msg, err := reader.Recv()
+	if err != nil {
+		return nil, err
+	}
+	return msg, nil
+}
+
+func (m *turnLoopTargetedResumeTimeoutModel) Stream(_ context.Context, _ []*schema.Message, _ ...model.Option) (*schema.StreamReader[*schema.Message], error) {
+	switch atomic.AddInt32(&m.calls, 1) {
+	case 1:
+		return schema.StreamReaderFromArray([]*schema.Message{{
+			Role: schema.Assistant,
+			ToolCalls: []schema.ToolCall{{
+				ID:   "ask_1",
+				Type: "function",
+				Function: schema.FunctionCall{
+					Name:      "ask_user",
+					Arguments: `{"question":"continue?"}`,
+				},
+			}},
+		}}), nil
+	case 2:
+		reader, writer := schema.Pipe[*schema.Message](1)
+		go func() {
+			defer writer.Close()
+			writer.Send(schema.AssistantMessage("partial", nil), nil)
+			close(m.secondStarted)
+			<-m.release
+		}()
+		return reader, nil
+	default:
+		close(m.thirdStarted)
+		return schema.StreamReaderFromArray([]*schema.Message{schema.AssistantMessage("resumed", nil)}), nil
+	}
+}
+
+func (m *turnLoopTargetedResumeTimeoutModel) BindTools(_ []*schema.ToolInfo) error { return nil }
+
+type turnLoopTargetedResumeTool struct {
+	calls int32
+}
+
+func (t *turnLoopTargetedResumeTool) Info(_ context.Context) (*schema.ToolInfo, error) {
+	return &schema.ToolInfo{
+		Name: "ask_user",
+		ParamsOneOf: schema.NewParamsOneOfByParams(map[string]*schema.ParameterInfo{
+			"question": {Type: schema.String},
+		}),
+	}, nil
+}
+
+func (t *turnLoopTargetedResumeTool) InvokableRun(ctx context.Context, _ string, _ ...tool.Option) (string, error) {
+	atomic.AddInt32(&t.calls, 1)
+	wasInterrupted, _, _ := tool.GetInterruptState[string](ctx)
+	isTarget, hasAnswer, answer := tool.GetResumeContext[string](ctx)
+	if wasInterrupted && isTarget && hasAnswer {
+		return answer, nil
+	}
+	return "", tool.StatefulInterrupt(ctx, "answer required", "awaiting answer")
+}
+
+type recordingTurnLoopCheckpointStore struct {
+	mu sync.Mutex
+	m  map[string][]byte
+}
+
+func (s *recordingTurnLoopCheckpointStore) Set(_ context.Context, key string, value []byte) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.m[key] = append([]byte{}, value...)
+	return nil
+}
+
+func (s *recordingTurnLoopCheckpointStore) Get(_ context.Context, key string) ([]byte, bool, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	value, ok := s.m[key]
+	return append([]byte{}, value...), ok, nil
+}
+
+func TestTurnLoop_TargetedResume_TimeoutEscalationReplacesCheckpoint(t *testing.T) {
+	ctx := context.Background()
+	store := &recordingTurnLoopCheckpointStore{m: make(map[string][]byte)}
+	model := &turnLoopTargetedResumeTimeoutModel{
+		secondStarted: make(chan struct{}),
+		thirdStarted:  make(chan struct{}),
+		release:       make(chan struct{}),
+	}
+	t.Cleanup(func() { close(model.release) })
+	askUser := &turnLoopTargetedResumeTool{}
+
+	agent, err := NewChatModelAgent(ctx, &ChatModelAgentConfig{
+		Name:        "TargetedResumeTimeout",
+		Description: "test agent",
+		Model:       model,
+		ToolsConfig: ToolsConfig{
+			ToolsNodeConfig: compose.ToolsNodeConfig{Tools: []tool.BaseTool{askUser}},
+		},
+	})
+	require.NoError(t, err)
+
+	var interruptID string
+	observeInterrupt := func(_ context.Context, _ *TurnContext[string, *schema.Message], events *AsyncIterator[*AgentEvent]) error {
+		for {
+			event, ok := events.Next()
+			if !ok {
+				return nil
+			}
+			if event.Action != nil && event.Action.Interrupted != nil {
+				for _, interrupt := range event.Action.Interrupted.InterruptContexts {
+					if interrupt.IsRootCause {
+						interruptID = interrupt.ID
+					}
+				}
+			}
+			if event.Err != nil {
+				return event.Err
+			}
+		}
+	}
+	newLoop := func(genResume TurnLoopConfig[string, *schema.Message]) *TurnLoop[string, *schema.Message] {
+		genResume.Store = store
+		genResume.CheckpointID = "targeted-resume-timeout"
+		genResume.GenInput = func(_ context.Context, _ *TurnLoop[string, *schema.Message], items []string) (*GenInputResult[string, *schema.Message], error) {
+			return &GenInputResult[string, *schema.Message]{
+				Input: &AgentInput{
+					Messages:        []Message{schema.UserMessage(items[0])},
+					EnableStreaming: true,
+				},
+				Consumed: items,
+			}, nil
+		}
+		genResume.PrepareAgent = prepareAgent(agent)
+		genResume.OnAgentEvents = observeInterrupt
+		return NewTurnLoop(genResume)
+	}
+
+	owner1 := newLoop(TurnLoopConfig[string, *schema.Message]{})
+	owner1.Push("start")
+	owner1.Run(ctx)
+	exit1 := owner1.Wait()
+	require.ErrorAs(t, exit1.ExitReason, new(*InterruptError))
+	require.True(t, exit1.CheckpointAttempted)
+	require.NoError(t, exit1.CheckpointErr)
+	require.NotEmpty(t, interruptID)
+	firstCheckpoint, ok, err := store.Get(ctx, "targeted-resume-timeout")
+	require.NoError(t, err)
+	require.True(t, ok)
+	firstTurnLoopCheckpoint, err := unmarshalTurnLoopCheckpoint[string](firstCheckpoint)
+	require.NoError(t, err)
+
+	owner2 := newLoop(TurnLoopConfig[string, *schema.Message]{
+		GenResume: func(_ context.Context, _ *TurnLoop[string, *schema.Message], _, _, _ []string) (*GenResumeResult[string, *schema.Message], error) {
+			return &GenResumeResult[string, *schema.Message]{
+				ResumeParams: &ResumeParams{Targets: map[string]any{interruptID: "approved"}},
+			}, nil
+		},
+	})
+	owner2.Run(ctx)
+	select {
+	case <-model.secondStarted:
+	case <-time.After(5 * time.Second):
+		t.Fatal("resumed model call did not begin streaming")
+	}
+	owner2.Stop(WithGracefulTimeout(20 * time.Millisecond))
+	exit2 := owner2.Wait()
+	require.True(t, exit2.CheckpointAttempted)
+	require.NoError(t, exit2.CheckpointErr)
+
+	finalCheckpoint, ok, err := store.Get(ctx, "targeted-resume-timeout")
+	require.NoError(t, err)
+	require.True(t, ok)
+	finalTurnLoopCheckpoint, err := unmarshalTurnLoopCheckpoint[string](finalCheckpoint)
+	require.NoError(t, err)
+	require.NotEqual(t, firstTurnLoopCheckpoint.RunnerCheckpoint, finalTurnLoopCheckpoint.RunnerCheckpoint,
+		"timeout escalation must replace the resumed runner checkpoint")
+
+	owner3 := newLoop(TurnLoopConfig[string, *schema.Message]{
+		GenResume: func(_ context.Context, _ *TurnLoop[string, *schema.Message], _, _, _ []string) (*GenResumeResult[string, *schema.Message], error) {
+			return &GenResumeResult[string, *schema.Message]{}, nil
+		},
+	})
+	owner3.Run(ctx)
+	select {
+	case <-model.thirdStarted:
+		owner3.Stop()
+		exit3 := owner3.Wait()
+		require.NotErrorAs(t, exit3.ExitReason, new(*InterruptError))
+	case <-owner3.done:
+		require.NotErrorAs(t, owner3.Wait().ExitReason, new(*InterruptError))
+	case <-time.After(5 * time.Second):
+		t.Fatal("targetless resume did not continue from the replacement checkpoint")
+	}
+	assert.Equal(t, int32(2), atomic.LoadInt32(&askUser.calls), "resolved tool interrupt must not be replayed")
 }
 
 func TestTurnLoop_Stop_EscalatesCancelMode(t *testing.T) {

--- a/compose/checkpoint.go
+++ b/compose/checkpoint.go
@@ -121,6 +121,29 @@ type checkpoint struct {
 type stateModifierKey struct{}
 type checkPointKey struct{} // *checkpoint
 
+func withSubGraphCheckpointPublisher(opts []any) (
+	[]any,
+	<-chan *subGraphInterruptError,
+) {
+	ready := make(chan *subGraphInterruptError, 1)
+	childOpts := append([]any(nil), opts...)
+	childOpts = append(childOpts, Option{
+		subGraphCheckpointPublisher: func(checkpoint *subGraphInterruptError) {
+			ready <- checkpoint
+		},
+	})
+	return childOpts, ready
+}
+
+func getSubGraphCheckpointPublisher(opts ...Option) func(*subGraphInterruptError) {
+	for _, opt := range opts {
+		if opt.subGraphCheckpointPublisher != nil {
+			return opt.subGraphCheckpointPublisher
+		}
+	}
+	return nil
+}
+
 func getStateModifier(ctx context.Context) StateModifier {
 	if sm, ok := ctx.Value(stateModifierKey{}).(StateModifier); ok {
 		return sm

--- a/compose/checkpoint.go
+++ b/compose/checkpoint.go
@@ -18,6 +18,7 @@ package compose
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"reflect"
 
@@ -300,21 +301,45 @@ func migrateCheckpoint(cp *checkpoint, migrate func(state any) (any, bool, error
 
 // convertCheckPoint if value in checkpoint is streamReader, convert it to non-stream
 func (c *checkPointer) convertCheckPoint(cp *checkpoint, isStream bool) (err error) {
+	ignoreInterrupt := func(err error) bool {
+		// The checkpoint maps already carry this control signal. A copied data
+		// stream may surface it again while being materialized.
+		return checkpointContainsInterrupt(cp, err)
+	}
 	for _, ch := range cp.Channels {
 		err = ch.convertValues(func(m map[string]any) error {
-			return c.sc.convertOutputs(isStream, m)
+			return c.sc.convertOutputs(isStream, m, ignoreInterrupt)
 		})
 		if err != nil {
 			return err
 		}
 	}
 
-	err = c.sc.convertInputs(isStream, cp.Inputs)
+	err = c.sc.convertInputs(isStream, cp.Inputs, ignoreInterrupt)
 	if err != nil {
 		return err
 	}
 
 	return nil
+}
+
+func checkpointContainsInterrupt(cp *checkpoint, err error) bool {
+	if cp == nil || err == nil {
+		return false
+	}
+
+	signal := &core.InterruptSignal{}
+	if errors.As(err, &signal) {
+		_, ok := cp.InterruptID2Addr[signal.ID]
+		return ok
+	}
+
+	if nested := isSubGraphInterrupt(err); nested != nil && nested.signal != nil {
+		_, ok := cp.InterruptID2Addr[nested.signal.ID]
+		return ok
+	}
+
+	return false
 }
 
 // convertCheckPoint convert values in checkpoint to streamReader if needed
@@ -347,23 +372,23 @@ type streamConverter struct {
 	inputPairs, outputPairs map[string]streamConvertPair
 }
 
-func (s *streamConverter) convertInputs(isStream bool, values map[string]any) error {
-	return convert(values, s.inputPairs, isStream)
+func (s *streamConverter) convertInputs(isStream bool, values map[string]any, ignoreError func(error) bool) error {
+	return convert(values, s.inputPairs, isStream, ignoreError)
 }
 
 func (s *streamConverter) restoreInputs(isStream bool, values map[string]any) error {
 	return restore(values, s.inputPairs, isStream)
 }
 
-func (s *streamConverter) convertOutputs(isStream bool, values map[string]any) error {
-	return convert(values, s.outputPairs, isStream)
+func (s *streamConverter) convertOutputs(isStream bool, values map[string]any, ignoreError func(error) bool) error {
+	return convert(values, s.outputPairs, isStream, ignoreError)
 }
 
 func (s *streamConverter) restoreOutputs(isStream bool, values map[string]any) error {
 	return restore(values, s.outputPairs, isStream)
 }
 
-func convert(values map[string]any, convPairs map[string]streamConvertPair, isStream bool) error {
+func convert(values map[string]any, convPairs map[string]streamConvertPair, isStream bool, ignoreError func(error) bool) error {
 	if !isStream {
 		return nil
 	}
@@ -376,7 +401,7 @@ func convert(values map[string]any, convPairs map[string]streamConvertPair, isSt
 		if !ok {
 			return fmt.Errorf("checkpoint conv stream fail, value of [%s] isn't stream", key)
 		}
-		nValue, err := convPair.concatStream(sr)
+		nValue, err := convPair.concatStream(sr, ignoreError)
 		if err != nil {
 			return err
 		}

--- a/compose/checkpoint_test.go
+++ b/compose/checkpoint_test.go
@@ -2094,7 +2094,7 @@ func TestAttack_InterruptOriginUsesCurrentGraphBoundary(t *testing.T) {
 			{Type: AddressSegmentRunnable, ID: "root"},
 			{Type: AddressSegmentNode, ID: "node_1"},
 			{Type: AddressSegmentNode, ID: "ToolNode"},
-			{Type: AddressSegmentMiddleware, ID: "permission"},
+			{Type: AddressSegmentTool, ID: "permission"},
 		}
 		assert.Equal(t, "node_1", r.interruptOriginNodeKey(completedTask, interruptAddress))
 	})

--- a/compose/checkpoint_test.go
+++ b/compose/checkpoint_test.go
@@ -21,16 +21,20 @@ import (
 	"context"
 	"encoding/gob"
 	"errors"
+	"fmt"
 	"io"
 	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 
 	"github.com/bytedance/sonic"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"github.com/cloudwego/eino/components/tool"
 	"github.com/cloudwego/eino/internal/callbacks"
+	"github.com/cloudwego/eino/internal/core"
 	"github.com/cloudwego/eino/internal/generic"
 	"github.com/cloudwego/eino/internal/serialization"
 	"github.com/cloudwego/eino/schema"
@@ -1941,6 +1945,291 @@ func TestPersistRerunInputSubGraph(t *testing.T) {
 	assert.Equal(t, "test_main", receivedInput)
 	assert.Equal(t, 2, callCount)
 	mu.Unlock()
+}
+
+func TestStreamingSubGraphReinterruptPreservesNestedCheckpoint(t *testing.T) {
+	ctx := context.Background()
+	store := newInMemoryStore()
+	var sideEffectCount int32
+
+	interruptingNode := StreamableLambda(func(ctx context.Context, input string) (*schema.StreamReader[string], error) {
+		wasInterrupted, hasState, state := GetInterruptState[string](ctx)
+		if !wasInterrupted {
+			return nil, StatefulInterrupt(ctx, "first approval", "awaiting_first_approval")
+		}
+		if !hasState {
+			return nil, errors.New("missing interrupt state")
+		}
+
+		switch state {
+		case "awaiting_first_approval":
+			r, w := schema.Pipe[string](1)
+			go func() {
+				defer w.Close()
+				w.Send("", StatefulInterrupt(ctx, "second approval", "awaiting_second_approval"))
+			}()
+			return r, nil
+		case "awaiting_second_approval":
+			atomic.AddInt32(&sideEffectCount, 1)
+			return schema.StreamReaderFromArray([]string{"done"}), nil
+		default:
+			return nil, fmt.Errorf("unexpected interrupt state %q", state)
+		}
+	})
+
+	inner := NewGraph[string, string]()
+	require.NoError(t, inner.AddLambdaNode("ToolNode", interruptingNode))
+	require.NoError(t, inner.AddLambdaNode("ConsumeToolOutput", CollectableLambda(
+		func(_ context.Context, input *schema.StreamReader[string]) (string, error) {
+			return concatStreamReader(input)
+		},
+	)))
+	require.NoError(t, inner.AddEdge(START, "ToolNode"))
+	require.NoError(t, inner.AddEdge("ToolNode", "ConsumeToolOutput"))
+	require.NoError(t, inner.AddEdge("ConsumeToolOutput", END))
+
+	outer := NewGraph[string, string]()
+	require.NoError(t, outer.AddGraphNode("node_1", inner))
+	require.NoError(t, outer.AddEdge(START, "node_1"))
+	require.NoError(t, outer.AddEdge("node_1", END))
+
+	runnable, err := outer.Compile(ctx, WithCheckPointStore(store))
+	require.NoError(t, err)
+
+	_, err = runnable.Stream(ctx, "input", WithCheckPointID("stream-reinterrupt"))
+	info, ok := ExtractInterruptInfo(err)
+	require.True(t, ok)
+	require.Contains(t, info.SubGraphs, "node_1")
+	firstID := info.InterruptContexts[0].ID
+
+	resumeCtx := ResumeWithData(ctx, firstID, "approved_1")
+	_, err = runnable.Stream(resumeCtx, "", WithCheckPointID("stream-reinterrupt"))
+	info, ok = ExtractInterruptInfo(err)
+	require.True(t, ok)
+	require.Contains(t, info.SubGraphs, "node_1")
+	assert.NotContains(t, info.RerunNodes, "node_1")
+	assert.Contains(t, info.SubGraphs["node_1"].RerunNodes, "ToolNode")
+	secondID := info.InterruptContexts[0].ID
+
+	resumeCtx = ResumeWithData(ctx, secondID, "approved_2")
+	output, err := runnable.Stream(resumeCtx, "", WithCheckPointID("stream-reinterrupt"))
+	require.NoError(t, err)
+	result, err := concatStreamReader(output)
+	require.NoError(t, err)
+	assert.Equal(t, "done", result)
+	assert.Equal(t, int32(1), atomic.LoadInt32(&sideEffectCount))
+}
+
+func TestCheckpointStreamConversionIgnoresOnlyRecordedInterrupt(t *testing.T) {
+	ctx := context.Background()
+	recordedErr := StatefulInterrupt(ctx, "recorded", "state")
+	recordedSignal := &core.InterruptSignal{}
+	require.ErrorAs(t, recordedErr, &recordedSignal)
+	id2Addr, id2State := core.SignalToPersistenceMaps(recordedSignal)
+
+	newCheckpoint := func(streamErr error) (*checkpoint, *checkPointer) {
+		r, w := schema.Pipe[string](2)
+		w.Send("partial", nil)
+		w.Send("", streamErr)
+		w.Close()
+		return &checkpoint{
+				Inputs:            map[string]any{"node": packStreamReader(r)},
+				InterruptID2Addr:  id2Addr,
+				InterruptID2State: id2State,
+			}, newCheckPointer(map[string]streamConvertPair{
+				"node": defaultStreamConvertPair[string](),
+			}, nil, nil, nil)
+	}
+
+	cp, pointer := newCheckpoint(recordedErr)
+	require.NoError(t, pointer.convertCheckPoint(cp, true))
+	assert.Equal(t, "partial", cp.Inputs["node"])
+
+	cp, pointer = newCheckpoint(&subGraphInterruptError{signal: recordedSignal})
+	require.NoError(t, pointer.convertCheckPoint(cp, true))
+	assert.Equal(t, "partial", cp.Inputs["node"])
+
+	cp, pointer = newCheckpoint(errors.New("ordinary stream failure"))
+	err := pointer.convertCheckPoint(cp, true)
+	require.ErrorContains(t, err, "ordinary stream failure")
+}
+
+func TestAttack_CheckpointStreamConversionRejectsUnrecordedInterrupt(t *testing.T) {
+	ctx := context.Background()
+	recordedErr := StatefulInterrupt(ctx, "recorded", "recorded-state")
+	recordedSignal := &core.InterruptSignal{}
+	require.ErrorAs(t, recordedErr, &recordedSignal)
+	id2Addr, id2State := core.SignalToPersistenceMaps(recordedSignal)
+
+	unrecordedErr := StatefulInterrupt(ctx, "unrecorded", "unrecorded-state")
+	r, w := schema.Pipe[string](1)
+	w.Send("", unrecordedErr)
+	w.Close()
+	cp := &checkpoint{
+		Inputs:            map[string]any{"node": packStreamReader(r)},
+		InterruptID2Addr:  id2Addr,
+		InterruptID2State: id2State,
+	}
+	pointer := newCheckPointer(map[string]streamConvertPair{
+		"node": defaultStreamConvertPair[string](),
+	}, nil, nil, nil)
+
+	err := pointer.convertCheckPoint(cp, true)
+	require.Error(t, err)
+	_, isInterrupt := IsInterruptRerunError(err)
+	assert.True(t, isInterrupt)
+}
+
+func TestAttack_InterruptOriginUsesCurrentGraphBoundary(t *testing.T) {
+	ctx := AppendAddressSegment(context.Background(), AddressSegmentRunnable, "root")
+	taskCtx := AppendAddressSegment(ctx, AddressSegmentNode, "node_1")
+	r := &runner{chanSubscribeTo: map[string]*chanCall{
+		"node_1":   {},
+		"ToolNode": {},
+	}}
+	completedTask := &task{ctx: taskCtx, nodeKey: "node_1"}
+
+	t.Run("selects node at current graph boundary", func(t *testing.T) {
+		interruptAddress := Address{
+			{Type: AddressSegmentRunnable, ID: "root"},
+			{Type: AddressSegmentNode, ID: "node_1"},
+			{Type: AddressSegmentNode, ID: "ToolNode"},
+			{Type: AddressSegmentMiddleware, ID: "permission"},
+		}
+		assert.Equal(t, "node_1", r.interruptOriginNodeKey(completedTask, interruptAddress))
+	})
+
+	t.Run("falls back when address belongs to another graph", func(t *testing.T) {
+		interruptAddress := Address{
+			{Type: AddressSegmentRunnable, ID: "other"},
+			{Type: AddressSegmentNode, ID: "ToolNode"},
+		}
+		assert.Equal(t, "node_1", r.interruptOriginNodeKey(completedTask, interruptAddress))
+	})
+
+	t.Run("falls back when task has no execution address", func(t *testing.T) {
+		assert.Equal(t, "node_1", r.interruptOriginNodeKey(&task{
+			ctx:     context.Background(),
+			nodeKey: "node_1",
+		}, nil))
+	})
+
+	t.Run("falls back when addressed node is not in current graph", func(t *testing.T) {
+		interruptAddress := Address{
+			{Type: AddressSegmentRunnable, ID: "root"},
+			{Type: AddressSegmentNode, ID: "missing"},
+		}
+		assert.Equal(t, "node_1", r.interruptOriginNodeKey(completedTask, interruptAddress))
+	})
+}
+
+func TestAttack_FanOutLateInterruptIsDeduplicated(t *testing.T) {
+	ctx := context.Background()
+	producer := StreamableLambda(func(ctx context.Context, _ string) (*schema.StreamReader[string], error) {
+		interruptErr := StatefulInterrupt(ctx, "approval", "state")
+		r, w := schema.Pipe[string](1)
+		w.Send("", interruptErr)
+		w.Close()
+		return r, nil
+	})
+	consumer := func(_ context.Context, input *schema.StreamReader[string]) (string, error) {
+		return concatStreamReader(input)
+	}
+
+	graph := NewGraph[string, string]()
+	require.NoError(t, graph.AddLambdaNode("ToolNode", producer))
+	require.NoError(t, graph.AddLambdaNode("consumer_a", CollectableLambda(consumer)))
+	require.NoError(t, graph.AddLambdaNode("consumer_b", CollectableLambda(consumer)))
+	require.NoError(t, graph.AddEdge(START, "ToolNode"))
+	require.NoError(t, graph.AddEdge("ToolNode", "consumer_a"))
+	require.NoError(t, graph.AddEdge("ToolNode", "consumer_b"))
+	require.NoError(t, graph.AddEdge("consumer_a", END))
+	require.NoError(t, graph.AddEdge("consumer_b", END))
+
+	runnable, err := graph.Compile(ctx, WithCheckPointStore(newInMemoryStore()))
+	require.NoError(t, err)
+	_, err = runnable.Stream(ctx, "input", WithCheckPointID("fan-out-interrupt"))
+	info, ok := ExtractInterruptInfo(err)
+	require.True(t, ok)
+	assert.Equal(t, []string{"ToolNode"}, info.RerunNodes)
+	require.Len(t, info.InterruptContexts, 1)
+}
+
+func TestAttack_EmptyIDInterruptSignalsRemainDistinct(t *testing.T) {
+	first := &core.InterruptSignal{}
+	second := &core.InterruptSignal{}
+	tempInfo := newInterruptTempInfo()
+
+	tempInfo.appendSignal(first)
+	tempInfo.appendSignal(second)
+	tempInfo.appendSignal(first)
+
+	assert.Equal(t, []*core.InterruptSignal{first, second}, tempInfo.signals)
+}
+
+func TestRestoreRejectsInputlessSubGraphRerunCheckpoint(t *testing.T) {
+	ctx := context.Background()
+	store := newInMemoryStore()
+	var childExecuted bool
+
+	child := NewGraph[string, string]()
+	require.NoError(t, child.AddLambdaNode("child", InvokableLambda(func(_ context.Context, input string) (string, error) {
+		childExecuted = true
+		return input, nil
+	})))
+	require.NoError(t, child.AddEdge(START, "child"))
+	require.NoError(t, child.AddEdge("child", END))
+
+	parent := NewGraph[string, string]()
+	require.NoError(t, parent.AddGraphNode("nested", child))
+	require.NoError(t, parent.AddEdge(START, "nested"))
+	require.NoError(t, parent.AddEdge("nested", END))
+
+	runnable, err := parent.Compile(ctx, WithCheckPointStore(store))
+	require.NoError(t, err)
+
+	data, err := (&serialization.InternalSerializer{}).Marshal(&checkpoint{
+		Inputs:     map[string]any{},
+		RerunNodes: []string{"nested"},
+		SubGraphs:  map[string]*checkpoint{},
+	})
+	require.NoError(t, err)
+	require.NoError(t, store.Set(ctx, "malformed", data))
+
+	_, err = runnable.Invoke(ctx, "", WithCheckPointID("malformed"))
+	require.ErrorContains(t, err, `invalid checkpoint: subgraph node "nested" is marked for rerun without a nested checkpoint or persisted input`)
+	assert.False(t, childExecuted)
+
+	nestedStore := newInMemoryStore()
+	middle := NewGraph[string, string]()
+	require.NoError(t, middle.AddGraphNode("nested", child))
+	require.NoError(t, middle.AddEdge(START, "nested"))
+	require.NoError(t, middle.AddEdge("nested", END))
+
+	root := NewGraph[string, string]()
+	require.NoError(t, root.AddGraphNode("middle", middle))
+	require.NoError(t, root.AddEdge(START, "middle"))
+	require.NoError(t, root.AddEdge("middle", END))
+
+	nestedRunnable, err := root.Compile(ctx, WithCheckPointStore(nestedStore))
+	require.NoError(t, err)
+	data, err = (&serialization.InternalSerializer{}).Marshal(&checkpoint{
+		Inputs:     map[string]any{},
+		RerunNodes: []string{"middle"},
+		SubGraphs: map[string]*checkpoint{
+			"middle": {
+				Inputs:     map[string]any{},
+				RerunNodes: []string{"nested"},
+				SubGraphs:  map[string]*checkpoint{},
+			},
+		},
+	})
+	require.NoError(t, err)
+	require.NoError(t, nestedStore.Set(ctx, "nested-malformed", data))
+
+	_, err = nestedRunnable.Invoke(ctx, "", WithCheckPointID("nested-malformed"))
+	require.ErrorContains(t, err, `invalid checkpoint: subgraph node "nested" is marked for rerun without a nested checkpoint or persisted input`)
+	assert.False(t, childExecuted)
 }
 
 type longRunningToolInput struct {

--- a/compose/generic_helper.go
+++ b/compose/generic_helper.go
@@ -161,19 +161,19 @@ type handlerPair struct {
 }
 
 type streamConvertPair struct {
-	concatStream  func(sr streamReader) (any, error)
+	concatStream  func(sr streamReader, ignoreError func(error) bool) (any, error)
 	restoreStream func(any) (streamReader, error)
 }
 
 func defaultStreamConvertPair[T any]() streamConvertPair {
 	var t T
 	return streamConvertPair{
-		concatStream: func(sr streamReader) (any, error) {
+		concatStream: func(sr streamReader, ignoreError func(error) bool) (any, error) {
 			tsr, ok := unpackStreamReader[T](sr)
 			if !ok {
 				return nil, fmt.Errorf("cannot convert sr to streamReader[%T]", t)
 			}
-			value, err := concatStreamReader(tsr)
+			value, err := concatStreamReaderWithErrorFilter(tsr, ignoreError)
 			if err != nil {
 				if errors.Is(err, emptyStreamConcatErr) {
 					return nil, nil

--- a/compose/graph_call_options.go
+++ b/compose/graph_call_options.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"fmt"
 	"reflect"
+	"sync"
 	"time"
 
 	"github.com/cloudwego/eino/callbacks"
@@ -31,9 +32,14 @@ import (
 	"github.com/cloudwego/eino/components/retriever"
 )
 
-type graphCancelChanKey struct{}
-type graphCancelChanVal struct {
-	ch chan *time.Duration
+type graphCancelSignalKey struct{}
+type graphCancelSignal struct {
+	done chan struct{}
+
+	mu        sync.RWMutex
+	triggered bool
+	timeout   *time.Duration
+	deadline  *time.Time
 }
 
 type graphInterruptOptions struct {
@@ -70,22 +76,40 @@ func WithGraphInterruptTimeout(timeout time.Duration) GraphInterruptOption {
 // or resuming from an interrupt. The recommended approach is to use compose.GetInterruptState() to explicitly
 // determine whether the current execution is a first run or a resume.
 func WithGraphInterrupt(parent context.Context) (ctx context.Context, interrupt func(opts ...GraphInterruptOption)) {
-	ch := make(chan *time.Duration, 1)
-	ctx = context.WithValue(parent, graphCancelChanKey{}, &graphCancelChanVal{
-		ch: ch,
-	})
+	cancel := &graphCancelSignal{done: make(chan struct{})}
+	ctx = context.WithValue(parent, graphCancelSignalKey{}, cancel)
 	return ctx, func(opts ...GraphInterruptOption) {
 		o := &graphInterruptOptions{}
 		for _, opt := range opts {
 			opt(o)
 		}
-		ch <- o.timeout
-		close(ch)
+		cancel.trigger(o.timeout)
 	}
 }
 
-func getGraphCancel(ctx context.Context) *graphCancelChanVal {
-	val, ok := ctx.Value(graphCancelChanKey{}).(*graphCancelChanVal)
+func (c *graphCancelSignal) trigger(timeout *time.Duration) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if c.triggered {
+		panic("compose: graph interrupt called more than once")
+	}
+	c.triggered = true
+	c.timeout = timeout
+	if timeout != nil && *timeout > 0 {
+		deadline := time.Now().Add(*timeout)
+		c.deadline = &deadline
+	}
+	close(c.done)
+}
+
+func (c *graphCancelSignal) request() (timeout *time.Duration, deadline *time.Time) {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+	return c.timeout, c.deadline
+}
+
+func getGraphCancel(ctx context.Context) *graphCancelSignal {
+	val, ok := ctx.Value(graphCancelSignalKey{}).(*graphCancelSignal)
 	if !ok {
 		return nil
 	}
@@ -104,6 +128,11 @@ type Option struct {
 	writeToCheckPointID *string
 	forceNewRun         bool
 	stateModifier       StateModifier
+
+	// subGraphCheckpointPublisher is a one-hop parent-child execution option.
+	// It is injected after option extraction and intentionally omitted from
+	// deepCopy so a child graph cannot forward its parent's publisher.
+	subGraphCheckpointPublisher func(*subGraphInterruptError)
 }
 
 func (o Option) deepCopy() Option {

--- a/compose/graph_manager.go
+++ b/compose/graph_manager.go
@@ -255,15 +255,18 @@ func appendIfNotExist(s []string, elem string) []string {
 }
 
 type task struct {
-	ctx            context.Context
-	nodeKey        string
-	call           *chanCall
-	input          any
-	originalInput  any
-	output         any
-	option         []any
-	err            error
-	skipPreHandler bool
+	ctx                     context.Context
+	nodeKey                 string
+	call                    *chanCall
+	input                   any
+	originalInput           any
+	output                  any
+	option                  []any
+	err                     error
+	skipPreHandler          bool
+	syntheticRerunInput     bool
+	subGraphCheckpointReady <-chan *subGraphInterruptError
+	finished                chan struct{}
 }
 
 type taskManager struct {
@@ -275,7 +278,7 @@ type taskManager struct {
 	done         *internal.UnboundedChan[*task]
 	runningTasks map[string]*task
 
-	cancelCh chan *time.Duration
+	cancel   *graphCancelSignal
 	canceled bool
 	deadline *time.Time
 
@@ -290,6 +293,7 @@ func (t *taskManager) execute(currentTask *task) {
 			currentTask.err = safe.NewPanicErr(panicInfo, debug.Stack())
 		}
 
+		close(currentTask.finished)
 		t.done.Send(currentTask)
 	}()
 
@@ -307,8 +311,11 @@ func (t *taskManager) submit(tasks []*task) error {
 	// 2. the task manager mode is set to needAll
 	for i := 0; i < len(tasks); i++ {
 		currentTask := tasks[i]
+		if currentTask.finished == nil {
+			currentTask.finished = make(chan struct{})
+		}
 
-		if t.persistRerunInput {
+		if t.persistRerunInput && !currentTask.syntheticRerunInput {
 			if sr, ok := currentTask.input.(streamReader); ok {
 				copies := sr.copy(2)
 				currentTask.originalInput, currentTask.input = copies[0], copies[1]
@@ -324,6 +331,7 @@ func (t *taskManager) submit(tasks []*task) error {
 			tasks = append(tasks[:i], tasks[i+1:]...)
 			i--
 			t.num++
+			close(currentTask.finished)
 			t.done.Send(currentTask)
 		}
 
@@ -335,7 +343,7 @@ func (t *taskManager) submit(tasks []*task) error {
 	}
 
 	var syncTask *task
-	if t.num == 0 && (len(tasks) == 1 || t.needAll) && t.cancelCh == nil /*if graph can be interrupted by user, shouldn't sync run task*/ {
+	if t.num == 0 && (len(tasks) == 1 || t.needAll) && t.cancel == nil /*if graph can be interrupted by user, shouldn't sync run task*/ {
 		syncTask = tasks[0]
 		tasks = tasks[1:]
 	}
@@ -358,13 +366,13 @@ func (t *taskManager) wait() (tasks []*task, canceled bool, canceledTasks []*tas
 
 	ta, success, canceled := t.waitOne()
 	if canceled {
-		// has canceled and timeout, return canceled tasks
-		for _, rta := range t.runningTasks {
-			canceledTasks = append(canceledTasks, rta)
-		}
+		// A framework-owned subgraph can always observe the same graph
+		// interrupt and produce its own stable checkpoint. Wait for that
+		// handoff before the parent snapshots its state.
+		tasks, canceledTasks = t.settleCanceledSubgraphs()
 		t.runningTasks = make(map[string]*task)
 		t.num = 0
-		return nil, true, canceledTasks
+		return tasks, true, canceledTasks
 	}
 	if t.canceled {
 		// has canceled, but not timeout, wait all
@@ -383,20 +391,23 @@ func (t *taskManager) waitOne() (ta *task, success bool, canceled bool) {
 		return nil, false, false
 	}
 
-	if t.cancelCh == nil {
+	if t.cancel == nil {
 		ta, _ = t.done.Receive()
 	} else {
 		ta, _, canceled = t.receive(t.done.Receive)
 	}
 
-	t.num--
-
 	if canceled {
 		return nil, false, true
 	}
 
+	t.num--
 	delete(t.runningTasks, ta.nodeKey)
+	t.finishTask(ta)
+	return ta, true, false
+}
 
+func (t *taskManager) finishTask(ta *task) {
 	if ta.originalInput != nil && (ta.err == nil || !isInterruptError(ta.err)) {
 		if sr, ok := ta.originalInput.(streamReader); ok {
 			sr.close()
@@ -406,10 +417,47 @@ func (t *taskManager) waitOne() (ta *task, success bool, canceled bool) {
 
 	if ta.err != nil {
 		// biz error, jump post processor
-		return ta, true, false
+		return
 	}
 	runPostHandler(ta, t.runWrapper)
-	return ta, true, false
+}
+
+func (t *taskManager) settleCanceledSubgraphs() (completedTasks, canceledTasks []*task) {
+	for key, runningTask := range t.runningTasks {
+		if runningTask.subGraphCheckpointReady == nil {
+			continue
+		}
+
+		var completedTask *task
+		select {
+		case subGraphCheckpoint := <-runningTask.subGraphCheckpointReady:
+			completedTask = &task{
+				ctx:                     runningTask.ctx,
+				nodeKey:                 runningTask.nodeKey,
+				call:                    runningTask.call,
+				input:                   runningTask.input,
+				originalInput:           runningTask.originalInput,
+				option:                  runningTask.option,
+				err:                     subGraphCheckpoint,
+				skipPreHandler:          runningTask.skipPreHandler,
+				syntheticRerunInput:     runningTask.syntheticRerunInput,
+				subGraphCheckpointReady: runningTask.subGraphCheckpointReady,
+				finished:                runningTask.finished,
+			}
+		case <-runningTask.finished:
+			completedTask = runningTask
+		}
+
+		t.num--
+		delete(t.runningTasks, key)
+		t.finishTask(completedTask)
+		completedTasks = append(completedTasks, completedTask)
+	}
+
+	for _, runningTask := range t.runningTasks {
+		canceledTasks = append(canceledTasks, runningTask)
+	}
+	return completedTasks, canceledTasks
 }
 
 func (t *taskManager) waitAll() (successTasks []*task, canceledTasks []*task) {
@@ -417,12 +465,11 @@ func (t *taskManager) waitAll() (successTasks []*task, canceledTasks []*task) {
 	for {
 		ta, success, canceled := t.waitOne()
 		if canceled {
-			for _, rt := range t.runningTasks {
-				canceledTasks = append(canceledTasks, rt)
-			}
+			settledTasks, remainingTasks := t.settleCanceledSubgraphs()
+			result = append(result, settledTasks...)
 			t.runningTasks = make(map[string]*task)
 			t.num = 0
-			return result, canceledTasks
+			return result, remainingTasks
 		}
 		if !success {
 			return result, nil
@@ -441,9 +488,9 @@ func (t *taskManager) receive(recv func() (*task, bool)) (ta *task, closed bool,
 		ta, closed = recv()
 		return ta, closed, false
 	}
-	if t.cancelCh != nil {
+	if t.cancel != nil {
 		// have not canceled, receive while listening
-		ta, closed, canceled, t.canceled, t.deadline = receiveWithListening(recv, t.cancelCh)
+		ta, closed, canceled, t.canceled, t.deadline = receiveWithListening(recv, t.cancel)
 		return ta, closed, canceled
 	}
 	// won't cancel
@@ -476,7 +523,10 @@ func receiveWithDeadline(recv func() (*task, bool), deadline time.Time) (ta *tas
 	}
 }
 
-func receiveWithListening(recv func() (*task, bool), cancel chan *time.Duration) (*task, bool, bool, bool, *time.Time) {
+func receiveWithListening(
+	recv func() (*task, bool),
+	cancel *graphCancelSignal,
+) (*task, bool, bool, bool, *time.Time) {
 	type pair struct {
 		ta     *task
 		closed bool
@@ -503,10 +553,8 @@ func receiveWithListening(recv func() (*task, bool), cancel chan *time.Duration)
 		// cancel call — that residual race is inherent to unsynchronized
 		// concurrent channel signals.
 		select {
-		case timeout, ok := <-cancel:
-			if !ok {
-				return nil, false, true, true, nil
-			}
+		case <-cancel.done:
+			timeout, requestedDeadline := cancel.request()
 			if timeout == nil {
 				// Unlimited grace period: the task's real result is authoritative.
 				return p.ta, p.closed, false, true, nil
@@ -515,20 +563,12 @@ func receiveWithListening(recv func() (*task, bool), cancel chan *time.Duration)
 				now := time.Now()
 				return nil, false, true, true, &now
 			}
-			dt := time.Now().Add(*timeout)
-			return p.ta, p.closed, false, true, &dt
+			return p.ta, p.closed, false, true, requestedDeadline
 		default:
 			return p.ta, p.closed, false, false, nil
 		}
-	case timeout, ok := <-cancel:
-		if !ok {
-			// The cancel channel has been closed — this means a previous call to
-			// receiveWithListening already consumed the cancel signal (task completed
-			// at the same time as cancel, and select picked the task result). Since
-			// cancel was already issued, treat this as an immediate cancel rather than
-			// blocking forever on resultCh.
-			return nil, false, true, true, nil
-		}
+	case <-cancel.done:
+		timeout, requestedDeadline := cancel.request()
 		canceled = true
 		if timeout == nil {
 			break
@@ -546,9 +586,12 @@ func receiveWithListening(recv func() (*task, bool), cancel chan *time.Duration)
 			now := time.Now()
 			return nil, false, true, true, &now
 		}
-		timeoutCh = time.After(*timeout)
-		dt := time.Now().Add(*timeout)
-		deadline = &dt
+		deadline = requestedDeadline
+		remaining := time.Until(*deadline)
+		if remaining <= 0 {
+			return nil, false, true, true, deadline
+		}
+		timeoutCh = time.After(remaining)
 	}
 
 	if timeoutCh != nil {

--- a/compose/graph_manager_test.go
+++ b/compose/graph_manager_test.go
@@ -17,11 +17,115 @@
 package compose
 
 import (
+	"context"
+	"errors"
 	"testing"
 	"time"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/cloudwego/eino/internal"
 )
+
+func triggeredGraphCancel(timeout *time.Duration) *graphCancelSignal {
+	cancel := &graphCancelSignal{done: make(chan struct{})}
+	cancel.trigger(timeout)
+	return cancel
+}
+
+func TestGraphCancelBroadcast(t *testing.T) {
+	timeout := 100 * time.Millisecond
+	cancel := triggeredGraphCancel(&timeout)
+
+	for i := 0; i < 3; i++ {
+		select {
+		case <-cancel.done:
+			gotTimeout, deadline := cancel.request()
+			require.NotNil(t, gotTimeout)
+			assert.Equal(t, timeout, *gotTimeout)
+			assert.NotNil(t, deadline)
+		case <-time.After(time.Second):
+			t.Fatalf("listener %d did not observe graph cancellation", i)
+		}
+	}
+}
+
+func TestTaskManagerSettleCanceledSubgraphUsesPublishedCheckpoint(t *testing.T) {
+	ready := make(chan *subGraphInterruptError, 1)
+	published := &subGraphInterruptError{CheckPoint: &checkpoint{}}
+	ready <- published
+
+	subGraphTask := &task{
+		nodeKey:                 "subgraph",
+		subGraphCheckpointReady: ready,
+		finished:                make(chan struct{}),
+	}
+	manager := &taskManager{
+		num:          1,
+		runningTasks: map[string]*task{"subgraph": subGraphTask},
+	}
+
+	completed, canceled := manager.settleCanceledSubgraphs()
+
+	require.Len(t, completed, 1)
+	assert.Same(t, published, completed[0].err)
+	assert.Empty(t, canceled)
+}
+
+func TestAttack_SubGraphCheckpointPublisherIsOneHop(t *testing.T) {
+	rawOpts, ready := withSubGraphCheckpointPublisher(nil)
+	opts, err := convertOption[Option](rawOpts...)
+	require.NoError(t, err)
+
+	publish := getSubGraphCheckpointPublisher(opts...)
+	require.NotNil(t, publish)
+	want := &subGraphInterruptError{CheckPoint: &checkpoint{}}
+	publish(want)
+	assert.Same(t, want, <-ready)
+
+	nodes := map[string]*chanCall{
+		"nested": {action: &composableRunnable{optionType: nil}},
+	}
+	forwarded, err := extractOption(nodes, opts...)
+	assert.NoError(t, err)
+	assert.Empty(t, forwarded, "the parent publisher must not propagate into a grandchild graph")
+}
+
+func TestTaskManagerPreHandlerFailureClosesFinished(t *testing.T) {
+	wantErr := errors.New("pre-handler failed")
+	preProcessor := &composableRunnable{}
+	failedTask := &task{
+		nodeKey: "subgraph",
+		call: &chanCall{
+			action:       &composableRunnable{},
+			preProcessor: preProcessor,
+		},
+		subGraphCheckpointReady: make(chan *subGraphInterruptError),
+	}
+	manager := &taskManager{
+		runWrapper: func(_ context.Context, runnable *composableRunnable, _ any, _ ...any) (any, error) {
+			if runnable == preProcessor {
+				return nil, wantErr
+			}
+			return nil, nil
+		},
+		done:         internal.NewUnboundedChan[*task](),
+		runningTasks: make(map[string]*task),
+	}
+
+	require.NoError(t, manager.submit([]*task{failedTask}))
+	select {
+	case <-failedTask.finished:
+	case <-time.After(time.Second):
+		t.Fatal("pre-handler failure did not mark task as finished")
+	}
+
+	completed, canceled := manager.settleCanceledSubgraphs()
+	require.Len(t, completed, 1)
+	assert.ErrorIs(t, completed[0].err, wantErr)
+	assert.Empty(t, canceled)
+}
 
 // TestReceiveWithListening_ZeroTimeout_WinsAgainstDelayedTaskCompletion
 // covers https://github.com/cloudwego/eino/issues/1148 at the compose level.
@@ -49,16 +153,13 @@ func TestReceiveWithListening_ZeroTimeout_WinsAgainstDelayedTaskCompletion(t *te
 			return &task{nodeKey: "n"}, true
 		}
 
-		cancelCh := make(chan *time.Duration, 1)
-
 		go func() {
 			time.Sleep(time.Microsecond)
 			close(recvReleased)
 		}()
 		zero := time.Duration(0)
-		cancelCh <- &zero
 
-		ta, _, immediateCanceled, canceled, _ := receiveWithListening(recv, cancelCh)
+		ta, _, immediateCanceled, canceled, _ := receiveWithListening(recv, triggeredGraphCancel(&zero))
 
 		assert.True(t, canceled, "iteration %d", i)
 		assert.True(t, immediateCanceled, "iteration %d: zero-timeout cancel must win against a slightly-delayed task completion", i)
@@ -78,15 +179,12 @@ func TestReceiveWithListening_UnlimitedGrace_UsesRealTaskResult(t *testing.T) {
 		return want, true
 	}
 
-	cancelCh := make(chan *time.Duration, 1)
-	cancelCh <- nil // unlimited grace: no timeout
-
 	go func() {
 		time.Sleep(20 * time.Millisecond)
 		close(recvReleased)
 	}()
 
-	ta, _, immediateCanceled, canceled, deadline := receiveWithListening(recv, cancelCh)
+	ta, _, immediateCanceled, canceled, deadline := receiveWithListening(recv, triggeredGraphCancel(nil))
 
 	assert.True(t, canceled)
 	assert.False(t, immediateCanceled)
@@ -105,16 +203,14 @@ func TestReceiveWithListening_PositiveTimeout_TaskFinishesWithinGrace(t *testing
 		return want, true
 	}
 
-	cancelCh := make(chan *time.Duration, 1)
 	timeout := 200 * time.Millisecond
-	cancelCh <- &timeout
 
 	go func() {
 		time.Sleep(20 * time.Millisecond)
 		close(recvReleased)
 	}()
 
-	ta, _, immediateCanceled, canceled, deadline := receiveWithListening(recv, cancelCh)
+	ta, _, immediateCanceled, canceled, deadline := receiveWithListening(recv, triggeredGraphCancel(&timeout))
 
 	assert.True(t, canceled)
 	assert.False(t, immediateCanceled)
@@ -133,11 +229,9 @@ func TestReceiveWithListening_PositiveTimeout_DeadlineExpiresFirst(t *testing.T)
 	}
 	defer close(recvReleased)
 
-	cancelCh := make(chan *time.Duration, 1)
 	timeout := 20 * time.Millisecond
-	cancelCh <- &timeout
 
-	ta, _, immediateCanceled, canceled, deadline := receiveWithListening(recv, cancelCh)
+	ta, _, immediateCanceled, canceled, deadline := receiveWithListening(recv, triggeredGraphCancel(&timeout))
 
 	assert.True(t, canceled)
 	assert.True(t, immediateCanceled)

--- a/compose/graph_run.go
+++ b/compose/graph_run.go
@@ -157,6 +157,9 @@ func (r *runner) run(ctx context.Context, isStream bool, input any, opts ...Opti
 		// in subgraph, try to load checkpoint from ctx
 		initialized = true
 
+		if err = r.validateCheckpointIntegrity(cp); err != nil {
+			return nil, newGraphRunError(fmt.Errorf("invalid checkpoint: %w", err))
+		}
 		ctx, err = r.restoreCheckPointState(ctx, *path, getStateModifier(ctx), cp, isStream, cm)
 		if err != nil {
 			return nil, err
@@ -178,6 +181,9 @@ func (r *runner) run(ctx context.Context, isStream bool, input any, opts ...Opti
 			// load checkpoint from store
 			initialized = true
 
+			if err = r.validateCheckpointIntegrity(cp); err != nil {
+				return nil, newGraphRunError(fmt.Errorf("invalid checkpoint: %w", err))
+			}
 			ctx = setStateModifier(ctx, stateModifier)
 			ctx = setCheckPointToCtx(ctx, cp)
 
@@ -424,18 +430,32 @@ func (r *runner) restoreCheckPointState(
 func newInterruptTempInfo() *interruptTempInfo {
 	return &interruptTempInfo{
 		subGraphInterrupts:  map[string]*subGraphInterruptError{},
+		interruptTaskNodes:  map[string]struct{}{},
 		interruptRerunExtra: map[string]any{},
 	}
 }
 
 type interruptTempInfo struct {
 	subGraphInterrupts   map[string]*subGraphInterruptError
+	interruptTaskNodes   map[string]struct{}
 	interruptRerunNodes  []string
 	interruptBeforeNodes []string
 	interruptAfterNodes  []string
 	interruptRerunExtra  map[string]any
 
 	signals []*core.InterruptSignal
+}
+
+func (ti *interruptTempInfo) appendSignal(signal *core.InterruptSignal) {
+	if signal == nil {
+		return
+	}
+	for _, existing := range ti.signals {
+		if existing == signal || signal.ID != "" && existing.ID == signal.ID {
+			return
+		}
+	}
+	ti.signals = append(ti.signals, signal)
 }
 
 func (ti *interruptTempInfo) collectCanceledInfo(canceled bool, canceledTasks, completedTasks []*task) {
@@ -459,18 +479,22 @@ func (r *runner) resolveInterruptCompletedTasks(tempInfo *interruptTempInfo, com
 		if completedTask.err != nil {
 			if info := isSubGraphInterrupt(completedTask.err); info != nil {
 				tempInfo.subGraphInterrupts[completedTask.nodeKey] = info
-				tempInfo.signals = append(tempInfo.signals, info.signal)
+				tempInfo.appendSignal(info.signal)
 				continue
 			}
 
 			ire := &core.InterruptSignal{}
 			if errors.As(completedTask.err, &ire) {
-				tempInfo.interruptRerunNodes = append(tempInfo.interruptRerunNodes, completedTask.nodeKey)
+				tempInfo.interruptTaskNodes[completedTask.nodeKey] = struct{}{}
+				// A downstream node can observe an interrupt while consuming a
+				// stream produced by an earlier node. Rerun the addressed node.
+				rerunNodeKey := r.interruptOriginNodeKey(completedTask, ire.Address)
+				tempInfo.interruptRerunNodes = appendIfNotExist(tempInfo.interruptRerunNodes, rerunNodeKey)
 				if ire.Info != nil {
-					tempInfo.interruptRerunExtra[completedTask.nodeKey] = ire.InterruptInfo.Info
+					tempInfo.interruptRerunExtra[rerunNodeKey] = ire.InterruptInfo.Info
 				}
 
-				tempInfo.signals = append(tempInfo.signals, ire)
+				tempInfo.appendSignal(ire)
 				continue
 			}
 
@@ -485,6 +509,26 @@ func (r *runner) resolveInterruptCompletedTasks(tempInfo *interruptTempInfo, com
 		}
 	}
 	return nil
+}
+
+func (r *runner) interruptOriginNodeKey(completedTask *task, address Address) string {
+	taskAddress := GetCurrentAddress(completedTask.ctx)
+	if len(taskAddress) == 0 || taskAddress[len(taskAddress)-1].Type != AddressSegmentNode {
+		return completedTask.nodeKey
+	}
+
+	graphAddress := taskAddress[:len(taskAddress)-1]
+	if len(address) <= len(graphAddress) || !address[:len(graphAddress)].Equals(graphAddress) {
+		return completedTask.nodeKey
+	}
+
+	segment := address[len(graphAddress)]
+	if segment.Type == AddressSegmentNode {
+		if _, ok := r.chanSubscribeTo[segment.ID]; ok {
+			return segment.ID
+		}
+	}
+	return completedTask.nodeKey
 }
 
 func getHitKey(tasks []*task, keys []string) []string {
@@ -612,6 +656,15 @@ func (r *runner) handleInterruptWithSubGraphAndRerunNodes(
 			skipPreHandler[t.nodeKey] = true // subgraph won't run pre-handler again, but rerun nodes will
 			continue
 		}
+		if _, ok := tempInfo.interruptTaskNodes[t.nodeKey]; ok {
+			for _, key := range tempInfo.interruptRerunNodes {
+				if key == t.nodeKey {
+					rerunTasks = append(rerunTasks, t)
+					break
+				}
+			}
+			continue
+		}
 		rerun := false
 		for _, key := range tempInfo.interruptRerunNodes {
 			if key == t.nodeKey {
@@ -681,11 +734,14 @@ func (r *runner) handleInterruptWithSubGraphAndRerunNodes(
 		cp.SubGraphs[t.nodeKey] = tempInfo.subGraphInterrupts[t.nodeKey].CheckPoint
 		intInfo.SubGraphs[t.nodeKey] = tempInfo.subGraphInterrupts[t.nodeKey].Info
 	}
+	cp.RerunNodes = append(cp.RerunNodes, tempInfo.interruptRerunNodes...)
 	for _, t := range rerunTasks {
-		cp.RerunNodes = append(cp.RerunNodes, t.nodeKey)
 		if t.originalInput != nil {
 			cp.Inputs[t.nodeKey] = t.originalInput
 		}
+	}
+	if err = r.validateCheckpointIntegrity(cp); err != nil {
+		return fmt.Errorf("invalid checkpoint: %w", err)
 	}
 	err = r.checkPointer.convertCheckPoint(cp, isStream)
 	if err != nil {
@@ -823,6 +879,27 @@ func (r *runner) restoreTasks(
 		ret = append(ret, newTask)
 	}
 	return ret, nil
+}
+
+func (r *runner) validateCheckpointIntegrity(cp *checkpoint) error {
+	for _, key := range cp.RerunNodes {
+		call, ok := r.chanSubscribeTo[key]
+		if !ok || call.action.meta == nil {
+			continue
+		}
+		cmp := call.action.meta.component
+		if cmp != ComponentOfGraph && cmp != ComponentOfChain && cmp != ComponentOfWorkflow {
+			continue
+		}
+		if subCP, hasSubGraph := cp.SubGraphs[key]; hasSubGraph && subCP != nil {
+			continue
+		}
+		if _, hasInput := cp.Inputs[key]; hasInput {
+			continue
+		}
+		return fmt.Errorf("subgraph node %q is marked for rerun without a nested checkpoint or persisted input", key)
+	}
+	return nil
 }
 
 func (r *runner) resolveCompletedTasks(ctx context.Context, completedTasks []*task, isStream bool, cm *channelManager) (map[string]map[string]any, map[string][]string, error) {

--- a/compose/graph_run.go
+++ b/compose/graph_run.go
@@ -143,6 +143,7 @@ func (r *runner) run(ctx context.Context, isStream bool, input any, opts ...Opti
 
 	// Extract CheckPointID
 	checkPointID, writeToCheckPointID, stateModifier, forceNewRun := getCheckPointInfo(opts...)
+	subGraphCheckpointPublisher := getSubGraphCheckpointPublisher(opts...)
 	if checkPointID != nil && r.checkPointer.store == nil {
 		return nil, newGraphRunError(fmt.Errorf("receive checkpoint id but have not set checkpoint store"))
 	}
@@ -236,6 +237,7 @@ func (r *runner) run(ctx context.Context, isStream bool, input any, opts ...Opti
 				isStream,
 				isSubGraph,
 				writeToCheckPointID,
+				subGraphCheckpointPublisher,
 			)
 		}
 	}
@@ -303,6 +305,7 @@ func (r *runner) run(ctx context.Context, isStream bool, input any, opts ...Opti
 				isSubGraph,
 				cm,
 				isStream,
+				subGraphCheckpointPublisher,
 			)
 		}
 
@@ -344,6 +347,7 @@ func (r *runner) run(ctx context.Context, isStream bool, input any, opts ...Opti
 					isSubGraph,
 					cm,
 					isStream,
+					subGraphCheckpointPublisher,
 				)
 			}
 
@@ -360,7 +364,16 @@ func (r *runner) run(ctx context.Context, isStream bool, input any, opts ...Opti
 			tempInfo.interruptBeforeNodes = append(tempInfo.interruptBeforeNodes, getHitKey(newNextTasks, r.interruptBeforeNodes)...)
 
 			// simple interrupt
-			return nil, r.handleInterrupt(ctx, tempInfo, append(nextTasks, newNextTasks...), cm.channels, isStream, isSubGraph, writeToCheckPointID)
+			return nil, r.handleInterrupt(
+				ctx,
+				tempInfo,
+				append(nextTasks, newNextTasks...),
+				cm.channels,
+				isStream,
+				isSubGraph,
+				writeToCheckPointID,
+				subGraphCheckpointPublisher,
+			)
 		}
 	}
 }
@@ -551,6 +564,7 @@ func (r *runner) handleInterrupt(
 	isStream bool,
 	isSubGraph bool,
 	checkPointID *string,
+	publishSubGraphCheckpoint func(*subGraphInterruptError),
 ) error {
 	cp := &checkpoint{
 		Channels:       channels,
@@ -596,11 +610,15 @@ func (r *runner) handleInterrupt(
 		return fmt.Errorf("failed to convert checkpoint: %w", err)
 	}
 	if isSubGraph {
-		return &subGraphInterruptError{
+		subGraphInterrupt := &subGraphInterruptError{
 			Info:       intInfo,
 			CheckPoint: cp,
 			signal:     is,
 		}
+		if publishSubGraphCheckpoint != nil {
+			publishSubGraphCheckpoint(subGraphInterrupt)
+		}
+		return subGraphInterrupt
 	} else if checkPointID != nil {
 		err := r.checkPointer.set(ctx, *checkPointID, cp)
 		if err != nil {
@@ -647,6 +665,7 @@ func (r *runner) handleInterruptWithSubGraphAndRerunNodes(
 	isSubGraph bool,
 	cm *channelManager,
 	isStream bool,
+	publishSubGraphCheckpoint func(*subGraphInterruptError),
 ) error {
 	var rerunTasks, subgraphTasks, otherTasks []*task
 	skipPreHandler := map[string]bool{}
@@ -748,11 +767,15 @@ func (r *runner) handleInterruptWithSubGraphAndRerunNodes(
 		return fmt.Errorf("failed to convert checkpoint: %w", err)
 	}
 	if isSubGraph {
-		return &subGraphInterruptError{
+		subGraphInterrupt := &subGraphInterruptError{
 			Info:       intInfo,
 			CheckPoint: cp,
 			signal:     is,
 		}
+		if publishSubGraphCheckpoint != nil {
+			publishSubGraphCheckpoint(subGraphInterrupt)
+		}
+		return subGraphInterrupt
 	} else if checkPointID != nil {
 		err = r.checkPointer.set(ctx, *checkPointID, cp)
 		if err != nil {
@@ -796,16 +819,23 @@ func (r *runner) createTasks(ctx context.Context, nodeMap map[string]any, optMap
 			return nil, fmt.Errorf("node[%s] has not been registered", nodeKey)
 		}
 
+		taskCtx := ctx
+		var subGraphCheckpointReady <-chan *subGraphInterruptError
+		taskOpts := optMap[nodeKey]
 		if call.action.nodeInfo != nil && call.action.nodeInfo.compileOption != nil {
-			ctx = forwardCheckPoint(ctx, nodeKey)
+			taskCtx = forwardCheckPoint(taskCtx, nodeKey)
+		}
+		if isSubGraphCall(call) {
+			taskOpts, subGraphCheckpointReady = withSubGraphCheckpointPublisher(taskOpts)
 		}
 
 		nextTasks = append(nextTasks, &task{
-			ctx:     AppendAddressSegment(ctx, AddressSegmentNode, nodeKey),
-			nodeKey: nodeKey,
-			call:    call,
-			input:   nodeInput,
-			option:  optMap[nodeKey],
+			ctx:                     AppendAddressSegment(taskCtx, AddressSegmentNode, nodeKey),
+			nodeKey:                 nodeKey,
+			call:                    call,
+			input:                   nodeInput,
+			option:                  taskOpts,
+			subGraphCheckpointReady: subGraphCheckpointReady,
 		})
 	}
 	return nextTasks, nil
@@ -838,6 +868,7 @@ func (r *runner) restoreTasks(
 	isStream bool,
 	optMap map[string][]any) ([]*task, error) {
 	ret := make([]*task, 0, len(inputs))
+	syntheticInputs := make(map[string]struct{})
 	for _, key := range rerunNodes {
 		if _, hasInput := inputs[key]; hasInput {
 			continue
@@ -852,6 +883,7 @@ func (r *runner) restoreTasks(
 		} else {
 			inputs[key] = call.action.inputZeroValue()
 		}
+		syntheticInputs[key] = struct{}{}
 	}
 	for key, input := range inputs {
 		call, ok := r.chanSubscribeTo[key]
@@ -859,23 +891,29 @@ func (r *runner) restoreTasks(
 			return nil, fmt.Errorf("channel[%s] from checkpoint is not registered", key)
 		}
 
+		taskCtx := ctx
+		var subGraphCheckpointReady <-chan *subGraphInterruptError
+		taskOpts := optMap[key]
 		if call.action.nodeInfo != nil && call.action.nodeInfo.compileOption != nil {
 			// sub graph
-			ctx = forwardCheckPoint(ctx, key)
+			taskCtx = forwardCheckPoint(taskCtx, key)
+		}
+		if isSubGraphCall(call) {
+			taskOpts, subGraphCheckpointReady = withSubGraphCheckpointPublisher(taskOpts)
 		}
 
 		newTask := &task{
-			ctx:            AppendAddressSegment(ctx, AddressSegmentNode, key),
-			nodeKey:        key,
-			call:           call,
-			input:          input,
-			option:         nil,
-			skipPreHandler: skipPreHandler[key],
+			ctx:                     AppendAddressSegment(taskCtx, AddressSegmentNode, key),
+			nodeKey:                 key,
+			call:                    call,
+			input:                   input,
+			option:                  taskOpts,
+			skipPreHandler:          skipPreHandler[key],
+			subGraphCheckpointReady: subGraphCheckpointReady,
 		}
-		if opt, ok := optMap[key]; ok {
-			newTask.option = opt
+		if _, ok := syntheticInputs[key]; ok {
+			newTask.syntheticRerunInput = true
 		}
-
 		ret = append(ret, newTask)
 	}
 	return ret, nil
@@ -884,11 +922,7 @@ func (r *runner) restoreTasks(
 func (r *runner) validateCheckpointIntegrity(cp *checkpoint) error {
 	for _, key := range cp.RerunNodes {
 		call, ok := r.chanSubscribeTo[key]
-		if !ok || call.action.meta == nil {
-			continue
-		}
-		cmp := call.action.meta.component
-		if cmp != ComponentOfGraph && cmp != ComponentOfChain && cmp != ComponentOfWorkflow {
+		if !ok || !isSubGraphCall(call) {
 			continue
 		}
 		if subCP, hasSubGraph := cp.SubGraphs[key]; hasSubGraph && subCP != nil {
@@ -900,6 +934,14 @@ func (r *runner) validateCheckpointIntegrity(cp *checkpoint) error {
 		return fmt.Errorf("subgraph node %q is marked for rerun without a nested checkpoint or persisted input", key)
 	}
 	return nil
+}
+
+func isSubGraphCall(call *chanCall) bool {
+	if call == nil || call.action == nil || call.action.meta == nil {
+		return false
+	}
+	cmp := call.action.meta.component
+	return cmp == ComponentOfGraph || cmp == ComponentOfChain || cmp == ComponentOfWorkflow
 }
 
 func (r *runner) resolveCompletedTasks(ctx context.Context, completedTasks []*task, isStream bool, cm *channelManager) (map[string]map[string]any, map[string][]string, error) {
@@ -1007,7 +1049,7 @@ func (r *runner) calculateBranch(ctx context.Context, curNodeKey string, startCh
 	return ret, nil
 }
 
-func (r *runner) initTaskManager(runWrapper runnableCallWrapper, cancelVal *graphCancelChanVal, opts ...Option) *taskManager {
+func (r *runner) initTaskManager(runWrapper runnableCallWrapper, cancelVal *graphCancelSignal, opts ...Option) *taskManager {
 	tm := &taskManager{
 		runWrapper:        runWrapper,
 		opts:              opts,
@@ -1017,7 +1059,7 @@ func (r *runner) initTaskManager(runWrapper runnableCallWrapper, cancelVal *grap
 		persistRerunInput: cancelVal != nil,
 	}
 	if cancelVal != nil {
-		tm.cancelCh = cancelVal.ch
+		tm.cancel = cancelVal
 	}
 	return tm
 }

--- a/compose/graph_run.go
+++ b/compose/graph_run.go
@@ -109,6 +109,9 @@ func runnableTransform(ctx context.Context, r *composableRunnable, input any, op
 func (r *runner) run(ctx context.Context, isStream bool, input any, opts ...Option) (result any, err error) {
 	haveOnStart := false // delay triggering onGraphStart until state initialization is complete, so that the state can be accessed within onGraphStart.
 	defer func() {
+		if panicValue := recover(); panicValue != nil {
+			panic(panicValue)
+		}
 		if !haveOnStart {
 			ctx, input = onGraphStart(ctx, input, isStream)
 		}

--- a/compose/graph_run_panic_test.go
+++ b/compose/graph_run_panic_test.go
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2026 CloudWeGo Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package compose
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/cloudwego/eino/schema"
+)
+
+func TestRunnerRunPreservesOriginalPanic(t *testing.T) {
+	want := errors.New("original graph panic")
+	r := &runner{
+		chanSubscribeTo:     make(map[string]*chanCall),
+		successors:          make(map[string][]string),
+		dataPredecessors:    make(map[string][]string),
+		controlPredecessors: make(map[string][]string),
+		genericHelper:       &genericHelper{},
+		options: graphCompileOptions{
+			maxRunSteps: 1,
+		},
+		runCtx: func(context.Context) context.Context {
+			panic(want)
+		},
+	}
+	input := packStreamReader(schema.StreamReaderFromArray([]string{"input"}))
+
+	require.PanicsWithValue(t, want, func() {
+		_, _ = r.run(context.Background(), true, input)
+	})
+}

--- a/compose/stream_concat.go
+++ b/compose/stream_concat.go
@@ -48,6 +48,10 @@ func RegisterStreamChunkConcatFunc[T any](fn func([]T) (T, error)) {
 var emptyStreamConcatErr = errors.New("stream reader is empty, concat fail")
 
 func concatStreamReader[T any](sr *schema.StreamReader[T]) (T, error) {
+	return concatStreamReaderWithErrorFilter(sr, nil)
+}
+
+func concatStreamReaderWithErrorFilter[T any](sr *schema.StreamReader[T], ignoreError func(error) bool) (T, error) {
 	defer sr.Close()
 
 	var items []T
@@ -61,6 +65,9 @@ func concatStreamReader[T any](sr *schema.StreamReader[T]) (T, error) {
 
 			if _, ok := schema.GetSourceName(err); ok {
 				continue
+			}
+			if ignoreError != nil && ignoreError(err) {
+				break
 			}
 
 			var t T


### PR DESCRIPTION
## Problem

In v0.9, a late interrupt carried by a stream can be attributed to the downstream consumer instead of its originating node. Nested graphs may then persist an incomplete checkpoint. A timeout during resumed streaming can also let the parent snapshot state before the child graph has published its stable checkpoint, causing resolved interrupts to be replayed.

The visible `interface conversion: interface is nil, not compose.streamReader` panic can mask the original checkpoint conversion failure.

## Solution

Backport the checkpoint fixes from #1213 and #1222:

- Attribute late stream interrupts to their originating node and preserve nested checkpoints.
- Ignore only interrupt errors already represented in the checkpoint while materializing copied streams.
- Broadcast graph cancellation to nested graphs and wait for child checkpoint publication before the parent snapshots state.
- Reject unsafe subgraph reruns that have neither a nested checkpoint nor persisted input.
- Persist only a checkpoint freshly written during the current resumed turn, rather than reusing the checkpoint loaded at startup.
- Preserve the original graph panic instead of running end callbacks with a nil stream result during panic unwinding.

## Key Insight

A nested graph checkpoint is valid only after the child has stopped mutating its stream state. Cancellation must therefore propagate to every graph level, and the parent must consume the child's published checkpoint before serializing its own state.

## Verification

- `golangci-lint run --new-from-rev=origin/main ./...`
- `go test -race ./...`
- `go test -coverprofile=/tmp/eino-v09-backport-full-coverage.out ./...`

---

## 问题

v0.9 中，流内延迟产生的 interrupt 可能被归因到下游消费节点，而不是实际发起 interrupt 的节点，导致嵌套 Graph 保存不完整的 checkpoint。恢复后的流式执行发生超时取消时，父 Graph 也可能在子 Graph 发布稳定 checkpoint 前抢先持久化，后续恢复会再次重放已经处理过的 interrupt。

日志中的 `interface conversion: interface is nil, not compose.streamReader` 是二次 panic，可能遮蔽最初的 checkpoint 转换异常。

## 解决方案

回植 #1213 和 #1222 的 checkpoint 修复：

- 将流内延迟 interrupt 归因到源节点，并保留嵌套 checkpoint。
- 物化流副本时，仅忽略已经记录在当前 checkpoint 中的 interrupt。
- 将 Graph 取消信号改为广播，并在父 Graph 持久化前等待子 Graph 发布稳定 checkpoint。
- 拒绝既无嵌套 checkpoint、也无持久化输入的不安全子图重跑。
- 恢复执行后只保存本轮新写入的 checkpoint，不再把启动时加载的旧 checkpoint 当成新结果。
- Graph panic 展开时不再用 nil 流结果执行结束回调，确保原始 panic 不被二次类型断言覆盖。

## 关键认知

只有子 Graph 停止修改流状态后，其 checkpoint 才是稳定的。取消信号必须传递到每一层 Graph，父 Graph 也必须先接收子 Graph 发布的 checkpoint，再序列化自己的状态。

## 验证

- `golangci-lint run --new-from-rev=origin/main ./...`
- `go test -race ./...`
- `go test -coverprofile=/tmp/eino-v09-backport-full-coverage.out ./...`
