### PR TITLE
fix(compose): register checkpoint boundary stream converters

### DIFF
--- a/compose/checkpoint.go
+++ b/compose/checkpoint.go
@@ -420,6 +420,9 @@ func convert(values map[string]any, convPairs map[string]streamConvertPair, isSt
 		if !ok {
 			return fmt.Errorf("checkpoint conv stream fail, node[%s] have not been registered", key)
 		}
+		if convPair.concatStream == nil {
+			return fmt.Errorf("checkpoint conv stream fail, node[%s] has no stream converter", key)
+		}
 		sr, ok := v.(streamReader)
 		if !ok {
 			return fmt.Errorf("checkpoint conv stream fail, value of [%s] isn't stream", key)
@@ -441,6 +444,9 @@ func restore(values map[string]any, convPairs map[string]streamConvertPair, isSt
 		convPair, ok := convPairs[key]
 		if !ok {
 			return fmt.Errorf("checkpoint restore stream fail, node[%s] have not been registered", key)
+		}
+		if convPair.restoreStream == nil {
+			return fmt.Errorf("checkpoint restore stream fail, node[%s] has no stream converter", key)
 		}
 		sr, err := convPair.restoreStream(v)
 		if err != nil {

--- a/compose/checkpoint_test.go
+++ b/compose/checkpoint_test.go
@@ -2020,6 +2020,63 @@ func TestStreamingSubGraphReinterruptPreservesNestedCheckpoint(t *testing.T) {
 	assert.Equal(t, int32(1), atomic.LoadInt32(&sideEffectCount))
 }
 
+func TestCheckpointConvertsPendingStartStream(t *testing.T) {
+	ctx := context.Background()
+	graph := NewGraph[map[string]any, map[string]any]()
+	require.NoError(t, graph.AddLambdaNode("interrupt", InvokableLambda(
+		func(ctx context.Context, _ map[string]any) (map[string]any, error) {
+			interrupted, _, _ := GetInterruptState[string](ctx)
+			if interrupted {
+				return map[string]any{"right": "done"}, nil
+			}
+			return nil, StatefulInterrupt(ctx, "pause", "state")
+		},
+	)))
+	require.NoError(t, graph.AddLambdaNode("join", InvokableLambda(
+		func(_ context.Context, input map[string]any) (map[string]any, error) {
+			return input, nil
+		},
+	)))
+	require.NoError(t, graph.AddEdge(START, "interrupt"))
+	require.NoError(t, graph.AddEdge(START, "join"))
+	require.NoError(t, graph.AddEdge("interrupt", "join"))
+	require.NoError(t, graph.AddEdge("join", END))
+
+	runnable, err := graph.Compile(ctx,
+		WithNodeTriggerMode(AllPredecessor),
+		WithCheckPointStore(newInMemoryStore()),
+	)
+	require.NoError(t, err)
+
+	require.NotPanics(t, func() {
+		_, err = runnable.Stream(ctx, map[string]any{"left": "input"}, WithCheckPointID("pending-start"))
+	})
+	_, ok := ExtractInterruptInfo(err)
+	require.True(t, ok)
+
+	output, err := runnable.Stream(ctx, nil, WithCheckPointID("pending-start"))
+	require.NoError(t, err)
+	result, err := concatStreamReader(output)
+	require.NoError(t, err)
+	require.Equal(t, map[string]any{
+		"left":  "input",
+		"right": "done",
+	}, result)
+}
+
+func TestCheckpointConversionRejectsMissingStreamConverter(t *testing.T) {
+	values := map[string]any{
+		"node": packStreamReader(schema.StreamReaderFromArray([]string{"input"})),
+	}
+	pairs := map[string]streamConvertPair{"node": {}}
+
+	err := convert(values, pairs, true, nil)
+	require.ErrorContains(t, err, "node[node] has no stream converter")
+
+	err = restore(map[string]any{"node": "input"}, pairs, true)
+	require.ErrorContains(t, err, "node[node] has no stream converter")
+}
+
 func TestCheckpointStreamConversionIgnoresOnlyRecordedInterrupt(t *testing.T) {
 	ctx := context.Background()
 	recordedErr := StatefulInterrupt(ctx, "recorded", "state")

--- a/compose/checkpoint_test.go
+++ b/compose/checkpoint_test.go
@@ -2064,17 +2064,32 @@ func TestCheckpointConvertsPendingStartStream(t *testing.T) {
 	}, result)
 }
 
-func TestCheckpointConversionRejectsMissingStreamConverter(t *testing.T) {
-	values := map[string]any{
-		"node": packStreamReader(schema.StreamReaderFromArray([]string{"input"})),
-	}
-	pairs := map[string]streamConvertPair{"node": {}}
+func TestCheckpointConversionValidation(t *testing.T) {
+	t.Run("non-stream conversion is a no-op", func(t *testing.T) {
+		require.NoError(t, convert(nil, nil, false, nil))
+		require.NoError(t, restore(nil, nil, false))
+	})
 
-	err := convert(values, pairs, true, nil)
-	require.ErrorContains(t, err, "node[node] has no stream converter")
+	t.Run("unregistered node", func(t *testing.T) {
+		values := map[string]any{"node": "input"}
+		require.ErrorContains(t, convert(values, nil, true, nil), "node[node] have not been registered")
+		require.ErrorContains(t, restore(values, nil, true), "node[node] have not been registered")
+	})
 
-	err = restore(map[string]any{"node": "input"}, pairs, true)
-	require.ErrorContains(t, err, "node[node] has no stream converter")
+	t.Run("missing converter", func(t *testing.T) {
+		values := map[string]any{
+			"node": packStreamReader(schema.StreamReaderFromArray([]string{"input"})),
+		}
+		pairs := map[string]streamConvertPair{"node": {}}
+		require.ErrorContains(t, convert(values, pairs, true, nil), "node[node] has no stream converter")
+		require.ErrorContains(t, restore(map[string]any{"node": "input"}, pairs, true), "node[node] has no stream converter")
+	})
+
+	t.Run("invalid value", func(t *testing.T) {
+		pairs := map[string]streamConvertPair{"node": defaultStreamConvertPair[string]()}
+		require.ErrorContains(t, convert(map[string]any{"node": "input"}, pairs, true, nil), "value of [node] isn't stream")
+		require.ErrorContains(t, restore(map[string]any{"node": 1}, pairs, true), "cannot convert value[int]")
+	})
 }
 
 func TestCheckpointStreamConversionIgnoresOnlyRecordedInterrupt(t *testing.T) {

--- a/compose/graph.go
+++ b/compose/graph.go
@@ -868,8 +868,8 @@ func (g *graph) compile(ctx context.Context, opt *graphCompileOptions) (*composa
 			inputPairs[key] = c.action.inputStreamConvertPair
 			outputPairs[key] = c.action.outputStreamConvertPair
 		}
-		inputPairs[END] = r.outputConvertStreamPair
-		outputPairs[START] = r.inputConvertStreamPair
+		inputPairs[END] = r.outputStreamConvertPair
+		outputPairs[START] = r.inputStreamConvertPair
 		r.checkPointer = newCheckPointer(inputPairs, outputPairs, opt.checkPointStore, opt.serializer)
 
 		r.interruptBeforeNodes = opt.interruptBeforeNodes

--- a/compose/graph_run.go
+++ b/compose/graph_run.go
@@ -61,10 +61,9 @@ type runner struct {
 	outputType reflect.Type
 
 	// take effect as a subgraph through toComposableRunnable
-	inputStreamFilter                               streamMapFilter
-	inputConverter                                  handlerPair
-	inputFieldMappingConverter                      handlerPair
-	inputConvertStreamPair, outputConvertStreamPair streamConvertPair
+	inputStreamFilter          streamMapFilter
+	inputConverter             handlerPair
+	inputFieldMappingConverter handlerPair
 
 	*genericHelper
 


### PR DESCRIPTION
## Problem

After #1225, v0.9.16 preserves the original panic and exposes a nil function call in checkpoint stream conversion.

A DAG can retain the graph input in a join channel while another predecessor interrupts:

```text
START ──────────────> join
  └─> interrupt ────> join
```

The retained channel value is keyed by `START`. Checkpoint compilation registered `outputPairs[START]` and `inputPairs[END]` from two unused zero-value `runner` fields, so materializing the pending stream called a nil `concatStream`.

## Solution

Register graph-boundary converters from the initialized `genericHelper`:

- `outputPairs[START]` uses the graph input stream converter.
- `inputPairs[END]` uses the graph output stream converter.
- Remove the unused duplicate converter fields from `runner`.
- Return a descriptive error if a converter function is ever missing instead of panicking.

## Key Insight

Checkpoint conversion is indexed by the producer of each channel value. `START` produces values of the graph input type, while `END` consumes values of the graph output type. Their converters therefore come from the graph's initialized generic helper, not standalone runner fields.

## Verification

- The regression test reproduces the v0.9.16 stack before the fix.
- The same DAG completes interrupt, checkpoint persistence, and resume after the fix.
- `go test -race ./...`
- `GOTOOLCHAIN=go1.18.10 go test ./compose -run 'TestCheckpointConvertsPendingStartStream|TestCheckpointConversionRejectsMissingStreamConverter' -count=20`
- `golangci-lint run --new-from-rev=origin/main ./...`

---

## 问题

#1225 合入后，v0.9.16 已能保留原始 panic，暴露出 checkpoint 流转换中的 nil 函数调用。

当 DAG 的 join 节点同时依赖 `START` 和另一个会 interrupt 的前驱时：

```text
START ──────────────> join
  └─> interrupt ────> join
```

interrupt 发生时，join channel 中仍保存着以 `START` 为 key 的图输入。checkpoint 编译阶段却从两个从未初始化的 `runner` 字段注册 `outputPairs[START]` 和 `inputPairs[END]`，最终在物化 pending stream 时调用 nil `concatStream`。

## 解决方案

改为从已经初始化的 `genericHelper` 注册图边界 converter：

- `outputPairs[START]` 使用 graph input stream converter。
- `inputPairs[END]` 使用 graph output stream converter。
- 删除 `runner` 中未使用且容易误用的重复 converter 字段。
- converter 函数缺失时返回明确错误，不再 panic。

## 关键认知

checkpoint converter 按 channel value 的生产者索引。`START` 产生 graph input 类型，`END` 消费 graph output 类型，因此两端必须复用 graph `genericHelper` 中已经初始化的 converter。

## 验证

- 修复前，回归测试稳定复现 v0.9.16 的相同堆栈。
- 修复后，同一 DAG 可以完成 interrupt、checkpoint 持久化与 resume。
- `go test -race ./...`
- `GOTOOLCHAIN=go1.18.10 go test ./compose -run 'TestCheckpointConvertsPendingStartStream|TestCheckpointConversionRejectsMissingStreamConverter' -count=20`
- `golangci-lint run --new-from-rev=origin/main ./...`
