### PR TITLE
refactor(compose): simplify agentic tool stream conversion

### DIFF
--- a/compose/agentic_tools_node.go
+++ b/compose/agentic_tools_node.go
@@ -56,11 +56,8 @@ func (a *AgenticToolsNode) Stream(ctx context.Context, input *schema.AgenticMess
 	if err != nil {
 		return nil, err
 	}
-	result = schema.StreamReaderWithConvert(
+	return streamToolMessageToAgenticMessage(
 		result,
-		func(messages []*schema.Message) ([]*schema.Message, error) {
-			return messages, nil
-		},
 		schema.WithErrWrapper(func(streamErr error) error {
 			checkpointErr := &toolStreamCheckpointError{}
 			if !errors.As(streamErr, &checkpointErr) {
@@ -70,8 +67,7 @@ func (a *AgenticToolsNode) Stream(ctx context.Context, input *schema.AgenticMess
 			agenticCheckpointErr.rerunInput = input
 			return &agenticCheckpointErr
 		}),
-	)
-	return streamToolMessageToAgenticMessage(result), nil
+	), nil
 }
 
 func agenticMessageToToolCallMessage(input *schema.AgenticMessage) *schema.Message {
@@ -127,7 +123,10 @@ func toolMessageToAgenticMessage(input []*schema.Message) []*schema.AgenticMessa
 	return results
 }
 
-func streamToolMessageToAgenticMessage(input *schema.StreamReader[[]*schema.Message]) *schema.StreamReader[[]*schema.AgenticMessage] {
+func streamToolMessageToAgenticMessage(
+	input *schema.StreamReader[[]*schema.Message],
+	opts ...schema.ConvertOption,
+) *schema.StreamReader[[]*schema.AgenticMessage] {
 	return schema.StreamReaderWithConvert(input, func(t []*schema.Message) ([]*schema.AgenticMessage, error) {
 		results := make([]*schema.AgenticMessage, len(t))
 		for i, m := range t {
@@ -162,7 +161,7 @@ func streamToolMessageToAgenticMessage(input *schema.StreamReader[[]*schema.Mess
 			}
 		}
 		return results, nil
-	})
+	}, opts...)
 }
 
 func toolSearchResultMessageToAgenticMessage(m *schema.Message, meta *schema.StreamingMeta) (*schema.AgenticMessage, bool) {


### PR DESCRIPTION
# Simplify Agentic tool stream conversion

## Problem

The Agentic checkpoint fix in #1227 is correct, but its stream path wraps the `ToolsNode` output twice:

1. an identity `[]*schema.Message → []*schema.Message` conversion used only to adapt checkpoint errors
2. the existing `[]*schema.Message → []*schema.AgenticMessage` conversion

The identity conversion makes `schema.Message` look like an additional data contract even though it only exists to attach an error handler.

## Solution

Allow the existing private `streamToolMessageToAgenticMessage` helper to accept `schema.ConvertOption` values. `AgenticToolsNode.Stream` now passes its checkpoint error adapter directly into the same conversion that produces Agentic messages.

There is one stream wrapper and one visible conversion:

```text
ToolsNode output → Agentic message conversion + checkpoint error adaptation
```

## Key Insight

Stream value conversion and stream error adaptation belong to the same boundary. Keeping them in one `StreamReaderWithConvert` makes the actual protocol transition explicit without changing checkpoint behavior.

## Summary

| Problem | Solution |
|---------|----------|
| An identity `schema.Message` wrapper obscured the Agentic conversion path | Apply the error option to the existing Agentic conversion |
| One logical boundary used two stream wrappers | Use a single `StreamReaderWithConvert` |

---

# 简化 Agentic 工具流转换

## 问题

#1227 对 Agentic checkpoint 的修复是正确的，但流式路径对 `ToolsNode` 输出包装了两次：

1. 一层仅用于适配 checkpoint 错误的 `[]*schema.Message → []*schema.Message` 原样转换
2. 已有的 `[]*schema.Message → []*schema.AgenticMessage` 转换

原样转换让 `schema.Message` 看起来像新增的数据契约，实际只是为了挂载错误处理器，增加了理解成本。

## 解决方案

让现有私有函数 `streamToolMessageToAgenticMessage` 接收 `schema.ConvertOption`。`AgenticToolsNode.Stream` 直接把 checkpoint 错误适配传给生成 Agentic 消息的同一层转换。

现在只保留一层 stream wrapper 和一次明确的协议转换：

```text
ToolsNode 输出 → Agentic 消息转换 + checkpoint 错误适配
```

## 关键洞察

流值转换与流错误适配属于同一个协议边界。把两者放在同一个 `StreamReaderWithConvert` 中，可以直接表达真实的数据流，同时保持 checkpoint 行为不变。

## 总结

| 问题 | 解决方案 |
|------|----------|
| 原样 `schema.Message` wrapper 模糊了 Agentic 转换链路 | 将错误选项直接应用到已有 Agentic 转换 |
| 一个逻辑边界存在两层 stream wrapper | 只保留一个 `StreamReaderWithConvert` |
