### PR TITLE
refactor(adk): make the foreground handoff API usable outside the module

### DIFF
--- a/adk/backgroundtask/foreground.go
+++ b/adk/backgroundtask/foreground.go
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2026 CloudWeGo Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package backgroundtask
+
+import "github.com/cloudwego/eino/adk/internal/foreground"
+
+// ForegroundCandidate describes a foreground execution that may be handed off
+// to background ownership. It is supplied to the ShouldAutoBackground policy
+// callbacks when a foreground observation timer expires. TaskID is
+// pre-allocated for correlation; no Task exists until a handoff succeeds.
+type ForegroundCandidate = foreground.CandidateInfo
+
+// DefaultForegroundTimeoutMs is the foreground observation timeout applied
+// when a configuration leaves it unset.
+const DefaultForegroundTimeoutMs = foreground.DefaultTimeoutMs

--- a/adk/backgroundtask/local/local.go
+++ b/adk/backgroundtask/local/local.go
@@ -83,11 +83,11 @@ type Config struct {
 	Executors *backgroundtask.ExecutorRegistry
 	// ForegroundTimeoutMs is the default foreground observation timeout for runs
 	// that do not set Input.ForegroundTimeoutMs. Nil uses the framework default
-	// (foreground.DefaultTimeoutMs); a non-positive value disables the timer, so
-	// runs wait until the work returns or ctx is canceled and ShouldAutoBackground
-	// is never consulted.
+	// (backgroundtask.DefaultForegroundTimeoutMs); a non-positive value disables
+	// the timer, so runs wait until the work returns or ctx is canceled and
+	// ShouldAutoBackground is never consulted.
 	ForegroundTimeoutMs  *int
-	ShouldAutoBackground func(context.Context, *foreground.CandidateInfo) bool
+	ShouldAutoBackground func(context.Context, *backgroundtask.ForegroundCandidate) bool
 	BackgroundNotice     func(context.Context, NoticeInfo) string
 }
 
@@ -104,7 +104,7 @@ func New(config *Config) (*Runner, error) {
 	if config == nil || config.Manager == nil || config.Executors == nil {
 		return nil, errors.New("backgroundtask/local: manager and executor registry are required")
 	}
-	timeoutMs := foreground.DefaultTimeoutMs
+	timeoutMs := backgroundtask.DefaultForegroundTimeoutMs
 	if config.ForegroundTimeoutMs != nil {
 		timeoutMs = *config.ForegroundTimeoutMs
 	}
@@ -216,7 +216,7 @@ func (r *Runner) runForeground(
 		cancel()
 		return nil, ctx.Err()
 	case <-timeout:
-		candidate := &foreground.CandidateInfo{
+		candidate := &backgroundtask.ForegroundCandidate{
 			TaskID: spec.ID, Kind: spec.Kind, Description: spec.Description,
 			OutputFile: spec.OutputFile, StartedAt: startedAt,
 			Elapsed: time.Since(startedAt),

--- a/adk/backgroundtask/local/local_test.go
+++ b/adk/backgroundtask/local/local_test.go
@@ -31,7 +31,6 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/cloudwego/eino/adk/backgroundtask"
-	"github.com/cloudwego/eino/adk/internal/foreground"
 	"github.com/cloudwego/eino/schema"
 )
 
@@ -167,7 +166,7 @@ func TestRunnerForegroundTimeoutPolicies_BitsUT(t *testing.T) {
 		timeout := 10
 		runner, manager := newTestRunner(t, func(config *Config) {
 			config.ForegroundTimeoutMs = &timeout
-			config.ShouldAutoBackground = func(context.Context, *foreground.CandidateInfo) bool {
+			config.ShouldAutoBackground = func(context.Context, *backgroundtask.ForegroundCandidate) bool {
 				return true
 			}
 		})
@@ -440,7 +439,7 @@ func TestRunnerStreamBackgroundNotices(t *testing.T) {
 				return fmt.Sprintf("notice:%t", info.AutoBackgrounded)
 			}
 			if auto {
-				config.ShouldAutoBackground = func(context.Context, *foreground.CandidateInfo) bool {
+				config.ShouldAutoBackground = func(context.Context, *backgroundtask.ForegroundCandidate) bool {
 					return true
 				}
 			}

--- a/adk/backgroundtask/local/stream.go
+++ b/adk/backgroundtask/local/stream.go
@@ -21,7 +21,6 @@ import (
 	"time"
 
 	"github.com/cloudwego/eino/adk/backgroundtask"
-	"github.com/cloudwego/eino/adk/internal/foreground"
 	"github.com/cloudwego/eino/schema"
 )
 
@@ -196,7 +195,7 @@ func (r *Runner) projectForegroundStream(projection *foregroundStreamProjection)
 			}
 			return
 		case <-timeout:
-			candidate := &foreground.CandidateInfo{
+			candidate := &backgroundtask.ForegroundCandidate{
 				TaskID: spec.ID, Kind: spec.Kind, Description: spec.Description,
 				OutputFile: spec.OutputFile, StartedAt: startedAt,
 				Elapsed: time.Since(startedAt),

--- a/adk/backgroundtask/tool/managed_tool.go
+++ b/adk/backgroundtask/tool/managed_tool.go
@@ -56,7 +56,7 @@ type ManagedToolConfig struct {
 	// timeout the operation instead of detaching. It may be called concurrently.
 	// A non-positive ForegroundTimeoutMs therefore also disables this policy:
 	// with no timer there is no expiry to evaluate it on.
-	ShouldAutoBackground func(context.Context, *foreground.CandidateInfo) bool
+	ShouldAutoBackground func(context.Context, *backgroundtask.ForegroundCandidate) bool
 	// RunInBackground requests explicit detachment from JSON arguments. Nil
 	// never requests it and takes precedence over foreground timeout.
 	RunInBackground func(context.Context, string) bool
@@ -118,7 +118,7 @@ func NewManagedTool(
 		return nil, fmt.Errorf("backgroundtask/tool: clone tool info: %w", err)
 	}
 	info.Desc += "\nSuccessful execution returns an Eino task_id for task_output and task_stop."
-	timeoutMs := foreground.DefaultTimeoutMs
+	timeoutMs := backgroundtask.DefaultForegroundTimeoutMs
 	if config.ForegroundTimeoutMs != nil {
 		timeoutMs = *config.ForegroundTimeoutMs
 	}
@@ -720,7 +720,7 @@ func (t *managedTool) tryHandoff(
 	ctx context.Context,
 	start *foregroundStart,
 ) (*backgroundtask.Task, error) {
-	candidate := &foreground.CandidateInfo{
+	candidate := &backgroundtask.ForegroundCandidate{
 		TaskID: start.taskID, Kind: start.spec.Kind,
 		Description: start.spec.Description, OutputFile: start.spec.OutputFile,
 	}

--- a/adk/backgroundtask/tool/managed_tool_test.go
+++ b/adk/backgroundtask/tool/managed_tool_test.go
@@ -30,7 +30,6 @@ import (
 
 	"github.com/cloudwego/eino/adk"
 	"github.com/cloudwego/eino/adk/backgroundtask"
-	"github.com/cloudwego/eino/adk/internal/foreground"
 	adksession "github.com/cloudwego/eino/adk/session"
 	"github.com/cloudwego/eino/components/model"
 	componenttool "github.com/cloudwego/eino/components/tool"
@@ -267,7 +266,7 @@ func newTestManagedTool(
 		SessionID:           func(context.Context) (string, error) { return "session", nil },
 	}
 	if _, ok := implementation.(ForegroundHandoffTool); ok {
-		config.ShouldAutoBackground = func(context.Context, *foreground.CandidateInfo) bool {
+		config.ShouldAutoBackground = func(context.Context, *backgroundtask.ForegroundCandidate) bool {
 			return true
 		}
 	}
@@ -1801,7 +1800,7 @@ func TestManagedToolDrainYieldsAndRecoversWithoutStop(t *testing.T) {
 	wrapped, err := NewManagedTool(context.Background(), &ManagedToolConfig{
 		Manager: managerOne, Executors: executorsOne, Registry: registry, ToolName: "external",
 		ForegroundTimeoutMs:  &timeoutMs,
-		ShouldAutoBackground: func(context.Context, *foreground.CandidateInfo) bool { return true },
+		ShouldAutoBackground: func(context.Context, *backgroundtask.ForegroundCandidate) bool { return true },
 		SessionID:            func(context.Context) (string, error) { return "session", nil },
 	})
 	require.NoError(t, err)

--- a/adk/middlewares/filesystem/bash_run.go
+++ b/adk/middlewares/filesystem/bash_run.go
@@ -86,9 +86,9 @@ type outputSink struct {
 }
 
 type toolDefinition struct {
-	name             string
-	desc             string
-	alwaysForeground bool
+	name                      string
+	desc                      string
+	backendOwnsCommandTimeout bool
 }
 
 // bashOutputWriter tees a managed execute task's output to a file via a
@@ -374,12 +374,12 @@ func newManagedExecuteTool(
 	toolName := selectToolName(definition.name, ToolNameExecute)
 	// The tool description is fixed at construction time (the arg schema is derived
 	// from struct tags), so the timeout argument must be explained for the mode this
-	// tool was built in: an always-foreground tool passes it to the backend as the
-	// command's own budget, otherwise it is the foreground wait before a handoff.
+	// tool was built in: a tool that hands the timeout to the backend passes it as
+	// the command's own budget, otherwise it is the foreground wait before a handoff.
 	defaultDesc, defaultDescChinese := ManagedExecuteToolDesc, ManagedExecuteToolDescChinese
-	if definition.alwaysForeground {
-		defaultDesc = AlwaysForegroundManagedExecuteToolDesc
-		defaultDescChinese = AlwaysForegroundManagedExecuteToolDescChinese
+	if definition.backendOwnsCommandTimeout {
+		defaultDesc = BackendTimeoutManagedExecuteToolDesc
+		defaultDescChinese = BackendTimeoutManagedExecuteToolDescChinese
 	}
 	d, err := selectToolDesc(definition.desc, defaultDesc, defaultDescChinese)
 	if err != nil {
@@ -397,13 +397,13 @@ func newManagedExecuteTool(
 	)
 }
 
-// backendOwnsCommandTimeout reports whether this invocation hands the timeout
+// backendOwnsTimeoutForRun reports whether this invocation hands the timeout
 // argument to the backend as a command execution limit, instead of using it as the
-// Manager's foreground wait before an automatic background handoff. That is only
-// true for an always-foreground run: an explicit background launch never waits in
-// the foreground, so its timeout argument is ignored either way.
-func backendOwnsCommandTimeout(input executeManagedArgs, alwaysForeground bool) bool {
-	return alwaysForeground && !input.RunInBackground
+// Manager's foreground wait before an automatic background handoff. Only a
+// foreground run in that mode qualifies: an explicit background launch never waits
+// in the foreground, so its timeout argument is ignored either way.
+func backendOwnsTimeoutForRun(input executeManagedArgs, backendOwnsCommandTimeout bool) bool {
+	return backendOwnsCommandTimeout && !input.RunInBackground
 }
 
 // managedRunInput builds the RunInput shared by the buffered and streaming managed
@@ -469,7 +469,7 @@ func newManagedBufferedExecuteTool(
 	definition toolDefinition,
 ) (tool.BaseTool, error) {
 	return utils.InferTool(definition.name, definition.desc, func(ctx context.Context, input executeManagedArgs) (string, error) {
-		backendOwnsTimeout := backendOwnsCommandTimeout(input, definition.alwaysForeground)
+		backendOwnsTimeout := backendOwnsTimeoutForRun(input, definition.backendOwnsCommandTimeout)
 		parentSessionID, err := sessionID(ctx)
 		if err != nil {
 			return "", err
@@ -528,7 +528,7 @@ func newManagedStreamingExecuteTool(
 	definition toolDefinition,
 ) (tool.BaseTool, error) {
 	return utils.InferStreamTool(definition.name, definition.desc, func(ctx context.Context, input executeManagedArgs) (*schema.StreamReader[string], error) {
-		backendOwnsTimeout := backendOwnsCommandTimeout(input, definition.alwaysForeground)
+		backendOwnsTimeout := backendOwnsTimeoutForRun(input, definition.backendOwnsCommandTimeout)
 		parentSessionID, err := sessionID(ctx)
 		if err != nil {
 			return nil, err

--- a/adk/middlewares/filesystem/bash_run_test.go
+++ b/adk/middlewares/filesystem/bash_run_test.go
@@ -33,7 +33,6 @@ import (
 	"github.com/cloudwego/eino/adk/backgroundtask"
 	backgroundlocal "github.com/cloudwego/eino/adk/backgroundtask/local"
 	"github.com/cloudwego/eino/adk/filesystem"
-	"github.com/cloudwego/eino/adk/internal/foreground"
 	"github.com/cloudwego/eino/components/tool"
 	"github.com/cloudwego/eino/schema"
 )
@@ -368,7 +367,7 @@ func TestManagedExecuteTool_TimeoutDoesNotSetExecutionTimeout(t *testing.T) {
 // A backend that stopped the command on its own budget reports TimedOut, and the
 // tool result names the timeout instead of the kill signal's exit code — that is the
 // fact the agent can act on.
-func TestManagedExecuteTool_AlwaysForegroundBackendTimedOut(t *testing.T) {
+func TestManagedExecuteTool_BackendOwnsCommandTimeoutBackendTimedOut(t *testing.T) {
 	mgr := newTestManager(t, context.Background())
 	defer func() {
 		ctx, cancel := context.WithTimeout(context.Background(), 100*time.Millisecond)
@@ -384,7 +383,7 @@ func TestManagedExecuteTool_AlwaysForegroundBackendTimedOut(t *testing.T) {
 	tools, err := getFilesystemTools(context.Background(), &MiddlewareConfig{
 		Shell: shell,
 		Background: &BackgroundConfig{Local: &LocalBackgroundConfig{
-			Runner: mustLocalRunner(t, mgr), AlwaysForeground: true,
+			Runner: mustLocalRunner(t, mgr), BackendOwnsCommandTimeout: true,
 		}},
 		notificationSessionID: testNotificationSessionID,
 	})
@@ -400,7 +399,7 @@ func TestManagedExecuteTool_AlwaysForegroundBackendTimedOut(t *testing.T) {
 	assert.Equal(t, time.Second, *shell.req.Timeout)
 }
 
-func TestManagedExecuteTool_AlwaysForegroundUsesCommandExecutionTimeout(t *testing.T) {
+func TestManagedExecuteTool_BackendOwnsCommandTimeoutUsesCommandExecutionTimeout(t *testing.T) {
 	mgr := newTestManager(t, context.Background())
 	defer func() {
 		ctx, cancel := context.WithTimeout(context.Background(), 100*time.Millisecond)
@@ -416,11 +415,11 @@ func TestManagedExecuteTool_AlwaysForegroundUsesCommandExecutionTimeout(t *testi
 				Runner: mustLocalRunner(t, mgr, func(config *backgroundlocal.Config) {
 					foregroundTimeoutMs := 5
 					config.ForegroundTimeoutMs = &foregroundTimeoutMs
-					config.ShouldAutoBackground = func(context.Context, *foreground.CandidateInfo) bool {
+					config.ShouldAutoBackground = func(context.Context, *backgroundtask.ForegroundCandidate) bool {
 						return true
 					}
 				}),
-				AlwaysForeground: true,
+				BackendOwnsCommandTimeout: true,
 			},
 		},
 		notificationSessionID: testNotificationSessionID,
@@ -435,7 +434,7 @@ func TestManagedExecuteTool_AlwaysForegroundUsesCommandExecutionTimeout(t *testi
 	assert.Equal(t, 10*time.Second, *shell.req.Timeout)
 }
 
-func TestManagedExecuteTool_AlwaysForegroundExplicitBackgroundIgnoresTimeout(t *testing.T) {
+func TestManagedExecuteTool_BackendOwnsCommandTimeoutExplicitBackgroundIgnoresTimeout(t *testing.T) {
 	mgr := newTestManager(t, context.Background())
 	defer func() {
 		ctx, cancel := context.WithTimeout(context.Background(), time.Second)
@@ -448,7 +447,7 @@ func TestManagedExecuteTool_AlwaysForegroundExplicitBackgroundIgnoresTimeout(t *
 	tools, err := getFilesystemTools(context.Background(), &MiddlewareConfig{
 		Shell: shell,
 		Background: &BackgroundConfig{Local: &LocalBackgroundConfig{
-			Runner: mustLocalRunner(t, mgr), AlwaysForeground: true,
+			Runner: mustLocalRunner(t, mgr), BackendOwnsCommandTimeout: true,
 		}},
 		notificationSessionID: testNotificationSessionID,
 	})
@@ -577,7 +576,7 @@ func TestManagedExecuteTool_TimeoutMovesToBackground(t *testing.T) {
 		Background: &BackgroundConfig{
 			Local: &LocalBackgroundConfig{
 				Runner: mustLocalRunner(t, mgr, func(config *backgroundlocal.Config) {
-					config.ShouldAutoBackground = func(context.Context, *foreground.CandidateInfo) bool {
+					config.ShouldAutoBackground = func(context.Context, *backgroundtask.ForegroundCandidate) bool {
 						return true
 					}
 				}),
@@ -675,18 +674,18 @@ func TestShellPayloadV1AndCommandFromTask(t *testing.T) {
 	assert.ErrorIs(t, err, backgroundtask.ErrUnsupportedExecutorPayloadVersion)
 }
 
-// Only an always-foreground run hands the timeout argument to the backend: an
-// explicit background launch ignores it in either mode.
-func TestBackendOwnsCommandTimeout(t *testing.T) {
+// Only a foreground run hands the timeout argument to the backend: an explicit
+// background launch ignores it in either mode.
+func TestBackendOwnsTimeoutForRun(t *testing.T) {
 	foreground := executeManagedArgs{executeArgs: executeArgs{Command: "cmd"}}
 	background := executeManagedArgs{
 		executeArgs: executeArgs{Command: "cmd"}, RunInBackground: true,
 	}
 
-	assert.False(t, backendOwnsCommandTimeout(foreground, false))
-	assert.True(t, backendOwnsCommandTimeout(foreground, true))
-	assert.False(t, backendOwnsCommandTimeout(background, false))
-	assert.False(t, backendOwnsCommandTimeout(background, true))
+	assert.False(t, backendOwnsTimeoutForRun(foreground, false))
+	assert.True(t, backendOwnsTimeoutForRun(foreground, true))
+	assert.False(t, backendOwnsTimeoutForRun(background, false))
+	assert.False(t, backendOwnsTimeoutForRun(background, true))
 
 	assert.Nil(t, managedExecuteRequest(foreground, false).Timeout)
 	assert.Nil(t, managedExecuteRequest(background, true).Timeout)
@@ -742,7 +741,7 @@ func TestManagedExecuteTool_StreamingBackendTimedOut(t *testing.T) {
 
 	executeTool, err := newManagedExecuteTool(
 		mustLocalRunner(t, mgr), nil, &mockStreamingShellTimedOutChunks{},
-		testNotificationSessionID, outputSink{}, toolDefinition{alwaysForeground: true},
+		testNotificationSessionID, outputSink{}, toolDefinition{backendOwnsCommandTimeout: true},
 	)
 	require.NoError(t, err)
 
@@ -794,7 +793,7 @@ func TestManagedExecuteTool_StreamingForeground(t *testing.T) {
 	assert.Contains(t, got, "chunk3")
 }
 
-func TestManagedExecuteTool_StreamingAlwaysForegroundUsesCommandExecutionTimeout(t *testing.T) {
+func TestManagedExecuteTool_StreamingBackendOwnsCommandTimeoutUsesCommandExecutionTimeout(t *testing.T) {
 	mgr := newTestManager(t, context.Background())
 	defer func() {
 		ctx, cancel := context.WithTimeout(context.Background(), time.Second)
@@ -805,7 +804,7 @@ func TestManagedExecuteTool_StreamingAlwaysForegroundUsesCommandExecutionTimeout
 	shell := &mockStreamingShell{}
 	executeTool, err := newManagedExecuteTool(
 		mustLocalRunner(t, mgr), nil, shell, testNotificationSessionID,
-		outputSink{}, toolDefinition{alwaysForeground: true},
+		outputSink{}, toolDefinition{backendOwnsCommandTimeout: true},
 	)
 	require.NoError(t, err)
 
@@ -984,7 +983,7 @@ func TestManagedExecuteTool_Schema(t *testing.T) {
 // The timeout argument means different things in the two modes, so the tool
 // description — fixed at construction, unlike the arg schema — must be selected
 // per mode.
-func TestManagedExecuteTool_AlwaysForegroundDesc(t *testing.T) {
+func TestManagedExecuteTool_BackendOwnsCommandTimeoutDesc(t *testing.T) {
 	mgr := newTestManager(t, context.Background())
 	defer func() {
 		ctx, cancel := context.WithTimeout(context.Background(), 100*time.Millisecond)
@@ -1004,7 +1003,7 @@ func TestManagedExecuteTool_AlwaysForegroundDesc(t *testing.T) {
 
 	fgTool, err := newManagedExecuteTool(
 		runner, shell, nil, testNotificationSessionID, outputSink{},
-		toolDefinition{alwaysForeground: true},
+		toolDefinition{backendOwnsCommandTimeout: true},
 	)
 	require.NoError(t, err)
 	fgInfo, err := fgTool.Info(context.Background())
@@ -1018,7 +1017,7 @@ func TestManagedExecuteTool_AlwaysForegroundDesc(t *testing.T) {
 	// An explicit description still wins over both defaults.
 	customTool, err := newManagedExecuteTool(
 		runner, shell, nil, testNotificationSessionID, outputSink{},
-		toolDefinition{desc: "custom desc", alwaysForeground: true},
+		toolDefinition{desc: "custom desc", backendOwnsCommandTimeout: true},
 	)
 	require.NoError(t, err)
 	customInfo, err := customTool.Info(context.Background())

--- a/adk/middlewares/filesystem/filesystem.go
+++ b/adk/middlewares/filesystem/filesystem.go
@@ -39,7 +39,6 @@ import (
 	backgroundtool "github.com/cloudwego/eino/adk/backgroundtask/tool"
 	"github.com/cloudwego/eino/adk/filesystem"
 	"github.com/cloudwego/eino/adk/internal"
-	"github.com/cloudwego/eino/adk/internal/foreground"
 	"github.com/cloudwego/eino/components/tool"
 	"github.com/cloudwego/eino/components/tool/utils"
 	"github.com/cloudwego/eino/compose"
@@ -106,25 +105,25 @@ type BackgroundConfig struct {
 type LocalBackgroundConfig struct {
 	// Runner owns task lifecycle and process-local closures.
 	Runner *backgroundlocal.Runner
-	// AlwaysForeground changes the timeout semantics for runs with
-	// run_in_background=false. When false, the tool timeout limits foreground
-	// waiting before the Manager applies its normal timeout policy. When true,
-	// the run stays attached until the shell backend returns and the tool timeout
-	// is passed to filesystem.ExecuteRequest.Timeout as the command execution
-	// limit. Explicit background runs ignore this option and the tool timeout.
+	// BackendOwnsCommandTimeout selects what the tool timeout argument bounds for
+	// runs with run_in_background=false. When false, it bounds how long the caller
+	// waits in the foreground; on expiry the Runner's ShouldAutoBackground policy
+	// either hands the run to the background or terminates it with a
+	// *backgroundtask.ForegroundTimeoutError. When true, it is passed to
+	// filesystem.ExecuteRequest.Timeout as the command execution limit and the
+	// Manager's foreground timer is disabled, so the run stays attached until the
+	// shell backend returns. Explicit background runs ignore this option and the
+	// tool timeout argument entirely.
 	//
-	// Setting it hands the command's time limit to the backend: the Manager's
-	// foreground timer is disabled for those runs, so nothing on this side stops a
-	// command whose Timeout the backend ignores. Canceling the invocation's context
-	// remains the only bound in that case. That handover is the point — only the
-	// backend knows when the command actually started, so only it can exclude
-	// transport and environment setup time from the limit the model asked for.
+	// Moving the limit to the backend is the point: only the backend knows when the
+	// command actually started, so only it can exclude transport and environment
+	// setup time from the limit the model asked for. The cost is that nothing on
+	// this side stops a command whose Timeout the backend ignores — canceling the
+	// invocation's context becomes the only bound.
 	//
-	// This invocation mode is separate from the Runner's ShouldAutoBackground
-	// policy, which is evaluated only after a foreground wait expires and may
-	// inspect the populated foreground candidate. With AlwaysForeground the
-	// foreground wait never expires, so that policy is never consulted.
-	AlwaysForeground bool
+	// It also implies the run is never auto-backgrounded: ShouldAutoBackground is
+	// evaluated only on foreground-timer expiry, and this mode has no timer.
+	BackendOwnsCommandTimeout bool
 	// OutputStore and OutputDir optionally materialize managed output.
 	OutputStore filesystem.AppendOpener
 	OutputDir   string
@@ -142,7 +141,7 @@ type RecoverableBackgroundConfig struct {
 	// ForegroundTimeoutMs is in milliseconds. ShouldAutoBackground may be called
 	// concurrently and must not mutate the candidate.
 	ForegroundTimeoutMs  *int
-	ShouldAutoBackground func(context.Context, *foreground.CandidateInfo) bool
+	ShouldAutoBackground func(context.Context, *backgroundtask.ForegroundCandidate) bool
 }
 
 // Config is the legacy configuration for the filesystem middleware.
@@ -685,7 +684,7 @@ func createExecuteTool(ctx context.Context, middlewareConfig *MiddlewareConfig) 
 				},
 				toolDefinition{
 					name: executeConfig.Name, desc: desc,
-					alwaysForeground: local.AlwaysForeground,
+					backendOwnsCommandTimeout: local.BackendOwnsCommandTimeout,
 				},
 			)
 		}
@@ -1260,14 +1259,14 @@ type executeManagedArgs struct {
 	executeArgs
 	RunInBackground bool `json:"run_in_background,omitempty" jsonschema_description:"Set to true to run the command in the background. Use task_output to query it and task_stop to cancel it."`
 	// TimeoutSeconds is ignored when run_in_background is true. For foreground runs
-	// its meaning is selected by LocalBackgroundConfig.AlwaysForeground: it either
-	// limits command execution in the backend or limits foreground waiting before
-	// the Manager stops or automatically backgrounds the command.
+	// its meaning is selected by LocalBackgroundConfig.BackendOwnsCommandTimeout: it
+	// either limits command execution in the backend or limits foreground waiting
+	// before the Manager stops or automatically backgrounds the command.
 	//
 	// The schema description stays mode-neutral because it is derived from this
 	// struct tag once, for every managed execute tool. Which of the two meanings
 	// applies is stated in the tool description, which is selected per mode (see
-	// AlwaysForegroundManagedExecuteToolDesc).
+	// BackendTimeoutManagedExecuteToolDesc).
 	TimeoutSeconds int `json:"timeout,omitempty" jsonschema_description:"Optional timeout in seconds, up to 3 days. Ignored when run_in_background is true. Omit to use the default. See the tool description for what this timeout bounds."`
 }
 

--- a/adk/middlewares/filesystem/prompt.go
+++ b/adk/middlewares/filesystem/prompt.go
@@ -159,21 +159,21 @@ When to use: creating a new file, or fully replacing one you've already Read. Ov
 - ` + "`" + `timeout` + "`" + ` 单位为秒：默认 120，最大 3 天。它限制的是本次调用等待命令的时长，而非命令自身可运行的时长：超时后命令继续运行，并被转为后台任务。` + "`" + `run_in_background` + "`" + ` 为 true 时忽略。
 - ` + "`" + `run_in_background` + "`" + ` 会立即创建后台任务：工具结果返回 task_id/启动预览。使用 task_output 查询状态并读取终态结果；宿主配置了完成通知时也可能主动投递通知。无需 ` + "`" + `&` + "`" + `。前台运行是同步执行，除非宿主支持安全 auto-background handoff，否则不会创建 task。前台 ` + "`" + `sleep` + "`" + ` 被禁止；用 Monitor 配合 until 循环来等待某个条件。`
 
-	// AlwaysForegroundManagedExecuteToolDesc is the ManagedExecuteToolDesc variant for
-	// a managed execute tool configured with LocalBackgroundConfig.AlwaysForeground.
-	// It differs only in the two lines the mode changes: `timeout` limits the command
-	// itself rather than the caller's wait, and a foreground run is never handed off
-	// to a background task.
-	AlwaysForegroundManagedExecuteToolDesc = `Executes a bash command and returns its output.
+	// BackendTimeoutManagedExecuteToolDesc is the ManagedExecuteToolDesc variant for
+	// a managed execute tool configured with
+	// LocalBackgroundConfig.BackendOwnsCommandTimeout. It differs only in the two
+	// lines the mode changes: `timeout` limits the command itself rather than the
+	// caller's wait, and a foreground run is never handed off to a background task.
+	BackendTimeoutManagedExecuteToolDesc = `Executes a bash command and returns its output.
 
 - Working directory persists between calls, but prefer absolute paths — ` + "`" + `cd` + "`" + ` in a compound command can trigger a permission prompt. Shell state (env vars, functions) does not persist; the shell is initialized from the user's profile.
 - IMPORTANT: Avoid using this tool to run ` + "`" + `cat` + "`" + `, ` + "`" + `head` + "`" + `, ` + "`" + `tail` + "`" + `, ` + "`" + `sed` + "`" + `, ` + "`" + `awk` + "`" + `, or ` + "`" + `echo` + "`" + ` commands, unless explicitly instructed or after you have verified that a dedicated tool cannot accomplish your task. Instead, use the appropriate dedicated tool as this will provide a much better experience for the user.
 - ` + "`" + `timeout` + "`" + ` is in seconds, max 3 days. It bounds how long the command itself may run; on expiry the command is stopped and the output collected so far is returned. Omit it to use the default. Ignored when ` + "`" + `run_in_background` + "`" + ` is true.
 - ` + "`" + `run_in_background` + "`" + ` starts a background task immediately: the tool result returns a task_id/startup preview. Use task_output to check status and read the terminal result; the host may also deliver a completion notification when configured. No ` + "`" + `&` + "`" + ` needed. Foreground runs are synchronous and are never handed off to a background task. Foreground ` + "`" + `sleep` + "`" + ` is blocked; use Monitor with an until-loop to wait on a condition.`
 
-	// AlwaysForegroundManagedExecuteToolDescChinese is the Chinese counterpart of
-	// AlwaysForegroundManagedExecuteToolDesc.
-	AlwaysForegroundManagedExecuteToolDescChinese = `执行一条 bash 命令并返回其输出。
+	// BackendTimeoutManagedExecuteToolDescChinese is the Chinese counterpart of
+	// BackendTimeoutManagedExecuteToolDesc.
+	BackendTimeoutManagedExecuteToolDescChinese = `执行一条 bash 命令并返回其输出。
 
 - 工作目录在多次调用间保持，但优先使用绝对路径 —— 复合命令中的 ` + "`" + `cd` + "`" + ` 可能触发权限确认。Shell 状态（环境变量、函数）不会保留；shell 以用户的 profile 初始化。
 - 重要：除非明确要求，或你已确认没有专用工具能完成任务，否则避免用本工具运行 ` + "`" + `cat` + "`" + `、` + "`" + `head` + "`" + `、` + "`" + `tail` + "`" + `、` + "`" + `sed` + "`" + `、` + "`" + `awk` + "`" + `、` + "`" + `echo` + "`" + ` 命令。请改用相应的专用工具，这会带来更好的体验。

--- a/adk/middlewares/subagent/middleware.go
+++ b/adk/middlewares/subagent/middleware.go
@@ -29,7 +29,6 @@ import (
 	durablesubagent "github.com/cloudwego/eino/adk/backgroundtask/subagent"
 	"github.com/cloudwego/eino/adk/filesystem"
 	"github.com/cloudwego/eino/adk/internal"
-	"github.com/cloudwego/eino/adk/internal/foreground"
 	"github.com/cloudwego/eino/adk/middlewares/internal/systemreminder"
 	"github.com/cloudwego/eino/components/tool"
 	"github.com/cloudwego/eino/schema"
@@ -122,7 +121,7 @@ type TypedDurableBackgroundConfig[M adk.MessageType] struct {
 	// ShouldAutoBackground is reserved for a future durable checkpoint handoff
 	// implementation. Supplying it currently makes construction fail rather
 	// than pre-creating a background task for foreground execution.
-	ShouldAutoBackground func(context.Context, *foreground.CandidateInfo) bool
+	ShouldAutoBackground func(context.Context, *backgroundtask.ForegroundCandidate) bool
 	// RunOptionsFactories reconstructs deployment-owned run options by sub-agent
 	// name for every execution attempt. Every worker serving a name must configure
 	// a semantically equivalent factory for the full lifetime of resumable tasks.

--- a/adk/middlewares/subagent/middleware_test.go
+++ b/adk/middlewares/subagent/middleware_test.go
@@ -35,7 +35,6 @@ import (
 	durablesubagent "github.com/cloudwego/eino/adk/backgroundtask/subagent"
 	"github.com/cloudwego/eino/adk/filesystem"
 	"github.com/cloudwego/eino/adk/internal/agenttool"
-	"github.com/cloudwego/eino/adk/internal/foreground"
 	adksession "github.com/cloudwego/eino/adk/session"
 	"github.com/cloudwego/eino/components/tool"
 	"github.com/cloudwego/eino/schema"
@@ -971,7 +970,7 @@ func TestDurableAutoBackgroundRequiresHandoffSupport(t *testing.T) {
 	agent := &mockAgent{name: "worker", desc: "done"}
 	background := durableBackground(t, manager, agent)
 	background.Durable.ForegroundTimeoutMs = &timeout
-	background.Durable.ShouldAutoBackground = func(context.Context, *foreground.CandidateInfo) bool { return true }
+	background.Durable.ShouldAutoBackground = func(context.Context, *backgroundtask.ForegroundCandidate) bool { return true }
 	_, err := New(ctx, &Config{
 		SubAgents: []adk.Agent{agent}, Background: background,
 	})

--- a/adk/prebuilt/deep/deep.go
+++ b/adk/prebuilt/deep/deep.go
@@ -31,7 +31,6 @@ import (
 	backgroundtool "github.com/cloudwego/eino/adk/backgroundtask/tool"
 	"github.com/cloudwego/eino/adk/filesystem"
 	"github.com/cloudwego/eino/adk/internal"
-	"github.com/cloudwego/eino/adk/internal/foreground"
 	backgroundtaskmw "github.com/cloudwego/eino/adk/middlewares/backgroundtask"
 	filesystem2 "github.com/cloudwego/eino/adk/middlewares/filesystem"
 	"github.com/cloudwego/eino/adk/middlewares/subagent"
@@ -60,7 +59,7 @@ type TypedBackgroundConfig[M adk.MessageType] struct {
 	LocalShell *LocalShellConfig
 	// ForegroundTimeoutMs and ShouldAutoBackground apply to every enabled capability.
 	ForegroundTimeoutMs  *int
-	ShouldAutoBackground func(context.Context, *foreground.CandidateInfo) bool
+	ShouldAutoBackground func(context.Context, *backgroundtask.ForegroundCandidate) bool
 	// TranscriptFormat customizes durable sub-agent session views.
 	TranscriptFormat subagent.TranscriptFormat[M]
 }


### PR DESCRIPTION
## Why

Two related problems on the public surface around foreground/background handoff.

**1. `ShouldAutoBackground` cannot be used outside this module.**

Its parameter type is `foreground.CandidateInfo`, defined in `adk/internal/foreground`. Packages under `adk/` may import it, so CI stayed green — but an external caller gets:

```
use of internal package github.com/cloudwego/eino/adk/internal/foreground not allowed
```

There is no workaround: Go does not infer function-literal parameter types from assignment context, and a defined type is not identical to a structurally equal struct literal, so no assignable closure can be written. The field was unusable for every user of the framework. It appeared on five public configs (`backgroundtask/local.Config`, `backgroundtask/tool.ManagedToolConfig`, `middlewares/subagent`, `middlewares/filesystem`, `prebuilt/deep`). The `Config` docs also referenced `foreground.DefaultTimeoutMs`, equally unreachable.

**2. `LocalBackgroundConfig.AlwaysForeground` names the wrong thing.**

Its only effect is selecting what the tool's `timeout` argument bounds — the caller's foreground wait, or the command's own execution limit passed to `filesystem.ExecuteRequest.Timeout`. "Always foreground" named a derived consequence rather than the thing being configured, and hid the cost: the mode disables the Manager's foreground timer, so context cancellation becomes the only bound on a backend that ignores `Timeout`.

Worth noting because it is easy to assume otherwise: a nil `ShouldAutoBackground` is *not* equivalent to this mode. On timer expiry it calls `cancel()` and returns a `*backgroundtask.ForegroundTimeoutError` rather than staying attached.

## What

- Add `backgroundtask.ForegroundCandidate` (alias for the internal type) and `backgroundtask.DefaultForegroundTimeoutMs`. Same pattern as `callbacks.RunInfo` and `schema.GobSerializer`. `foreground.Policy` and `ProjectionDetached` stay internal — they are wiring, not user API.
- Point all five `ShouldAutoBackground` fields at the public name, and the internal construction sites too, so no file carries two names for one type.
- Rename `AlwaysForeground` → `BackendOwnsCommandTimeout`, with the doc comment restructured to state the timeout ownership, the cost, and the never-auto-backgrounded implication separately.
- Rename the description variants to `BackendTimeoutManagedExecuteToolDesc` / `...Chinese`.
- Rename the internal helper to `backendOwnsTimeoutForRun` so it no longer collides with the struct field it reads.

No behavior change. Breaking change to API that has only shipped in `v0.10.0-alpha.*`.

## Verification

- `go build ./...`
- `go test -race ./...` — full suite passes
- `golangci-lint run ./adk/...` — 0 issues
- `gofmt -s -l ./adk` — clean
- Confirmed from a separate module (`replace` to this tree) that both renamed APIs are now reachable: constructing the callback, reading every `ForegroundCandidate` field, and referencing `DefaultForegroundTimeoutMs` and `BackendOwnsCommandTimeout` all compile and run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)