### PR TITLE
fix(summarization): place preserved skills after summary with read-only framing

### DIFF
--- a/adk/middlewares/summarization/finalizer_builder.go
+++ b/adk/middlewares/summarization/finalizer_builder.go
@@ -68,7 +68,7 @@ type FinalizerBuilder = TypedFinalizerBuilder[*schema.Message]
 // as DefaultFinalize does after all handlers have run. For example, with
 // PreserveSkills and a system message in originalMessages, the final output is:
 //
-//	[system message, preserved skill message, processed summary]
+//	[system message, processed summary, preserved skill message]
 //
 // Example:
 //
@@ -95,7 +95,7 @@ func NewFinalizer() *FinalizerBuilder {
 // For example, with PreserveSkills and a system message in
 // originalMessages, the final output is:
 //
-//	[system message, preserved skill message, processed summary]
+//	[system message, processed summary, preserved skill message]
 func (b *TypedFinalizerBuilder[M]) Build() (TypedFinalizeFunc[M], error) {
 	if len(b.errs) > 0 {
 		msgs := make([]string, len(b.errs))
@@ -136,10 +136,10 @@ func (b *TypedFinalizerBuilder[M]) Build() (TypedFinalizeFunc[M], error) {
 			return nil, err
 		}
 
-		result := make([]M, 0, len(systemMsgs)+len(extraMessages)+1)
+		result := make([]M, 0, len(systemMsgs)+1+len(extraMessages))
 		result = append(result, systemMsgs...)
-		result = append(result, extraMessages...)
 		result = append(result, processed)
+		result = append(result, extraMessages...)
 		return result, nil
 	}, nil
 }
@@ -173,7 +173,8 @@ type PreserveSkillsConfig struct {
 
 // PreserveSkills preserves skill contents loaded by the ADK skill middleware.
 // It scans the conversation for matching skill tool calls and returns the preserved
-// skill content as a user message before the summary.
+// skill content as a user message placed after the summary, marked as read-only
+// historical context (invoked earlier in the session, before compaction).
 //
 // Example:
 //
@@ -182,7 +183,7 @@ type PreserveSkillsConfig struct {
 //
 // When skill content is found, PreserveSkills returns:
 //
-//	[]M{user("<preserved foo: bar>"), S}
+//	[]M{S, user("<preserved foo: bar>")}
 func (b *TypedFinalizerBuilder[M]) PreserveSkills(config *PreserveSkillsConfig) *TypedFinalizerBuilder[M] {
 	if err := config.check(); err != nil {
 		b.errs = append(b.errs, fmt.Errorf("PreserveSkills: %w", err))

--- a/adk/middlewares/summarization/finalizer_builder_test.go
+++ b/adk/middlewares/summarization/finalizer_builder_test.go
@@ -275,13 +275,13 @@ func TestPreserveSkillsViaBuilder(t *testing.T) {
 	assert.Equal(t, "system prompt", result[0].Content)
 
 	assert.Equal(t, schema.User, result[1].Role)
-	assert.Equal(t, contentTypeSkills, typedGetContentType(result[1]))
-	assert.Contains(t, result[1].Content, "test-skill")
-	assert.Contains(t, result[1].Content, "skill content 1")
+	assert.Equal(t, contentTypeSummary, typedGetContentType(result[1]))
+	assert.Contains(t, result[1].Content, "test summary")
 
 	assert.Equal(t, schema.User, result[2].Role)
-	assert.Equal(t, contentTypeSummary, typedGetContentType(result[2]))
-	assert.Contains(t, result[2].Content, "test summary")
+	assert.Equal(t, contentTypeSkills, typedGetContentType(result[2]))
+	assert.Contains(t, result[2].Content, "test-skill")
+	assert.Contains(t, result[2].Content, "skill content 1")
 }
 
 func TestBuildPreservedSkillsText(t *testing.T) {

--- a/adk/middlewares/summarization/prompt.go
+++ b/adk/middlewares/summarization/prompt.go
@@ -334,9 +334,9 @@ const userMessagesReplacedNoteZh = "部分较早的用户消息已被清除，�
 
 const skillSectionFormat = "### Skill: %s\n\n%s"
 
-const skillPreamble = "The following skills were invoked in this session. Continue to follow these guidelines:\n\n%s"
+const skillPreamble = "The following skills were invoked EARLIER in this session (before the conversation was summarized), not on the current turn. They are shown here for context only so you remain aware of their guidelines.\n\nIMPORTANT: Do NOT re-execute these skills or perform their one-time setup actions (e.g., scheduling, creating files) again. The arguments shown below reflect the original invocation — they are NOT the user's current message. Only continue to apply ongoing behavioral guidelines from these skills where still relevant.\n\n%s"
 
-const skillPreambleZh = "以下 Skill 已在本会话中被调用，请继续遵循这些指导原则：\n\n%s"
+const skillPreambleZh = "以下 Skill 是在本会话中更早的时候被调用的（在对话被总结之前），而非本轮。此处仅作为上下文展示，以便你继续了解它们的指导原则。\n\n重要：不要重新执行这些 Skill，也不要再次执行它们的一次性初始化操作（例如创建定时任务、创建文件）。下面展示的参数反映的是最初调用时的输入——它们不是用户当前的消息。仅在仍然相关时，继续遵循这些 Skill 中持续生效的行为准则。\n\n%s"
 
 func getSkillPreamble() string {
 	return internal.SelectPrompt(internal.I18nPrompts{


### PR DESCRIPTION
## Summary

Align the summarization middleware's preserved-skill handling with how compaction is expected to present skill context: skills invoked before summarization are read-only historical context, not fresh instructions for the current turn. Previously the preserved skill message was placed before the summary with a preamble that read like an active directive ("Continue to follow these guidelines"), which risks the model re-executing one-time skill setup after a summary.

## Key Changes

1. **Ordering**: `Build()` now emits `[system message, summary, preserved skill message]` instead of `[system message, preserved skill message, summary]`, so preserved skills follow the summary as trailing context.
2. **Framing**: The skill preamble (both English and Chinese) is rewritten to mark the content as invoked EARLIER in the session, explicitly instruct the model NOT to re-execute skills or repeat one-time setup actions, and clarify that the shown arguments are the original invocation rather than the user's current message.
