### PR TITLE
fix(adk): preserve parallel tool result order across turns

### DIFF
--- a/adk/integration_middleware_test.go
+++ b/adk/integration_middleware_test.go
@@ -393,6 +393,79 @@ func TestPatchToolCallsIntegration_PersistsMessageInserted(t *testing.T) {
 		"patchtoolcalls middleware must persist a MessageInserted event for the synthetic tool result")
 }
 
+func TestPatchToolCallsIntegration_InsertsMissingParallelResultInCallOrder(t *testing.T) {
+	ctx := context.Background()
+	store := session.NewInMemoryStore[*schema.Message](nil)
+	sid := "patchtoolcalls-parallel-order"
+
+	user := schema.UserMessage("run parallel tools")
+	assistant := schema.AssistantMessage("", []schema.ToolCall{
+		{ID: "call-1", Function: schema.FunctionCall{Name: "first", Arguments: "{}"}},
+		{ID: "call-2", Function: schema.FunctionCall{Name: "second", Arguments: "{}"}},
+		{ID: "call-3", Function: schema.FunctionCall{Name: "third", Arguments: "{}"}},
+	})
+	result1 := schema.ToolMessage("first result", "call-1", schema.WithToolName("first"))
+	result3 := schema.ToolMessage("third result", "call-3", schema.WithToolName("third"))
+	for _, message := range []*schema.Message{user, assistant, result3, result1} {
+		adk.EnsureMessageID(message)
+		require.NoError(t, store.AppendEvents(ctx, sid, []*adk.SessionEvent[*schema.Message]{
+			{EventID: uuid.NewString(), Kind: adk.SessionEventMessage, Message: message},
+		}))
+	}
+
+	mw, err := patchtoolcalls.New(ctx, nil)
+	require.NoError(t, err)
+	chatModel := &stubChatModel{reply: "done"}
+	agent, err := adk.NewChatModelAgent(ctx, &adk.ChatModelAgentConfig{
+		Name:        "patchtoolcalls-parallel-order",
+		Description: "patch parallel tool result order",
+		Model:       chatModel,
+		Handlers:    []adk.ChatModelAgentMiddleware{mw},
+	})
+	require.NoError(t, err)
+	runner := adk.NewRunner(ctx, adk.RunnerConfig{
+		Agent:        agent,
+		SessionID:    sid,
+		SessionStore: store,
+	})
+
+	drainEvents := func(query string) {
+		for iter := runner.Query(ctx, query); ; {
+			event, ok := iter.Next()
+			if !ok {
+				return
+			}
+			require.NoError(t, event.Err)
+		}
+	}
+	toolResultIDs := func(messages []*schema.Message) []string {
+		var ids []string
+		for _, message := range messages {
+			if message.Role == schema.Tool {
+				ids = append(ids, message.ToolCallID)
+			}
+		}
+		return ids
+	}
+
+	drainEvents("first new turn")
+	require.Equal(t, []string{"call-1", "call-2", "call-3"}, toolResultIDs(chatModel.lastInput))
+
+	events, err := store.LoadEvents(ctx, sid, &adk.LoadSessionEventsRequest{})
+	require.NoError(t, err)
+	var inserted []*adk.MessageInsertedEvent[*schema.Message]
+	for _, event := range events.Events {
+		if event.MessageInserted != nil && event.MessageInserted.Message.ToolCallID == "call-2" {
+			inserted = append(inserted, event.MessageInserted)
+		}
+	}
+	require.Len(t, inserted, 1)
+	assert.Equal(t, adk.GetMessageID(result3), inserted[0].BeforeMessageID)
+
+	drainEvents("second new turn")
+	require.Equal(t, []string{"call-1", "call-2", "call-3"}, toolResultIDs(chatModel.lastInput))
+}
+
 // TestReductionIntegration_PersistsBothMessageUpdated seeds the session log
 // with two rounds of (assistant tool call → tool result). With reduction's
 // ClearRetentionSuffixLimit=1 (the framework default), the LAST round is

--- a/adk/integration_middleware_test.go
+++ b/adk/integration_middleware_test.go
@@ -466,6 +466,60 @@ func TestPatchToolCallsIntegration_InsertsMissingParallelResultInCallOrder(t *te
 	require.Equal(t, []string{"call-1", "call-2", "call-3"}, toolResultIDs(chatModel.lastInput))
 }
 
+func TestAttack_PatchToolCallsOrphanRemovalPreservesKnownResultOrder(t *testing.T) {
+	ctx := context.Background()
+	store := session.NewInMemoryStore[*schema.Message](nil)
+	sid := "patchtoolcalls-orphan-order"
+
+	messages := []*schema.Message{
+		schema.AssistantMessage("", []schema.ToolCall{
+			{ID: "call-1", Function: schema.FunctionCall{Name: "first", Arguments: "{}"}},
+			{ID: "call-2", Function: schema.FunctionCall{Name: "second", Arguments: "{}"}},
+		}),
+		schema.ToolMessage("second result", "call-2", schema.WithToolName("second")),
+		schema.ToolMessage("orphan result", "call-orphan", schema.WithToolName("orphan")),
+		schema.ToolMessage("first result", "call-1", schema.WithToolName("first")),
+	}
+	for _, message := range messages {
+		adk.EnsureMessageID(message)
+		require.NoError(t, store.AppendEvents(ctx, sid, []*adk.SessionEvent[*schema.Message]{
+			{EventID: uuid.NewString(), Kind: adk.SessionEventMessage, Message: message},
+		}))
+	}
+
+	mw, err := patchtoolcalls.New(ctx, &patchtoolcalls.Config{RemoveOrphanResults: true})
+	require.NoError(t, err)
+	chatModel := &stubChatModel{reply: "done"}
+	agent, err := adk.NewChatModelAgent(ctx, &adk.ChatModelAgentConfig{
+		Name:        "patchtoolcalls-orphan-order",
+		Description: "remove orphan without disrupting known result order",
+		Model:       chatModel,
+		Handlers:    []adk.ChatModelAgentMiddleware{mw},
+	})
+	require.NoError(t, err)
+	runner := adk.NewRunner(ctx, adk.RunnerConfig{
+		Agent:        agent,
+		SessionID:    sid,
+		SessionStore: store,
+	})
+
+	for iter := runner.Query(ctx, "next turn"); ; {
+		event, ok := iter.Next()
+		if !ok {
+			break
+		}
+		require.NoError(t, event.Err)
+	}
+
+	var toolResultIDs []string
+	for _, message := range chatModel.lastInput {
+		if message.Role == schema.Tool {
+			toolResultIDs = append(toolResultIDs, message.ToolCallID)
+		}
+	}
+	assert.Equal(t, []string{"call-1", "call-2"}, toolResultIDs)
+}
+
 // TestReductionIntegration_PersistsBothMessageUpdated seeds the session log
 // with two rounds of (assistant tool call → tool result). With reduction's
 // ClearRetentionSuffixLimit=1 (the framework default), the LAST round is

--- a/adk/middlewares/patchtoolcalls/patchtoolcalls.go
+++ b/adk/middlewares/patchtoolcalls/patchtoolcalls.go
@@ -220,7 +220,7 @@ func buildMessageNormalizationPlan(ctx context.Context, cfg Config, messages []*
 		if msg.Role != schema.Assistant || len(msg.ToolCalls) == 0 {
 			continue
 		}
-		for _, tc := range msg.ToolCalls {
+		for callIndex, tc := range msg.ToolCalls {
 			if tc.ID == "" || hasCorrespondingKeptToolMessage(messages, keep, i+1, tc.ID) {
 				continue
 			}
@@ -229,17 +229,20 @@ func buildMessageNormalizationPlan(ctx context.Context, cfg Config, messages []*
 				return nil, err
 			}
 			adk.EnsureMessageID(toolMsg)
-			patched = append(patched, toolMsg)
 			inserted = append(inserted, &adk.SessionEvent[*schema.Message]{
 				Kind: adk.SessionEventMessageInserted,
 				MessageInserted: &adk.MessageInsertedEvent[*schema.Message]{
 					Message:         toolMsg,
-					BeforeMessageID: firstKeptMessageID(messages, keep, i+1),
+					BeforeMessageID: messageToolResultInsertionAnchor(messages, keep, i+1, msg.ToolCalls[callIndex+1:]),
 				},
 			})
 		}
 	}
 
+	patched, err := applyInsertionEvents(patched, inserted)
+	if err != nil {
+		return nil, err
+	}
 	events := make([]*adk.SessionEvent[*schema.Message], 0, len(inserted)+1)
 	events = append(events, inserted...)
 	if deletedIDs := deletedMessageIDs(messages, keep); len(deletedIDs) > 0 {
@@ -383,7 +386,8 @@ func buildAgenticNormalizationPlan(ctx context.Context, cfg Config, messages []*
 		if msg.Role != schema.AgenticRoleTypeAssistant {
 			continue
 		}
-		for _, tc := range collectAgenticToolCalls(msg) {
+		toolCalls := collectAgenticToolCalls(msg)
+		for callIndex, tc := range toolCalls {
 			if tc.callID == "" || hasCorrespondingRewrittenAgenticToolResult(rewrites, i+1, tc.callID) {
 				continue
 			}
@@ -395,17 +399,20 @@ func buildAgenticNormalizationPlan(ctx context.Context, cfg Config, messages []*
 				markSyntheticAgenticToolResult(toolMsg)
 			}
 			adk.EnsureMessageID(toolMsg)
-			patched = append(patched, toolMsg)
 			inserted = append(inserted, &adk.SessionEvent[*schema.AgenticMessage]{
 				Kind: adk.SessionEventMessageInserted,
 				MessageInserted: &adk.MessageInsertedEvent[*schema.AgenticMessage]{
 					Message:         toolMsg,
-					BeforeMessageID: firstKeptAgenticMessageID(messages, rewrites, i+1),
+					BeforeMessageID: agenticToolResultInsertionAnchor(messages, rewrites, i+1, toolCalls[callIndex+1:]),
 				},
 			})
 		}
 	}
 
+	patched, err := applyInsertionEvents(patched, inserted)
+	if err != nil {
+		return nil, err
+	}
 	events := make([]*adk.SessionEvent[*schema.AgenticMessage], 0, len(inserted)+len(updated)+1)
 	events = append(events, inserted...)
 	events = append(events, updated...)
@@ -670,24 +677,82 @@ func agenticResultCallID(block *schema.ContentBlock) (string, bool) {
 	return "", false
 }
 
-func firstKeptMessageID(messages []*schema.Message, keep []bool, start int) string {
+// Existing results arrive in tool-call order from the current run state or
+// session reconstruction. Anchor a synthetic result before the first kept
+// result for a later call, or before the next non-result message.
+func messageToolResultInsertionAnchor(messages []*schema.Message, keep []bool, start int, laterCalls []schema.ToolCall) string {
+	laterCallIDs := make(map[string]struct{}, len(laterCalls))
+	for _, toolCall := range laterCalls {
+		laterCallIDs[toolCall.ID] = struct{}{}
+	}
 	for i := start; i < len(messages); i++ {
-		if keep[i] {
-			adk.EnsureMessageID(messages[i])
+		if !keep[i] {
+			continue
+		}
+		if messages[i].Role != schema.Tool {
+			return adk.GetMessageID(messages[i])
+		}
+		if _, later := laterCallIDs[messages[i].ToolCallID]; later {
 			return adk.GetMessageID(messages[i])
 		}
 	}
 	return ""
 }
 
-func firstKeptAgenticMessageID(messages []*schema.AgenticMessage, rewrites []agenticRewrite, start int) string {
+func agenticToolResultInsertionAnchor(
+	messages []*schema.AgenticMessage,
+	rewrites []agenticRewrite,
+	start int,
+	laterCalls []agenticToolCall,
+) string {
+	laterCallIDs := make(map[string]struct{}, len(laterCalls))
+	for _, toolCall := range laterCalls {
+		laterCallIDs[toolCall.callID] = struct{}{}
+	}
 	for i := start; i < len(messages); i++ {
-		if rewrites[i].keep {
-			adk.EnsureMessageID(messages[i])
+		if !rewrites[i].keep {
+			continue
+		}
+		message := rewrites[i].message
+		if message.Role != schema.AgenticRoleTypeUser || !agenticMessageHasToolResult(message) {
 			return adk.GetMessageID(messages[i])
+		}
+		for _, block := range message.ContentBlocks {
+			callID, isResult := agenticResultCallID(block)
+			if _, later := laterCallIDs[callID]; isResult && later {
+				return adk.GetMessageID(messages[i])
+			}
 		}
 	}
 	return ""
+}
+
+func applyInsertionEvents[M adk.MessageType](
+	messages []M,
+	events []*adk.SessionEvent[M],
+) ([]M, error) {
+	for _, event := range events {
+		insertion := event.MessageInserted
+		if insertion.BeforeMessageID == "" {
+			messages = append(messages, insertion.Message)
+			continue
+		}
+		insertAt := -1
+		for i, message := range messages {
+			if adk.GetMessageID(message) == insertion.BeforeMessageID {
+				insertAt = i
+				break
+			}
+		}
+		if insertAt < 0 {
+			return nil, fmt.Errorf("patchtoolcalls: insertion anchor %q not found", insertion.BeforeMessageID)
+		}
+		var zero M
+		messages = append(messages, zero)
+		copy(messages[insertAt+1:], messages[insertAt:])
+		messages[insertAt] = insertion.Message
+	}
+	return messages, nil
 }
 
 func deletedMessageIDs(messages []*schema.Message, keep []bool) []string {

--- a/adk/middlewares/patchtoolcalls/patchtoolcalls_test.go
+++ b/adk/middlewares/patchtoolcalls/patchtoolcalls_test.go
@@ -720,6 +720,37 @@ func TestAttack_PatchToolCallsMultipleMissingResultsShareLaterAnchor(t *testing.
 	assert.Equal(t, []string{"call_1", "call_2", "call_3", "call_4"}, collectToolResultIDs(plan.messages))
 }
 
+func TestAttack_PatchToolCallsAgenticInsertionAnchorsRewrittenResult(t *testing.T) {
+	ctx := context.Background()
+	assistant := makeAssistantMsgWithToolCalls[*schema.AgenticMessage]("", []testToolCall{
+		{ID: "call_1", Name: "tool_a", Arguments: "{}"},
+		{ID: "call_2", Name: "tool_b", Arguments: "{}"},
+	})
+	mixed := &schema.AgenticMessage{
+		Role: schema.AgenticRoleTypeUser,
+		ContentBlocks: []*schema.ContentBlock{
+			schema.NewContentBlock(&schema.FunctionToolResult{CallID: "call_orphan", Name: "tool_orphan"}),
+			schema.NewContentBlock(&schema.FunctionToolResult{CallID: "call_2", Name: "tool_b"}),
+		},
+	}
+	adk.EnsureMessageID(mixed)
+
+	plan, err := buildAgenticNormalizationPlan(
+		ctx,
+		Config{RemoveOrphanResults: true},
+		[]*schema.AgenticMessage{assistant, mixed},
+	)
+
+	require.NoError(t, err)
+	require.Len(t, plan.messages, 3)
+	assert.Equal(t, []string{"call_1", "call_2"}, collectToolResultIDs(plan.messages))
+	require.Len(t, plan.events, 2)
+	require.NotNil(t, plan.events[0].MessageInserted)
+	assert.Equal(t, adk.GetMessageID(mixed), plan.events[0].MessageInserted.BeforeMessageID)
+	require.NotNil(t, plan.events[1].MessageUpdated)
+	assert.Equal(t, adk.GetMessageID(mixed), plan.events[1].MessageUpdated.MessageID)
+}
+
 func TestPatchToolCallsAgenticToolSearchResult(t *testing.T) {
 	ctx := context.Background()
 	mw, err := NewTyped[*schema.AgenticMessage](ctx, nil)

--- a/adk/middlewares/patchtoolcalls/patchtoolcalls_test.go
+++ b/adk/middlewares/patchtoolcalls/patchtoolcalls_test.go
@@ -220,7 +220,7 @@ func testPatchToolCallsGeneric[M adk.MessageType](t *testing.T) {
 				makeToolResultMsg[M]("result_a", "call_1", "tool_a"),
 			},
 			wantLen:        4,
-			checkPatchedAt: 2,
+			checkPatchedAt: 3,
 			wantCallID:     "call_2",
 			wantToolName:   "tool_b",
 			wantContent:    fmt.Sprintf(defaultPatchedToolMessageTemplate, "tool_b", "call_2"),
@@ -241,7 +241,7 @@ func testPatchToolCallsGeneric[M adk.MessageType](t *testing.T) {
 				makeToolResultMsg[M]("result_a", "call_1", "tool_a"),
 			},
 			wantLen:        4,
-			checkPatchedAt: 2,
+			checkPatchedAt: 3,
 			wantCallID:     "call_2",
 			wantToolName:   "tool_b",
 			wantContent:    "123 tool_b call_2",
@@ -268,7 +268,7 @@ func testPatchToolCallsGeneric[M adk.MessageType](t *testing.T) {
 				makeToolResultMsg[M]("result_a", "call_1", "tool_a"),
 			},
 			wantLen:        4,
-			checkPatchedAt: 2,
+			checkPatchedAt: 3,
 			wantCallID:     "call_2",
 			wantToolName:   "tool_b",
 			wantContent:    `result tool_b call_2 {"x":1}`,
@@ -652,17 +652,19 @@ func TestPatchToolCallsInsertionEventAnchorsReplayOrder(t *testing.T) {
 	assistant := makeAssistantMsgWithToolCalls[*schema.Message]("", []testToolCall{
 		{ID: "call_1", Name: "tool_a", Arguments: "{}"},
 		{ID: "call_2", Name: "tool_b", Arguments: "{}"},
+		{ID: "call_3", Name: "tool_c", Arguments: "{}"},
 	})
-	result := makeToolResultMsg[*schema.Message]("result", "call_1", "tool_a")
-	messages := []*schema.Message{assistant, result}
+	result1 := makeToolResultMsg[*schema.Message]("result 1", "call_1", "tool_a")
+	result3 := makeToolResultMsg[*schema.Message]("result 3", "call_3", "tool_c")
+	messages := []*schema.Message{assistant, result1, result3}
 
 	plan, err := buildMessageNormalizationPlan(ctx, Config{}, messages)
 	require.NoError(t, err)
-	require.Len(t, plan.messages, 3)
+	require.Len(t, plan.messages, 4)
 	require.Len(t, plan.events, 1)
 	event := plan.events[0]
 	require.Equal(t, adk.SessionEventMessageInserted, event.Kind)
-	assert.Equal(t, adk.GetMessageID(result), event.MessageInserted.BeforeMessageID)
+	assert.Equal(t, adk.GetMessageID(result3), event.MessageInserted.BeforeMessageID)
 
 	replayed := append([]*schema.Message{}, messages...)
 	for i, msg := range replayed {
@@ -673,8 +675,49 @@ func TestPatchToolCallsInsertionEventAnchorsReplayOrder(t *testing.T) {
 			break
 		}
 	}
-	assert.Equal(t, []string{"call_2", "call_1"}, collectToolResultIDs(replayed))
-	assert.Equal(t, []string{"call_2", "call_1"}, collectToolResultIDs(plan.messages))
+	assert.Equal(t, []string{"call_1", "call_2", "call_3"}, collectToolResultIDs(replayed))
+	assert.Equal(t, []string{"call_1", "call_2", "call_3"}, collectToolResultIDs(plan.messages))
+}
+
+func TestPatchToolCallsAgenticInsertionEventAnchorsReplayOrder(t *testing.T) {
+	ctx := context.Background()
+	assistant := makeAssistantMsgWithToolCalls[*schema.AgenticMessage]("", []testToolCall{
+		{ID: "call_1", Name: "tool_a", Arguments: "{}"},
+		{ID: "call_2", Name: "tool_b", Arguments: "{}"},
+		{ID: "call_3", Name: "tool_c", Arguments: "{}"},
+	})
+	result1 := makeToolResultMsg[*schema.AgenticMessage]("result 1", "call_1", "tool_a")
+	result3 := makeToolResultMsg[*schema.AgenticMessage]("result 3", "call_3", "tool_c")
+	messages := []*schema.AgenticMessage{assistant, result1, result3}
+
+	plan, err := buildAgenticNormalizationPlan(ctx, Config{}, messages)
+	require.NoError(t, err)
+	require.Len(t, plan.messages, 4)
+	require.Len(t, plan.events, 1)
+	event := plan.events[0]
+	require.Equal(t, adk.SessionEventMessageInserted, event.Kind)
+	assert.Equal(t, adk.GetMessageID(result3), event.MessageInserted.BeforeMessageID)
+	assert.Equal(t, []string{"call_1", "call_2", "call_3"}, collectToolResultIDs(plan.messages))
+}
+
+func TestAttack_PatchToolCallsMultipleMissingResultsShareLaterAnchor(t *testing.T) {
+	ctx := context.Background()
+	assistant := makeAssistantMsgWithToolCalls[*schema.Message]("", []testToolCall{
+		{ID: "call_1", Name: "tool_a", Arguments: "{}"},
+		{ID: "call_2", Name: "tool_b", Arguments: "{}"},
+		{ID: "call_3", Name: "tool_c", Arguments: "{}"},
+		{ID: "call_4", Name: "tool_d", Arguments: "{}"},
+	})
+	result1 := makeToolResultMsg[*schema.Message]("result 1", "call_1", "tool_a")
+	result4 := makeToolResultMsg[*schema.Message]("result 4", "call_4", "tool_d")
+
+	plan, err := buildMessageNormalizationPlan(ctx, Config{}, []*schema.Message{assistant, result1, result4})
+
+	require.NoError(t, err)
+	require.Len(t, plan.events, 2)
+	assert.Equal(t, adk.GetMessageID(result4), plan.events[0].MessageInserted.BeforeMessageID)
+	assert.Equal(t, adk.GetMessageID(result4), plan.events[1].MessageInserted.BeforeMessageID)
+	assert.Equal(t, []string{"call_1", "call_2", "call_3", "call_4"}, collectToolResultIDs(plan.messages))
 }
 
 func TestPatchToolCallsAgenticToolSearchResult(t *testing.T) {

--- a/adk/session.go
+++ b/adk/session.go
@@ -1872,7 +1872,131 @@ func replayDurableContextEvents[M MessageType](events []*SessionEvent[M]) (*reco
 		}
 	}
 	state.Messages = replay.visibleMessages()
+	reorderParallelToolResults(state.Messages)
 	return state, nil
+}
+
+// reorderParallelToolResults canonicalizes reconstructed model context without
+// changing the completion-ordered session log or live event delivery. It only
+// reorders a contiguous result group when every result belongs to the preceding
+// multi-tool assistant message; malformed or unfamiliar history is left intact.
+func reorderParallelToolResults[M MessageType](messages []M) {
+	for i := 0; i < len(messages); i++ {
+		callIDs, ok := messageToolCallIDs(messages[i])
+		if !ok || len(callIDs) < 2 {
+			continue
+		}
+
+		resultStart := i + 1
+		resultEnd := resultStart
+		resultIDs := make([]string, 0, len(callIDs))
+		for resultEnd < len(messages) {
+			callID, isResult := messageToolResultCallID(messages[resultEnd])
+			if !isResult {
+				break
+			}
+			resultIDs = append(resultIDs, callID)
+			resultEnd++
+		}
+		if len(resultIDs) < 2 {
+			continue
+		}
+
+		knownCallIDs := make(map[string]struct{}, len(callIDs))
+		validGroup := true
+		for _, callID := range callIDs {
+			if callID == "" {
+				validGroup = false
+				break
+			}
+			if _, exists := knownCallIDs[callID]; exists {
+				validGroup = false
+				break
+			}
+			knownCallIDs[callID] = struct{}{}
+		}
+		if !validGroup {
+			continue
+		}
+		resultsByCallID := make(map[string][]M, len(resultIDs))
+		for _, callID := range resultIDs {
+			if _, exists := knownCallIDs[callID]; !exists {
+				validGroup = false
+				break
+			}
+		}
+		if !validGroup {
+			continue
+		}
+		for offset, callID := range resultIDs {
+			resultsByCallID[callID] = append(resultsByCallID[callID], messages[resultStart+offset])
+		}
+
+		ordered := make([]M, 0, len(resultIDs))
+		for _, callID := range callIDs {
+			ordered = append(ordered, resultsByCallID[callID]...)
+		}
+		copy(messages[resultStart:resultEnd], ordered)
+		i = resultEnd - 1
+	}
+}
+
+func messageToolCallIDs[M MessageType](message M) ([]string, bool) {
+	switch msg := any(message).(type) {
+	case *schema.Message:
+		if msg == nil || msg.Role != schema.Assistant || len(msg.ToolCalls) == 0 {
+			return nil, false
+		}
+		callIDs := make([]string, 0, len(msg.ToolCalls))
+		for _, toolCall := range msg.ToolCalls {
+			callIDs = append(callIDs, toolCall.ID)
+		}
+		return callIDs, true
+	case *schema.AgenticMessage:
+		if msg == nil || msg.Role != schema.AgenticRoleTypeAssistant {
+			return nil, false
+		}
+		var callIDs []string
+		for _, block := range msg.ContentBlocks {
+			if block != nil && block.Type == schema.ContentBlockTypeFunctionToolCall && block.FunctionToolCall != nil {
+				callIDs = append(callIDs, block.FunctionToolCall.CallID)
+			}
+		}
+		return callIDs, len(callIDs) > 0
+	default:
+		return nil, false
+	}
+}
+
+func messageToolResultCallID[M MessageType](message M) (string, bool) {
+	switch msg := any(message).(type) {
+	case *schema.Message:
+		if msg == nil || msg.Role != schema.Tool {
+			return "", false
+		}
+		return msg.ToolCallID, true
+	case *schema.AgenticMessage:
+		if msg == nil || msg.Role != schema.AgenticRoleTypeUser || len(msg.ContentBlocks) != 1 {
+			return "", false
+		}
+		block := msg.ContentBlocks[0]
+		if block == nil {
+			return "", false
+		}
+		switch block.Type {
+		case schema.ContentBlockTypeFunctionToolResult:
+			if block.FunctionToolResult != nil {
+				return block.FunctionToolResult.CallID, true
+			}
+		case schema.ContentBlockTypeToolSearchResult:
+			if block.ToolSearchFunctionToolResult != nil {
+				return block.ToolSearchFunctionToolResult.CallID, true
+			}
+		}
+		return "", false
+	default:
+		return "", false
+	}
 }
 
 func isCommittedIdleEvent[M MessageType](event *SessionEvent[M]) bool {

--- a/adk/session.go
+++ b/adk/session.go
@@ -1878,8 +1878,8 @@ func replayDurableContextEvents[M MessageType](events []*SessionEvent[M]) (*reco
 
 // reorderParallelToolResults canonicalizes reconstructed model context without
 // changing the completion-ordered session log or live event delivery. It only
-// reorders a contiguous result group when every result belongs to the preceding
-// multi-tool assistant message; malformed or unfamiliar history is left intact.
+// reorders results belonging to the preceding multi-tool assistant message;
+// unrecognized results keep their original positions.
 func reorderParallelToolResults[M MessageType](messages []M) {
 	for i := 0; i < len(messages); i++ {
 		callIDs, ok := messageToolCallIDs(messages[i])
@@ -1919,24 +1919,29 @@ func reorderParallelToolResults[M MessageType](messages []M) {
 			continue
 		}
 		resultsByCallID := make(map[string][]M, len(resultIDs))
-		for _, callID := range resultIDs {
-			if _, exists := knownCallIDs[callID]; !exists {
-				validGroup = false
-				break
+		knownResultCount := 0
+		for offset, callID := range resultIDs {
+			if _, exists := knownCallIDs[callID]; exists {
+				resultsByCallID[callID] = append(resultsByCallID[callID], messages[resultStart+offset])
+				knownResultCount++
 			}
 		}
-		if !validGroup {
+		if knownResultCount < 2 {
 			continue
 		}
-		for offset, callID := range resultIDs {
-			resultsByCallID[callID] = append(resultsByCallID[callID], messages[resultStart+offset])
-		}
 
-		ordered := make([]M, 0, len(resultIDs))
+		ordered := make([]M, 0, knownResultCount)
 		for _, callID := range callIDs {
 			ordered = append(ordered, resultsByCallID[callID]...)
 		}
-		copy(messages[resultStart:resultEnd], ordered)
+		orderedIndex := 0
+		for offset, callID := range resultIDs {
+			if _, exists := knownCallIDs[callID]; !exists {
+				continue
+			}
+			messages[resultStart+offset] = ordered[orderedIndex]
+			orderedIndex++
+		}
 		i = resultEnd - 1
 	}
 }

--- a/adk/session_test.go
+++ b/adk/session_test.go
@@ -711,6 +711,71 @@ func TestRunnerSessionModeSkipsDuplicateToolModelContext(t *testing.T) {
 	require.Len(t, result.Events, 0)
 }
 
+func TestRunnerSessionModeReordersParallelToolResultsByToolCallOrder(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	store := newSessionHelperStore()
+	sessionID := "parallel-tool-result-order"
+	releaseFirst := make(chan struct{})
+	model := &parallelToolSessionModel{}
+	agent, err := NewChatModelAgent(ctx, &ChatModelAgentConfig{
+		Name:        "parallel-tool-session-agent",
+		Description: "parallel tool result order test agent",
+		Model:       model,
+		ToolsConfig: ToolsConfig{
+			ToolsNodeConfig: compose.ToolsNodeConfig{
+				Tools: []tool.BaseTool{
+					sessionOrderTool{name: "first", result: "first result", wait: releaseFirst},
+					sessionOrderTool{name: "second", result: "second result"},
+				},
+			},
+		},
+	})
+	require.NoError(t, err)
+
+	runner := NewRunner(ctx, RunnerConfig{
+		Agent:        agent,
+		SessionID:    sessionID,
+		SessionStore: store,
+	})
+	iter := runner.Query(ctx, "first turn")
+	secondResultCount := 0
+	for {
+		event, ok := iter.Next()
+		if !ok {
+			break
+		}
+		require.NoError(t, event.Err)
+		if event.Output == nil || event.Output.MessageOutput == nil {
+			continue
+		}
+		msg, err := event.Output.MessageOutput.GetMessage()
+		require.NoError(t, err)
+		if msg.Role == schema.Tool && msg.ToolCallID == "call-2" {
+			if secondResultCount == 0 {
+				close(releaseFirst)
+			}
+			secondResultCount++
+		}
+	}
+	require.Equal(t, 1, secondResultCount, "second tool result must complete once before the first tool is released")
+
+	var persistedToolCallIDs []string
+	for _, event := range decodeStoredSessionEvents(t, store.events) {
+		if event.Message != nil && event.Message.Role == schema.Tool {
+			persistedToolCallIDs = append(persistedToolCallIDs, event.Message.ToolCallID)
+		}
+	}
+	require.Equal(t, []string{"call-2", "call-1"}, persistedToolCallIDs)
+	require.Len(t, model.inputs, 2)
+	require.Equal(t, []string{"call-1", "call-2"}, toolResultCallIDs(model.inputs[1]))
+
+	drainSessionEvents(t, runner.Query(ctx, "second turn"))
+
+	require.Len(t, model.inputs, 3)
+	require.Equal(t, []string{"call-1", "call-2"}, toolResultCallIDs(model.inputs[2]))
+}
+
 func TestAttack_SessionEventIDGeneratorCoversRunnerEvents(t *testing.T) {
 	ctx := context.Background()
 	store := newSessionHelperStore()
@@ -2342,6 +2407,161 @@ func TestReconstructFromEventLog_MultiTurn(t *testing.T) {
 	assert.Equal(t, "A1", result2.state.Messages[1].Content)
 	assert.Equal(t, "Q2", result2.state.Messages[2].Content)
 	assert.Equal(t, "A2", result2.state.Messages[3].Content)
+}
+
+func TestAttack_ReorderParallelToolResults(t *testing.T) {
+	t.Run("message reorders each result group", func(t *testing.T) {
+		messages := []*schema.Message{
+			testToolCallMessage("call-1", "call-2"),
+			schema.ToolMessage("second", "call-2"),
+			schema.ToolMessage("first", "call-1"),
+			testToolCallMessage("call-3", "call-4"),
+			schema.ToolMessage("fourth", "call-4"),
+			schema.ToolMessage("third", "call-3"),
+		}
+
+		reorderParallelToolResults(messages)
+
+		require.Equal(t, []string{"call-1", "call-2"}, toolResultCallIDs(messages[1:3]))
+		require.Equal(t, []string{"call-3", "call-4"}, toolResultCallIDs(messages[4:]))
+	})
+
+	t.Run("agentic message reorders function and tool search results", func(t *testing.T) {
+		messages := []*schema.AgenticMessage{
+			testAgenticToolCallMessage("call-1", "call-2"),
+			{
+				Role: schema.AgenticRoleTypeUser,
+				ContentBlocks: []*schema.ContentBlock{
+					schema.NewContentBlock(&schema.ToolSearchFunctionToolResult{CallID: "call-2", Name: "second"}),
+				},
+			},
+			agenticToolResultMessage("call-1", "first", "first"),
+		}
+
+		reorderParallelToolResults(messages)
+
+		firstID, firstIsResult := messageToolResultCallID(messages[1])
+		secondID, secondIsResult := messageToolResultCallID(messages[2])
+		require.True(t, firstIsResult)
+		require.True(t, secondIsResult)
+		assert.Equal(t, "call-1", firstID)
+		assert.Equal(t, "call-2", secondID)
+	})
+
+	t.Run("unknown result keeps physical order", func(t *testing.T) {
+		messages := []*schema.Message{
+			testToolCallMessage("call-1", "call-2"),
+			schema.ToolMessage("second", "call-2"),
+			schema.ToolMessage("unknown", "call-other"),
+			schema.ToolMessage("first", "call-1"),
+		}
+
+		reorderParallelToolResults(messages)
+
+		require.Equal(t, []string{"call-2", "call-other", "call-1"}, toolResultCallIDs(messages[1:]))
+	})
+
+	t.Run("ordinary message terminates result group", func(t *testing.T) {
+		messages := []*schema.Message{
+			testToolCallMessage("call-1", "call-2"),
+			schema.ToolMessage("second", "call-2"),
+			schema.UserMessage("next input"),
+			schema.ToolMessage("first", "call-1"),
+		}
+
+		reorderParallelToolResults(messages)
+
+		assert.Equal(t, "call-2", messages[1].ToolCallID)
+		assert.Equal(t, schema.User, messages[2].Role)
+		assert.Equal(t, "call-1", messages[3].ToolCallID)
+	})
+
+	t.Run("partial result group follows relative call order", func(t *testing.T) {
+		messages := []*schema.Message{
+			testToolCallMessage("call-1", "call-2", "call-3"),
+			schema.ToolMessage("third", "call-3"),
+			schema.ToolMessage("first", "call-1"),
+		}
+
+		reorderParallelToolResults(messages)
+
+		require.Equal(t, []string{"call-1", "call-3"}, toolResultCallIDs(messages[1:]))
+	})
+
+	t.Run("duplicate call ID keeps physical order", func(t *testing.T) {
+		messages := []*schema.Message{
+			testToolCallMessage("call-1", "call-1"),
+			schema.ToolMessage("second physical result", "call-1"),
+			schema.ToolMessage("first physical result", "call-1"),
+		}
+
+		reorderParallelToolResults(messages)
+
+		assert.Equal(t, "second physical result", messages[1].Content)
+		assert.Equal(t, "first physical result", messages[2].Content)
+	})
+
+	t.Run("empty call ID keeps physical order", func(t *testing.T) {
+		messages := []*schema.Message{
+			testToolCallMessage("", "call-2"),
+			schema.ToolMessage("second", "call-2"),
+			schema.ToolMessage("empty", ""),
+		}
+
+		reorderParallelToolResults(messages)
+
+		assert.Equal(t, "second", messages[1].Content)
+		assert.Equal(t, "empty", messages[2].Content)
+	})
+
+	t.Run("mixed agentic user message terminates result group", func(t *testing.T) {
+		mixed := agenticToolResultMessage("call-2", "second", "second")
+		mixed.ContentBlocks = append(mixed.ContentBlocks, schema.NewContentBlock(&schema.UserInputText{Text: "user text"}))
+		messages := []*schema.AgenticMessage{
+			testAgenticToolCallMessage("call-1", "call-2"),
+			mixed,
+			agenticToolResultMessage("call-1", "first", "first"),
+		}
+
+		reorderParallelToolResults(messages)
+
+		assert.Same(t, mixed, messages[1])
+	})
+
+	t.Run("malformed agentic result terminates result group", func(t *testing.T) {
+		malformed := &schema.AgenticMessage{
+			Role: schema.AgenticRoleTypeUser,
+			ContentBlocks: []*schema.ContentBlock{
+				{Type: schema.ContentBlockTypeFunctionToolResult},
+			},
+		}
+		messages := []*schema.AgenticMessage{
+			testAgenticToolCallMessage("call-1", "call-2"),
+			malformed,
+			agenticToolResultMessage("call-1", "first", "first"),
+		}
+
+		reorderParallelToolResults(messages)
+
+		assert.Same(t, malformed, messages[1])
+	})
+
+	t.Run("replacement payload is normalized without mutation", func(t *testing.T) {
+		replacement := []*schema.Message{
+			testToolCallMessage("call-1", "call-2"),
+			schema.ToolMessage("second", "call-2"),
+			schema.ToolMessage("first", "call-1"),
+		}
+		events := []*SessionEvent[*schema.Message]{
+			{MessagesReplaced: &replacement},
+		}
+
+		state, err := replayDurableContextEvents(events)
+
+		require.NoError(t, err)
+		require.Equal(t, []string{"call-1", "call-2"}, toolResultCallIDs(state.Messages[1:]))
+		require.Equal(t, []string{"call-2", "call-1"}, toolResultCallIDs(replacement[1:]))
+	})
 }
 
 func TestReconstructFromEventLog_CorruptEventReturnsError(t *testing.T) {
@@ -5577,6 +5797,80 @@ func (m *sessionToolCallingModel) Stream(ctx context.Context, input []*schema.Me
 
 func (m *sessionToolCallingModel) WithTools(_ []*schema.ToolInfo) (model.ToolCallingChatModel, error) {
 	return m, nil
+}
+
+type parallelToolSessionModel struct {
+	inputs [][]*schema.Message
+}
+
+func (m *parallelToolSessionModel) Generate(_ context.Context, input []*schema.Message, _ ...model.Option) (*schema.Message, error) {
+	m.inputs = append(m.inputs, append([]*schema.Message{}, input...))
+	if len(m.inputs) == 1 {
+		return schema.AssistantMessage("", []schema.ToolCall{
+			{ID: "call-1", Function: schema.FunctionCall{Name: "first", Arguments: "{}"}},
+			{ID: "call-2", Function: schema.FunctionCall{Name: "second", Arguments: "{}"}},
+		}), nil
+	}
+	return schema.AssistantMessage("done", nil), nil
+}
+
+func (m *parallelToolSessionModel) Stream(ctx context.Context, input []*schema.Message, opts ...model.Option) (*schema.StreamReader[*schema.Message], error) {
+	msg, err := m.Generate(ctx, input, opts...)
+	if err != nil {
+		return nil, err
+	}
+	return schema.StreamReaderFromArray([]*schema.Message{msg}), nil
+}
+
+func (m *parallelToolSessionModel) WithTools(_ []*schema.ToolInfo) (model.ToolCallingChatModel, error) {
+	return m, nil
+}
+
+type sessionOrderTool struct {
+	name   string
+	result string
+	wait   <-chan struct{}
+}
+
+func (t sessionOrderTool) Info(context.Context) (*schema.ToolInfo, error) {
+	return &schema.ToolInfo{Name: t.name, Desc: t.name}, nil
+}
+
+func (t sessionOrderTool) InvokableRun(ctx context.Context, _ string, _ ...tool.Option) (string, error) {
+	if t.wait != nil {
+		select {
+		case <-t.wait:
+		case <-ctx.Done():
+			return "", ctx.Err()
+		}
+	}
+	return t.result, nil
+}
+
+func testToolCallMessage(callIDs ...string) *schema.Message {
+	toolCalls := make([]schema.ToolCall, 0, len(callIDs))
+	for _, callID := range callIDs {
+		toolCalls = append(toolCalls, schema.ToolCall{ID: callID})
+	}
+	return schema.AssistantMessage("", toolCalls)
+}
+
+func testAgenticToolCallMessage(callIDs ...string) *schema.AgenticMessage {
+	blocks := make([]*schema.ContentBlock, 0, len(callIDs))
+	for _, callID := range callIDs {
+		blocks = append(blocks, schema.NewContentBlock(&schema.FunctionToolCall{CallID: callID, Name: callID}))
+	}
+	return &schema.AgenticMessage{Role: schema.AgenticRoleTypeAssistant, ContentBlocks: blocks}
+}
+
+func toolResultCallIDs(messages []*schema.Message) []string {
+	var ids []string
+	for _, message := range messages {
+		if message != nil && message.Role == schema.Tool {
+			ids = append(ids, message.ToolCallID)
+		}
+	}
+	return ids
 }
 
 type modelContextExtraTool struct{}

--- a/adk/session_test.go
+++ b/adk/session_test.go
@@ -2415,15 +2415,15 @@ func TestAttack_ReorderParallelToolResults(t *testing.T) {
 			testToolCallMessage("call-1", "call-2"),
 			schema.ToolMessage("second", "call-2"),
 			schema.ToolMessage("first", "call-1"),
-			testToolCallMessage("call-3", "call-4"),
-			schema.ToolMessage("fourth", "call-4"),
-			schema.ToolMessage("third", "call-3"),
+			testToolCallMessage("call-1", "call-2"),
+			schema.ToolMessage("second again", "call-2"),
+			schema.ToolMessage("first again", "call-1"),
 		}
 
 		reorderParallelToolResults(messages)
 
 		require.Equal(t, []string{"call-1", "call-2"}, toolResultCallIDs(messages[1:3]))
-		require.Equal(t, []string{"call-3", "call-4"}, toolResultCallIDs(messages[4:]))
+		require.Equal(t, []string{"call-1", "call-2"}, toolResultCallIDs(messages[4:]))
 	})
 
 	t.Run("agentic message reorders function and tool search results", func(t *testing.T) {
@@ -2448,7 +2448,7 @@ func TestAttack_ReorderParallelToolResults(t *testing.T) {
 		assert.Equal(t, "call-2", secondID)
 	})
 
-	t.Run("unknown result keeps physical order", func(t *testing.T) {
+	t.Run("unknown result keeps position while known results reorder", func(t *testing.T) {
 		messages := []*schema.Message{
 			testToolCallMessage("call-1", "call-2"),
 			schema.ToolMessage("second", "call-2"),
@@ -2458,7 +2458,26 @@ func TestAttack_ReorderParallelToolResults(t *testing.T) {
 
 		reorderParallelToolResults(messages)
 
-		require.Equal(t, []string{"call-2", "call-other", "call-1"}, toolResultCallIDs(messages[1:]))
+		require.Equal(t, []string{"call-1", "call-other", "call-2"}, toolResultCallIDs(messages[1:]))
+	})
+
+	t.Run("agentic unknown result keeps position while known results reorder", func(t *testing.T) {
+		messages := []*schema.AgenticMessage{
+			testAgenticToolCallMessage("call-1", "call-2"),
+			agenticToolResultMessage("call-2", "second", "second"),
+			agenticToolResultMessage("call-other", "other", "other"),
+			agenticToolResultMessage("call-1", "first", "first"),
+		}
+
+		reorderParallelToolResults(messages)
+
+		var resultIDs []string
+		for _, message := range messages[1:] {
+			callID, isResult := messageToolResultCallID(message)
+			require.True(t, isResult)
+			resultIDs = append(resultIDs, callID)
+		}
+		require.Equal(t, []string{"call-1", "call-other", "call-2"}, resultIDs)
 	})
 
 	t.Run("ordinary message terminates result group", func(t *testing.T) {
@@ -2486,6 +2505,21 @@ func TestAttack_ReorderParallelToolResults(t *testing.T) {
 		reorderParallelToolResults(messages)
 
 		require.Equal(t, []string{"call-1", "call-3"}, toolResultCallIDs(messages[1:]))
+	})
+
+	t.Run("duplicate results preserve completion order within one call", func(t *testing.T) {
+		messages := []*schema.Message{
+			testToolCallMessage("call-1", "call-2"),
+			schema.ToolMessage("second first result", "call-2"),
+			schema.ToolMessage("first result", "call-1"),
+			schema.ToolMessage("second duplicate result", "call-2"),
+		}
+
+		reorderParallelToolResults(messages)
+
+		require.Equal(t, []string{"call-1", "call-2", "call-2"}, toolResultCallIDs(messages[1:]))
+		assert.Equal(t, "second first result", messages[2].Content)
+		assert.Equal(t, "second duplicate result", messages[3].Content)
 	})
 
 	t.Run("duplicate call ID keeps physical order", func(t *testing.T) {
@@ -2562,6 +2596,84 @@ func TestAttack_ReorderParallelToolResults(t *testing.T) {
 		require.Equal(t, []string{"call-1", "call-2"}, toolResultCallIDs(state.Messages[1:]))
 		require.Equal(t, []string{"call-2", "call-1"}, toolResultCallIDs(replacement[1:]))
 	})
+}
+
+func TestAttack_ReconstructParallelToolResultsAcrossPaginationAndDeletion(t *testing.T) {
+	ctx := context.Background()
+	store := newSessionHelperStore()
+	sid := "parallel-tool-result-pagination-deletion"
+	assistant := testToolCallMessage("call-1", "call-2", "call-3")
+	result1 := schema.ToolMessage("first", "call-1")
+	result2 := schema.ToolMessage("second", "call-2")
+	result3 := schema.ToolMessage("third", "call-3")
+	for _, message := range []*schema.Message{assistant, result3, result2, result1} {
+		EnsureMessageID(message)
+		appendTestSessionEvent(t, ctx, store, sid, &SessionEvent[*schema.Message]{
+			Kind:    SessionEventMessage,
+			Message: message,
+		})
+	}
+	appendTestSessionEvent(t, ctx, store, sid, &SessionEvent[*schema.Message]{
+		Kind: SessionEventMessagesDeleted,
+		MessagesDeleted: &MessagesDeletedEvent{
+			MessageIDs: []string{GetMessageID(result2)},
+		},
+	})
+
+	result, err := reconstructSessionState[*schema.Message](ctx, store, sid, 2)
+
+	require.NoError(t, err)
+	require.NotNil(t, result)
+	require.NotNil(t, result.state)
+	require.Len(t, result.state.Messages, 3)
+	require.Equal(t, []string{"call-1", "call-3"}, toolResultCallIDs(result.state.Messages[1:]))
+}
+
+func TestAttack_ReconstructParallelToolResultsAfterUpdateAndRollback(t *testing.T) {
+	ctx := context.Background()
+	store := newSessionHelperStore()
+	sid := "parallel-tool-result-update-rollback"
+	assistant := testToolCallMessage("call-1", "call-2")
+	EnsureMessageID(assistant)
+	updatedAssistant := *assistant
+	updatedAssistant.ToolCalls = []schema.ToolCall{{ID: "call-2"}, {ID: "call-1"}}
+	result1 := schema.ToolMessage("first", "call-1")
+	result2 := schema.ToolMessage("second", "call-2")
+	for _, message := range []*schema.Message{assistant, result1, result2} {
+		EnsureMessageID(message)
+		appendTestSessionEvent(t, ctx, store, sid, &SessionEvent[*schema.Message]{
+			Kind:    SessionEventMessage,
+			Message: message,
+		})
+	}
+	appendTestSessionEvent(t, ctx, store, sid, &SessionEvent[*schema.Message]{
+		Kind: SessionEventMessageUpdated,
+		MessageUpdated: &MessageUpdatedEvent[*schema.Message]{
+			MessageID: GetMessageID(assistant),
+			Message:   &updatedAssistant,
+		},
+	})
+	firstTurn := withTestCommittedIdle[*schema.Message]("turn-1")
+	require.NoError(t, store.AppendEventsForSession(ctx, sid, []*SessionEvent[*schema.Message]{firstTurn}))
+	appendTestSessionEvent(t, ctx, store, sid, &SessionEvent[*schema.Message]{
+		Kind:    SessionEventMessage,
+		Message: schema.UserMessage("rolled back"),
+	})
+	require.NoError(t, store.AppendEventsForSession(ctx, sid, []*SessionEvent[*schema.Message]{
+		withTestCommittedIdle[*schema.Message]("turn-2"),
+	}))
+	require.NoError(t, RollbackSession[*schema.Message](ctx, store, sid, firstTurn.EventID))
+
+	result, err := reconstructSessionState[*schema.Message](ctx, store, sid, 2)
+
+	require.NoError(t, err)
+	require.NotNil(t, result)
+	require.NotNil(t, result.state)
+	require.Len(t, result.state.Messages, 3)
+	require.Equal(t, []string{"call-2", "call-1"}, toolResultCallIDs(result.state.Messages[1:]))
+	for _, message := range result.state.Messages {
+		assert.NotEqual(t, "rolled back", message.Content)
+	}
 }
 
 func TestReconstructFromEventLog_CorruptEventReturnsError(t *testing.T) {


### PR DESCRIPTION
# Stable Parallel Tool Result Order Across Session Turns

## Problem

Parallel tool results are emitted and persisted as soon as each tool completes.
This keeps first-result latency low, but completion order can differ from the
tool-call order.

Within the current turn, ChatModelAgent builds the next model input from state,
where tool results already follow tool-call order. On the next turn, session
reconstruction previously replayed the persisted completion order instead:

```text
tool calls:              call-1, call-2
persisted results:       call-2, call-1
next-turn model context: call-2, call-1
```

Some models rely on positional consistency between calls and results. More
importantly, changing the historical message order between turns invalidates
otherwise reusable prompt-cache prefixes.

## Solution

Keep live delivery and the append-only session log completion ordered. After
session replay has applied message replacements, updates, insertions, and
deletions, canonicalize only the reconstructed model-facing message view.

For each assistant message with multiple tool calls, its contiguous tool-result
group is ordered by call ID according to the assistant message. Unrecognized
results keep their positions while recognized results are ordered around them;
malformed tool-call lists remain unchanged.

When `patchtoolcalls` fills a missing result, it inserts that result before the
first existing result for a later call. For calls `1,2,3` with results `1,3`,
the synthetic result is therefore placed between them. The in-memory
normalization plan and its persisted `MessageInserted` event use the same
anchor.

## Key Insight

The session log serves two different needs:

- Live consumers need completion order so finished tool results are available immediately.
- A later model turn needs canonical call/result order so its context is stable.

The log should preserve occurrence order; reconstruction is the correct boundary
for deriving canonical model context.

## Summary

| Problem | Solution |
|---|---|
| Next-turn history used parallel tool completion order | Reorder reconstructed result groups by tool-call order |
| Reordering persistence would delay live consumers | Preserve live and durable completion order |
| A patched missing result could precede earlier completed calls | Anchor it before the first result for a later call |
| Orphan results could prevent valid results from being ordered | Keep orphan positions while ordering recognized results |
| Malformed tool-call lists could be reordered incorrectly | Leave those groups unchanged |

---

# 跨 Session Turn 稳定并行 Tool Result 顺序

## 问题

并行 tool result 会在各自执行完成后立即向上游发送并持久化。这样可以保证首个结果的低延迟，但完成顺序可能与 tool call 顺序不同。

在当前 Turn 内，ChatModelAgent 从 state 构建下一次模型输入，其中 tool result 已按 tool call 顺序排列。但到了下一个 Turn，session 重建原先会直接回放持久化的完成顺序：

```text
tool call 顺序:          call-1, call-2
持久化 result 顺序:     call-2, call-1
下一 Turn 模型上下文:   call-2, call-1
```

部分模型依赖 call 与 result 的位置一致性。更重要的是，跨 Turn 改变历史消息顺序会破坏本可复用的 prompt cache 前缀。

## 解决方案

继续让 live event 和 append-only session log 保持完成顺序。在 session replay 完成 message replacement、update、insert 和 delete 投影后，只规范化重建出的模型消息视图。

对于包含多个 tool call 的 assistant 消息，将其后连续的 tool result 按 assistant 消息中的 call ID 顺序排列。无法识别的 result 保持原位置，已识别的 result 围绕它恢复 call 顺序；tool call 列表本身异常时不做猜测。

当 `patchtoolcalls` 补缺失 result 时，将它插到第一个“属于后续 call 的已有 result”之前。例如 call 顺序为 `1,2,3`、已有 result 为 `1,3` 时，synthetic result 会补在二者中间。内存 normalization plan 与持久化的 `MessageInserted` event 使用同一个 anchor。

## 关键洞察

session log 同时服务两个不同目标：

- live consumer 需要完成顺序，以便尽快拿到已经完成的 tool result。
- 后续模型 Turn 需要稳定的 call/result 顺序，以保持上下文与缓存前缀一致。

因此 log 应保留真实发生顺序，而 reconstruction 才是派生规范模型上下文的正确边界。

## 总结

| 问题 | 解决方案 |
|---|---|
| 下一 Turn 历史使用并行 tool 的完成顺序 | 按 tool call 顺序重排重建视图中的 result 组 |
| 修改持久化顺序会增加 live consumer 延迟 | 保留 live 与 durable event 的完成顺序 |
| 补缺失 result 时可能排到更早 call 之前 | 锚定到第一个后续 call 的已有 result |
| orphan result 阻断其他有效 result 的排序 | orphan 保持原位置，已识别 result 继续排序 |
| tool call 列表本身异常 | 保持该组原序 |