### PR TITLE
fix(adk): avoid duplicate nested checkpoint payloads

### DIFF
--- a/adk/interrupt.go
+++ b/adk/interrupt.go
@@ -210,10 +210,14 @@ func init() {
 type serialization struct {
 	RunCtx *runContext
 	// deprecated: still keep it here for backward compatibility
-	Info                *InterruptInfo
-	EnableStreaming     bool
-	InterruptID2Address map[string]Address
-	InterruptID2State   map[string]core.InterruptState
+	Info *InterruptInfo
+	// InfoDataSourceInterruptID identifies the InterruptID2State entry whose
+	// checkpoint bytes must be restored into ChatModelAgentInterruptInfo.Data.
+	// It is empty when Info.Data is stored inline.
+	InfoDataSourceInterruptID string
+	EnableStreaming           bool
+	InterruptID2Address       map[string]Address
+	InterruptID2State         map[string]core.InterruptState
 }
 
 func runnerLoadCheckPointImpl(store CheckPointStore, ctx context.Context, checkpointID string) (
@@ -232,6 +236,9 @@ func runnerLoadCheckPointImpl(store CheckPointStore, ctx context.Context, checkp
 	err = gob.NewDecoder(bytes.NewReader(data)).Decode(s)
 	if err != nil {
 		return nil, nil, nil, fmt.Errorf("failed to decode checkpoint: %w", err)
+	}
+	if err = restoreRunnerCheckpointInfoData(s); err != nil {
+		return nil, nil, nil, err
 	}
 	ctx = core.PopulateInterruptState(ctx, s.InterruptID2Address, s.InterruptID2State)
 
@@ -295,19 +302,66 @@ func runnerSaveCheckPointImpl(
 	runCtx := getRunCtx(ctx)
 
 	id2Addr, id2State := core.SignalToPersistenceMaps(is)
+	info, infoDataStateID := compactRunnerCheckpointInfoData(info, is)
 
 	buf := &bytes.Buffer{}
 	err := gob.NewEncoder(buf).Encode(&serialization{
-		RunCtx:              runCtx,
-		Info:                info,
-		InterruptID2Address: id2Addr,
-		InterruptID2State:   id2State,
-		EnableStreaming:     enableStreaming,
+		RunCtx:                    runCtx,
+		Info:                      info,
+		InfoDataSourceInterruptID: infoDataStateID,
+		InterruptID2Address:       id2Addr,
+		InterruptID2State:         id2State,
+		EnableStreaming:           enableStreaming,
 	})
 	if err != nil {
 		return fmt.Errorf("failed to encode checkpoint: %w", err)
 	}
 	return store.Set(ctx, key, buf.Bytes())
+}
+
+func compactRunnerCheckpointInfoData(info *InterruptInfo, is *core.InterruptSignal) (*InterruptInfo, string) {
+	if info == nil || is == nil || is.ID == "" {
+		return info, ""
+	}
+	chatModelInfo, ok := info.Data.(*ChatModelAgentInterruptInfo)
+	if !ok || chatModelInfo == nil {
+		return info, ""
+	}
+	state, ok := is.State.([]byte)
+	if !ok || !bytes.Equal(chatModelInfo.Data, state) {
+		return info, ""
+	}
+
+	compactedChatModelInfo := *chatModelInfo
+	compactedChatModelInfo.Data = nil
+	compactedInfo := *info
+	compactedInfo.Data = &compactedChatModelInfo
+	return &compactedInfo, is.ID
+}
+
+func restoreRunnerCheckpointInfoData(s *serialization) error {
+	if s.InfoDataSourceInterruptID == "" {
+		return nil
+	}
+	if s.Info == nil {
+		return errors.New("failed to decode checkpoint: compacted interrupt info is missing")
+	}
+	chatModelInfo, ok := s.Info.Data.(*ChatModelAgentInterruptInfo)
+	if !ok || chatModelInfo == nil {
+		return fmt.Errorf("failed to decode checkpoint: compacted interrupt info has invalid type %T", s.Info.Data)
+	}
+	state, ok := s.InterruptID2State[s.InfoDataSourceInterruptID]
+	if !ok {
+		return fmt.Errorf("failed to decode checkpoint: compacted interrupt state %q is missing",
+			s.InfoDataSourceInterruptID)
+	}
+	data, ok := state.State.([]byte)
+	if !ok {
+		return fmt.Errorf("failed to decode checkpoint: compacted interrupt state %q has invalid type %T",
+			s.InfoDataSourceInterruptID, state.State)
+	}
+	chatModelInfo.Data = append([]byte(nil), data...)
+	return nil
 }
 
 const bridgeCheckpointID = "adk_react_mock_key"

--- a/adk/interrupt_test.go
+++ b/adk/interrupt_test.go
@@ -19,6 +19,7 @@ package adk
 import (
 	"bytes"
 	"context"
+	"encoding/gob"
 	"errors"
 	"fmt"
 	"sync"
@@ -26,10 +27,12 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"github.com/cloudwego/eino/components/model"
 	"github.com/cloudwego/eino/components/tool"
 	"github.com/cloudwego/eino/compose"
+	"github.com/cloudwego/eino/internal/core"
 	"github.com/cloudwego/eino/schema"
 )
 
@@ -57,6 +60,179 @@ func TestPreprocessADKCheckpoint(t *testing.T) {
 		assert.True(t, bytes.Contains(out, []byte(lenPrefixedCompatName)))
 		assert.False(t, bytes.Contains(out, []byte(lenPrefixedReactStateName)))
 	})
+}
+
+func TestRunnerCheckpointDoesNotDuplicateChatModelState(t *testing.T) {
+	ctx := context.Background()
+	original := bytes.Repeat([]byte{0xab}, 1<<20)
+	payload := original
+	var checkpoints [][]byte
+
+	for i := 0; i < 3; i++ {
+		event := StatefulInterrupt(ctx, "interrupt", payload)
+		store := newMyStore()
+		err := runnerSaveCheckPointImpl(false, store, ctx, "checkpoint", &InterruptInfo{
+			Data: &ChatModelAgentInterruptInfo{Data: payload},
+		}, event.Action.internalInterrupted)
+		require.NoError(t, err)
+		payload = store.m["checkpoint"]
+		checkpoints = append(checkpoints, payload)
+	}
+
+	require.Less(t, len(payload), (1<<20)+(64<<10))
+
+	for i := len(checkpoints) - 1; i >= 0; i-- {
+		store := newMyStore()
+		store.m["checkpoint"] = checkpoints[i]
+		_, _, resumeInfo, err := runnerLoadCheckPointImpl(store, ctx, "checkpoint")
+		require.NoError(t, err)
+		interruptInfo, ok := resumeInfo.Data.(*ChatModelAgentInterruptInfo)
+		require.True(t, ok)
+		expected := original
+		if i > 0 {
+			expected = checkpoints[i-1]
+		}
+		assert.Equal(t, expected, interruptInfo.Data)
+	}
+}
+
+func TestAttack_RunnerCheckpointCompactionPreservesCompatibility(t *testing.T) {
+	ctx := context.Background()
+	payload := bytes.Repeat([]byte{0xab}, 128<<10)
+	event := StatefulInterrupt(ctx, "interrupt", payload)
+	legacyInfo := &ChatModelAgentInterruptInfo{Data: payload}
+	store := newMyStore()
+
+	err := runnerSaveCheckPointImpl(false, store, ctx, "checkpoint", &InterruptInfo{
+		Data: legacyInfo,
+	}, event.Action.internalInterrupted)
+	require.NoError(t, err)
+	assert.Equal(t, payload, legacyInfo.Data)
+
+	serialized := &serialization{}
+	err = gob.NewDecoder(bytes.NewReader(store.m["checkpoint"])).Decode(serialized)
+	require.NoError(t, err)
+	assert.Equal(t, event.Action.internalInterrupted.ID, serialized.InfoDataSourceInterruptID)
+	compactedInfo, ok := serialized.Info.Data.(*ChatModelAgentInterruptInfo)
+	require.True(t, ok)
+	assert.Empty(t, compactedInfo.Data)
+
+	_, _, resumeInfo, err := runnerLoadCheckPointImpl(store, ctx, "checkpoint")
+	require.NoError(t, err)
+	restoredInfo, ok := resumeInfo.Data.(*ChatModelAgentInterruptInfo)
+	require.True(t, ok)
+	assert.Equal(t, payload, restoredInfo.Data)
+	restoredInfo.Data[0] ^= 0xff
+	assert.Equal(t, byte(0xab), event.Action.internalInterrupted.State.([]byte)[0])
+}
+
+func TestAttack_RunnerCheckpointLoadsLegacyInlineChatModelData(t *testing.T) {
+	payload := []byte("legacy checkpoint")
+	state := &serialization{
+		Info: &InterruptInfo{
+			Data: &ChatModelAgentInterruptInfo{Data: payload},
+		},
+		InterruptID2State: map[string]core.InterruptState{
+			"interrupt": {State: payload},
+		},
+	}
+	buf := &bytes.Buffer{}
+	assert.NoError(t, gob.NewEncoder(buf).Encode(state))
+	store := newMyStore()
+	store.m["checkpoint"] = buf.Bytes()
+
+	_, _, resumeInfo, err := runnerLoadCheckPointImpl(store, context.Background(), "checkpoint")
+	require.NoError(t, err)
+	interruptInfo, ok := resumeInfo.Data.(*ChatModelAgentInterruptInfo)
+	require.True(t, ok)
+	assert.Equal(t, payload, interruptInfo.Data)
+}
+
+func TestAttack_RunnerCheckpointCompactionKeepsNonCanonicalData(t *testing.T) {
+	canonical := []byte("canonical")
+	cases := []struct {
+		name string
+		info *InterruptInfo
+		id   string
+	}{
+		{
+			name: "custom interrupt data",
+			info: &InterruptInfo{Data: []byte("custom")},
+			id:   "interrupt",
+		},
+		{
+			name: "mismatched chat model data",
+			info: &InterruptInfo{Data: &ChatModelAgentInterruptInfo{Data: []byte("other")}},
+			id:   "interrupt",
+		},
+		{
+			name: "missing interrupt ID",
+			info: &InterruptInfo{Data: &ChatModelAgentInterruptInfo{Data: canonical}},
+		},
+	}
+
+	for _, tt := range cases {
+		t.Run(tt.name, func(t *testing.T) {
+			signal := StatefulInterrupt(context.Background(), "interrupt", canonical).Action.internalInterrupted
+			signal.ID = tt.id
+			compacted, stateID := compactRunnerCheckpointInfoData(tt.info, signal)
+			assert.Same(t, tt.info, compacted)
+			assert.Empty(t, stateID)
+		})
+	}
+}
+
+func TestAttack_RunnerCheckpointRejectsBrokenCompactedReference(t *testing.T) {
+	cases := []struct {
+		name  string
+		state *serialization
+		err   string
+	}{
+		{
+			name:  "missing interrupt info",
+			state: &serialization{InfoDataSourceInterruptID: "interrupt"},
+			err:   "failed to decode checkpoint: compacted interrupt info is missing",
+		},
+		{
+			name: "invalid interrupt info type",
+			state: &serialization{
+				Info:                      &InterruptInfo{Data: "invalid"},
+				InfoDataSourceInterruptID: "interrupt",
+			},
+			err: "failed to decode checkpoint: compacted interrupt info has invalid type string",
+		},
+		{
+			name: "missing interrupt state",
+			state: &serialization{
+				Info:                      &InterruptInfo{Data: &ChatModelAgentInterruptInfo{}},
+				InfoDataSourceInterruptID: "interrupt",
+			},
+			err: `failed to decode checkpoint: compacted interrupt state "interrupt" is missing`,
+		},
+		{
+			name: "invalid interrupt state type",
+			state: &serialization{
+				Info:                      &InterruptInfo{Data: &ChatModelAgentInterruptInfo{}},
+				InfoDataSourceInterruptID: "interrupt",
+				InterruptID2State: map[string]core.InterruptState{
+					"interrupt": {State: "invalid"},
+				},
+			},
+			err: `failed to decode checkpoint: compacted interrupt state "interrupt" has invalid type string`,
+		},
+	}
+
+	for _, tt := range cases {
+		t.Run(tt.name, func(t *testing.T) {
+			buf := &bytes.Buffer{}
+			require.NoError(t, gob.NewEncoder(buf).Encode(tt.state))
+			store := newMyStore()
+			store.m["checkpoint"] = buf.Bytes()
+
+			_, _, _, err := runnerLoadCheckPointImpl(store, context.Background(), "checkpoint")
+			assert.EqualError(t, err, tt.err)
+		})
+	}
 }
 
 func TestAttack_ResumeBridgeStoreRequiresFreshWrite(t *testing.T) {


### PR DESCRIPTION
# Avoid Exponential AgentTool Checkpoint Growth

## Problem

`ChatModelAgent` checkpoint bytes were persisted twice by `Runner`: once as the
authoritative interrupt state and again inside the deprecated
`ChatModelAgentInterruptInfo.Data` view.

`AgentTool` embeds a child Runner checkpoint in its parent checkpoint. Repeating
the duplicate payload at every nested boundary caused checkpoint size to grow
exponentially with depth. Three layers around a 1 MiB payload produced an
8.4 MiB checkpoint.

## Solution

Persist the checkpoint bytes only in `InterruptID2State`. The serialized legacy
view records the interrupt state ID instead of another copy of the bytes.
During load, Runner resolves that ID and reconstructs
`ChatModelAgentInterruptInfo.Data` before resume callbacks or agents observe it.

Compaction is applied only when the legacy bytes exactly match the root
interrupt state. Custom, mismatched, and unaddressed interrupt data remains
inline and unchanged.

## Decisions

The existing gob schema remains additive. Old inline checkpoints continue to
load, while malformed compacted references fail instead of silently resuming
with incomplete state.

## Key Insight

For nested `AgentTool` execution, the child Runner checkpoint is already the
canonical state of the AgentTool interrupt. Persisting the same bytes in the
legacy presentation field changes linear checkpoint composition into
approximately twofold growth at every agent level.

## Summary

| Problem | Solution |
|---------|----------|
| Nested AgentTool checkpoints duplicate the full child payload at every Runner layer | Store one canonical payload and persist an internal reference |
| Existing consumers expect `ChatModelAgentInterruptInfo.Data` during resume | Reconstruct the legacy view while loading |
| Corrupt references could cause incomplete resume state | Reject missing or invalid referenced state |

---

# 避免 AgentTool Checkpoint 随嵌套层级指数膨胀

## 问题

`ChatModelAgent` 的 checkpoint bytes 会被 `Runner` 持久化两次：一份位于权威的
interrupt state 中，另一份位于已废弃的 `ChatModelAgentInterruptInfo.Data` 兼容视图中。

`AgentTool` 会把 Child Runner checkpoint 嵌入 Parent checkpoint。每层都重复完整
payload，导致 checkpoint 大小随嵌套深度指数增长。三层包装 1 MiB payload 时，
checkpoint 会增长到约 8.4 MiB。

## 方案

checkpoint bytes 只持久化在 `InterruptID2State`。序列化后的 legacy 视图不再保存
第二份 bytes，而是记录对应的 interrupt state ID。加载时，Runner 根据该 ID 恢复
`ChatModelAgentInterruptInfo.Data`，因此 Resume callback 和 Agent 看到的行为不变。

只有当 legacy bytes 与根 interrupt state 完全一致时才会去重。自定义、不一致或
缺少地址的 interrupt data 仍按原方式内联保存。

## 决策

继续使用可增量兼容的 gob schema。旧的内联 checkpoint 可以正常读取；新的引用
如果缺失或类型错误，则明确失败，避免用不完整状态继续 Resume。

## 核心认识

在嵌套 `AgentTool` 场景中，Child Runner checkpoint 已经是 AgentTool interrupt 的
权威状态。同一份 bytes 再写入 legacy 展示字段，会让原本线性的 checkpoint 组合
变成每经过一层 Agent 都近似翻倍。

## 总结

| 问题 | 解决方式 |
|------|----------|
| 嵌套 AgentTool 在每层重复完整 Child payload | 只持久化一份权威 payload，并保存内部引用 |
| 现有调用方在 Resume 时依赖 `ChatModelAgentInterruptInfo.Data` | 加载 checkpoint 时重建 legacy 视图 |
| 损坏引用可能产生不完整 Resume 状态 | 缺失或类型不匹配时明确报错 |
