### PR TITLE
fix(adk): preserve terminal stream rejections

### DIFF
--- a/adk/chatmodel_retry_test.go
+++ b/adk/chatmodel_retry_test.go
@@ -2928,10 +2928,11 @@ func TestRetryChatModel_ShouldRetryStreamRewriteErrorOnCleanStream(t *testing.T)
 
 	done := make(chan struct{})
 	var events []agentEvent
+	var streamTermErrs []error
 	go func() {
 		defer close(done)
 		iterator := agent.Run(ctx, input)
-		events, _ = drainStreamingAgentEvents(t, iterator)
+		events, streamTermErrs = drainStreamingAgentEvents(t, iterator)
 	}()
 
 	select {
@@ -2940,6 +2941,8 @@ func TestRetryChatModel_ShouldRetryStreamRewriteErrorOnCleanStream(t *testing.T)
 		t.Fatal("test deadlocked")
 	}
 
+	require.Len(t, streamTermErrs, 1)
+	require.ErrorIs(t, streamTermErrs[0], fatalErr)
 	var foundFatal bool
 	for _, e := range events {
 		if e.Err != nil && errors.Is(e.Err, fatalErr) {
@@ -2947,6 +2950,53 @@ func TestRetryChatModel_ShouldRetryStreamRewriteErrorOnCleanStream(t *testing.T)
 		}
 	}
 	assert.True(t, foundFatal, "RewriteError on clean stream should propagate the fatal error")
+}
+
+func TestAttack_TerminalRewriteErrorOverridesPartialStreamError(t *testing.T) {
+	// A terminal RewriteError must replace a partial stream's transport error,
+	// otherwise consumers can persist or surface the rejected partial output as a model failure.
+	ctx := context.Background()
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	cm := mockModel.NewMockToolCallingChatModel(ctrl)
+	transportErr := errors.New("connection reset mid-stream")
+	terminalErr := errors.New("invalid tool call arguments")
+	cm.EXPECT().Stream(gomock.Any(), gomock.Any(), gomock.Any()).
+		DoAndReturn(func(context.Context, []*schema.Message, ...model.Option) (*schema.StreamReader[*schema.Message], error) {
+			reader, writer := schema.Pipe[*schema.Message](1)
+			go func() {
+				_ = writer.Send(schema.AssistantMessage("partial", nil), nil)
+				_ = writer.Send(nil, transportErr)
+			}()
+			return reader, nil
+		}).Times(1)
+
+	agent, err := NewChatModelAgent(ctx, &ChatModelAgentConfig{
+		Name:        "TerminalRewritePartialStreamAgent",
+		Description: "terminal rewrite error overrides a partial stream failure",
+		Instruction: "You are a helpful assistant.",
+		Model:       cm,
+		ModelRetryConfig: &ModelRetryConfig{
+			ShouldRetry: func(context.Context, *RetryContext) *RetryDecision {
+				return &RetryDecision{RewriteError: terminalErr}
+			},
+		},
+	})
+	require.NoError(t, err)
+
+	events, streamErrs := drainStreamingAgentEvents(t, agent.Run(ctx, &AgentInput{
+		Messages:        []Message{schema.UserMessage("Hello")},
+		EnableStreaming: true,
+	}))
+
+	require.Len(t, streamErrs, 1)
+	require.ErrorIs(t, streamErrs[0], terminalErr)
+	for _, event := range events {
+		if event.Err != nil {
+			require.ErrorIs(t, event.Err, terminalErr)
+		}
+	}
 }
 
 func TestRetryChatModel_ShouldRetryConcatMessagesFailsEmptyStream(t *testing.T) {

--- a/adk/retry_chatmodel.go
+++ b/adk/retry_chatmodel.go
@@ -667,7 +667,7 @@ func streamWithShouldRetry[M MessageType](r *typedRetryModelWrapper[M], ctx cont
 		}
 
 		if !decision.Retry {
-			signal.ch <- retryVerdict{WillRetry: false}
+			signal.ch <- retryVerdict{WillRetry: false, Err: decision.RewriteError}
 
 			if decision.RewriteError != nil {
 				returnCopy.Close()

--- a/adk/session_test.go
+++ b/adk/session_test.go
@@ -3975,6 +3975,180 @@ func TestAttack_IncompleteStreamPersistsAllTerminalErrors(t *testing.T) {
 	}
 }
 
+func TestRunnerSessionTerminalModelRejectionPersistsIncompleteStream(t *testing.T) {
+	ctx := context.Background()
+	store := newSessionHelperStore()
+	invalidArguments := `{"input":`
+	terminalErr := errors.New("invalid tool call arguments")
+	var attempts int32
+	require.False(t, json.Valid([]byte(invalidArguments)))
+
+	agent, err := NewChatModelAgent(ctx, &ChatModelAgentConfig{
+		Name:        "terminal-rejection-session-agent",
+		Description: "rejects invalid streamed tool calls",
+		Instruction: "You are a helpful assistant.",
+		Model: &simpleChatModel{response: schema.AssistantMessage("", []schema.ToolCall{{
+			ID:   "invalid-call",
+			Type: "function",
+			Function: schema.FunctionCall{
+				Name:      "echo",
+				Arguments: invalidArguments,
+			},
+		}})},
+		ModelRetryConfig: &ModelRetryConfig{
+			MaxRetries: 1,
+			ShouldRetry: func(_ context.Context, _ *RetryContext) *RetryDecision {
+				if atomic.AddInt32(&attempts, 1) == 1 {
+					return &RetryDecision{Retry: true}
+				}
+				return &RetryDecision{RewriteError: terminalErr}
+			},
+			BackoffFunc: instantBackoff,
+		},
+	})
+	require.NoError(t, err)
+
+	runner := NewRunner(ctx, RunnerConfig{
+		Agent:           agent,
+		EnableStreaming: true,
+		SessionID:       "terminal-rejection-session",
+		SessionStore:    store,
+	})
+
+	var sawRunTerminalErr bool
+	var sawStreamTerminalErr bool
+	for iter := runner.Query(ctx, "call the tool"); ; {
+		event, ok := iter.Next()
+		if !ok {
+			break
+		}
+		if event.Err != nil {
+			require.ErrorIs(t, event.Err, terminalErr)
+			sawRunTerminalErr = true
+			continue
+		}
+		if event.Output == nil || event.Output.MessageOutput == nil || !event.Output.MessageOutput.IsStreaming {
+			continue
+		}
+		for {
+			_, streamErr := event.Output.MessageOutput.MessageStream.Recv()
+			if streamErr == nil {
+				continue
+			}
+			if errors.Is(streamErr, terminalErr) {
+				sawStreamTerminalErr = true
+			}
+			break
+		}
+	}
+	require.True(t, sawRunTerminalErr, "runner must return the terminal RewriteError")
+	require.True(t, sawStreamTerminalErr, "terminal rejection must end the live stream with RewriteError")
+
+	persistedMessages := filterStoredSessionEvents(t, store.events, func(se *SessionEvent[*schema.Message]) bool {
+		if se.Kind != SessionEventMessage || se.Message == nil || se.Message.Role != schema.Assistant {
+			return false
+		}
+		for _, toolCall := range se.Message.ToolCalls {
+			if !json.Valid([]byte(toolCall.Function.Arguments)) {
+				return true
+			}
+		}
+		return false
+	})
+	assert.Empty(t, persistedMessages, "terminally rejected tool call must not enter durable model history")
+
+	incompleteMessages := filterStoredSessionEvents(t, store.events, func(se *SessionEvent[*schema.Message]) bool {
+		return se.Kind == SessionEventMessageStreamIncomplete &&
+			se.MessageStreamIncomplete != nil &&
+			se.MessageStreamIncomplete.Message != nil &&
+			len(se.MessageStreamIncomplete.Message.ToolCalls) == 1 &&
+			se.MessageStreamIncomplete.Message.ToolCalls[0].Function.Arguments == invalidArguments
+	})
+	require.Len(t, incompleteMessages, 2)
+}
+
+func TestRunnerSessionRetryExhaustionPersistsIncompleteStream(t *testing.T) {
+	ctx := context.Background()
+	store := newSessionHelperStore()
+	invalidArguments := `{"input":`
+	require.False(t, json.Valid([]byte(invalidArguments)))
+
+	agent, err := NewChatModelAgent(ctx, &ChatModelAgentConfig{
+		Name:        "retry-exhaustion-session-agent",
+		Description: "exhausts retries for invalid streamed tool calls",
+		Instruction: "You are a helpful assistant.",
+		Model: &simpleChatModel{response: schema.AssistantMessage("", []schema.ToolCall{{
+			ID:   "invalid-call",
+			Type: "function",
+			Function: schema.FunctionCall{
+				Name:      "echo",
+				Arguments: invalidArguments,
+			},
+		}})},
+		ModelRetryConfig: &ModelRetryConfig{
+			MaxRetries:  1,
+			ShouldRetry: func(context.Context, *RetryContext) *RetryDecision { return &RetryDecision{Retry: true} },
+			BackoffFunc: instantBackoff,
+		},
+	})
+	require.NoError(t, err)
+
+	runner := NewRunner(ctx, RunnerConfig{
+		Agent:           agent,
+		EnableStreaming: true,
+		SessionID:       "retry-exhaustion-session",
+		SessionStore:    store,
+	})
+
+	var sawRetryExhausted bool
+	for iter := runner.Query(ctx, "call the tool"); ; {
+		event, ok := iter.Next()
+		if !ok {
+			break
+		}
+		if event.Err != nil {
+			var exhaustedErr *RetryExhaustedError
+			require.ErrorAs(t, event.Err, &exhaustedErr)
+			sawRetryExhausted = true
+			continue
+		}
+		if event.Output == nil || event.Output.MessageOutput == nil || !event.Output.MessageOutput.IsStreaming {
+			continue
+		}
+		for {
+			_, streamErr := event.Output.MessageOutput.MessageStream.Recv()
+			if streamErr != nil {
+				var willRetryErr *WillRetryError
+				require.ErrorAs(t, streamErr, &willRetryErr)
+				break
+			}
+		}
+	}
+	require.True(t, sawRetryExhausted, "runner must report retry exhaustion")
+
+	persistedMessages := filterStoredSessionEvents(t, store.events, func(se *SessionEvent[*schema.Message]) bool {
+		if se.Kind != SessionEventMessage || se.Message == nil || se.Message.Role != schema.Assistant {
+			return false
+		}
+		for _, toolCall := range se.Message.ToolCalls {
+			if !json.Valid([]byte(toolCall.Function.Arguments)) {
+				return true
+			}
+		}
+		return false
+	})
+	assert.Empty(t, persistedMessages, "retry-exhausted tool call must not enter durable model history")
+
+	incompleteMessages := filterStoredSessionEvents(t, store.events, func(se *SessionEvent[*schema.Message]) bool {
+		return se.Kind == SessionEventMessageStreamIncomplete &&
+			se.MessageStreamIncomplete != nil &&
+			se.MessageStreamIncomplete.Message != nil &&
+			len(se.MessageStreamIncomplete.Message.ToolCalls) == 1 &&
+			se.MessageStreamIncomplete.Message.ToolCalls[0].Function.Arguments == invalidArguments
+	})
+	require.Len(t, incompleteMessages, 2)
+}
+
 func drainErroredStreamEvents(t *testing.T, iter *AsyncIterator[*AgentEvent], streamErr error) {
 	t.Helper()
 	var sawStreamErr bool

--- a/adk/wrappers.go
+++ b/adk/wrappers.go
@@ -778,9 +778,11 @@ func concatMessagesForSpan[M MessageType](chunks []M) (M, error) {
 //
 // Two hooks cooperate to cover all stream termination paths:
 //   - WithErrWrapper intercepts mid-stream errors. It blocks on the verdict to decide
-//     whether to wrap the error as WillRetryError (rejected attempt) or pass it through (accepted).
+//     whether to wrap the error as WillRetryError (retryable rejection), replace it with
+//     RewriteError (terminal rejection), or pass it through (accepted).
 //   - WithOnEOF intercepts clean EOF (successful stream). It blocks on the verdict to
-//     either inject a WillRetryError (rejected) or pass through io.EOF (accepted).
+//     inject a WillRetryError (retryable rejection), RewriteError (terminal rejection), or
+//     pass through io.EOF (accepted).
 //
 // Both hooks share a sync.Once-guarded reader so the verdict channel is read at most once.
 // This prevents a goroutine leak when a mid-stream error is followed by EOF: errWrapper fires
@@ -804,7 +806,7 @@ func (m *typedEventSenderModel[M]) buildStreamConvertOptions(ctx context.Context
 
 	var opts []schema.ConvertOption
 
-	var retryWrapper func(error) error
+	var retryWrapper func(error) (error, bool)
 	if m.modelRetryConfig != nil {
 		if m.modelRetryConfig.ShouldRetry != nil {
 			execCtx := getTypedChatModelAgentExecCtx[M](ctx)
@@ -824,7 +826,10 @@ func (m *typedEventSenderModel[M]) buildStreamConvertOptions(ctx context.Context
 					return cachedVerdict
 				}
 
-				retryWrapper = wrapWithCancelGuard(func(err error) error {
+				retryWrapper = func(err error) (error, bool) {
+					if errors.Is(err, ErrStreamCanceled) {
+						return err, false
+					}
 					verdict := readVerdict()
 					if verdict.WillRetry {
 						return &WillRetryError{
@@ -832,10 +837,13 @@ func (m *typedEventSenderModel[M]) buildStreamConvertOptions(ctx context.Context
 							RetryAttempt: verdict.RetryAttempt,
 							rejectReason: verdict.RejectReason,
 							err:          err,
-						}
+						}, false
 					}
-					return err
-				})
+					if verdict.Err != nil {
+						return verdict.Err, true
+					}
+					return err, false
+				}
 
 				opts = append(opts, schema.WithOnEOF(func() (any, error) {
 					verdict := readVerdict()
@@ -847,13 +855,19 @@ func (m *typedEventSenderModel[M]) buildStreamConvertOptions(ctx context.Context
 							err:          verdict.Err,
 						}
 					}
+					if verdict.Err != nil {
+						return nil, verdict.Err
+					}
 					return nil, io.EOF
 				}))
 			}
 		} else {
-			retryWrapper = wrapWithCancelGuard(
+			legacyRetryWrapper := wrapWithCancelGuard(
 				genErrWrapper(ctx, m.modelRetryConfig.MaxRetries, retryAttempt, m.modelRetryConfig.IsRetryAble),
 			)
+			retryWrapper = func(err error) (error, bool) {
+				return legacyRetryWrapper(err), false
+			}
 		}
 	}
 
@@ -871,8 +885,8 @@ func (m *typedEventSenderModel[M]) buildStreamConvertOptions(ctx context.Context
 	combinedErrWrapper := func(err error) error {
 		// If retry is configured and will retry this error, use the retry wrapper's WillRetryError.
 		if retryWrapper != nil {
-			wrapped := retryWrapper(err)
-			if errors.As(wrapped, new(*WillRetryError)) {
+			wrapped, terminalRewrite := retryWrapper(err)
+			if terminalRewrite || errors.As(wrapped, new(*WillRetryError)) {
 				return wrapped
 			}
 		}


### PR DESCRIPTION
## Problem

When `ShouldRetry` terminally rejected streamed output with `RewriteError`, a clean EOF was still exposed to the stream consumer. The runner therefore treated rejected assistant output as complete and could persist it as normal session history.

## Solution

Carry `RewriteError` in the retry verdict and apply it in both stream termination paths:

- clean EOF returns `RewriteError` instead of `io.EOF`;
- a partial stream's transport error is replaced by the same terminal `RewriteError`.

## Key Insight

`WillRetry` only distinguishes retryable rejection from non-retry. It does not distinguish accepted output from a terminal rejection. The verdict must therefore also carry the terminal error so every consumer of the fan-out stream reaches the same outcome.

## Summary

| Problem | Solution |
| --- | --- |
| Rejected streamed tool calls entered durable model history | Expose terminal rejection to the stream consumer so the runner stores an incomplete stream instead |
| Partial stream failures surfaced transport errors after a rewrite | Apply `RewriteError` consistently in the error-wrapper path |

---

## 问题

当 `ShouldRetry` 通过 `RewriteError` 终止拒绝流式输出时，干净 EOF 仍会传给 stream consumer。Runner 因而将被拒绝的 assistant 输出视为完整消息，并可能写入正常的 session history。

## 方案

在 retry verdict 中携带 `RewriteError`，并在两种流终止路径中统一应用：

- 干净 EOF 返回 `RewriteError`，而不是 `io.EOF`；
- partial stream 的 transport error 同样会被终止的 `RewriteError` 替换。

## 关键结论

`WillRetry` 只能区分“可重试拒绝”和“非重试”，无法区分“接受输出”和“终止拒绝”。因此 verdict 必须同时携带终止错误，才能让 fan-out stream 的所有消费者得到一致结果。

## 总结

| 问题 | 方案 |
| --- | --- |
| 被拒绝的流式 tool call 进入了 durable model history | 将终止拒绝传给 stream consumer，使 Runner 记录不完整流而不是普通消息 |
| partial stream 在重写后仍暴露 transport error | 在 error-wrapper 路径中也统一应用 `RewriteError` |
