### PR TITLE
fix(compose): preserve agentic tool checkpoint input

### DIFF
--- a/compose/agentic_tools_node.go
+++ b/compose/agentic_tools_node.go
@@ -18,6 +18,7 @@ package compose
 
 import (
 	"context"
+	"errors"
 
 	"github.com/cloudwego/eino/schema"
 )
@@ -55,6 +56,21 @@ func (a *AgenticToolsNode) Stream(ctx context.Context, input *schema.AgenticMess
 	if err != nil {
 		return nil, err
 	}
+	result = schema.StreamReaderWithConvert(
+		result,
+		func(messages []*schema.Message) ([]*schema.Message, error) {
+			return messages, nil
+		},
+		schema.WithErrWrapper(func(streamErr error) error {
+			checkpointErr := &toolStreamCheckpointError{}
+			if !errors.As(streamErr, &checkpointErr) {
+				return streamErr
+			}
+			agenticCheckpointErr := *checkpointErr
+			agenticCheckpointErr.rerunInput = input
+			return &agenticCheckpointErr
+		}),
+	)
 	return streamToolMessageToAgenticMessage(result), nil
 }
 

--- a/compose/agentic_tools_node_test.go
+++ b/compose/agentic_tools_node_test.go
@@ -18,6 +18,7 @@ package compose
 
 import (
 	"context"
+	"errors"
 	"io"
 	"testing"
 
@@ -26,6 +27,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/cloudwego/eino/components/tool"
+	"github.com/cloudwego/eino/internal/core"
 	"github.com/cloudwego/eino/schema"
 )
 
@@ -394,6 +396,95 @@ func TestAgenticToolsNodeStreamSetsStreamingMeta(t *testing.T) {
 	assert.Equal(t, "mock_tool", block.FunctionToolResult.Name)
 	require.Len(t, block.FunctionToolResult.Content, 1)
 	assert.JSONEq(t, `{"echo":"jack: 0"}`, block.FunctionToolResult.Content[0].Text.Text)
+}
+
+func TestAttack_AgenticToolsCheckpointPreservesRerunInputType(t *testing.T) {
+	ctx := AppendAddressSegment(context.Background(), AddressSegmentNode, "tools")
+	streamTool := &addressStreamTool{
+		name: "stream_tool",
+		run: func(context.Context, string) (*schema.StreamReader[string], error) {
+			reader, writer := schema.Pipe[string](2)
+			writer.Send("partial", nil)
+			writer.Send("", core.ErrStreamCanceled)
+			writer.Close()
+			return reader, nil
+		},
+	}
+	node, err := NewAgenticToolsNode(ctx, &ToolsNodeConfig{
+		Tools: []tool.BaseTool{streamTool},
+	})
+	require.NoError(t, err)
+	input := &schema.AgenticMessage{
+		Role: schema.AgenticRoleTypeAssistant,
+		ContentBlocks: []*schema.ContentBlock{{
+			Type: schema.ContentBlockTypeFunctionToolCall,
+			FunctionToolCall: &schema.FunctionToolCall{
+				CallID:    "call-1",
+				Name:      "stream_tool",
+				Arguments: `{}`,
+			},
+		}},
+	}
+
+	output, err := node.Stream(ctx, input)
+	require.NoError(t, err)
+	cp := &checkpoint{
+		Inputs:     map[string]any{"consumer": packStreamReader(output)},
+		RerunNodes: []string{"consumer"},
+	}
+	pointer := newCheckPointer(map[string]streamConvertPair{
+		"consumer": defaultStreamConvertPair[[]*schema.AgenticMessage](),
+		"tools":    defaultStreamConvertPair[*schema.AgenticMessage](),
+	}, nil, nil, nil)
+
+	require.NoError(t, pointer.convertCheckPoint(cp, true, &core.InterruptSignal{ID: "root"}))
+	require.Equal(t, []string{"tools"}, cp.RerunNodes)
+	require.NotContains(t, cp.Inputs, "consumer")
+	require.Same(t, input, cp.Inputs["tools"])
+	require.NoError(t, pointer.restoreCheckPoint(cp, true))
+	packedInput, ok := cp.Inputs["tools"].(streamReader)
+	require.True(t, ok)
+	restoredInput, ok := unpackStreamReader[*schema.AgenticMessage](packedInput)
+	require.True(t, ok)
+	defer restoredInput.Close()
+	actualInput, err := restoredInput.Recv()
+	require.NoError(t, err)
+	require.Same(t, input, actualInput)
+	_, err = restoredInput.Recv()
+	require.ErrorIs(t, err, io.EOF)
+}
+
+func TestAttack_AgenticToolsPreservesOrdinaryStreamErrors(t *testing.T) {
+	streamErr := errors.New("stream failed")
+	streamTool := &addressStreamTool{
+		name: "stream_tool",
+		run: func(context.Context, string) (*schema.StreamReader[string], error) {
+			reader, writer := schema.Pipe[string](1)
+			writer.Send("", streamErr)
+			writer.Close()
+			return reader, nil
+		},
+	}
+	node, err := NewAgenticToolsNode(context.Background(), &ToolsNodeConfig{
+		Tools: []tool.BaseTool{streamTool},
+	})
+	require.NoError(t, err)
+
+	output, err := node.Stream(context.Background(), &schema.AgenticMessage{
+		Role: schema.AgenticRoleTypeAssistant,
+		ContentBlocks: []*schema.ContentBlock{{
+			Type: schema.ContentBlockTypeFunctionToolCall,
+			FunctionToolCall: &schema.FunctionToolCall{
+				CallID:    "call-1",
+				Name:      "stream_tool",
+				Arguments: `{}`,
+			},
+		}},
+	})
+	require.NoError(t, err)
+	defer output.Close()
+	_, err = output.Recv()
+	require.ErrorIs(t, err, streamErr)
 }
 
 func testStreamToolMessageTextOnly(t *testing.T) {

--- a/compose/checkpoint.go
+++ b/compose/checkpoint.go
@@ -325,13 +325,13 @@ func (c *checkPointer) convertCheckPoint(
 	isStream bool,
 	interrupt *core.InterruptSignal,
 ) (err error) {
-	toolRerunInputs := make(map[string]*schema.Message)
+	toolRerunInputs := make(map[string]any)
 	handleStreamError := func(key string, err error) streamErrorAction {
 		toolStreamErr := &toolStreamCheckpointError{}
 		if errors.As(err, &toolStreamErr) {
 			applyToolStreamCheckpoint(cp, key, interrupt, toolStreamErr)
-			if toolStreamErr.nodeKey != "" && toolStreamErr.input != nil {
-				toolRerunInputs[toolStreamErr.nodeKey] = toolStreamErr.input
+			if toolStreamErr.nodeKey != "" && toolStreamErr.rerunInput != nil {
+				toolRerunInputs[toolStreamErr.nodeKey] = toolStreamErr.rerunInput
 			}
 			return streamErrorAction{ignore: true, dropValue: true}
 		}

--- a/compose/checkpoint_test.go
+++ b/compose/checkpoint_test.go
@@ -2204,9 +2204,9 @@ func TestCheckpointToolStreamCancellationRerunsProducerOnce(t *testing.T) {
 		reader, writer := schema.Pipe[string](2)
 		writer.Send("partial", nil)
 		writer.Send("", &toolStreamCheckpointError{
-			nodeKey: "tools",
-			input:   input,
-			signal:  toolSignal,
+			nodeKey:    "tools",
+			rerunInput: input,
+			signal:     toolSignal,
 		})
 		writer.Close()
 		inputs[consumer] = packStreamReader(reader)

--- a/compose/tool_node.go
+++ b/compose/tool_node.go
@@ -390,9 +390,9 @@ type toolsInterruptAndRerunState struct {
 }
 
 type toolStreamCheckpointError struct {
-	nodeKey string
-	input   *schema.Message
-	signal  *core.InterruptSignal
+	nodeKey    string
+	rerunInput any
+	signal     *core.InterruptSignal
 }
 
 func (e *toolStreamCheckpointError) Error() string {
@@ -487,9 +487,9 @@ func (t *toolStreamCheckpointTracker) interrupt(ctx context.Context) error {
 		}
 	}
 	return &toolStreamCheckpointError{
-		nodeKey: nodeKey,
-		input:   t.input,
-		signal:  signal,
+		nodeKey:    nodeKey,
+		rerunInput: t.input,
+		signal:     signal,
 	}
 }
 


### PR DESCRIPTION
# Preserve Agentic tool checkpoint input

## Problem

When a streaming tool is canceled after emitting partial output, `ToolsNode` moves rerun ownership from downstream consumers back to the tool node. It previously persisted the normalized `*schema.Message` used internally by `ToolsNode`.

That input is valid for `ToolsNode`, but not for `AgenticToolsNode`, whose graph input contract is `*schema.AgenticMessage`. A later streaming resume therefore failed while restoring the checkpoint:

```text
cannot convert value[*schema.Message] to streamReader[*schema.AgenticMessage]
```

## Solution

Keep the two kinds of state separate:

- `toolsInterruptAndRerunState` retains the normalized `*schema.Message` needed for internal tool-call recovery.
- The private checkpoint error carries the graph node's rerun input without assuming a message protocol.
- `AgenticToolsNode` replaces that rerun input with the original `*schema.AgenticMessage` as the error crosses the adapter boundary.

Ordinary `ToolsNode` behavior, successful streams, and non-cancellation errors remain unchanged.

## Key Insight

A composite node can normalize its input for internal execution, but checkpoint rerun input must still match the type declared by the graph node. Internal recovery state and graph scheduling input are different contracts and must not share one representation.

## Summary

| Problem | Solution |
|---------|----------|
| Agentic stream checkpoints persisted a standard message as node input | Preserve the original Agentic message at the adapter boundary |
| Restoring a canceled Agentic tool stream failed type conversion | Restore a stream whose element type matches `AgenticToolsNode` |

---

# 保留 Agentic 工具节点的 checkpoint 输入

## 问题

流式工具输出部分结果后被取消时，`ToolsNode` 会把 rerun ownership 从下游 consumer 收回到工具节点。此前写入 checkpoint 的是 `ToolsNode` 内部使用的标准化 `*schema.Message`。

这个输入适用于 `ToolsNode`，但不符合 `AgenticToolsNode` 声明的 `*schema.AgenticMessage` 图输入契约。后续流式恢复会因此失败：

```text
cannot convert value[*schema.Message] to streamReader[*schema.AgenticMessage]
```

## 解决方案

区分两类状态：

- `toolsInterruptAndRerunState` 继续保存工具调用内部恢复所需的标准化 `*schema.Message`。
- 私有 checkpoint 错误以协议中立的形式携带图节点重跑输入。
- 错误跨越 Agentic 适配边界时，`AgenticToolsNode` 将重跑输入替换为原始 `*schema.AgenticMessage`。

普通 `ToolsNode`、成功完成的流以及非取消错误的行为保持不变。

## 关键洞察

复合节点可以为内部执行标准化输入，但 checkpoint 中用于重新调度节点的输入必须匹配该图节点声明的类型。内部恢复状态与图调度输入是两个不同契约，不能共用同一种表示。

## 总结

| 问题 | 解决方案 |
|------|----------|
| Agentic 流式 checkpoint 把标准消息保存为节点输入 | 在 Agentic 适配边界保留原始 Agentic 消息 |
| 取消后的 Agentic 工具流恢复时类型转换失败 | 恢复与 `AgenticToolsNode` 输入类型一致的流 |
