### PR TITLE
fix(adk): avoid panic on closed agent tool event stream

### DIFF
--- a/adk/agent_tool.go
+++ b/adk/agent_tool.go
@@ -240,7 +240,7 @@ func (at *typedAgentTool[M]) InvokableRun(ctx context.Context, argumentsInJSON s
 					event.RunPath = rp
 				}
 				tmp := copyTypedAgentEvent(event)
-				gen.Send(event)
+				gen.trySend(event)
 				event = tmp
 			}
 		}

--- a/adk/agent_tool_test.go
+++ b/adk/agent_tool_test.go
@@ -908,6 +908,52 @@ func TestAgentTool_InvokableRun_FinalOnly(t *testing.T) {
 	}
 }
 
+type delayedAgentToolEventAgent struct {
+	started chan struct{}
+	release chan struct{}
+}
+
+func (a *delayedAgentToolEventAgent) Name(context.Context) string        { return "inner" }
+func (a *delayedAgentToolEventAgent) Description(context.Context) string { return "inner" }
+func (a *delayedAgentToolEventAgent) Run(context.Context, *AgentInput, ...AgentRunOption) *AsyncIterator[*AgentEvent] {
+	it, gen := NewAsyncIteratorPair[*AgentEvent]()
+	go func() {
+		close(a.started)
+		<-a.release
+		gen.Send(EventFromMessage(schema.AssistantMessage("done", nil), nil, schema.Assistant, ""))
+		gen.Close()
+	}()
+	return it
+}
+
+func TestAgentTool_InvokableRun_ParentGeneratorClosesWhileAgentRuns(t *testing.T) {
+	ctx := context.Background()
+	agent := &delayedAgentToolEventAgent{started: make(chan struct{}), release: make(chan struct{})}
+	_, gen := NewAsyncIteratorPair[*AgentEvent]()
+	result := make(chan struct {
+		output string
+		err    error
+	})
+
+	go func() {
+		output, err := NewAgentTool(ctx, agent).(tool.InvokableTool).InvokableRun(
+			ctx, `{"request":"q"}`, withAgentToolEventGenerator(gen),
+		)
+		result <- struct {
+			output string
+			err    error
+		}{output: output, err: err}
+	}()
+
+	<-agent.started
+	gen.Close()
+	close(agent.release)
+
+	got := <-result
+	require.NoError(t, got.err)
+	assert.Equal(t, "done", got.output)
+}
+
 type streamingAgent struct{}
 
 func (s *streamingAgent) Name(context.Context) string        { return "stream" }


### PR DESCRIPTION
## Summary

Fixes #1236.

Replace `gen.Send(event)` with `gen.trySend(event)` in `typedAgentTool.InvokableRun`. This prevents a send-after-close panic when the parent run closes its event generator while an agent-as-tool invocation is still running.

Events targeting a closed parent stream are safely rejected. The forwarding loop continues consuming child events, preserving final tool-result handling and existing child-error propagation.

A deterministic regression test closes the parent generator before releasing the child's first event, then verifies that the tool invocation completes without panic and returns its final result. The ordering is controlled by synchronization signals, not timing sleeps.

### Validation

- `go test ./adk -run 'TestAgentTool_InvokableRun_(ParentGeneratorClosesWhileAgentRuns|FinalOnly)$' -count=100`
- `go test -race ./adk -run '^TestAgentTool_InvokableRun_ParentGeneratorClosesWhileAgentRuns$' -count=100`
- `go test ./adk`
- `gofmt`
- `git diff --check`

## Current Limitations

This change makes event forwarding safe after closure; it does not change the cancellation or teardown contract.

- The parent stream may still close before in-flight child tasks finish.
- The fix does not ensure that child tasks terminate within a bounded time or that all associated resources are released when the parent run returns.
- The regression test covers the close/send ordering, not end-to-end cancellation or resource retention across repeated cancellations.

Whether this lifecycle overlap can result in long-lived tasks or retained queue references remains unverified. This PR does not establish a goroutine or memory leak.

## Proposed Follow-up

Address broader lifecycle guarantees separately, based on evidence and an agreed cancellation contract:

1. **Verify teardown behavior.** Trace the existing cancellation path and add integration tests that track child-task completion and resource retention across repeated cancellations, including tools that respond to cancellation and tools that do not.
2. **Define ownership and shutdown policy if gaps are confirmed.** Make cancellation and completion tracking explicit for in-flight child calls. Define a bounded waiting policy, whether pending events must be drained or may be discarded, and which component closes associated message streams. Preserve the existing `Close` semantics unless an API change is explicitly agreed.
3. **Retain safe late-event handling.** Keep `trySend` as a safeguard for work that outlives the shutdown window. Parent cancellation must not depend on indefinitely waiting for a non-cooperative child task.

These follow-up changes are proposed, not implemented by this PR.
