### PR TITLE
fix(adk): reject nil events from custom agents

### DIFF
--- a/adk/agent_tool_test.go
+++ b/adk/agent_tool_test.go
@@ -1153,6 +1153,16 @@ func (n *noOutputAgent) Run(context.Context, *AgentInput, ...AgentRunOption) *As
 	return it
 }
 
+type nilEventAgent struct{}
+
+func (n *nilEventAgent) Name(context.Context) string        { return "nil-event" }
+func (n *nilEventAgent) Description(context.Context) string { return "nil-event" }
+func (n *nilEventAgent) Run(context.Context, *AgentInput, ...AgentRunOption) *AsyncIterator[*AgentEvent] {
+	it, gen := NewAsyncIteratorPair[*AgentEvent]()
+	go func() { gen.Send(nil); gen.Close() }()
+	return it
+}
+
 func TestInvokableAgentTool_ErrorCases(t *testing.T) {
 	ctx := context.Background()
 
@@ -1165,6 +1175,11 @@ func TestInvokableAgentTool_ErrorCases(t *testing.T) {
 	out2, err := atNo.(tool.InvokableTool).InvokableRun(ctx, `{"request":"x"}`)
 	assert.NoError(t, err)
 	assert.Equal(t, "", out2)
+
+	atNil := NewAgentTool(ctx, &nilEventAgent{})
+	out3, err := atNil.(tool.InvokableTool).InvokableRun(ctx, `{"request":"x"}`)
+	assert.Equal(t, "", out3)
+	assert.EqualError(t, err, "agent 'nil-event' returned nil event")
 }
 
 func TestCrossTypeAgentToolGracefulError(t *testing.T) {

--- a/adk/agentic_test.go
+++ b/adk/agentic_test.go
@@ -302,6 +302,35 @@ func TestAgenticRunnerQuery(t *testing.T) {
 	assert.False(t, ok)
 }
 
+type nilEventAgenticAgent struct{}
+
+func (a *nilEventAgenticAgent) Name(context.Context) string        { return "nil-event-agentic" }
+func (a *nilEventAgenticAgent) Description(context.Context) string { return "nil-event-agentic" }
+func (a *nilEventAgenticAgent) Run(context.Context, *TypedAgentInput[*schema.AgenticMessage], ...AgentRunOption) *AsyncIterator[*TypedAgentEvent[*schema.AgenticMessage]] {
+	iter, gen := NewAsyncIteratorPair[*TypedAgentEvent[*schema.AgenticMessage]]()
+	go func() {
+		defer gen.Close()
+		gen.Send(nil)
+	}()
+	return iter
+}
+
+func TestAgenticRunnerNilEvent(t *testing.T) {
+	ctx := context.Background()
+	runner := NewTypedRunner(TypedRunnerConfig[*schema.AgenticMessage]{
+		Agent: &nilEventAgenticAgent{},
+	})
+
+	iter := runner.Query(ctx, "query")
+	event, ok := iter.Next()
+	require.True(t, ok)
+	require.NotNil(t, event)
+	assert.EqualError(t, event.Err, "agent 'nil-event-agentic' returned nil event")
+
+	_, ok = iter.Next()
+	assert.False(t, ok)
+}
+
 func agenticAssistantMessage(text string) *schema.AgenticMessage {
 	return &schema.AgenticMessage{
 		Role: schema.AgenticRoleTypeAssistant,

--- a/adk/flow.go
+++ b/adk/flow.go
@@ -508,6 +508,10 @@ func (a *flowAgent) run(
 		if !ok {
 			break
 		}
+		if event == nil {
+			generator.Send(&AgentEvent{Err: fmt.Errorf("agent '%s' returned nil event", a.Name(ctx))})
+			return
+		}
 
 		// RunPath ownership: the eino framework sets RunPath exactly once.
 		// If event.RunPath is already set (e.g., by agentTool), we don't modify it.
@@ -752,6 +756,10 @@ func (a *typedFlowAgent[M]) run(
 		event, ok := aIter.Next()
 		if !ok {
 			break
+		}
+		if event == nil {
+			generator.Send(&TypedAgentEvent[M]{Err: fmt.Errorf("agent '%s' returned nil event", a.Name(ctx))})
+			return
 		}
 
 		if len(event.RunPath) == 0 {


### PR DESCRIPTION
#### What type of PR is this?

fix

#### Check the PR title.

- [x] This PR title matches the format: <type>(optional scope): <description>
- [x] The description is user-oriented and clear.
- [x] No user documentation update is required; this only replaces a recovered panic with a descriptive error for invalid custom-agent output.

#### (Optional) Translate the PR title into Chinese.

fix(adk): 拒绝自定义 Agent 返回的 nil 事件

#### (Optional) More detailed description for this PR(en: English/zh: Chinese).

en:

A custom Agent can currently send a nil event through its AsyncIterator. Both flowAgent.run and typedFlowAgent.run dereference that event while assigning RunPath, which triggers a nil-pointer panic. Although the outer recovery keeps the process alive, callers receive a generic panic error and stack trace instead of an actionable contract error.

This change validates events at the shared flow boundary for both Message and AgenticMessage paths. A nil event now terminates that run with a descriptive error containing the agent name. It also adds regression coverage for a nil event consumed directly through TypedRunner and through an AgentTool.

Validation:

- `go test ./adk/...`
- focused tests under `go test -race`
- `git diff --check`

zh:

自定义 Agent 通过 AsyncIterator 返回 nil event 时，统一 flow 管线此前会在设置 RunPath 时发生空指针 panic。该修改在 Message 和 AgenticMessage 的公共边界进行校验，将 panic 转换为包含 Agent 名称的明确错误，并补充 Runner 与 AgentTool 回归测试。

#### (Optional) Which issue(s) this PR fixes:

Fixes #1244

#### (optional) The PR that updates user documentation:

Not required.