### PR TITLE
fix(adk): return errors for invalid resume state

### DIFF
--- a/adk/chatmodel.go
+++ b/adk/chatmodel.go
@@ -1561,6 +1561,19 @@ func (a *TypedChatModelAgent[M]) Resume(ctx context.Context, info *ResumeInfo, o
 		}()
 		return iterator
 	}
+	resumeError := func(err error) *AsyncIterator[*TypedAgentEvent[M]] {
+		go func() {
+			if abortOnlyCancel != nil {
+				defer abortOnlyCancel()
+			}
+			if cancelCtxOwned && cancelCtx != nil {
+				defer cancelCtx.markDone()
+			}
+			generator.Send(&TypedAgentEvent[M]{Err: err})
+			generator.Close()
+		}()
+		return iterator
+	}
 
 	co := getComposeOptions(opts)
 	co = append(co, compose.WithCheckPointID(bridgeCheckpointID))
@@ -1579,16 +1592,16 @@ func (a *TypedChatModelAgent[M]) Resume(ctx context.Context, info *ResumeInfo, o
 	}
 
 	if info == nil {
-		panic(fmt.Sprintf("ChatModelAgent.Resume: agent '%s' was asked to resume but info is nil", a.Name(ctx)))
+		return resumeError(fmt.Errorf("ChatModelAgent.Resume: agent '%s' was asked to resume but info is nil", a.Name(ctx)))
 	}
 
 	if info.InterruptState == nil {
-		panic(fmt.Sprintf("ChatModelAgent.Resume: agent '%s' was asked to resume but has no state", a.Name(ctx)))
+		return resumeError(fmt.Errorf("ChatModelAgent.Resume: agent '%s' was asked to resume but has no state", a.Name(ctx)))
 	}
 
 	stateByte, ok := info.InterruptState.([]byte)
 	if !ok {
-		panic(fmt.Sprintf("ChatModelAgent.Resume: agent '%s' was asked to resume but has invalid interrupt state type: %T",
+		return resumeError(fmt.Errorf("ChatModelAgent.Resume: agent '%s' was asked to resume but has invalid interrupt state type: %T",
 			a.Name(ctx), info.InterruptState))
 	}
 
@@ -1611,7 +1624,7 @@ func (a *TypedChatModelAgent[M]) Resume(ctx context.Context, info *ResumeInfo, o
 	if info.ResumeData != nil {
 		resumeData, ok := info.ResumeData.(*ChatModelAgentResumeData)
 		if !ok {
-			panic(fmt.Sprintf("ChatModelAgent.Resume: agent '%s' was asked to resume but has invalid resume data type: %T",
+			return resumeError(fmt.Errorf("ChatModelAgent.Resume: agent '%s' was asked to resume but has invalid resume data type: %T",
 				a.Name(ctx), info.ResumeData))
 		}
 		historyModifier = resumeData.HistoryModifier

--- a/adk/chatmodel_test.go
+++ b/adk/chatmodel_test.go
@@ -2019,6 +2019,59 @@ func TestChatModelAgent_PrepareExecContextError(t *testing.T) {
 	})
 }
 
+func TestChatModelAgent_ResumeInvalidInputReturnsError(t *testing.T) {
+	ctx := context.Background()
+
+	ctrl := gomock.NewController(t)
+	cm := mockModel.NewMockToolCallingChatModel(ctrl)
+	agent, err := NewChatModelAgent(ctx, &ChatModelAgentConfig{
+		Name:        "TestAgent",
+		Description: "Test agent",
+		Model:       cm,
+	})
+	require.NoError(t, err)
+
+	tests := []struct {
+		name string
+		info *ResumeInfo
+		want string
+	}{
+		{
+			name: "nil resume info",
+			info: nil,
+			want: "info is nil",
+		},
+		{
+			name: "missing interrupt state",
+			info: &ResumeInfo{},
+			want: "has no state",
+		},
+		{
+			name: "invalid interrupt state type",
+			info: &ResumeInfo{InterruptState: "invalid"},
+			want: "invalid interrupt state type",
+		},
+		{
+			name: "invalid resume data type",
+			info: &ResumeInfo{InterruptState: []byte("dummy"), ResumeData: "invalid"},
+			want: "invalid resume data type",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			iter := agent.Resume(ctx, tt.info)
+			event, ok := iter.Next()
+			require.True(t, ok)
+			require.NotNil(t, event)
+			require.Error(t, event.Err)
+			assert.Contains(t, event.Err.Error(), tt.want)
+			_, ok = iter.Next()
+			assert.False(t, ok)
+		})
+	}
+}
+
 // fakeEnhancedInvokableToolForTest implements tool.EnhancedInvokableTool for testing.
 type fakeEnhancedInvokableToolForTest struct{}
 


### PR DESCRIPTION
#### What type of PR is this?
<!-- fix -->

#### Check the PR title.
- [x] This PR title matches the format: `fix(adk): description`
- [x] The description is user-oriented and explains why the change is needed.
- [ ] User documentation update is not required for this internal error-handling fix.

#### More detailed description

en:
`ChatModelAgent.Resume` previously panicked synchronously when checkpoint input was missing or had an unexpected shape. That can take down callers recovering long-running agent workflows from external stores.

The four validation branches now emit an error event through the returned iterator and close it, matching the existing asynchronous error path used for checkpoint preprocessing. Normal resume behavior is unchanged.

The regression test covers nil resume info, missing interrupt state, an invalid interrupt-state type, and invalid resume-data type.

Validation:
- `go test ./adk -run '^TestChatModelAgent_ResumeInvalidInputReturnsError$' -count=1`
- `go test ./adk -count=1`
- `go vet ./adk/...`
- `gofmt` and `git diff --check`
- `golangci-lint` was not available in the local environment.

zh(optional):
恢复外部 checkpoint 时，非法状态不再同步 panic，而是通过 iterator 返回错误事件并结束迭代器；正常恢复路径保持不变。

#### Which issue(s) this PR fixes:
Fixes #1246
