### PR TITLE
feat: add per-file byte cap and budget-aware truncation to agentsmd

### DIFF
--- a/adk/middlewares/agentsmd/agentsmd.go
+++ b/adk/middlewares/agentsmd/agentsmd.go
@@ -40,11 +40,17 @@ type Config struct {
 	// Supports @import syntax inside files for recursive inclusion (max depth 5).
 	AgentsMDFiles []string
 
-	// AllAgentsMDMaxBytes limits the total byte size of all loaded Agents.md content.
-	// Files are loaded in order; once the cumulative size exceeds this limit,
-	// remaining files are skipped. Each individual file is always loaded in full.
-	// 0 means no limit.
+	// AllAgentsMDMaxBytes limits the total byte size of all loaded Agents.md content,
+	// counting top-level files and their @imported files alike. The limit applies to
+	// every file, including the first. When loading a file would exceed the limit, that
+	// file is truncated to fit, and no further files are loaded. 0 means no limit.
 	AllAgentsMDMaxBytes int
+
+	// PerAgentsMDMaxBytes limits the byte size of each individual Agents.md file,
+	// applied to every loaded file including @imported ones. A file larger than this
+	// is truncated to the limit (with a notice appended) before the cumulative
+	// AllAgentsMDMaxBytes budget is applied. 0 means no per-file limit.
+	PerAgentsMDMaxBytes int
 
 	// OnLoadWarning is an optional callback invoked when a non-fatal error occurs
 	// during Agents.md file loading (e.g. file not found, circular @import, depth
@@ -69,7 +75,7 @@ func NewTyped[M adk.MessageType](_ context.Context, cfg *Config) (adk.TypedChatM
 	}
 
 	return &typedMiddleware[M]{
-		loader: newLoaderConfig(cfg.Backend, cfg.AgentsMDFiles, cfg.AllAgentsMDMaxBytes, cfg.OnLoadWarning),
+		loader: newLoaderConfig(cfg.Backend, cfg.AgentsMDFiles, cfg.AllAgentsMDMaxBytes, cfg.PerAgentsMDMaxBytes, cfg.OnLoadWarning),
 	}, nil
 }
 
@@ -207,7 +213,10 @@ func (c *Config) validate() error {
 		return fmt.Errorf("[agentsmd]: at least one agent file path is required")
 	}
 	if c.AllAgentsMDMaxBytes < 0 {
-		return fmt.Errorf("[agentsmd]: AllAgentMDDocsMaxBytes must be non-negative")
+		return fmt.Errorf("[agentsmd]: AllAgentsMDMaxBytes must be non-negative")
+	}
+	if c.PerAgentsMDMaxBytes < 0 {
+		return fmt.Errorf("[agentsmd]: PerAgentsMDMaxBytes must be non-negative")
 	}
 	return nil
 }

--- a/adk/middlewares/agentsmd/agentsmd_test.go
+++ b/adk/middlewares/agentsmd/agentsmd_test.go
@@ -22,6 +22,7 @@ import (
 	"os"
 	"strings"
 	"testing"
+	"unicode/utf8"
 
 	"github.com/cloudwego/eino/adk"
 	"github.com/cloudwego/eino/adk/filesystem"
@@ -89,6 +90,11 @@ func TestNew_Validation(t *testing.T) {
 	_, err = New(ctx, &Config{Backend: b, AgentsMDFiles: []string{"/test.md"}, AllAgentsMDMaxBytes: -1})
 	if err == nil {
 		t.Fatal("expected error for negative max bytes")
+	}
+
+	_, err = New(ctx, &Config{Backend: b, AgentsMDFiles: []string{"/test.md"}, PerAgentsMDMaxBytes: -1})
+	if err == nil {
+		t.Fatal("expected error for negative per-file max bytes")
 	}
 
 	_, err = New(ctx, &Config{AgentsMDFiles: []string{"/test.md"}})
@@ -308,14 +314,14 @@ func TestMiddleware_CircularImport(t *testing.T) {
 
 func TestMiddleware_MaxBytesLimit(t *testing.T) {
 	b := newMemBackend()
-	b.set("/a.md", "AAAA") // 4 bytes
-	b.set("/b.md", "BBBB") // 4 bytes
+	b.set("/a.md", strings.Repeat("A", 560)) // fills the budget exactly
+	b.set("/b.md", "BBBB")
 
 	ctx := context.Background()
 	mw, err := New(ctx, &Config{
 		Backend:             b,
 		AgentsMDFiles:       []string{"/a.md", "/b.md"},
-		AllAgentsMDMaxBytes: 5, // file a (4) fits, file b (4) would exceed
+		AllAgentsMDMaxBytes: 560, // file a fills it, so file b is excluded
 	})
 	if err != nil {
 		t.Fatal(err)
@@ -328,7 +334,7 @@ func TestMiddleware_MaxBytesLimit(t *testing.T) {
 	}
 
 	content := state.Messages[0].Content
-	if !strings.Contains(content, "AAAA") {
+	if !strings.Contains(content, strings.Repeat("A", 560)) {
 		t.Fatal("first file should be included")
 	}
 	if strings.Contains(content, "BBBB") {
@@ -456,7 +462,7 @@ func TestLoader_NoImportsPassthrough(t *testing.T) {
 	b := newMemBackend()
 	b.set("/agent.md", "plain text without imports\nline two")
 
-	l := newLoaderConfig(b, []string{"/agent.md"}, 0, nil)
+	l := newLoaderConfig(b, []string{"/agent.md"}, 0, 0, nil)
 	content, err := l.load(context.Background())
 	if err != nil {
 		t.Fatal(err)
@@ -475,7 +481,7 @@ func TestLoader_ImportAsSeparateSection(t *testing.T) {
 	b.set("/doc.md", "before @/snippet.md after")
 	b.set("/snippet.md", "INJECTED")
 
-	l := newLoaderConfig(b, []string{"/doc.md"}, 0, nil)
+	l := newLoaderConfig(b, []string{"/doc.md"}, 0, 0, nil)
 	content, err := l.load(context.Background())
 	if err != nil {
 		t.Fatal(err)
@@ -500,7 +506,7 @@ func TestLoader_MultipleImportsSameLine(t *testing.T) {
 	b.set("/a.txt", "AAA")
 	b.set("/b.txt", "BBB")
 
-	l := newLoaderConfig(b, []string{"/doc.md"}, 0, nil)
+	l := newLoaderConfig(b, []string{"/doc.md"}, 0, 0, nil)
 	content, err := l.load(context.Background())
 	if err != nil {
 		t.Fatal(err)
@@ -530,7 +536,7 @@ func TestLoader_SameFileTwiceOnSameLine(t *testing.T) {
 	b.set("/doc.md", "@/shared.md and @/shared.md again")
 	b.set("/shared.md", "SHARED")
 
-	l := newLoaderConfig(b, []string{"/doc.md"}, 0, nil)
+	l := newLoaderConfig(b, []string{"/doc.md"}, 0, 0, nil)
 	content, err := l.load(context.Background())
 	if err != nil {
 		t.Fatal(err)
@@ -550,7 +556,7 @@ func TestLoader_ImportFileNotFound(t *testing.T) {
 	b := newMemBackend()
 	b.set("/doc.md", "load @/missing.md please")
 
-	l := newLoaderConfig(b, []string{"/doc.md"}, 0, nil)
+	l := newLoaderConfig(b, []string{"/doc.md"}, 0, 0, nil)
 	content, err := l.load(context.Background())
 	if err != nil {
 		t.Fatalf("expected no error (missing import is logged), got %v", err)
@@ -570,7 +576,7 @@ func TestLoader_RelativePathResolution(t *testing.T) {
 	b.set("/a/b/host.md", "ref @../c/target.md done")
 	b.set("/a/c/target.md", "TARGET")
 
-	l := newLoaderConfig(b, []string{"/a/b/host.md"}, 0, nil)
+	l := newLoaderConfig(b, []string{"/a/b/host.md"}, 0, 0, nil)
 	content, err := l.load(context.Background())
 	if err != nil {
 		t.Fatal(err)
@@ -594,7 +600,7 @@ func TestLoader_RelativeTopLevelPath(t *testing.T) {
 	b.set("sub/agents.md", "start @./other.md end")
 	b.set("sub/other.md", "OTHER CONTENT")
 
-	l := newLoaderConfig(b, []string{"sub/agents.md"}, 0, nil)
+	l := newLoaderConfig(b, []string{"sub/agents.md"}, 0, 0, nil)
 	content, err := l.load(context.Background())
 	if err != nil {
 		t.Fatal(err)
@@ -613,7 +619,7 @@ func TestLoader_RelativeTopLevelWithDotDotImport(t *testing.T) {
 	b.set("sub/agents.md", "see @../shared/x.md here")
 	b.set("shared/x.md", "SHARED X")
 
-	l := newLoaderConfig(b, []string{"sub/agents.md"}, 0, nil)
+	l := newLoaderConfig(b, []string{"sub/agents.md"}, 0, 0, nil)
 	content, err := l.load(context.Background())
 	if err != nil {
 		t.Fatal(err)
@@ -633,7 +639,7 @@ func TestLoader_RelativeTopLevelDedup(t *testing.T) {
 	b := newMemBackend()
 	b.set("sub/a.md", "CONTENT A")
 
-	l := newLoaderConfig(b, []string{"sub/a.md", "./sub/a.md"}, 0, nil)
+	l := newLoaderConfig(b, []string{"sub/a.md", "./sub/a.md"}, 0, 0, nil)
 	content, err := l.load(context.Background())
 	if err != nil {
 		t.Fatal(err)
@@ -650,7 +656,7 @@ func TestLoader_AbsoluteTopLevelWithRelativeImport(t *testing.T) {
 	b.set("/project/agents.md", "ref @./lib/helper.md done")
 	b.set("/project/lib/helper.md", "HELPER")
 
-	l := newLoaderConfig(b, []string{"/project/agents.md"}, 0, nil)
+	l := newLoaderConfig(b, []string{"/project/agents.md"}, 0, 0, nil)
 	content, err := l.load(context.Background())
 	if err != nil {
 		t.Fatal(err)
@@ -669,7 +675,7 @@ func TestLoader_AbsoluteTopLevelWithDotDotImport(t *testing.T) {
 	b.set("/project/sub/agents.md", "load @../shared/x.md here")
 	b.set("/project/shared/x.md", "SHARED")
 
-	l := newLoaderConfig(b, []string{"/project/sub/agents.md"}, 0, nil)
+	l := newLoaderConfig(b, []string{"/project/sub/agents.md"}, 0, 0, nil)
 	content, err := l.load(context.Background())
 	if err != nil {
 		t.Fatal(err)
@@ -690,7 +696,7 @@ func TestLoader_RelativeImportDedup(t *testing.T) {
 	b.set("/a/main.md", "first @/a/b/shared.md second @../a/b/shared.md end")
 	b.set("/a/b/shared.md", "SHARED ONCE")
 
-	l := newLoaderConfig(b, []string{"/a/main.md"}, 0, nil)
+	l := newLoaderConfig(b, []string{"/a/main.md"}, 0, 0, nil)
 	content, err := l.load(context.Background())
 	if err != nil {
 		t.Fatal(err)
@@ -709,7 +715,7 @@ func TestLoader_NestedRelativeImport(t *testing.T) {
 	b.set("/root/sub/mid.md", "mid @deep/leaf.md mid_end")
 	b.set("/root/sub/deep/leaf.md", "LEAF")
 
-	l := newLoaderConfig(b, []string{"/root/main.md"}, 0, nil)
+	l := newLoaderConfig(b, []string{"/root/main.md"}, 0, 0, nil)
 	content, err := l.load(context.Background())
 	if err != nil {
 		t.Fatal(err)
@@ -731,7 +737,7 @@ func TestLoader_TransitiveImport(t *testing.T) {
 	b.set("/mid.md", "mid-start @/leaf.md mid-end")
 	b.set("/leaf.md", "LEAF_VALUE")
 
-	l := newLoaderConfig(b, []string{"/main.md"}, 0, nil)
+	l := newLoaderConfig(b, []string{"/main.md"}, 0, 0, nil)
 	content, err := l.load(context.Background())
 	if err != nil {
 		t.Fatal(err)
@@ -750,7 +756,7 @@ func TestLoader_EmptyFile(t *testing.T) {
 	b := newMemBackend()
 	b.set("/empty.md", "")
 
-	l := newLoaderConfig(b, []string{"/empty.md"}, 0, nil)
+	l := newLoaderConfig(b, []string{"/empty.md"}, 0, 0, nil)
 	content, err := l.load(context.Background())
 	if err != nil {
 		t.Fatal(err)
@@ -761,18 +767,71 @@ func TestLoader_EmptyFile(t *testing.T) {
 	}
 }
 
-func TestLoader_MaxBytesFirstFileFull(t *testing.T) {
-	// Even if the first file alone exceeds maxBytes, it should still be loaded in full.
+func TestLoader_MaxBytesFirstFileTruncated(t *testing.T) {
+	// The budget applies to the first file too: it is truncated to the remaining
+	// budget (with a notice) when at least minTruncatableBytes remain.
 	b := newMemBackend()
-	b.set("/big.md", "ABCDEFGHIJ") // 10 bytes
+	b.set("/big.md", strings.Repeat("A", 1000)) // 1000 bytes
 
-	l := newLoaderConfig(b, []string{"/big.md"}, 3, nil)
-	content, err := l.load(context.Background()) // maxBytes=3, but first file always loads
+	l := newLoaderConfig(b, []string{"/big.md"}, 600, 0, nil)
+	content, err := l.load(context.Background())
 	if err != nil {
 		t.Fatal(err)
 	}
-	if !strings.Contains(content, "ABCDEFGHIJ") {
-		t.Fatalf("first file should always load in full, got %q", content)
+	if !strings.Contains(content, strings.Repeat("A", 600)) {
+		t.Fatalf("first file should retain 600 bytes, got %q", content)
+	}
+	if strings.Contains(content, strings.Repeat("A", 601)) {
+		t.Fatalf("first file should be truncated to 600 bytes, got more")
+	}
+	if !strings.Contains(content, "truncated 400 bytes") {
+		t.Fatalf("expected truncation notice, got %q", content)
+	}
+}
+
+func TestLoader_MaxBytesBelowThresholdStillCaps(t *testing.T) {
+	// A positive budget below minTruncatableBytes is still a hard cap: the first
+	// (and only) file is truncated to fit rather than being dropped or loaded whole.
+	// minTruncatableBytes is a tail-only optimization and must have no effect here.
+	b := newMemBackend()
+	b.set("/big.md", strings.Repeat("A", 1000))
+
+	l := newLoaderConfig(b, []string{"/big.md"}, 100, 0, nil)
+	content, err := l.load(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(content, strings.Repeat("A", 100)) {
+		t.Fatalf("first file should be truncated to the 100-byte budget, got %q", content)
+	}
+	if strings.Contains(content, strings.Repeat("A", 101)) {
+		t.Fatalf("content must not exceed the 100-byte budget, got %q", content)
+	}
+	if !strings.Contains(content, "truncated") {
+		t.Fatalf("truncation notice expected, got %q", content)
+	}
+}
+
+func TestLoader_MaxBytesLaterFileDropped(t *testing.T) {
+	// Once earlier content leaves less than minTruncatableBytes of budget, the next
+	// file is dropped whole and listed as omitted.
+	b := newMemBackend()
+	b.set("/a.md", strings.Repeat("A", 550)) // consumes most of a 600-byte budget
+	b.set("/b.md", strings.Repeat("B", 200))
+
+	l := newLoaderConfig(b, []string{"/a.md", "/b.md"}, 600, 0, nil)
+	content, err := l.load(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(content, strings.Repeat("A", 550)) {
+		t.Fatalf("a.md should load in full, got %q", content)
+	}
+	if strings.Contains(content, "B") && strings.Contains(content, strings.Repeat("B", 2)) {
+		t.Fatalf("b.md should be dropped whole (remaining budget below threshold), got %q", content)
+	}
+	if !strings.Contains(content, "1 more file(s) not loaded due to the total byte limit") {
+		t.Fatalf("dropped file should be listed as omitted, got %q", content)
 	}
 }
 
@@ -782,7 +841,7 @@ func TestLoader_CircularImportInline(t *testing.T) {
 	b.set("/a.md", "text @/b.md more")
 	b.set("/b.md", "ref @/a.md back")
 
-	l := newLoaderConfig(b, []string{"/a.md"}, 0, nil)
+	l := newLoaderConfig(b, []string{"/a.md"}, 0, 0, nil)
 	content, err := l.load(context.Background())
 	if err != nil {
 		t.Fatalf("expected no error (circular import is logged), got %v", err)
@@ -809,7 +868,7 @@ func TestLoader_MaxDepthInline(t *testing.T) {
 		b.set(fmt.Sprintf("/level%d.md", i), content)
 	}
 
-	l := newLoaderConfig(b, []string{"/level0.md"}, 0, nil)
+	l := newLoaderConfig(b, []string{"/level0.md"}, 0, 0, nil)
 	content, err := l.load(context.Background())
 	if err != nil {
 		t.Fatalf("expected no error (depth exceeded is logged), got %v", err)
@@ -836,7 +895,7 @@ func TestLoader_DiamondDependency(t *testing.T) {
 	b.set("/d.md", "D(@/c.md)")
 	b.set("/c.md", "SHARED")
 
-	l := newLoaderConfig(b, []string{"/a.md"}, 0, nil)
+	l := newLoaderConfig(b, []string{"/a.md"}, 0, 0, nil)
 	content, err := l.load(context.Background())
 	if err != nil {
 		t.Fatalf("diamond dependency should not be circular, got error: %v", err)
@@ -861,7 +920,7 @@ func TestLoader_AtSignInNormalText(t *testing.T) {
 	b := newMemBackend()
 	b.set("/agent.md", "contact me @ anytime or @  spaces and @someone mentioned and user@example.com and @company.org")
 
-	l := newLoaderConfig(b, []string{"/agent.md"}, 0, nil)
+	l := newLoaderConfig(b, []string{"/agent.md"}, 0, 0, nil)
 	content, err := l.load(context.Background())
 	if err != nil {
 		t.Fatal(err)
@@ -886,11 +945,11 @@ func TestLoader_MaxBytesWithImports(t *testing.T) {
 	b := newMemBackend()
 	b.set("/a.md", "A(@/shared.md)")
 	b.set("/b.md", "B(@/shared.md)")
-	b.set("/shared.md", strings.Repeat("X", 100)) // 100 bytes
+	b.set("/shared.md", strings.Repeat("X", 600)) // 600 bytes
 
-	l := newLoaderConfig(b, []string{"/a.md", "/b.md"}, 120, nil)
-	// /a.md = 14 bytes + /shared.md = 100 bytes => 114 total after /a.md.
-	// Budget = 120: /b.md (14 bytes) would push to 128, exceeding budget.
+	l := newLoaderConfig(b, []string{"/a.md", "/b.md"}, 620, 0, nil)
+	// /a.md = 14 bytes + /shared.md = 600 bytes => 614 total after /a.md.
+	// Budget = 620: only 6 bytes remain, below minTruncatableBytes, so /b.md is dropped.
 	content, err := l.load(context.Background())
 	if err != nil {
 		t.Fatalf("load failed: %v", err)
@@ -945,7 +1004,7 @@ func TestLoader_DuplicateTopLevelFiles(t *testing.T) {
 	b := newMemBackend()
 	b.set("/agent.md", "unique content")
 
-	l := newLoaderConfig(b, []string{"/agent.md", "/agent.md"}, 0, nil)
+	l := newLoaderConfig(b, []string{"/agent.md", "/agent.md"}, 0, 0, nil)
 	content, err := l.load(context.Background())
 	if err != nil {
 		t.Fatal(err)
@@ -960,7 +1019,7 @@ func TestLoader_DuplicateTopLevelFiles(t *testing.T) {
 func TestLoader_LoadFileError(t *testing.T) {
 	// Missing file (ErrNotExist) is silently skipped.
 	b := newMemBackend()
-	l := newLoaderConfig(b, []string{"/missing.md"}, 0, nil)
+	l := newLoaderConfig(b, []string{"/missing.md"}, 0, 0, nil)
 	content, err := l.load(context.Background())
 	if err != nil {
 		t.Fatalf("expected missing file to be skipped, got error: %v", err)
@@ -974,10 +1033,10 @@ func TestLoader_MaxBytesStopsImports(t *testing.T) {
 	// When budget is exhausted, further imports in collectImports should be skipped.
 	b := newMemBackend()
 	b.set("/main.md", "@/big.md @/small.md")
-	b.set("/big.md", strings.Repeat("B", 200))
+	b.set("/big.md", strings.Repeat("B", 600))
 	b.set("/small.md", "SMALL")
 
-	l := newLoaderConfig(b, []string{"/main.md"}, 50, nil)
+	l := newLoaderConfig(b, []string{"/main.md"}, 560, 0, nil)
 	content, err := l.load(context.Background())
 	if err != nil {
 		t.Fatal(err)
@@ -993,12 +1052,98 @@ func TestLoader_MaxBytesStopsImports(t *testing.T) {
 	}
 }
 
+func TestLoader_PerFileMaxBytesTruncates(t *testing.T) {
+	// PerAgentsMDMaxBytes caps each file individually; a per-file truncation does
+	// not stop the loader, so later files still load.
+	b := newMemBackend()
+	b.set("/a.md", strings.Repeat("A", 1000))
+	b.set("/b.md", "KEEP")
+
+	l := newLoaderConfig(b, []string{"/a.md", "/b.md"}, 0, 100, nil)
+	content, err := l.load(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if !strings.Contains(content, strings.Repeat("A", 100)) {
+		t.Fatalf("a.md should retain 100 bytes, got %q", content)
+	}
+	if strings.Contains(content, strings.Repeat("A", 101)) {
+		t.Fatal("a.md should be truncated to 100 bytes")
+	}
+	if !strings.Contains(content, "truncated 900 bytes") {
+		t.Fatalf("expected per-file truncation notice, got %q", content)
+	}
+	if !strings.Contains(content, "KEEP") {
+		t.Fatal("b.md should still load; per-file cap must not stop the loader")
+	}
+}
+
+func TestLoader_PerFileTruncatedSkipsImports(t *testing.T) {
+	// A file truncated by the per-file cap must not pull in its @imports.
+	b := newMemBackend()
+	b.set("/a.md", "@/imp.md "+strings.Repeat("A", 200))
+	b.set("/imp.md", "IMPORTED")
+
+	l := newLoaderConfig(b, []string{"/a.md"}, 0, 50, nil)
+	content, err := l.load(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if strings.Contains(content, "IMPORTED") {
+		t.Fatal("imports of a truncated file must be skipped")
+	}
+}
+
+func TestLoader_OmittedNoticeListsFiles(t *testing.T) {
+	// When the cumulative budget is exhausted, the remaining top-level files are
+	// listed in the summary line with cleaned paths.
+	b := newMemBackend()
+	b.set("/a.md", strings.Repeat("A", 1000))
+	b.set("/b.md", "B")
+	b.set("/c.md", "C")
+
+	l := newLoaderConfig(b, []string{"/a.md", "/b/../b.md", "/c.md"}, 600, 0, nil)
+	content, err := l.load(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if !strings.Contains(content, "2 more file(s) not loaded due to the total byte limit") {
+		t.Fatalf("expected omitted-files summary line, got %q", content)
+	}
+	if !strings.Contains(content, "/b.md") || !strings.Contains(content, "/c.md") {
+		t.Fatalf("summary should list cleaned paths /b.md and /c.md, got %q", content)
+	}
+	if strings.Contains(content, "/b/../b.md") {
+		t.Fatal("summary should use the cleaned path, not the raw one")
+	}
+}
+
+func TestTruncateBytes_RuneBoundary(t *testing.T) {
+	// A cut landing inside a multibyte rune backs up to the rune boundary.
+	got := truncateBytes(strings.Repeat("好", 4), 10) // each 好 is 3 bytes; 10 lands mid-rune
+	if want := strings.Repeat("好", 3); got != want {
+		t.Fatalf("expected %q (rune boundary), got %q", want, got)
+	}
+	if !utf8.ValidString(got) {
+		t.Fatalf("truncated result is not valid UTF-8: %q", got)
+	}
+
+	if got := truncateBytes("abc", 10); got != "abc" {
+		t.Fatalf("content shorter than max should be unchanged, got %q", got)
+	}
+	if got := truncateBytes("abcdef", 3); got != "abc" {
+		t.Fatalf("ascii cut on boundary should be exact, got %q", got)
+	}
+}
+
 func TestFormatContent_Empty(t *testing.T) {
 	// formatContent with nil/empty slice should return empty string.
-	if got := formatContent(nil); got != "" {
+	if got := formatContent(nil, nil); got != "" {
 		t.Fatalf("expected empty string for nil, got %q", got)
 	}
-	if got := formatContent([]loadedFile{}); got != "" {
+	if got := formatContent([]loadedFile{}, nil); got != "" {
 		t.Fatalf("expected empty string for empty slice, got %q", got)
 	}
 }
@@ -1038,7 +1183,7 @@ func TestLoader_ExactOutput(t *testing.T) {
 	b.set("/project/CLAUDE.md", "this is project claude.md\n\n- git workflow @git/git-instructions.md")
 	b.set("/project/git/git-instructions.md", "this is git-instructions.md")
 
-	l := newLoaderConfig(b, []string{"/project/CLAUDE.md"}, 0, nil)
+	l := newLoaderConfig(b, []string{"/project/CLAUDE.md"}, 0, 0, nil)
 	content, err := l.load(context.Background())
 	if err != nil {
 		t.Fatal(err)
@@ -1070,7 +1215,7 @@ func TestLoader_MissingFileSkipped(t *testing.T) {
 	b.set("/good.md", "GOOD CONTENT")
 	// /missing.md is not set
 
-	l := newLoaderConfig(b, []string{"/missing.md", "/good.md"}, 0, nil)
+	l := newLoaderConfig(b, []string{"/missing.md", "/good.md"}, 0, 0, nil)
 	content, err := l.load(context.Background())
 	if err != nil {
 		t.Fatalf("expected no error for missing file, got %v", err)
@@ -1083,7 +1228,7 @@ func TestLoader_MissingFileSkipped(t *testing.T) {
 func TestLoader_AllMissingFilesSkipped(t *testing.T) {
 	b := newMemBackend()
 
-	l := newLoaderConfig(b, []string{"/missing1.md", "/missing2.md"}, 0, nil)
+	l := newLoaderConfig(b, []string{"/missing1.md", "/missing2.md"}, 0, 0, nil)
 	content, err := l.load(context.Background())
 	if err != nil {
 		t.Fatalf("expected no error for missing files, got %v", err)
@@ -1099,7 +1244,7 @@ func TestLoader_CircularImportSkipped(t *testing.T) {
 	b.set("/b.md", "B content @/a.md")
 
 	// Circular import in collectImports is logged via onWarning and skipped.
-	l := newLoaderConfig(b, []string{"/a.md"}, 0, nil)
+	l := newLoaderConfig(b, []string{"/a.md"}, 0, 0, nil)
 	content, err := l.load(context.Background())
 	if err != nil {
 		t.Fatalf("expected no error, got %v", err)
@@ -1123,7 +1268,7 @@ func TestLoader_DepthExceededSkipped(t *testing.T) {
 	b.set("/l5.md", "@/l6.md")
 	b.set("/l6.md", "DEEP")
 
-	l := newLoaderConfig(b, []string{"/l0.md"}, 0, nil)
+	l := newLoaderConfig(b, []string{"/l0.md"}, 0, 0, nil)
 	content, err := l.load(context.Background())
 	if err != nil {
 		t.Fatalf("expected no error for depth exceeded, got %v", err)
@@ -1143,7 +1288,7 @@ func TestLoader_OnLoadWarningCallback(t *testing.T) {
 		warnings = append(warnings, fmt.Errorf("%s: %w", filePath, err))
 	}
 
-	l := newLoaderConfig(b, []string{"/missing.md", "/good.md"}, 0, onWarning)
+	l := newLoaderConfig(b, []string{"/missing.md", "/good.md"}, 0, 0, onWarning)
 	content, err := l.load(context.Background())
 	if err != nil {
 		t.Fatalf("expected no error, got %v", err)
@@ -1267,7 +1412,7 @@ func TestLoader_ImportIOError(t *testing.T) {
 		// /broken.md is NOT in the map, so Read returns I/O error (not ErrNotExist)
 	}
 
-	l := newLoaderConfig(b, []string{"/main.md"}, 0, nil)
+	l := newLoaderConfig(b, []string{"/main.md"}, 0, 0, nil)
 	_, err := l.load(context.Background())
 	if err == nil {
 		t.Fatal("expected error from I/O failure on imported file")

--- a/adk/middlewares/agentsmd/loader.go
+++ b/adk/middlewares/agentsmd/loader.go
@@ -25,6 +25,7 @@ import (
 	"path/filepath"
 	"regexp"
 	"strings"
+	"unicode/utf8"
 
 	"github.com/cloudwego/eino/adk/filesystem"
 	"github.com/cloudwego/eino/adk/internal"
@@ -53,6 +54,13 @@ var allowedImportExts = map[string]bool{
 
 const maxImportDepth = 5
 
+// minTruncatableBytes is a tail-only optimization threshold: once some content has
+// already been loaded and the remaining cumulative budget falls below this, the next
+// file is dropped whole rather than cut into a uselessly small fragment. It never
+// affects the first file (always truncated to fit), so a maxBytes below this value
+// still behaves as an ordinary hard cap.
+const minTruncatableBytes = 500
+
 // ReadRequest is an alias for filesystem.ReadRequest.
 type ReadRequest = filesystem.ReadRequest
 type FileContent = filesystem.FileContent
@@ -71,32 +79,35 @@ type Backend interface {
 // loaderConfig holds the immutable configuration for creating loaders.
 // It is safe for concurrent use by multiple goroutines.
 type loaderConfig struct {
-	backend   Backend
-	files     []string                         // ordered file paths from config
-	maxBytes  int                              // cumulative read budget; 0 means unlimited
-	onWarning func(filePath string, err error) // callback for non-fatal loading warnings
+	backend      Backend
+	files        []string                         // ordered file paths from config
+	maxBytes     int                              // cumulative read budget; 0 means unlimited
+	perFileBytes int                              // per-file byte cap; 0 means unlimited
+	onWarning    func(filePath string, err error) // callback for non-fatal loading warnings
 }
 
-func newLoaderConfig(backend Backend, files []string, maxBytes int, onWarning func(filePath string, err error)) *loaderConfig {
+func newLoaderConfig(backend Backend, files []string, maxBytes, perFileBytes int, onWarning func(filePath string, err error)) *loaderConfig {
 	if onWarning == nil {
 		onWarning = func(filePath string, err error) {
 			log.Printf("[agentsmd] warning: %s: %v", filePath, err)
 		}
 	}
 	return &loaderConfig{
-		backend:   backend,
-		files:     files,
-		maxBytes:  maxBytes,
-		onWarning: onWarning,
+		backend:      backend,
+		files:        files,
+		maxBytes:     maxBytes,
+		perFileBytes: perFileBytes,
+		onWarning:    onWarning,
 	}
 }
 
 // loader handles loading and @import resolution for agents.md files.
 // A new loader is created for each load() call to avoid sharing mutable state
-// (totalBytes) across concurrent invocations.
+// (totalBytes, stopped) across concurrent invocations.
 type loader struct {
 	*loaderConfig
-	totalBytes int // accumulated bytes during this load call
+	totalBytes int  // accumulated content bytes during this load call
+	stopped    bool // set once the cumulative budget is exhausted; halts further loading
 }
 
 func (cfg *loaderConfig) newLoader() *loader {
@@ -105,29 +116,39 @@ func (cfg *loaderConfig) newLoader() *loader {
 
 // load reads all agents.md files and returns the formatted content.
 // Each top-level file and its @imported files appear as separate sections.
+// Files are loaded in order until the cumulative byte budget (maxBytes) is exhausted;
+// the file that crosses the budget is truncated to fit, and no further files are loaded.
+// A tail file may instead be dropped whole when too little budget remains (see applyBudget).
 func (cfg *loaderConfig) load(ctx context.Context) (string, error) {
 	l := cfg.newLoader()
 
 	var parts []loadedFile
+	var omitted []string          // top-level files not loaded because the budget ran out
 	seen := make(map[string]bool) // dedup across all files and imports
 
 	for i, filePath := range l.files {
+		if l.stopped {
+			// The budget was exhausted by an earlier file; the rest never load.
+			for _, p := range l.files[i:] {
+				omitted = append(omitted, filepath.Clean(p))
+			}
+			break
+		}
+
+		before := len(parts)
 		files, err := l.loadFile(ctx, filePath, 0, make(map[string]bool), seen)
 		if err != nil {
 			return "", fmt.Errorf("failed to load %q: %w", filePath, err)
 		}
-
-		// If loading this file caused the budget to be exceeded, skip it
-		// (but always include the first file).
-		if i > 0 && l.maxBytes > 0 && l.totalBytes > l.maxBytes {
-			l.onWarning(filePath, fmt.Errorf("skipped: cumulative size %d exceeds max bytes %d", l.totalBytes, l.maxBytes))
-			break
-		}
-
 		parts = append(parts, files...)
+
+		// This file crossed the budget and was dropped whole (truncated files stay in parts).
+		if l.stopped && len(parts) == before {
+			omitted = append(omitted, filepath.Clean(filePath))
+		}
 	}
 
-	return formatContent(parts), nil
+	return formatContent(parts, omitted), nil
 }
 
 // loadFile reads a file via Backend and collects @imported files as separate entries.
@@ -167,18 +188,25 @@ func (l *loader) loadFile(ctx context.Context, filePath string, depth int, visit
 	if fileContent != nil {
 		content = fileContent.Content
 	}
-
-	l.totalBytes += len(content)
 	seen[filePath] = true
 
 	if content == "" {
 		return nil, nil
 	}
 
-	// Collect imported files as separate sections (content stays untouched).
-	imports, err := l.collectImports(ctx, filePath, content, depth, visited, seen)
-	if err != nil {
-		return nil, err
+	content, truncated := l.applyBudget(filePath, content)
+	if content == "" { // dropped whole by the cumulative budget
+		return nil, nil
+	}
+
+	// Only scan for @imports when the file was kept in full; a truncated file has
+	// hit a byte cap, so pulling in more content would defeat the cap.
+	var imports []loadedFile
+	if !truncated {
+		imports, err = l.collectImports(ctx, filePath, content, depth, visited, seen)
+		if err != nil {
+			return nil, err
+		}
 	}
 
 	// This file first, then its imports.
@@ -186,6 +214,53 @@ func (l *loader) loadFile(ctx context.Context, filePath string, depth int, visit
 	result = append(result, loadedFile{path: filePath, content: content})
 	result = append(result, imports...)
 	return result, nil
+}
+
+// applyBudget caps content against the per-file limit and then the cumulative budget,
+// updates l.totalBytes with the retained content size, and appends a truncation notice
+// when content was cut. It returns "" to signal the file should be dropped whole
+// (cumulative budget too small to bother truncating), setting l.stopped in that case.
+// The returned bool reports whether any truncation occurred.
+func (l *loader) applyBudget(filePath, content string) (string, bool) {
+	originalLen := len(content)
+	truncated := false
+
+	if l.perFileBytes > 0 && len(content) > l.perFileBytes {
+		content = truncateBytes(content, l.perFileBytes)
+		truncated = true
+	}
+
+	if l.maxBytes > 0 {
+		remaining := l.maxBytes - l.totalBytes
+		if len(content) > remaining {
+			// Drop a boundary-crossing file whole only when it is a tail file
+			// (something is already loaded) and the leftover budget is too small
+			// to hold a useful fragment. The first file is always truncated to fit
+			// instead, so even a tiny limit still loads something.
+			if remaining < minTruncatableBytes && l.totalBytes > 0 {
+				l.stopped = true
+				l.onWarning(filePath, fmt.Errorf("dropped: remaining budget %d below %d", remaining, minTruncatableBytes))
+				return "", false
+			}
+			content = truncateBytes(content, remaining)
+			truncated = true
+			l.stopped = true
+		}
+	}
+
+	l.totalBytes += len(content)
+
+	// Once the budget is fully consumed, stop: no later file or @import can add
+	// content, so there is no reason to keep reading (and risk a read error on a
+	// file that would be dropped anyway).
+	if l.maxBytes > 0 && l.totalBytes >= l.maxBytes {
+		l.stopped = true
+	}
+
+	if truncated {
+		content += truncationNotice(originalLen-len(content), originalLen)
+	}
+	return content, truncated
 }
 
 // collectImports scans content for @path/to/file references and loads each
@@ -200,17 +275,15 @@ func (l *loader) collectImports(ctx context.Context, hostPath, content string, d
 
 	matches := importRegex.FindAllStringSubmatch(content, -1)
 	for _, match := range matches {
+		if l.stopped {
+			break
+		}
 		rawPath := match[1]
 
 		// Only treat as import if path contains "/" or ends with an allowed extension.
 		// This avoids false positives on email addresses and social mentions.
 		if !strings.Contains(rawPath, "/") && !allowedImportExts[filepath.Ext(rawPath)] {
 			continue
-		}
-
-		// If budget is exhausted, skip further imports.
-		if l.maxBytes > 0 && l.totalBytes > l.maxBytes {
-			break
 		}
 
 		importPath := rawPath
@@ -238,6 +311,28 @@ type loadedFile struct {
 	content string
 }
 
+// truncateBytes returns the longest prefix of s that is at most max bytes and ends on
+// a UTF-8 rune boundary, so multibyte characters are never split.
+func truncateBytes(s string, max int) string {
+	if len(s) <= max {
+		return s
+	}
+	for max > 0 && !utf8.RuneStart(s[max]) {
+		max--
+	}
+	return s[:max]
+}
+
+// truncationNotice renders the marker appended to a file that was cut down, reporting
+// how many bytes were removed and the file's original size. It is not counted toward
+// the byte budget, matching how the surrounding format headers/footers are excluded.
+func truncationNotice(cut, total int) string {
+	return internal.SelectPrompt(internal.I18nPrompts{
+		English: fmt.Sprintf("\n\n[…content too large, truncated %d bytes; original size %d bytes]", cut, total),
+		Chinese: fmt.Sprintf("\n\n[…内容过大，已截断 %d 字节，总大小 %d 字节]", cut, total),
+	})
+}
+
 const formatHeaderEn = `<system-reminder>
 As you answer the user's questions, you can use the following context:
 Codebase and user instructions are shown below. Be sure to adhere to these instructions. IMPORTANT: These instructions OVERRIDE any default behavior and you MUST follow them exactly as written.
@@ -262,7 +357,19 @@ const formatFooterEn = `IMPORTANT: this context may or may not be relevant to yo
 const formatFooterCn = `重要提示：此上下文可能与你的任务相关，也可能不相关。除非此上下文与你的任务高度相关，否则不要响应此上下文。
 </system-reminder>`
 
-func formatContent(files []loadedFile) string {
+// omittedNotice renders the summary line listing top-level files that were never loaded
+// because the cumulative size limit was reached. Returns "" when nothing was omitted.
+func omittedNotice(paths []string) string {
+	if len(paths) == 0 {
+		return ""
+	}
+	return internal.SelectPrompt(internal.I18nPrompts{
+		English: fmt.Sprintf("\n[%d more file(s) not loaded due to the total byte limit: %s]\n", len(paths), strings.Join(paths, ", ")),
+		Chinese: fmt.Sprintf("\n[还有 %d 个文件因超出总字节上限未加载：%s]\n", len(paths), strings.Join(paths, "、")),
+	})
+}
+
+func formatContent(files []loadedFile, omitted []string) string {
 	if len(files) == 0 {
 		return ""
 	}
@@ -294,6 +401,7 @@ func formatContent(files []loadedFile) string {
 		sb.WriteString(f.content)
 		sb.WriteString("\n")
 	}
+	sb.WriteString(omittedNotice(omitted))
 	sb.WriteString(footer)
 	return sb.String()
 }


### PR DESCRIPTION
## Summary

The agentsmd middleware previously always loaded each individual AGENTS.md file in full and only skipped later files once the cumulative budget was exceeded, so a single oversized file could blow past `AllAgentsMDMaxBytes` unbounded. This change makes the byte limits authoritative: content is now truncated to fit the budget rather than admitted whole, and the model is told what was cut or omitted.

## API Changes

1. **Added**: `Config.PerAgentsMDMaxBytes` — caps the byte size of each individual AGENTS.md file (including @imported ones); a larger file is truncated to the limit with a notice appended. `0` means no per-file limit.

## Key Changes

1. `AllAgentsMDMaxBytes` now applies to every file, **including the first**. When loading a file would cross the cumulative budget, it is truncated to the remaining budget if at least 500 bytes remain, otherwise dropped whole; either way no further files load.
2. Truncation happens on UTF-8 rune boundaries, so multibyte (e.g. Chinese) characters are never split.
3. A truncated file gets a bracketed notice reporting bytes cut and original size; top-level files skipped because the budget ran out are listed in a summary line before the footer.
4. A truncated file is not scanned for @imports, since pulling in more content would defeat the cap it just hit.
5. Fixed an incorrect error string (`AllAgentMDDocsMaxBytes` → `AllAgentsMDMaxBytes`) and added validation for the new field.