### PR TITLE
fix(adk): sanitize gob-unsafe error values when encoding agent event checkpoints

### DIFF
--- a/adk/prebuilt/supervisor/issue782_checkpoint_test.go
+++ b/adk/prebuilt/supervisor/issue782_checkpoint_test.go
@@ -1,0 +1,219 @@
+package supervisor
+
+// Regression test for issue #782: in a supervisor multi-agent flow, an
+// internal error from one sub-agent (e.g. exceeding max iterations) used to
+// leave a gob-unencodable error value (compose.internalError) inside the run
+// session. When a later sub-agent interrupted and the runner saved a
+// checkpoint, gob failed with "type not registered for interface:
+// compose.internalError", breaking the whole interrupt/resume flow.
+//
+// With the gobSafeError sanitization in agentEventWrapper.GobEncode, the
+// checkpoint save must succeed.
+
+import (
+	"context"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/cloudwego/eino/adk"
+	"github.com/cloudwego/eino/components/model"
+	"github.com/cloudwego/eino/components/tool"
+	"github.com/cloudwego/eino/compose"
+	"github.com/cloudwego/eino/schema"
+)
+
+type issue782Store struct {
+	mu sync.Mutex
+	m  map[string][]byte
+}
+
+func (s *issue782Store) Set(_ context.Context, key string, value []byte) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.m[key] = value
+	return nil
+}
+
+func (s *issue782Store) Get(_ context.Context, key string) ([]byte, bool, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	v, ok := s.m[key]
+	return v, ok, nil
+}
+
+// issue782Model either returns scripted messages in order, or (when
+// alwaysToolCall is set) keeps returning a tool call so that the agent hits
+// its MaxIterations limit and fails with an internal error.
+type issue782Model struct {
+	name           string
+	steps          []*schema.Message
+	alwaysToolCall string
+	calls          int32
+}
+
+func (m *issue782Model) Generate(_ context.Context, _ []*schema.Message, _ ...model.Option) (*schema.Message, error) {
+	n := atomic.AddInt32(&m.calls, 1)
+	if m.alwaysToolCall != "" {
+		return issue782ToolCallMsg(m.alwaysToolCall, m.name), nil
+	}
+	if int(n) <= len(m.steps) {
+		return m.steps[n-1], nil
+	}
+	return schema.AssistantMessage(m.name+" final answer", nil), nil
+}
+
+func (m *issue782Model) Stream(ctx context.Context, in []*schema.Message, opts ...model.Option) (*schema.StreamReader[*schema.Message], error) {
+	msg, err := m.Generate(ctx, in, opts...)
+	if err != nil {
+		return nil, err
+	}
+	sr, sw := schema.Pipe[*schema.Message](1)
+	sw.Send(msg, nil)
+	sw.Close()
+	return sr, nil
+}
+
+func (m *issue782Model) WithTools(_ []*schema.ToolInfo) (model.ToolCallingChatModel, error) {
+	return m, nil
+}
+
+func issue782TransferMsg(agent string) *schema.Message {
+	return schema.AssistantMessage("", []schema.ToolCall{{
+		ID:       "issue782_transfer_" + agent,
+		Function: schema.FunctionCall{Name: "transfer_to_agent", Arguments: `{"agent_name":"` + agent + `"}`},
+	}})
+}
+
+func issue782ToolCallMsg(name, caller string) *schema.Message {
+	return schema.AssistantMessage("", []schema.ToolCall{{
+		ID:       "issue782_call_" + name + "_" + caller,
+		Function: schema.FunctionCall{Name: name, Arguments: "{}"},
+	}})
+}
+
+type issue782LoopTool struct{ name string }
+
+func (t *issue782LoopTool) Info(_ context.Context) (*schema.ToolInfo, error) {
+	return &schema.ToolInfo{Name: t.name, Desc: "noop tool that always succeeds"}, nil
+}
+
+func (t *issue782LoopTool) InvokableRun(_ context.Context, _ string, _ ...tool.Option) (string, error) {
+	return "loop ok", nil
+}
+
+type issue782InterruptTool struct{ name string }
+
+func (t *issue782InterruptTool) Info(_ context.Context) (*schema.ToolInfo, error) {
+	return &schema.ToolInfo{Name: t.name, Desc: "tool that triggers an interrupt"}, nil
+}
+
+func (t *issue782InterruptTool) InvokableRun(ctx context.Context, _ string, _ ...tool.Option) (string, error) {
+	if was, _, _ := compose.GetInterruptState[any](ctx); !was {
+		return "", compose.Interrupt(ctx, "need user input")
+	}
+	if isResume, has, data := compose.GetResumeContext[string](ctx); isResume && has {
+		return data, nil
+	}
+	return "resumed without data", nil
+}
+
+func TestSupervisorSubAgentErrorThenInterruptCheckpoint(t *testing.T) {
+	ctx := context.Background()
+
+	// SubAgentA: exceeds MaxIterations -> internal node error -> the error
+	// event enters the run session.
+	subA, err := adk.NewChatModelAgent(ctx, &adk.ChatModelAgentConfig{
+		Name:          "SubAgentA",
+		Description:   "agent that exceeds max iterations",
+		Instruction:   "you must call the loop_tool",
+		Model:         &issue782Model{name: "SubAgentA", alwaysToolCall: "loop_tool"},
+		MaxIterations: 2,
+		ToolsConfig: adk.ToolsConfig{
+			ToolsNodeConfig: compose.ToolsNodeConfig{
+				Tools: []tool.BaseTool{&issue782LoopTool{name: "loop_tool"}},
+			},
+		},
+	})
+	assert.NoError(t, err)
+
+	// SubAgentB: interrupts, which triggers a checkpoint save.
+	subB, err := adk.NewChatModelAgent(ctx, &adk.ChatModelAgentConfig{
+		Name:        "SubAgentB",
+		Description: "interruptible agent",
+		Instruction: "call the interrupt_tool",
+		Model: &issue782Model{name: "SubAgentB", steps: []*schema.Message{
+			issue782ToolCallMsg("interrupt_tool", "SubAgentB"),
+		}},
+		ToolsConfig: adk.ToolsConfig{
+			ToolsNodeConfig: compose.ToolsNodeConfig{
+				Tools: []tool.BaseTool{&issue782InterruptTool{name: "interrupt_tool"}},
+			},
+		},
+	})
+	assert.NoError(t, err)
+
+	// Supervisor: transfer to SubAgentA first, then to SubAgentB.
+	mainAgent, err := adk.NewChatModelAgent(ctx, &adk.ChatModelAgentConfig{
+		Name:        "MainAgent",
+		Description: "supervisor",
+		Instruction: "route work to sub agents",
+		Model: &issue782Model{name: "MainAgent", steps: []*schema.Message{
+			issue782TransferMsg("SubAgentA"),
+			issue782TransferMsg("SubAgentB"),
+		}},
+	})
+	assert.NoError(t, err)
+
+	sup, err := New(ctx, &Config{
+		Supervisor: mainAgent,
+		SubAgents:  []adk.Agent{subA, subB},
+	})
+	assert.NoError(t, err)
+
+	runner := adk.NewRunner(ctx, adk.RunnerConfig{
+		Agent:           sup,
+		CheckPointStore: &issue782Store{m: map[string][]byte{}},
+	})
+
+	// Phase 1: SubAgentA fails, flow continues to SubAgentB which interrupts
+	// and saves a checkpoint. The save must not fail on the gob-unencodable
+	// error left behind by SubAgentA.
+	iter := runner.Run(ctx, []adk.Message{schema.UserMessage("start")},
+		adk.WithCheckPointID("issue782"))
+
+	var gobErr error
+	var interrupted bool
+	for {
+		ev, ok := iter.Next()
+		if !ok {
+			break
+		}
+		if ev.Err != nil && strings.Contains(ev.Err.Error(), "gob") {
+			gobErr = ev.Err
+		}
+		if ev.Action != nil && ev.Action.Interrupted != nil {
+			interrupted = true
+		}
+	}
+	assert.NoError(t, gobErr, "checkpoint save must not fail on gob-unencodable error values")
+	assert.True(t, interrupted, "SubAgentB should interrupt")
+
+	// Phase 2: resume must read back the saved checkpoint without gob errors.
+	iter2 := runner.Run(ctx, []adk.Message{schema.UserMessage("user reply")},
+		adk.WithCheckPointID("issue782"))
+
+	for {
+		ev, ok := iter2.Next()
+		if !ok {
+			break
+		}
+		if ev.Err != nil && strings.Contains(ev.Err.Error(), "gob") {
+			gobErr = ev.Err
+		}
+	}
+	assert.NoError(t, gobErr, "resume must not fail on the saved checkpoint")
+}

--- a/adk/runctx.go
+++ b/adk/runctx.go
@@ -92,9 +92,21 @@ func (e *typedAgentEventWrapper[M]) GobEncode() ([]byte, error) {
 		}
 	}
 
+	// Build a detached copy of the event with gob-encodable error values, see
+	// gobSafeError. The live event is shared with consumers and must not be
+	// mutated here.
+	var eventCopy *TypedAgentEvent[M]
+	if e.event != nil {
+		ev := *e.event
+		if ev.Err != nil {
+			ev.Err = &gobSafeError{Msg: ev.Err.Error()}
+		}
+		eventCopy = &ev
+	}
+
 	buf := &bytes.Buffer{}
 	err := gob.NewEncoder(buf).Encode(&typedAgentEventWrapperForGob[M]{
-		Event: e.event,
+		Event: eventCopy,
 		TS:    e.TS,
 	})
 	if err != nil {
@@ -170,6 +182,24 @@ func (e *typedAgentEventWrapper[M]) consumeStream() {
 
 type otherAgentEventWrapperForEncode agentEventWrapper
 
+// gobSafeError is a gob-encodable error that preserves only the error message.
+// AgentEvent.Err may hold arbitrary concrete error types, e.g. the unexported
+// compose.internalError produced when a node fails inside an agent. gob cannot
+// encode such interface values ("type not registered for interface: ..."),
+// which breaks the whole checkpoint save and, with it, the interrupt/resume
+// flow. Before encoding, error values carried by an event are replaced with
+// gobSafeError so that the persisted checkpoint depends only on the error
+// message, never on the concrete error type.
+type gobSafeError struct {
+	Msg string
+}
+
+func (e *gobSafeError) Error() string { return e.Msg }
+
+func init() {
+	gob.RegisterName("_eino_adk_gobSafeError", &gobSafeError{})
+}
+
 func (a *agentEventWrapper) GobEncode() ([]byte, error) {
 	if a.Output != nil && a.Output.MessageOutput != nil && a.Output.MessageOutput.IsStreaming {
 		// Materialize the stream before encoding. An unconsumed stream that
@@ -181,8 +211,28 @@ func (a *agentEventWrapper) GobEncode() ([]byte, error) {
 		}
 	}
 
+	// Build a detached copy of the event with gob-encodable error values, see
+	// gobSafeError. The live event is shared with consumers and must not be
+	// mutated here.
+	var eventCopy *AgentEvent
+	if a.AgentEvent != nil {
+		ev := *a.AgentEvent
+		if ev.Err != nil {
+			ev.Err = &gobSafeError{Msg: ev.Err.Error()}
+		}
+		eventCopy = &ev
+	}
+	streamErr := a.StreamErr
+	if streamErr != nil {
+		streamErr = &gobSafeError{Msg: a.StreamErr.Error()}
+	}
+
 	buf := &bytes.Buffer{}
-	err := gob.NewEncoder(buf).Encode((*otherAgentEventWrapperForEncode)(a))
+	err := gob.NewEncoder(buf).Encode(&otherAgentEventWrapperForEncode{
+		AgentEvent: eventCopy,
+		TS:         a.TS,
+		StreamErr:  streamErr,
+	})
 	if err != nil {
 		return nil, fmt.Errorf("failed to gob encode agent event wrapper: %w", err)
 	}


### PR DESCRIPTION
## Problem

Fixes #782.

In a supervisor multi-agent flow, an internal error from one sub-agent (e.g. exceeding max iterations) leaves a `compose.internalError` value inside the run session (events are recorded unconditionally, including failed ones). When a later sub-agent interrupts and the runner saves a checkpoint, gob encoding of the session fails:

```
failed to save checkpoint: failed to encode checkpoint:
failed to gob encode agent event wrapper:
gob: type not registered for interface: compose.internalError
```

The interrupted sub-agent is never resumable, and the user's reply to the interrupt is effectively lost. I reproduced this end-to-end (supervisor + one sub-agent exceeding `MaxIterations` + one interruptible sub-agent + in-memory `CheckPointStore`, mock models, no real LLM) on **v0.9.18** and **v0.10.0-alpha.27** — the reported v0.7.30 behavior is alive in both.

## Root cause

Errors reach the persisted session through two channels; only one was sealed:

1. **Stream channel** — an error chunk inside `MessageStream`. Already handled: `agentEventWrapper.GobEncode` materializes the stream via `consumeStream()` before encoding (guarded by `TestStreamRetryThenToolInterruptCheckpoint`).
2. **Direct channel** — `AgentEvent.Err` itself. A failed sub-agent run emits an event with `Err = *compose.internalError` (unexported, never gob-registered). `GobEncode` never looked at this field.

Simply registering the concrete type is not viable: `internalError` is unexported, and its `origError error` field can hold arbitrary user-created errors, so the registration set is unbounded.

## Fix

Encode-time sanitization at the persistence boundary (`adk/runctx.go`):

- New `gobSafeError` type: keeps only the error message, registered via `gob.RegisterName("_eino_adk_gobSafeError", ...)`.
- `agentEventWrapper.GobEncode` now builds a **detached copy** of the event with `Err` (and `StreamErr`) replaced by `gobSafeError`. The live event object — which is shared with consumers — is never mutated, and the gob wire format is unchanged (same struct type, same exported fields), so `GobDecode` needs no changes.
- `typedAgentEventWrapper[M].GobEncode` had the same hazard through `TypedAgentEvent.Err`; it gets the identical treatment on its `forGob` copy.

Semantics deliberately **not** changed: after SubAgentA fails, the flow still continues to SubAgentB (the issue thread discusses whether it should abort instead — that is a flow-semantics decision I left to the maintainers; this PR only guarantees that whatever happens, the checkpoint stays encodable). Trade-off to be aware of: after resume, restored errors are `gobSafeError`, so `errors.Is` against original sentinels no longer matches — only the message survives, which is the standard price of a persistence boundary.

## Test

- `adk/prebuilt/supervisor/issue782_checkpoint_test.go` — regression test mirroring the issue: SubAgentA exceeds `MaxIterations`, flow continues to interruptible SubAgentB; asserts the checkpoint save produces no gob error, the interrupt is delivered, and the resume read-back is clean. Fails with the reported gob error before the fix, passes after.
- Also verified end-to-end with a standalone mock-model scenario against v0.9.18 / v0.10.0-alpha.27 (broken) and this branch (green), including the resume phase.

## Note on local verification

I could not run the complete `./adk/...` suite locally (machine ran out of memory compiling the core `adk` package); `./adk/prebuilt/...` and `./compose`-dependent paths pass, and I'd appreciate CI confirming the rest.
