### PR TITLE
feat(adk): add pluggable memory middleware

### DIFF
--- a/adk/middlewares/memory/doc.go
+++ b/adk/middlewares/memory/doc.go
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2026 CloudWeGo Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// Package memory provides a pluggable long-term memory middleware for Eino ADK
+// agents.
+//
+// It connects the ADK middleware hooks with an application-provided
+// [MemoryStore] so that long-running agents can retrieve relevant memory
+// before a run and optionally write facts or summaries back after a run,
+// without depending on any specific vector database.
+//
+// The store implementation lives outside Eino core: an in-memory or
+// Retriever/Indexer-backed implementation can be provided by the application
+// or by eino-ext.
+package memory

--- a/adk/middlewares/memory/memory.go
+++ b/adk/middlewares/memory/memory.go
@@ -1,0 +1,197 @@
+/*
+ * Copyright 2026 CloudWeGo Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package memory
+
+import (
+	"context"
+	"errors"
+
+	"github.com/cloudwego/eino/adk"
+	"github.com/cloudwego/eino/schema"
+)
+
+// MemoryStore abstracts long-term memory retrieval and persistence. It is the
+// seam that lets applications plug in any backend — a Retriever/Indexer pair,
+// a vector database client, or a remote memory service — without the middleware
+// depending on a specific implementation.
+type MemoryStore interface {
+	// Search returns documents relevant to the query, most relevant first.
+	Search(ctx context.Context, query string, opts ...MemoryOption) ([]*schema.Document, error)
+	// Save persists documents to memory.
+	Save(ctx context.Context, docs []*schema.Document, opts ...MemoryOption) error
+}
+
+// MemoryOption configures a single Search or Save operation.
+type MemoryOption func(*memoryOptions)
+
+type memoryOptions struct {
+	namespace string
+}
+
+// WithNamespace scopes the operation to a memory namespace such as a user,
+// session, agent or project identifier. Stores that do not support namespaces
+// may ignore it.
+func WithNamespace(namespace string) MemoryOption {
+	return func(o *memoryOptions) {
+		o.namespace = namespace
+	}
+}
+
+// Config configures the memory middleware. Only Store is required; the
+// remaining fields fall back to sensible defaults.
+type Config struct {
+	// Store is the memory backend. Required.
+	Store MemoryStore
+
+	// NamespaceResolver returns the namespace to scope the current run's
+	// retrieval and writes. It is called once per agent run in BeforeAgent.
+	// Defaults to returning "" (a single shared namespace).
+	NamespaceResolver func(ctx context.Context, runCtx *adk.ChatModelAgentContext) string
+
+	// QueryBuilder builds the retrieval query from the conversation state.
+	// Called once per run before the first model invocation. Defaults to the
+	// content of the most recent user message.
+	QueryBuilder func(ctx context.Context, state *adk.ChatModelAgentState) string
+
+	// MemoryFormatter renders retrieved documents as messages to inject into
+	// the conversation. Defaults to one system message per document,
+	// prefixed with "[memory] ".
+	MemoryFormatter func(ctx context.Context, docs []*schema.Document) []*schema.Message
+
+	// WritePolicy decides what to persist once the agent reaches a successful
+	// terminal state. It is called in AfterAgent. Returning false means
+	// nothing is written. Defaults to nil (nothing written).
+	WritePolicy func(ctx context.Context, state *adk.ChatModelAgentState) ([]*schema.Document, bool, error)
+}
+
+type namespaceKey struct{}
+
+type memoryInjectedKey struct{}
+
+type middleware struct {
+	*adk.BaseChatModelAgentMiddleware
+	cfg *Config
+}
+
+// New builds a ChatModelAgentMiddleware that injects long-term memory before
+// each agent run and optionally writes memory back after the run.
+func New(cfg *Config) (adk.ChatModelAgentMiddleware, error) {
+	if cfg == nil {
+		return nil, errors.New("memory: nil Config")
+	}
+	if cfg.Store == nil {
+		return nil, errors.New("memory: Config.Store is required")
+	}
+	return &middleware{
+		BaseChatModelAgentMiddleware: &adk.BaseChatModelAgentMiddleware{},
+		cfg:                          cfg,
+	}, nil
+}
+
+// BeforeAgent resolves the memory namespace once per run and stashes it in the
+// context for the later hooks.
+func (m *middleware) BeforeAgent(ctx context.Context, runCtx *adk.ChatModelAgentContext) (context.Context, *adk.ChatModelAgentContext, error) {
+	ns := ""
+	if m.cfg.NamespaceResolver != nil {
+		ns = m.cfg.NamespaceResolver(ctx, runCtx)
+	}
+	return context.WithValue(ctx, namespaceKey{}, ns), runCtx, nil
+}
+
+// BeforeModelRewriteState retrieves and injects memory before the first model
+// invocation of a run. Subsequent model iterations are left untouched to avoid
+// re-injecting the same memory on every tool-call loop.
+func (m *middleware) BeforeModelRewriteState(ctx context.Context, state *adk.ChatModelAgentState, _ *adk.ModelContext) (context.Context, *adk.ChatModelAgentState, error) {
+	if ctx.Value(memoryInjectedKey{}) != nil {
+		return ctx, state, nil
+	}
+
+	query := m.buildQuery(ctx, state)
+	if query == "" {
+		return ctx, state, nil
+	}
+
+	docs, err := m.cfg.Store.Search(ctx, query, WithNamespace(namespaceFrom(ctx)))
+	if err != nil {
+		return ctx, state, err
+	}
+	if len(docs) == 0 {
+		return ctx, state, nil
+	}
+
+	memoryMsgs := m.format(ctx, docs)
+	if len(memoryMsgs) == 0 {
+		return ctx, state, nil
+	}
+
+	state.Messages = append(append([]*schema.Message{}, memoryMsgs...), state.Messages...)
+	return context.WithValue(ctx, memoryInjectedKey{}, true), state, nil
+}
+
+// AfterAgent writes memory back once the agent reaches a successful terminal
+// state.
+func (m *middleware) AfterAgent(ctx context.Context, state *adk.ChatModelAgentState) (context.Context, error) {
+	if m.cfg.WritePolicy == nil {
+		return ctx, nil
+	}
+
+	docs, ok, err := m.cfg.WritePolicy(ctx, state)
+	if err != nil {
+		return ctx, err
+	}
+	if !ok || len(docs) == 0 {
+		return ctx, nil
+	}
+
+	if err := m.cfg.Store.Save(ctx, docs, WithNamespace(namespaceFrom(ctx))); err != nil {
+		return ctx, err
+	}
+	return ctx, nil
+}
+
+func (m *middleware) buildQuery(ctx context.Context, state *adk.ChatModelAgentState) string {
+	if m.cfg.QueryBuilder != nil {
+		return m.cfg.QueryBuilder(ctx, state)
+	}
+
+	for i := len(state.Messages) - 1; i >= 0; i-- {
+		if state.Messages[i].Role == schema.User && state.Messages[i].Content != "" {
+			return state.Messages[i].Content
+		}
+	}
+	return ""
+}
+
+func (m *middleware) format(ctx context.Context, docs []*schema.Document) []*schema.Message {
+	if m.cfg.MemoryFormatter != nil {
+		return m.cfg.MemoryFormatter(ctx, docs)
+	}
+
+	msgs := make([]*schema.Message, 0, len(docs))
+	for _, doc := range docs {
+		if doc == nil || doc.Content == "" {
+			continue
+		}
+		msgs = append(msgs, schema.SystemMessage("[memory] "+doc.Content))
+	}
+	return msgs
+}
+
+func namespaceFrom(ctx context.Context) string {
+	ns, _ := ctx.Value(namespaceKey{}).(string)
+	return ns
+}

--- a/adk/middlewares/memory/memory_test.go
+++ b/adk/middlewares/memory/memory_test.go
@@ -1,0 +1,158 @@
+/*
+ * Copyright 2026 CloudWeGo Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package memory
+
+import (
+	"context"
+	"testing"
+
+	"github.com/cloudwego/eino/adk"
+	"github.com/cloudwego/eino/schema"
+)
+
+type fakeStore struct {
+	searchedQueries []string
+	savedDocs       []*schema.Document
+	savedNamespaces []string
+}
+
+func (f *fakeStore) Search(_ context.Context, query string, opts ...MemoryOption) ([]*schema.Document, error) {
+	f.searchedQueries = append(f.searchedQueries, query)
+	ns := ""
+	for _, opt := range opts {
+		o := &memoryOptions{}
+		opt(o)
+		ns = o.namespace
+	}
+	f.savedNamespaces = append(f.savedNamespaces, ns)
+	return []*schema.Document{{ID: "1", Content: "remember this fact"}}, nil
+}
+
+func (f *fakeStore) Save(_ context.Context, docs []*schema.Document, opts ...MemoryOption) error {
+	f.savedDocs = append(f.savedDocs, docs...)
+	ns := ""
+	for _, opt := range opts {
+		o := &memoryOptions{}
+		opt(o)
+		ns = o.namespace
+	}
+	f.savedNamespaces = append(f.savedNamespaces, ns)
+	return nil
+}
+
+func TestNewRequiresStore(t *testing.T) {
+	if _, err := New(nil); err == nil {
+		t.Fatal("expected error for nil Config")
+	}
+	if _, err := New(&Config{}); err == nil {
+		t.Fatal("expected error for nil Store")
+	}
+}
+
+func TestMemoryInjectedOnce(t *testing.T) {
+	store := &fakeStore{}
+	mw, err := New(&Config{Store: store})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	ctx := context.Background()
+	ctx, _, err = mw.BeforeAgent(ctx, &adk.ChatModelAgentContext{})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	state := &adk.ChatModelAgentState{
+		Messages: []*schema.Message{schema.UserMessage("what did I tell you?")},
+	}
+
+	// First model call injects memory.
+	ctx, state, err = mw.BeforeModelRewriteState(ctx, state, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(state.Messages) != 2 {
+		t.Fatalf("expected memory message prepended, got %d messages", len(state.Messages))
+	}
+	if state.Messages[0].Role != schema.System || state.Messages[0].Content != "[memory] remember this fact" {
+		t.Fatalf("unexpected injected message: %+v", state.Messages[0])
+	}
+
+	// Second model call must not re-inject.
+	ctx, state, err = mw.BeforeModelRewriteState(ctx, state, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(state.Messages) != 2 {
+		t.Fatalf("expected no re-injection, got %d messages", len(state.Messages))
+	}
+	if len(store.searchedQueries) != 1 {
+		t.Fatalf("expected 1 search, got %d", len(store.searchedQueries))
+	}
+}
+
+func TestWritePolicySavesAfterAgent(t *testing.T) {
+	store := &fakeStore{}
+	mw, err := New(&Config{
+		Store:             store,
+		NamespaceResolver: func(context.Context, *adk.ChatModelAgentContext) string { return "user-42" },
+		WritePolicy: func(_ context.Context, state *adk.ChatModelAgentState) ([]*schema.Document, bool, error) {
+			return []*schema.Document{{ID: "2", Content: "user preference"}}, true, nil
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	ctx := context.Background()
+	ctx, _, err = mw.BeforeAgent(ctx, &adk.ChatModelAgentContext{})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	_, err = mw.AfterAgent(ctx, &adk.ChatModelAgentState{})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if len(store.savedDocs) != 1 || store.savedDocs[0].Content != "user preference" {
+		t.Fatalf("unexpected saved docs: %+v", store.savedDocs)
+	}
+	if len(store.savedNamespaces) != 1 || store.savedNamespaces[0] != "user-42" {
+		t.Fatalf("unexpected saved namespaces: %v", store.savedNamespaces)
+	}
+}
+
+func TestWritePolicyFalseSkipsSave(t *testing.T) {
+	store := &fakeStore{}
+	mw, err := New(&Config{
+		Store: store,
+		WritePolicy: func(context.Context, *adk.ChatModelAgentState) ([]*schema.Document, bool, error) {
+			return nil, false, nil
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if _, err := mw.AfterAgent(context.Background(), &adk.ChatModelAgentState{}); err != nil {
+		t.Fatal(err)
+	}
+	if len(store.savedDocs) != 0 {
+		t.Fatalf("expected no save, got %d docs", len(store.savedDocs))
+	}
+}


### PR DESCRIPTION
Closes #995

Adds a pluggable long-term memory middleware under `adk/middlewares/memory` that connects the ADK agent lifecycle hooks to an application-provided `MemoryStore`.

## Why

Long-running or general-purpose agents need to retrieve relevant memory before a run and persist facts/preferences/summaries afterward. Today each application wires its own injection and write logic against `Retriever` / `Indexer` / `Embedding`. This middleware gives that a standard shape while keeping the storage backend outside Eino core.

## What it does

- `MemoryStore` interface — `Search` / `Save`, with `MemoryOption` (currently `WithNamespace`) for per-operation scoping.
- `Config` with four optional hooks, all defaulted:
  - `NamespaceResolver` — namespace per run (default: shared).
  - `QueryBuilder` — retrieval query from conversation state (default: most recent user message).
  - `MemoryFormatter` — docs → messages to inject (default: one `[memory]` system message per doc).
  - `WritePolicy` — what to persist after a terminal state (default: nothing).
- Memory is injected once per run in `BeforeModelRewriteState` (not re-injected on every tool-call loop), and written in `AfterAgent`.

## Scope notes

This first increment targets the default `*schema.Message` agent (`adk.ChatModelAgentMiddleware`). A generic `TypedChatModelAgentMiddleware[M]` variant and richer defaults (e.g. summarization-based write policy) can follow if maintainers want them. No vector database is introduced to core — the `MemoryStore` implementation stays in the application or eino-ext.

## Tests

`go test ./adk/middlewares/memory/` covers required-store validation, once-per-run injection, namespace-scoped writes via `WritePolicy`, and no-op when `WritePolicy` declines.
