### PR TITLE
fix(adk): prevent nested agent stream hangs

### DIFF
--- a/adk/agent_tool.go
+++ b/adk/agent_tool.go
@@ -21,6 +21,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"time"
 
 	"github.com/bytedance/sonic"
 
@@ -42,6 +43,7 @@ var (
 type AgentToolOptions struct {
 	fullChatHistoryAsInput bool
 	agentInputSchema       *schema.ParamsOneOf
+	timeout                time.Duration
 }
 
 type AgentToolOption func(*AgentToolOptions)
@@ -57,6 +59,15 @@ func WithFullChatHistoryAsInput() AgentToolOption {
 func WithAgentInputSchema(schema *schema.ParamsOneOf) AgentToolOption {
 	return func(options *AgentToolOptions) {
 		options.agentInputSchema = schema
+	}
+}
+
+// WithAgentToolTimeout sets the maximum duration of an AgentTool invocation.
+// A non-positive duration disables the timeout. The timeout is applied to both
+// new and resumed agent-tool runs and preserves an earlier parent deadline.
+func WithAgentToolTimeout(timeout time.Duration) AgentToolOption {
+	return func(options *AgentToolOptions) {
+		options.timeout = timeout
 	}
 }
 
@@ -100,6 +111,7 @@ func NewAgentTool(_ context.Context, agent Agent, options ...AgentToolOption) to
 		agent:                  agent,
 		fullChatHistoryAsInput: opts.fullChatHistoryAsInput,
 		inputSchema:            opts.agentInputSchema,
+		timeout:                opts.timeout,
 	}
 }
 
@@ -114,6 +126,7 @@ func NewTypedAgentTool[M MessageType](_ context.Context, agent TypedAgent[M], op
 		agent:                  agent,
 		fullChatHistoryAsInput: opts.fullChatHistoryAsInput,
 		inputSchema:            opts.agentInputSchema,
+		timeout:                opts.timeout,
 	}
 }
 
@@ -122,6 +135,7 @@ type typedAgentTool[M MessageType] struct {
 
 	fullChatHistoryAsInput bool
 	inputSchema            *schema.ParamsOneOf
+	timeout                time.Duration
 }
 
 type agentTool = typedAgentTool[*schema.Message]
@@ -152,6 +166,13 @@ func (at *typedAgentTool[M]) Info(ctx context.Context) (*schema.ToolInfo, error)
 }
 
 func (at *typedAgentTool[M]) InvokableRun(ctx context.Context, argumentsInJSON string, opts ...tool.Option) (string, error) {
+	if at.timeout > 0 {
+		var cancel context.CancelFunc
+		ctx, cancel = context.WithTimeout(ctx, at.timeout)
+		defer cancel()
+	}
+
+	agentName := at.agent.Name(ctx)
 	if cancelCtx := getCancelContext(ctx); cancelCtx != nil {
 		cancelCtx.markCheckpointAwareDescendant()
 	}
@@ -198,7 +219,7 @@ func (at *typedAgentTool[M]) InvokableRun(ctx context.Context, argumentsInJSON s
 			append(extractAndDeriveAgentToolCancelCtx(ctx, at.agent.Name(ctx), opts), WithCheckPointID(bridgeCheckpointID), withSharedParentSession())...)
 	} else {
 		if !hasState {
-			return "", fmt.Errorf("agent tool '%s' interrupt has happened, but cannot find interrupt state", at.agent.Name(ctx))
+			return "", fmt.Errorf("agent tool '%s' interrupt has happened, but cannot find interrupt state", agentName)
 		}
 
 		ms = newResumeBridgeStore(bridgeCheckpointID, state)
@@ -214,18 +235,27 @@ func (at *typedAgentTool[M]) InvokableRun(ctx context.Context, argumentsInJSON s
 	}
 
 	var lastEvent *TypedAgentEvent[M]
+	lastEventStreamClosed := true
+	closeLastEventStream := func() {
+		if lastEventStreamClosed || lastEvent == nil || lastEvent.Output == nil ||
+			lastEvent.Output.MessageOutput == nil || lastEvent.Output.MessageOutput.MessageStream == nil {
+			return
+		}
+		lastEvent.Output.MessageOutput.MessageStream.Close()
+		lastEventStreamClosed = true
+	}
+	defer closeLastEventStream()
+
 	for {
-		event, ok := iter.Next()
+		event, ok := iter.NextWithContext(ctx)
 		if !ok {
+			if err := ctx.Err(); err != nil {
+				return "", fmt.Errorf("agent tool '%s' context done: %w", agentName, err)
+			}
 			break
 		}
 
-		if lastEvent != nil &&
-			lastEvent.Output != nil &&
-			lastEvent.Output.MessageOutput != nil &&
-			lastEvent.Output.MessageOutput.MessageStream != nil {
-			lastEvent.Output.MessageOutput.MessageStream.Close()
-		}
+		closeLastEventStream()
 
 		if event.Err != nil {
 			return "", event.Err
@@ -246,6 +276,8 @@ func (at *typedAgentTool[M]) InvokableRun(ctx context.Context, argumentsInJSON s
 		}
 
 		lastEvent = event
+		lastEventStreamClosed = event.Output == nil || event.Output.MessageOutput == nil ||
+			event.Output.MessageOutput.MessageStream == nil
 	}
 
 	if lastEvent != nil && lastEvent.Action != nil && lastEvent.Action.Interrupted != nil {
@@ -269,6 +301,7 @@ func (at *typedAgentTool[M]) InvokableRun(ctx context.Context, argumentsInJSON s
 	if lastEvent.Output != nil {
 		if output := lastEvent.Output.MessageOutput; output != nil {
 			msg, err := output.GetMessage()
+			lastEventStreamClosed = true
 			if err != nil {
 				return "", err
 			}

--- a/adk/prebuilt/deep/deep.go
+++ b/adk/prebuilt/deep/deep.go
@@ -20,6 +20,7 @@ package deep
 import (
 	"context"
 	"fmt"
+	"time"
 
 	"github.com/bytedance/sonic"
 
@@ -62,6 +63,9 @@ type TypedConfig[M adk.MessageType] struct {
 	ToolsConfig adk.ToolsConfig
 	// MaxIteration limits the maximum number of reasoning iterations the agent can perform.
 	MaxIteration int
+	// TaskToolTimeout limits each task tool invocation. A non-positive duration
+	// disables the timeout and leaves cancellation to the caller's context.
+	TaskToolTimeout time.Duration
 
 	// Backend provides filesystem operations used by tools and offloading.
 	// If set, filesystem tools (read_file, write_file, edit_file, glob, grep) will be registered.
@@ -141,6 +145,7 @@ func NewTyped[M adk.MessageType](ctx context.Context, cfg *TypedConfig[M]) (adk.
 			cfg.Middlewares,
 			append(handlers, cfg.Handlers...),
 			cfg.ModelFailoverConfig,
+			cfg.TaskToolTimeout,
 		)
 		if err != nil {
 			return nil, fmt.Errorf("failed to new task tool: %w", err)

--- a/adk/prebuilt/deep/task_tool.go
+++ b/adk/prebuilt/deep/task_tool.go
@@ -21,6 +21,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"strings"
+	"time"
 
 	"github.com/bytedance/sonic"
 	"github.com/slongfield/pyfmt"
@@ -45,8 +46,9 @@ func typedTaskToolMiddleware[M adk.MessageType](
 	middlewares []adk.AgentMiddleware,
 	handlers []adk.TypedChatModelAgentMiddleware[M],
 	modelFailoverConfig *adk.ModelFailoverConfig[M],
+	taskToolTimeout time.Duration,
 ) (adk.TypedChatModelAgentMiddleware[M], error) {
-	t, err := typedNewTaskTool(ctx, taskToolDescriptionGenerator, subAgents, withoutGeneralSubAgent, cm, instruction, toolsConfig, maxIteration, middlewares, handlers, modelFailoverConfig)
+	t, err := typedNewTaskTool(ctx, taskToolDescriptionGenerator, subAgents, withoutGeneralSubAgent, cm, instruction, toolsConfig, maxIteration, middlewares, handlers, modelFailoverConfig, taskToolTimeout)
 	if err != nil {
 		return nil, err
 	}
@@ -71,6 +73,7 @@ func typedNewTaskTool[M adk.MessageType](
 	middlewares []adk.AgentMiddleware,
 	handlers []adk.TypedChatModelAgentMiddleware[M],
 	modelFailoverConfig *adk.ModelFailoverConfig[M],
+	taskToolTimeout time.Duration,
 ) (tool.InvokableTool, error) {
 	t := &typedTaskTool[M]{
 		subAgents:     map[string]tool.InvokableTool{},
@@ -103,7 +106,7 @@ func typedNewTaskTool[M adk.MessageType](
 			return nil, err
 		}
 
-		it, err := assertAgentTool(adk.NewTypedAgentTool(ctx, adk.TypedAgent[M](generalAgent)))
+		it, err := assertAgentTool(adk.NewTypedAgentTool(ctx, adk.TypedAgent[M](generalAgent), adk.WithAgentToolTimeout(taskToolTimeout)))
 		if err != nil {
 			return nil, err
 		}
@@ -113,7 +116,7 @@ func typedNewTaskTool[M adk.MessageType](
 
 	for _, a := range subAgents {
 		name := a.Name(ctx)
-		it, err := assertAgentTool(adk.NewTypedAgentTool(ctx, a))
+		it, err := assertAgentTool(adk.NewTypedAgentTool(ctx, a, adk.WithAgentToolTimeout(taskToolTimeout)))
 		if err != nil {
 			return nil, err
 		}

--- a/adk/prebuilt/deep/task_tool_test.go
+++ b/adk/prebuilt/deep/task_tool_test.go
@@ -18,7 +18,9 @@ package deep
 
 import (
 	"context"
+	"errors"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 
@@ -42,6 +44,7 @@ func TestTaskTool(t *testing.T) {
 		nil,
 		nil,
 		nil,
+		0,
 	)
 	assert.NoError(t, err)
 
@@ -57,9 +60,54 @@ func TestTaskTool(t *testing.T) {
 	assert.Equal(t, "desc of my agent 2", result)
 }
 
+func TestTaskToolTimeout(t *testing.T) {
+	ctx := context.Background()
+	agent := &blockingAgent{name: "blocking", desc: "blocking agent", canceled: make(chan struct{})}
+	taskTool, err := typedNewTaskTool(
+		ctx,
+		nil,
+		[]adk.Agent{agent},
+		true,
+		nil,
+		"",
+		adk.ToolsConfig{},
+		10,
+		nil,
+		nil,
+		nil,
+		20*time.Millisecond,
+	)
+	assert.NoError(t, err)
+
+	result, err := taskTool.InvokableRun(ctx, `{"subagent_type":"blocking","description":"wait"}`)
+	assert.Empty(t, result)
+	assert.True(t, errors.Is(err, context.DeadlineExceeded), "expected deadline exceeded, got %v", err)
+
+	select {
+	case <-agent.canceled:
+	case <-time.After(time.Second):
+		t.Fatal("sub-agent did not receive timeout cancellation")
+	}
+}
+
 type myAgent struct {
 	name string
 	desc string
+}
+
+type blockingAgent struct {
+	name     string
+	desc     string
+	canceled chan struct{}
+}
+
+func (a *blockingAgent) Name(context.Context) string        { return a.name }
+func (a *blockingAgent) Description(context.Context) string { return a.desc }
+func (a *blockingAgent) Run(ctx context.Context, _ *adk.AgentInput, _ ...adk.AgentRunOption) *adk.AsyncIterator[*adk.AgentEvent] {
+	it, gen := adk.NewAsyncIteratorPair[*adk.AgentEvent]()
+	gen.Send(adk.EventFromMessage(schema.AssistantMessage("done", nil), nil, schema.Assistant, ""))
+	go func() { <-ctx.Done(); close(a.canceled) }()
+	return it
 }
 
 func (m *myAgent) Name(_ context.Context) string {

--- a/adk/utils.go
+++ b/adk/utils.go
@@ -36,6 +36,13 @@ func (ai *AsyncIterator[T]) Next() (T, bool) {
 	return ai.ch.Receive()
 }
 
+// NextWithContext is like Next but returns when ctx is done. When the context
+// is canceled, it returns the zero value and false; callers can inspect
+// ctx.Err() to distinguish cancellation from a closed iterator.
+func (ai *AsyncIterator[T]) NextWithContext(ctx context.Context) (T, bool) {
+	return ai.ch.ReceiveWithContext(ctx)
+}
+
 type AsyncGenerator[T any] struct {
 	ch *internal.UnboundedChan[T]
 }

--- a/internal/channel.go
+++ b/internal/channel.go
@@ -16,21 +16,32 @@
 
 package internal
 
-import "sync"
+import (
+	"context"
+	"sync"
+)
 
 // UnboundedChan represents a channel with unlimited capacity
 type UnboundedChan[T any] struct {
-	buffer   []T        // Internal buffer to store data
-	mutex    sync.Mutex // Mutex to protect buffer access
-	notEmpty *sync.Cond // Condition variable to wait for data
-	closed   bool       // Indicates if the channel has been closed
+	buffer   []T           // Internal buffer to store data
+	mutex    sync.Mutex    // Mutex to protect buffer access
+	notEmpty *sync.Cond    // Condition variable to wait for data
+	notify   chan struct{} // Notification channel for context-aware receives
+	closed   bool          // Indicates if the channel has been closed
 }
 
 // NewUnboundedChan initializes and returns an UnboundedChan
 func NewUnboundedChan[T any]() *UnboundedChan[T] {
-	ch := &UnboundedChan[T]{}
+	ch := &UnboundedChan[T]{notify: make(chan struct{}, 1)}
 	ch.notEmpty = sync.NewCond(&ch.mutex)
 	return ch
+}
+
+func (ch *UnboundedChan[T]) signal() {
+	select {
+	case ch.notify <- struct{}{}:
+	default:
+	}
 }
 
 // Send puts an item into the channel
@@ -44,6 +55,7 @@ func (ch *UnboundedChan[T]) Send(value T) {
 
 	ch.buffer = append(ch.buffer, value)
 	ch.notEmpty.Signal() // Wake up one goroutine waiting to receive
+	ch.signal()
 }
 
 // TrySend attempts to put an item into the channel.
@@ -58,6 +70,7 @@ func (ch *UnboundedChan[T]) TrySend(value T) bool {
 
 	ch.buffer = append(ch.buffer, value)
 	ch.notEmpty.Signal()
+	ch.signal()
 	return true
 }
 
@@ -82,6 +95,42 @@ func (ch *UnboundedChan[T]) Receive() (T, bool) {
 	return val, true
 }
 
+// ReceiveWithContext gets an item from the channel or returns when ctx is done.
+// It has the same closed-channel semantics as Receive.
+func (ch *UnboundedChan[T]) ReceiveWithContext(ctx context.Context) (T, bool) {
+	if ctx == nil {
+		return ch.Receive()
+	}
+
+	for {
+		ch.mutex.Lock()
+		if ctx.Err() != nil {
+			var zero T
+			ch.mutex.Unlock()
+			return zero, false
+		}
+		if len(ch.buffer) > 0 {
+			val := ch.buffer[0]
+			ch.buffer = ch.buffer[1:]
+			ch.mutex.Unlock()
+			return val, true
+		}
+		if ch.closed {
+			var zero T
+			ch.mutex.Unlock()
+			return zero, false
+		}
+		ch.mutex.Unlock()
+
+		select {
+		case <-ch.notify:
+		case <-ctx.Done():
+			var zero T
+			return zero, false
+		}
+	}
+}
+
 // Close marks the channel as closed
 func (ch *UnboundedChan[T]) Close() {
 	ch.mutex.Lock()
@@ -90,5 +139,6 @@ func (ch *UnboundedChan[T]) Close() {
 	if !ch.closed {
 		ch.closed = true
 		ch.notEmpty.Broadcast()
+		ch.signal()
 	}
 }


### PR DESCRIPTION
Fixes #1137

## Summary
- Make nested AgentTool event iteration context-aware so caller cancellation and deadlines cannot block forever in AsyncIterator.Next.
- Add optional WithAgentToolTimeout and DeepAgent TaskToolTimeout settings for bounded task execution, including resumed runs.
- Close pending message streams on cancellation and error paths.

The normal model-stream contract is unchanged: providers must close their streams and produce io.EOF for normal completion. With a configured caller or task timeout, the wait now terminates and returns a wrapped context error instead of hanging indefinitely.

## Tests
- go test ./internal ./adk ./adk/prebuilt/deep
- go test -race ./internal ./adk ./adk/prebuilt/deep -run Test(UnboundedChan|AsyncIterator|AgentTool|TaskTool)
- go vet ./internal ./adk ./adk/prebuilt/deep
- go test ./... (the only failure is the existing CRLF/LF fixture mismatch in components/document/parser/parser_test.go)