### PR TITLE
feat(adk): add structured AgentEventType taxonomy to AgentEvent

### DIFF
--- a/adk/cancel.go
+++ b/adk/cancel.go
@@ -757,7 +757,7 @@ func checkPreExecCancel[M MessageType](cc *cancelContext, gen *AsyncGenerator[*T
 			if !ok {
 				return true
 			}
-			gen.Send(&TypedAgentEvent[M]{Err: cancelErr})
+			gen.Send(&TypedAgentEvent[M]{Type: AgentEventError, Err: cancelErr})
 			return true
 		}
 	}
@@ -976,7 +976,7 @@ func wrapIterWithCancelCtx[M MessageType](iter *AsyncIterator[*TypedAgentEvent[M
 					cancelErr, ok := cancelCtx.createAndMarkCancelHandled()
 					if ok {
 						cancelErr.interruptSignal = event.Action.internalInterrupted
-						gen.Send(&TypedAgentEvent[M]{Err: cancelErr})
+						gen.Send(&TypedAgentEvent[M]{Type: AgentEventError, Err: cancelErr})
 					}
 					return
 				}

--- a/adk/chatmodel.go
+++ b/adk/chatmodel.go
@@ -783,7 +783,7 @@ func setOutputToSession[M MessageType](ctx context.Context, msg M, msgStream *sc
 
 func typedErrFunc[M MessageType](err error) typedRunFunc[M] {
 	return func(ctx context.Context, p *typedRunParams[M]) {
-		p.generator.Send(&TypedAgentEvent[M]{Err: err})
+		p.generator.Send(&TypedAgentEvent[M]{Type: AgentEventError, Err: err})
 	}
 }
 
@@ -981,7 +981,7 @@ func (a *TypedChatModelAgent[M]) handleRunFuncError(
 	if cancelCtxOwned && cancelCtx != nil {
 		cancelCtx.markDone()
 	}
-	generator.Send(&TypedAgentEvent[M]{Err: err})
+	generator.Send(&TypedAgentEvent[M]{Type: AgentEventError, Err: err})
 }
 
 type typedNoToolsInput[M MessageType] struct {
@@ -1054,7 +1054,7 @@ func (a *TypedChatModelAgent[M]) buildNoToolsRunFunc(_ context.Context) (typedRu
 
 		r, err := chain.Compile(ctx, compileOptions...)
 		if err != nil {
-			p.generator.Send(&TypedAgentEvent[M]{Err: err})
+			p.generator.Send(&TypedAgentEvent[M]{Type: AgentEventError, Err: err})
 			return
 		}
 
@@ -1082,7 +1082,7 @@ func (a *TypedChatModelAgent[M]) buildNoToolsRunFunc(_ context.Context) (typedRu
 			if a.outputKey != "" {
 				err = setOutputToSession(ctx, msg, msgStream, a.outputKey)
 				if err != nil {
-					p.generator.Send(&TypedAgentEvent[M]{Err: err})
+					p.generator.Send(&TypedAgentEvent[M]{Type: AgentEventError, Err: err})
 				}
 			} else if msgStream != nil {
 				msgStream.Close()
@@ -1150,7 +1150,7 @@ func (a *TypedChatModelAgent[M]) buildMessageReActRunFunc(_ context.Context, bc 
 
 		g, err := newReact(ctx, msgConf)
 		if err != nil {
-			mp.generator.Send(&AgentEvent{Err: err})
+			mp.generator.Send(&AgentEvent{Type: AgentEventError, Err: err})
 			return
 		}
 
@@ -1183,7 +1183,7 @@ func (a *TypedChatModelAgent[M]) buildMessageReActRunFunc(_ context.Context, bc 
 
 		runnable, err_ := chain.Compile(ctx, compileOptions...)
 		if err_ != nil {
-			mp.generator.Send(&AgentEvent{Err: err_})
+			mp.generator.Send(&AgentEvent{Type: AgentEventError, Err: err_})
 			return
 		}
 
@@ -1225,7 +1225,7 @@ func (a *TypedChatModelAgent[M]) buildMessageReActRunFunc(_ context.Context, bc 
 			if a.outputKey != "" {
 				err_ = setOutputToSession[*schema.Message](ctx, msg, msgStream, a.outputKey)
 				if err_ != nil {
-					mp.generator.Send(&AgentEvent{Err: err_})
+					mp.generator.Send(&AgentEvent{Type: AgentEventError, Err: err_})
 				}
 			} else if msgStream != nil {
 				msgStream.Close()
@@ -1467,7 +1467,7 @@ func (a *TypedChatModelAgent[M]) Run(ctx context.Context, input *TypedAgentInput
 			if cancelCtxOwned && cancelCtx != nil {
 				defer cancelCtx.markDone()
 			}
-			generator.Send(&TypedAgentEvent[M]{Err: fmt.Errorf("ChatModelAgent getRunFunc error: %w", err)})
+			generator.Send(&TypedAgentEvent[M]{Type: AgentEventError, Err: fmt.Errorf("ChatModelAgent getRunFunc error: %w", err)})
 			generator.Close()
 		}()
 		return iterator
@@ -1497,7 +1497,7 @@ func (a *TypedChatModelAgent[M]) Run(ctx context.Context, input *TypedAgentInput
 			panicErr := recover()
 			if panicErr != nil {
 				e := safe.NewPanicErr(panicErr, debug.Stack())
-				generator.Send(&TypedAgentEvent[M]{Err: e})
+				generator.Send(&TypedAgentEvent[M]{Type: AgentEventError, Err: e})
 			}
 
 			generator.Close()
@@ -1556,7 +1556,7 @@ func (a *TypedChatModelAgent[M]) Resume(ctx context.Context, info *ResumeInfo, o
 			if cancelCtxOwned && cancelCtx != nil {
 				defer cancelCtx.markDone()
 			}
-			generator.Send(&TypedAgentEvent[M]{Err: fmt.Errorf("ChatModelAgent getRunFunc error: %w", err)})
+			generator.Send(&TypedAgentEvent[M]{Type: AgentEventError, Err: fmt.Errorf("ChatModelAgent getRunFunc error: %w", err)})
 			generator.Close()
 		}()
 		return iterator
@@ -1601,7 +1601,7 @@ func (a *TypedChatModelAgent[M]) Resume(ctx context.Context, info *ResumeInfo, o
 	stateByte, err = preprocessComposeCheckpoint(stateByte)
 	if err != nil {
 		go func() {
-			generator.Send(&TypedAgentEvent[M]{Err: err})
+			generator.Send(&TypedAgentEvent[M]{Type: AgentEventError, Err: err})
 			generator.Close()
 		}()
 		return iterator
@@ -1636,7 +1636,7 @@ func (a *TypedChatModelAgent[M]) Resume(ctx context.Context, info *ResumeInfo, o
 			panicErr := recover()
 			if panicErr != nil {
 				e := safe.NewPanicErr(panicErr, debug.Stack())
-				generator.Send(&TypedAgentEvent[M]{Err: e})
+				generator.Send(&TypedAgentEvent[M]{Type: AgentEventError, Err: e})
 			}
 
 			generator.Close()

--- a/adk/deterministic_transfer.go
+++ b/adk/deterministic_transfer.go
@@ -141,7 +141,7 @@ func forwardEventsAndAppendTransfer(iter *AsyncIterator[*AgentEvent],
 
 	defer func() {
 		if panicErr := recover(); panicErr != nil {
-			generator.Send(&AgentEvent{Err: safe.NewPanicErr(panicErr, debug.Stack())})
+			generator.Send(&AgentEvent{Type: AgentEventError, Err: safe.NewPanicErr(panicErr, debug.Stack())})
 		}
 		generator.Close()
 	}()
@@ -236,7 +236,7 @@ func handleFlowAgentEvents(ctx context.Context, iter *AsyncIterator[*AgentEvent]
 
 	defer func() {
 		if panicErr := recover(); panicErr != nil {
-			generator.Send(&AgentEvent{Err: safe.NewPanicErr(panicErr, debug.Stack())})
+			generator.Send(&AgentEvent{Type: AgentEventError, Err: safe.NewPanicErr(panicErr, debug.Stack())})
 		}
 		generator.Close()
 	}()
@@ -296,6 +296,7 @@ func sendTransferEvents(generator *AsyncGenerator[*AgentEvent], toAgentNames []s
 				DestAgentName: toAgentName,
 			},
 		}
+		tEvent.Type = actionEventType(tEvent.Action)
 		generator.Send(tEvent)
 	}
 }

--- a/adk/event_type_test.go
+++ b/adk/event_type_test.go
@@ -1,0 +1,101 @@
+/*
+ * Copyright 2026 CloudWeGo Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package adk
+
+import (
+	"context"
+	"testing"
+
+	"github.com/cloudwego/eino/schema"
+)
+
+func TestMessageEventType(t *testing.T) {
+	tests := []struct {
+		name      string
+		role      schema.RoleType
+		streaming bool
+		want      AgentEventType
+	}{
+		{"model end", schema.Assistant, false, AgentEventModelEnd},
+		{"model delta", schema.Assistant, true, AgentEventModelDelta},
+		{"tool end", schema.Tool, false, AgentEventToolEnd},
+		{"tool delta", schema.Tool, true, AgentEventToolDelta},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := messageEventType(tt.role, tt.streaming); got != tt.want {
+				t.Fatalf("messageEventType(%q, %v) = %q, want %q", tt.role, tt.streaming, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestEventFromMessageSetsType(t *testing.T) {
+	msg := schema.AssistantMessage("hi", nil)
+
+	if e := EventFromMessage(msg, nil, schema.Assistant, ""); e.Type != AgentEventModelEnd {
+		t.Fatalf("assistant message event type = %q, want %q", e.Type, AgentEventModelEnd)
+	}
+
+	if e := EventFromMessage(msg, nil, schema.Tool, "lookup"); e.Type != AgentEventToolEnd {
+		t.Fatalf("tool message event type = %q, want %q", e.Type, AgentEventToolEnd)
+	}
+}
+
+func TestEventFromAgenticMessageSetsType(t *testing.T) {
+	msg := &schema.AgenticMessage{}
+
+	if e := EventFromAgenticMessage(msg, nil, schema.AgenticRoleTypeAssistant); e.Type != AgentEventModelEnd {
+		t.Fatalf("assistant agentic event type = %q, want %q", e.Type, AgentEventModelEnd)
+	}
+
+	if e := EventFromAgenticMessage(msg, nil, schema.AgenticRoleTypeUser); e.Type != AgentEventToolEnd {
+		t.Fatalf("tool agentic event type = %q, want %q", e.Type, AgentEventToolEnd)
+	}
+}
+
+func TestActionEventType(t *testing.T) {
+	tests := []struct {
+		name   string
+		action *AgentAction
+		want   AgentEventType
+	}{
+		{"nil", nil, AgentEventUnknown},
+		{"exit", &AgentAction{Exit: true}, AgentEventAgentEnd},
+		{"transfer", &AgentAction{TransferToAgent: &TransferToAgentAction{DestAgentName: "a"}}, AgentEventTransfer},
+		{"interrupt", &AgentAction{Interrupted: &InterruptInfo{}}, AgentEventInterrupt},
+		{"break loop", &AgentAction{BreakLoop: &BreakLoopAction{}}, AgentEventBreakLoop},
+		{"customized only", &AgentAction{CustomizedAction: struct{}{}}, AgentEventUnknown},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := actionEventType(tt.action); got != tt.want {
+				t.Fatalf("actionEventType() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestInterruptEventSetsType(t *testing.T) {
+	e := Interrupt(context.Background(), "need input")
+	if e.Type != AgentEventInterrupt {
+		t.Fatalf("interrupt event type = %q, want %q", e.Type, AgentEventInterrupt)
+	}
+	if e.Action == nil || e.Action.Interrupted == nil {
+		t.Fatalf("interrupt event missing Interrupted action: %+v", e)
+	}
+}

--- a/adk/flow.go
+++ b/adk/flow.go
@@ -495,7 +495,7 @@ func (a *flowAgent) run(
 		panicErr := recover()
 		if panicErr != nil {
 			e := safe.NewPanicErr(panicErr, debug.Stack())
-			generator.Send(&AgentEvent{Err: e})
+			generator.Send(&AgentEvent{Type: AgentEventError, Err: e})
 		}
 
 		cbGen.Close()
@@ -562,7 +562,7 @@ func (a *flowAgent) run(
 		if agentToRun == nil {
 			e := fmt.Errorf("transfer failed: agent '%s' not found when transferring from '%s'",
 				destName, a.Name(ctxForSubAgents))
-			generator.Send(&AgentEvent{Err: e})
+			generator.Send(&AgentEvent{Type: AgentEventError, Err: e})
 			return
 		}
 
@@ -741,7 +741,7 @@ func (a *typedFlowAgent[M]) run(
 		panicErr := recover()
 		if panicErr != nil {
 			e := safe.NewPanicErr(panicErr, debug.Stack())
-			generator.Send(&TypedAgentEvent[M]{Err: e})
+			generator.Send(&TypedAgentEvent[M]{Type: AgentEventError, Err: e})
 		}
 
 		agenticCbGen.Close()

--- a/adk/interface.go
+++ b/adk/interface.go
@@ -247,6 +247,7 @@ func gobDecodeAgenticMessageVariant(mv *TypedMessageVariant[*schema.AgenticMessa
 func typedEventFromMessage[M MessageType](msg M, msgStream *schema.StreamReader[M],
 	role schema.RoleType, toolName string) *TypedAgentEvent[M] {
 	return &TypedAgentEvent[M]{
+		Type: messageEventType(role, msgStream != nil),
 		Output: &TypedAgentOutput[M]{
 			MessageOutput: &TypedMessageVariant[M]{
 				IsStreaming:   msgStream != nil,
@@ -257,6 +258,21 @@ func typedEventFromMessage[M MessageType](msg M, msgStream *schema.StreamReader[
 			},
 		},
 	}
+}
+
+// messageEventType maps a message role and streaming flag to the event type.
+// Tool results and model outputs are the only message kinds ADK emits today.
+func messageEventType(role schema.RoleType, streaming bool) AgentEventType {
+	if role == schema.Tool {
+		if streaming {
+			return AgentEventToolDelta
+		}
+		return AgentEventToolEnd
+	}
+	if streaming {
+		return AgentEventModelDelta
+	}
+	return AgentEventModelEnd
 }
 
 // typedModelOutputEvent creates a model-output event for the generic path.
@@ -297,6 +313,7 @@ func EventFromMessage(msg Message, msgStream *schema.StreamReader[Message],
 // In streaming mode, the role is available on the event before consuming the stream.
 func EventFromAgenticMessage(msg AgenticMessage, msgStream AgenticMessageStream, agenticRole schema.AgenticRoleType) *TypedAgentEvent[AgenticMessage] {
 	return &TypedAgentEvent[AgenticMessage]{
+		Type: agenticMessageEventType(agenticRole, msgStream != nil),
 		Output: &TypedAgentOutput[AgenticMessage]{
 			MessageOutput: &TypedMessageVariant[AgenticMessage]{
 				IsStreaming:   msgStream != nil,
@@ -306,6 +323,22 @@ func EventFromAgenticMessage(msg AgenticMessage, msgStream AgenticMessageStream,
 			},
 		},
 	}
+}
+
+// agenticMessageEventType maps an AgenticMessage role and streaming flag to
+// the event type. Tool results are carried with the user role on the
+// AgenticMessage path.
+func agenticMessageEventType(agenticRole schema.AgenticRoleType, streaming bool) AgentEventType {
+	if agenticRole == schema.AgenticRoleTypeAssistant {
+		if streaming {
+			return AgentEventModelDelta
+		}
+		return AgentEventModelEnd
+	}
+	if streaming {
+		return AgentEventToolDelta
+	}
+	return AgentEventToolEnd
 }
 
 // TransferToAgentAction represents a transfer-to-agent action.
@@ -419,6 +452,12 @@ type runStepSerialization struct {
 type TypedAgentEvent[M MessageType] struct {
 	AgentName string
 
+	// Type classifies the event into a stable taxonomy for debugging, tracing,
+	// UI rendering and durable event logs. See AgentEventType for the full list
+	// of kinds. The zero value (AgentEventUnknown) is reserved for events
+	// produced by code that predates the taxonomy.
+	Type AgentEventType
+
 	// RunPath represents the execution path from root agent to the current event source.
 	// This field is managed entirely by the framework and cannot be set by end-users.
 	//
@@ -432,6 +471,72 @@ type TypedAgentEvent[M MessageType] struct {
 	Action *AgentAction
 
 	Err error
+}
+
+// AgentEventType identifies the kind of an ADK agent event. It provides a
+// stable, documented taxonomy that applications can rely on for debugging,
+// tracing (e.g. Langfuse, Cozeloop, OpenTelemetry), UI rendering and durable
+// event stores.
+type AgentEventType string
+
+const (
+	// AgentEventUnknown is the zero value. It is reserved for events produced
+	// by code that predates the taxonomy and carries no semantic meaning.
+	AgentEventUnknown AgentEventType = ""
+
+	// AgentEventAgentEnd marks the terminal event of an agent run, produced by
+	// an Exit action.
+	AgentEventAgentEnd AgentEventType = "agent_end"
+
+	// AgentEventModelEnd marks a complete (non-streaming) model message.
+	AgentEventModelEnd AgentEventType = "model_end"
+
+	// AgentEventModelDelta marks one chunk of a streaming model message.
+	AgentEventModelDelta AgentEventType = "model_delta"
+
+	// AgentEventToolEnd marks a complete (non-streaming) tool result.
+	AgentEventToolEnd AgentEventType = "tool_end"
+
+	// AgentEventToolDelta marks one chunk of a streaming tool result.
+	AgentEventToolDelta AgentEventType = "tool_delta"
+
+	// AgentEventTransfer marks a transfer-to-agent action.
+	AgentEventTransfer AgentEventType = "transfer"
+
+	// AgentEventBreakLoop marks a break-loop action.
+	AgentEventBreakLoop AgentEventType = "break_loop"
+
+	// AgentEventInterrupt marks an interrupt action that pauses execution to
+	// request external input.
+	AgentEventInterrupt AgentEventType = "interrupt"
+
+	// AgentEventResume is reserved for future resume events. ADK currently
+	// resumes by emitting regular model/tool events after a Resume call, so no
+	// distinct resume event is emitted yet.
+	AgentEventResume AgentEventType = "resume"
+
+	// AgentEventError marks a terminal error event.
+	AgentEventError AgentEventType = "error"
+)
+
+// actionEventType returns the event type for an action, or AgentEventUnknown
+// when the action does not carry a known kind.
+func actionEventType(a *AgentAction) AgentEventType {
+	if a == nil {
+		return AgentEventUnknown
+	}
+	switch {
+	case a.Interrupted != nil:
+		return AgentEventInterrupt
+	case a.TransferToAgent != nil:
+		return AgentEventTransfer
+	case a.BreakLoop != nil:
+		return AgentEventBreakLoop
+	case a.Exit:
+		return AgentEventAgentEnd
+	default:
+		return AgentEventUnknown
+	}
 }
 
 // AgentEvent is the default event type using *schema.Message.

--- a/adk/interrupt.go
+++ b/adk/interrupt.go
@@ -66,12 +66,13 @@ func TypedInterrupt[M MessageType](ctx context.Context, info any) *TypedAgentEve
 	is, err := core.Interrupt(ctx, info, nil, nil,
 		core.WithLayerPayload(rp))
 	if err != nil {
-		return &TypedAgentEvent[M]{Err: err}
+		return &TypedAgentEvent[M]{Type: AgentEventError, Err: err}
 	}
 
 	contexts := core.ToInterruptContexts(is, allowedAddressSegmentTypes)
 
 	return &TypedAgentEvent[M]{
+		Type: AgentEventInterrupt,
 		Action: &AgentAction{
 			Interrupted: &InterruptInfo{
 				InterruptContexts: contexts,
@@ -101,12 +102,13 @@ func TypedStatefulInterrupt[M MessageType](ctx context.Context, info any, state 
 	is, err := core.Interrupt(ctx, info, state, nil,
 		core.WithLayerPayload(rp))
 	if err != nil {
-		return &TypedAgentEvent[M]{Err: err}
+		return &TypedAgentEvent[M]{Type: AgentEventError, Err: err}
 	}
 
 	contexts := core.ToInterruptContexts(is, allowedAddressSegmentTypes)
 
 	return &TypedAgentEvent[M]{
+		Type: AgentEventInterrupt,
 		Action: &AgentAction{
 			Interrupted: &InterruptInfo{
 				InterruptContexts: contexts,
@@ -137,12 +139,13 @@ func TypedCompositeInterrupt[M MessageType](ctx context.Context, info any, state
 	is, err := core.Interrupt(ctx, info, state, subInterruptSignals,
 		core.WithLayerPayload(rp))
 	if err != nil {
-		return &TypedAgentEvent[M]{Err: err}
+		return &TypedAgentEvent[M]{Type: AgentEventError, Err: err}
 	}
 
 	contexts := core.ToInterruptContexts(is, allowedAddressSegmentTypes)
 
 	return &TypedAgentEvent[M]{
+		Type: AgentEventInterrupt,
 		Action: &AgentAction{
 			Interrupted: &InterruptInfo{
 				InterruptContexts: contexts,

--- a/adk/middlewares/memory/doc.go
+++ b/adk/middlewares/memory/doc.go
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2026 CloudWeGo Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// Package memory provides a pluggable long-term memory middleware for Eino ADK
+// agents.
+//
+// It connects the ADK middleware hooks with an application-provided
+// [MemoryStore] so that long-running agents can retrieve relevant memory
+// before a run and optionally write facts or summaries back after a run,
+// without depending on any specific vector database.
+//
+// The store implementation lives outside Eino core: an in-memory or
+// Retriever/Indexer-backed implementation can be provided by the application
+// or by eino-ext.
+package memory

--- a/adk/middlewares/memory/memory.go
+++ b/adk/middlewares/memory/memory.go
@@ -1,0 +1,197 @@
+/*
+ * Copyright 2026 CloudWeGo Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package memory
+
+import (
+	"context"
+	"errors"
+
+	"github.com/cloudwego/eino/adk"
+	"github.com/cloudwego/eino/schema"
+)
+
+// MemoryStore abstracts long-term memory retrieval and persistence. It is the
+// seam that lets applications plug in any backend — a Retriever/Indexer pair,
+// a vector database client, or a remote memory service — without the middleware
+// depending on a specific implementation.
+type MemoryStore interface {
+	// Search returns documents relevant to the query, most relevant first.
+	Search(ctx context.Context, query string, opts ...MemoryOption) ([]*schema.Document, error)
+	// Save persists documents to memory.
+	Save(ctx context.Context, docs []*schema.Document, opts ...MemoryOption) error
+}
+
+// MemoryOption configures a single Search or Save operation.
+type MemoryOption func(*memoryOptions)
+
+type memoryOptions struct {
+	namespace string
+}
+
+// WithNamespace scopes the operation to a memory namespace such as a user,
+// session, agent or project identifier. Stores that do not support namespaces
+// may ignore it.
+func WithNamespace(namespace string) MemoryOption {
+	return func(o *memoryOptions) {
+		o.namespace = namespace
+	}
+}
+
+// Config configures the memory middleware. Only Store is required; the
+// remaining fields fall back to sensible defaults.
+type Config struct {
+	// Store is the memory backend. Required.
+	Store MemoryStore
+
+	// NamespaceResolver returns the namespace to scope the current run's
+	// retrieval and writes. It is called once per agent run in BeforeAgent.
+	// Defaults to returning "" (a single shared namespace).
+	NamespaceResolver func(ctx context.Context, runCtx *adk.ChatModelAgentContext) string
+
+	// QueryBuilder builds the retrieval query from the conversation state.
+	// Called once per run before the first model invocation. Defaults to the
+	// content of the most recent user message.
+	QueryBuilder func(ctx context.Context, state *adk.ChatModelAgentState) string
+
+	// MemoryFormatter renders retrieved documents as messages to inject into
+	// the conversation. Defaults to one system message per document,
+	// prefixed with "[memory] ".
+	MemoryFormatter func(ctx context.Context, docs []*schema.Document) []*schema.Message
+
+	// WritePolicy decides what to persist once the agent reaches a successful
+	// terminal state. It is called in AfterAgent. Returning false means
+	// nothing is written. Defaults to nil (nothing written).
+	WritePolicy func(ctx context.Context, state *adk.ChatModelAgentState) ([]*schema.Document, bool, error)
+}
+
+type namespaceKey struct{}
+
+type memoryInjectedKey struct{}
+
+type middleware struct {
+	*adk.BaseChatModelAgentMiddleware
+	cfg *Config
+}
+
+// New builds a ChatModelAgentMiddleware that injects long-term memory before
+// each agent run and optionally writes memory back after the run.
+func New(cfg *Config) (adk.ChatModelAgentMiddleware, error) {
+	if cfg == nil {
+		return nil, errors.New("memory: nil Config")
+	}
+	if cfg.Store == nil {
+		return nil, errors.New("memory: Config.Store is required")
+	}
+	return &middleware{
+		BaseChatModelAgentMiddleware: &adk.BaseChatModelAgentMiddleware{},
+		cfg:                          cfg,
+	}, nil
+}
+
+// BeforeAgent resolves the memory namespace once per run and stashes it in the
+// context for the later hooks.
+func (m *middleware) BeforeAgent(ctx context.Context, runCtx *adk.ChatModelAgentContext) (context.Context, *adk.ChatModelAgentContext, error) {
+	ns := ""
+	if m.cfg.NamespaceResolver != nil {
+		ns = m.cfg.NamespaceResolver(ctx, runCtx)
+	}
+	return context.WithValue(ctx, namespaceKey{}, ns), runCtx, nil
+}
+
+// BeforeModelRewriteState retrieves and injects memory before the first model
+// invocation of a run. Subsequent model iterations are left untouched to avoid
+// re-injecting the same memory on every tool-call loop.
+func (m *middleware) BeforeModelRewriteState(ctx context.Context, state *adk.ChatModelAgentState, _ *adk.ModelContext) (context.Context, *adk.ChatModelAgentState, error) {
+	if ctx.Value(memoryInjectedKey{}) != nil {
+		return ctx, state, nil
+	}
+
+	query := m.buildQuery(ctx, state)
+	if query == "" {
+		return ctx, state, nil
+	}
+
+	docs, err := m.cfg.Store.Search(ctx, query, WithNamespace(namespaceFrom(ctx)))
+	if err != nil {
+		return ctx, state, err
+	}
+	if len(docs) == 0 {
+		return ctx, state, nil
+	}
+
+	memoryMsgs := m.format(ctx, docs)
+	if len(memoryMsgs) == 0 {
+		return ctx, state, nil
+	}
+
+	state.Messages = append(append([]*schema.Message{}, memoryMsgs...), state.Messages...)
+	return context.WithValue(ctx, memoryInjectedKey{}, true), state, nil
+}
+
+// AfterAgent writes memory back once the agent reaches a successful terminal
+// state.
+func (m *middleware) AfterAgent(ctx context.Context, state *adk.ChatModelAgentState) (context.Context, error) {
+	if m.cfg.WritePolicy == nil {
+		return ctx, nil
+	}
+
+	docs, ok, err := m.cfg.WritePolicy(ctx, state)
+	if err != nil {
+		return ctx, err
+	}
+	if !ok || len(docs) == 0 {
+		return ctx, nil
+	}
+
+	if err := m.cfg.Store.Save(ctx, docs, WithNamespace(namespaceFrom(ctx))); err != nil {
+		return ctx, err
+	}
+	return ctx, nil
+}
+
+func (m *middleware) buildQuery(ctx context.Context, state *adk.ChatModelAgentState) string {
+	if m.cfg.QueryBuilder != nil {
+		return m.cfg.QueryBuilder(ctx, state)
+	}
+
+	for i := len(state.Messages) - 1; i >= 0; i-- {
+		if state.Messages[i].Role == schema.User && state.Messages[i].Content != "" {
+			return state.Messages[i].Content
+		}
+	}
+	return ""
+}
+
+func (m *middleware) format(ctx context.Context, docs []*schema.Document) []*schema.Message {
+	if m.cfg.MemoryFormatter != nil {
+		return m.cfg.MemoryFormatter(ctx, docs)
+	}
+
+	msgs := make([]*schema.Message, 0, len(docs))
+	for _, doc := range docs {
+		if doc == nil || doc.Content == "" {
+			continue
+		}
+		msgs = append(msgs, schema.SystemMessage("[memory] "+doc.Content))
+	}
+	return msgs
+}
+
+func namespaceFrom(ctx context.Context) string {
+	ns, _ := ctx.Value(namespaceKey{}).(string)
+	return ns
+}

--- a/adk/middlewares/memory/memory_test.go
+++ b/adk/middlewares/memory/memory_test.go
@@ -1,0 +1,158 @@
+/*
+ * Copyright 2026 CloudWeGo Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package memory
+
+import (
+	"context"
+	"testing"
+
+	"github.com/cloudwego/eino/adk"
+	"github.com/cloudwego/eino/schema"
+)
+
+type fakeStore struct {
+	searchedQueries []string
+	savedDocs       []*schema.Document
+	savedNamespaces []string
+}
+
+func (f *fakeStore) Search(_ context.Context, query string, opts ...MemoryOption) ([]*schema.Document, error) {
+	f.searchedQueries = append(f.searchedQueries, query)
+	ns := ""
+	for _, opt := range opts {
+		o := &memoryOptions{}
+		opt(o)
+		ns = o.namespace
+	}
+	f.savedNamespaces = append(f.savedNamespaces, ns)
+	return []*schema.Document{{ID: "1", Content: "remember this fact"}}, nil
+}
+
+func (f *fakeStore) Save(_ context.Context, docs []*schema.Document, opts ...MemoryOption) error {
+	f.savedDocs = append(f.savedDocs, docs...)
+	ns := ""
+	for _, opt := range opts {
+		o := &memoryOptions{}
+		opt(o)
+		ns = o.namespace
+	}
+	f.savedNamespaces = append(f.savedNamespaces, ns)
+	return nil
+}
+
+func TestNewRequiresStore(t *testing.T) {
+	if _, err := New(nil); err == nil {
+		t.Fatal("expected error for nil Config")
+	}
+	if _, err := New(&Config{}); err == nil {
+		t.Fatal("expected error for nil Store")
+	}
+}
+
+func TestMemoryInjectedOnce(t *testing.T) {
+	store := &fakeStore{}
+	mw, err := New(&Config{Store: store})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	ctx := context.Background()
+	ctx, _, err = mw.BeforeAgent(ctx, &adk.ChatModelAgentContext{})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	state := &adk.ChatModelAgentState{
+		Messages: []*schema.Message{schema.UserMessage("what did I tell you?")},
+	}
+
+	// First model call injects memory.
+	ctx, state, err = mw.BeforeModelRewriteState(ctx, state, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(state.Messages) != 2 {
+		t.Fatalf("expected memory message prepended, got %d messages", len(state.Messages))
+	}
+	if state.Messages[0].Role != schema.System || state.Messages[0].Content != "[memory] remember this fact" {
+		t.Fatalf("unexpected injected message: %+v", state.Messages[0])
+	}
+
+	// Second model call must not re-inject.
+	ctx, state, err = mw.BeforeModelRewriteState(ctx, state, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(state.Messages) != 2 {
+		t.Fatalf("expected no re-injection, got %d messages", len(state.Messages))
+	}
+	if len(store.searchedQueries) != 1 {
+		t.Fatalf("expected 1 search, got %d", len(store.searchedQueries))
+	}
+}
+
+func TestWritePolicySavesAfterAgent(t *testing.T) {
+	store := &fakeStore{}
+	mw, err := New(&Config{
+		Store:             store,
+		NamespaceResolver: func(context.Context, *adk.ChatModelAgentContext) string { return "user-42" },
+		WritePolicy: func(_ context.Context, state *adk.ChatModelAgentState) ([]*schema.Document, bool, error) {
+			return []*schema.Document{{ID: "2", Content: "user preference"}}, true, nil
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	ctx := context.Background()
+	ctx, _, err = mw.BeforeAgent(ctx, &adk.ChatModelAgentContext{})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	_, err = mw.AfterAgent(ctx, &adk.ChatModelAgentState{})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if len(store.savedDocs) != 1 || store.savedDocs[0].Content != "user preference" {
+		t.Fatalf("unexpected saved docs: %+v", store.savedDocs)
+	}
+	if len(store.savedNamespaces) != 1 || store.savedNamespaces[0] != "user-42" {
+		t.Fatalf("unexpected saved namespaces: %v", store.savedNamespaces)
+	}
+}
+
+func TestWritePolicyFalseSkipsSave(t *testing.T) {
+	store := &fakeStore{}
+	mw, err := New(&Config{
+		Store: store,
+		WritePolicy: func(context.Context, *adk.ChatModelAgentState) ([]*schema.Document, bool, error) {
+			return nil, false, nil
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if _, err := mw.AfterAgent(context.Background(), &adk.ChatModelAgentState{}); err != nil {
+		t.Fatal(err)
+	}
+	if len(store.savedDocs) != 0 {
+		t.Fatalf("expected no save, got %d docs", len(store.savedDocs))
+	}
+}

--- a/adk/runner.go
+++ b/adk/runner.go
@@ -30,7 +30,7 @@ import (
 
 func errorIterator[M MessageType](err error) *AsyncIterator[*TypedAgentEvent[M]] {
 	iter, gen := NewAsyncIteratorPair[*TypedAgentEvent[M]]()
-	gen.Send(&TypedAgentEvent[M]{Err: err})
+	gen.Send(&TypedAgentEvent[M]{Type: AgentEventError, Err: err})
 	gen.Close()
 	return iter
 }
@@ -274,7 +274,7 @@ func typedRunnerHandleIterImpl[M MessageType](enableStreaming bool, store CheckP
 		panicErr := recover()
 		if panicErr != nil {
 			e := safe.NewPanicErr(panicErr, debug.Stack())
-			gen.Send(&TypedAgentEvent[M]{Err: e})
+			gen.Send(&TypedAgentEvent[M]{Type: AgentEventError, Err: e})
 		}
 
 		gen.Close()
@@ -299,7 +299,7 @@ func typedRunnerHandleIterImpl[M MessageType](enableStreaming bool, store CheckP
 					cancelErr.InterruptContexts = core.ToInterruptContexts(cancelErr.interruptSignal, allowedAddressSegmentTypes)
 					err := runnerSaveCheckPointImpl(enableStreaming, store, ctx, *checkPointID, &InterruptInfo{}, cancelErr.interruptSignal)
 					if err != nil {
-						gen.Send(&TypedAgentEvent[M]{Err: fmt.Errorf("failed to save checkpoint on cancel: %w", err)})
+						gen.Send(&TypedAgentEvent[M]{Type: AgentEventError, Err: fmt.Errorf("failed to save checkpoint on cancel: %w", err)})
 					}
 				}
 				gen.Send(event)
@@ -315,6 +315,7 @@ func typedRunnerHandleIterImpl[M MessageType](enableStreaming bool, store CheckP
 			interruptContexts := core.ToInterruptContexts(interruptSignal, allowedAddressSegmentTypes)
 			event = &TypedAgentEvent[M]{
 				AgentName: event.AgentName,
+				Type:      AgentEventInterrupt,
 				RunPath:   event.RunPath,
 				Output:    event.Output,
 				Action: &AgentAction{
@@ -332,7 +333,7 @@ func typedRunnerHandleIterImpl[M MessageType](enableStreaming bool, store CheckP
 					Data: legacyData,
 				}, interruptSignal)
 				if err != nil {
-					gen.Send(&TypedAgentEvent[M]{Err: fmt.Errorf("failed to save checkpoint: %w", err)})
+					gen.Send(&TypedAgentEvent[M]{Type: AgentEventError, Err: fmt.Errorf("failed to save checkpoint: %w", err)})
 				}
 			}
 		}

--- a/adk/utils.go
+++ b/adk/utils.go
@@ -303,7 +303,7 @@ func GetMessage(e *AgentEvent) (Message, *AgentEvent, error) {
 
 func typedErrorIter[M MessageType](err error) *AsyncIterator[*TypedAgentEvent[M]] {
 	iterator, generator := NewAsyncIteratorPair[*TypedAgentEvent[M]]()
-	generator.Send(&TypedAgentEvent[M]{Err: err})
+	generator.Send(&TypedAgentEvent[M]{Type: AgentEventError, Err: err})
 	generator.Close()
 	return iterator
 }

--- a/adk/workflow.go
+++ b/adk/workflow.go
@@ -77,9 +77,9 @@ func (a *workflowAgent) Run(ctx context.Context, _ *AgentInput, opts ...AgentRun
 			panicErr := recover()
 			if panicErr != nil {
 				e := safe.NewPanicErr(panicErr, debug.Stack())
-				generator.Send(&AgentEvent{Err: e})
+				generator.Send(&AgentEvent{Type: AgentEventError, Err: e})
 			} else if err != nil {
-				generator.Send(&AgentEvent{Err: err})
+				generator.Send(&AgentEvent{Type: AgentEventError, Err: err})
 			}
 
 			generator.Close()
@@ -129,9 +129,9 @@ func (a *workflowAgent) Resume(ctx context.Context, info *ResumeInfo, opts ...Ag
 			panicErr := recover()
 			if panicErr != nil {
 				e := safe.NewPanicErr(panicErr, debug.Stack())
-				generator.Send(&AgentEvent{Err: e})
+				generator.Send(&AgentEvent{Type: AgentEventError, Err: e})
 			} else if err != nil {
-				generator.Send(&AgentEvent{Err: err})
+				generator.Send(&AgentEvent{Type: AgentEventError, Err: err})
 			}
 
 			generator.Close()
@@ -523,7 +523,7 @@ func (a *workflowAgent) runParallel(ctx context.Context, generator *AsyncGenerat
 				panicErr := recover()
 				if panicErr != nil {
 					e := safe.NewPanicErr(panicErr, debug.Stack())
-					generator.Send(&AgentEvent{Err: e})
+					generator.Send(&AgentEvent{Type: AgentEventError, Err: e})
 				}
 				wg.Done()
 			}()
@@ -610,7 +610,7 @@ func cancelAtTransition(ctx context.Context, info string, state any) *AgentEvent
 	is, err := core.Interrupt(ctx, info, state, nil,
 		core.WithLayerPayload(getRunCtx(ctx).RunPath))
 	if err != nil {
-		return &AgentEvent{Err: err}
+		return &AgentEvent{Type: AgentEventError, Err: err}
 	}
 
 	contexts := core.ToInterruptContexts(is, allowedAddressSegmentTypes)

--- a/adk/wrappers.go
+++ b/adk/wrappers.go
@@ -856,6 +856,7 @@ func (w *typedEventSenderToolWrapper[M]) WrapInvokableToolCall(_ context.Context
 		event := typedToolInvokeEvent[M](callID, toolName, result, toolMsgID)
 		if prePopAction != nil {
 			event.Action = prePopAction
+			event.Type = actionEventType(prePopAction)
 		}
 
 		execCtx := getTypedChatModelAgentExecCtx[M](ctx)
@@ -889,6 +890,7 @@ func (w *typedEventSenderToolWrapper[M]) WrapStreamableToolCall(_ context.Contex
 		toolMsgID := uuid.NewString()
 		event := typedToolStreamEvent[M](callID, toolName, toolMsgID, streams[0])
 		event.Action = prePopAction
+		event.Type = actionEventType(prePopAction)
 
 		execCtx := getTypedChatModelAgentExecCtx[M](ctx)
 		_ = compose.ProcessState(ctx, func(_ context.Context, st *typedState[M]) error {
@@ -923,6 +925,7 @@ func (w *typedEventSenderToolWrapper[M]) WrapEnhancedInvokableToolCall(_ context
 		}
 		if prePopAction != nil {
 			event.Action = prePopAction
+			event.Type = actionEventType(prePopAction)
 		}
 
 		execCtx := getTypedChatModelAgentExecCtx[M](ctx)
@@ -956,6 +959,7 @@ func (w *typedEventSenderToolWrapper[M]) WrapEnhancedStreamableToolCall(_ contex
 		toolMsgID := uuid.NewString()
 		event := typedToolEnhancedStreamEvent[M](callID, toolName, toolMsgID, streams[0])
 		event.Action = prePopAction
+		event.Type = actionEventType(prePopAction)
 
 		execCtx := getTypedChatModelAgentExecCtx[M](ctx)
 		_ = compose.ProcessState(ctx, func(_ context.Context, st *typedState[M]) error {


### PR DESCRIPTION
Closes #997

Adds a stable, documented event taxonomy to ADK `AgentEvent` so applications can reliably distinguish event kinds for debugging, tracing, UI rendering and durable event logs — without inferring them from `Output`/`Action`/`Err`.

## What changed

`TypedAgentEvent[M]` gains an additive `Type AgentEventType` field (zero value `AgentEventUnknown`, so existing consumers and persisted checkpoints are unaffected), plus the following taxonomy:

| Constant | Meaning | Populated from |
|----------|---------|----------------|
| `AgentEventModelEnd` / `ModelDelta` | model output (final / streaming chunk) | `typedEventFromMessage`, `EventFromAgenticMessage` |
| `AgentEventToolEnd` / `ToolDelta` | tool result (final / streaming chunk) | same |
| `AgentEventAgentEnd` | Exit action | action attachment |
| `AgentEventTransfer` | transfer-to-agent | action attachment |
| `AgentEventBreakLoop` | break-loop action | action attachment |
| `AgentEventInterrupt` | interrupt action | `TypedInterrupt`/`StatefulInterrupt`/`CompositeInterrupt` + Runner reconstruction |
| `AgentEventError` | terminal error | every error emission point (~30 sites) |
| `AgentEventResume` | reserved for future resume events | not emitted yet |

Type is set at the framework's central constructors (`typedEventFromMessage`, `EventFromAgenticMessage`) and action-attachment points (`typedEventSenderToolWrapper`, `sendTransferEvents`, `Runner` interrupt reconstruction), so it is populated uniformly across the message and AgenticMessage paths.

## Scope note

`agent_start` / `model_start` / `tool_start` are intentionally **deferred**: they require new emission points at lifecycle boundaries rather than tagging existing events, and are better as a follow-up so this change stays purely additive and low-risk. This PR establishes the taxonomy and metadata model the issue asks for.

## Tests

- `adk/event_type_test.go` covers message/tool/agentic type mapping, action classification (exit/transfer/interrupt/break-loop), and interrupt event typing.
- Full `go test ./adk/...` passes.
