### PR TITLE
feat(compose): node-boundary checkpoint without interrupt and chunked checkpoint storage

### DIFF
--- a/compose/checkpoint.go
+++ b/compose/checkpoint.go
@@ -17,7 +17,9 @@
 package compose
 
 import (
+	"bytes"
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"reflect"
@@ -51,6 +53,10 @@ func RegisterSerializableType[T any](name string) (err error) {
 }
 
 type CheckPointStore = core.CheckPointStore
+
+// CheckPointDeleter is an optional interface that CheckPointStore
+// implementations can implement to support explicit checkpoint deletion.
+type CheckPointDeleter = core.CheckPointDeleter
 
 type Serializer interface {
 	Marshal(v any) ([]byte, error)
@@ -102,6 +108,59 @@ type StateModifier func(ctx context.Context, path NodePath, state any) error
 func WithStateModifier(sm StateModifier) Option {
 	return Option{
 		stateModifier: sm,
+	}
+}
+
+// WithComponentCheckpoint enables saving a checkpoint at each node boundary
+// without interrupting the run.
+//
+// By default, a checkpoint is only persisted when an interrupt occurs. Enabling
+// this option additionally persists progress after every batch of nodes
+// completes and the next tasks have been determined — while the run keeps
+// going (no interrupt is raised, no resume is needed to continue).
+//
+// This is useful for crash resilience: if the process dies mid-run, the last
+// node-boundary checkpoint can be used to resume from that point instead of
+// restarting from the beginning.
+//
+// Notes:
+//   - Requires a checkpoint store (WithCheckPointStore) and a checkpoint ID
+//     (WithCheckPointID / WithWriteToCheckPointID) to take effect.
+//   - Currently only supported in non-streaming (Invoke/Transform) runs,
+//     because persisting streaming channel values would consume the in-flight
+//     streams that the remaining graph execution still needs. Streaming runs
+//     silently skip node-boundary checkpoints (interrupts still checkpoint).
+//   - Interrupts still take precedence: when a node boundary coincides with an
+//     interrupt, the interrupt path handles the checkpoint.
+func WithComponentCheckpoint() GraphCompileOption {
+	return func(o *graphCompileOptions) {
+		o.componentCheckpoint = true
+	}
+}
+
+// WithCheckpointChunkSize sets the maximum size (in bytes) of a single value
+// written to the checkpoint store.
+//
+// Some KV stores impose an upper bound on a value's size (e.g. etcd's default
+// ~1.5MB limit). When a serialized checkpoint exceeds this size and chunking is
+// enabled, the checkpoint is split into multiple keys so that each stored value
+// stays within the limit.
+//
+// Layout when chunking kicks in:
+//
+//	<id>      → a small header describing the chunk count and total size
+//	<id>#0    → first chunk
+//	<id>#1    → second chunk
+//	...
+//
+// Reading is transparent and backward compatible: checkpoints written as a
+// single value (or by older versions) are still read correctly — the header is
+// detected by a magic prefix.
+//
+// A size <= 0 (the default) disables chunking.
+func WithCheckpointChunkSize(size int) GraphCompileOption {
+	return func(o *graphCompileOptions) {
+		o.checkpointChunkSize = size
 	}
 }
 
@@ -211,12 +270,40 @@ type checkPointer struct {
 	sc         *streamConverter
 	store      CheckPointStore
 	serializer Serializer
+
+	// chunkSize is the max size of a single value written to the store.
+	// <= 0 disables chunking (a checkpoint is stored as one value).
+	chunkSize int
+}
+
+// chunkedMagic prefixes the chunk-header value stored under the checkpoint id.
+// Checkpoint payloads produced by the serializer never start with this, so a
+// plain (non-chunked) checkpoint is still readable.
+const chunkedMagic = "_eino_chunked_cp_v1_"
+
+// chunkHeader describes a chunked checkpoint stored across multiple keys.
+type chunkHeader struct {
+	Chunks int `json:"chunks"`
+	Size   int `json:"size"`
+}
+
+func chunkKey(id string, idx int) string {
+	return fmt.Sprintf("%s#%d", id, idx)
 }
 
 func (c *checkPointer) get(ctx context.Context, id string) (*checkpoint, bool, error) {
 	data, existed, err := c.store.Get(ctx, id)
 	if err != nil || existed == false {
 		return nil, existed, err
+	}
+
+	// A chunked checkpoint stores a header under the id and the payload across
+	// <id>#N keys. Reassemble before unmarshalling.
+	if bytes.HasPrefix(data, []byte(chunkedMagic)) {
+		data, err = c.getChunked(ctx, id, data[len(chunkedMagic):])
+		if err != nil {
+			return nil, false, err
+		}
 	}
 
 	cp := &checkpoint{}
@@ -228,6 +315,40 @@ func (c *checkPointer) get(ctx context.Context, id string) (*checkpoint, bool, e
 	return cp, true, nil
 }
 
+// getChunked reads and concatenates all chunks described by the header bytes.
+func (c *checkPointer) getChunked(ctx context.Context, id string, headerBytes []byte) ([]byte, error) {
+	var h chunkHeader
+	if err := json.Unmarshal(headerBytes, &h); err != nil {
+		return nil, fmt.Errorf("failed to decode chunked checkpoint header: %w, checkPointID: %s", err, id)
+	}
+	if h.Chunks <= 0 {
+		return nil, fmt.Errorf("invalid chunked checkpoint header: chunks=%d, checkPointID: %s", h.Chunks, id)
+	}
+	if h.Size < 0 {
+		return nil, fmt.Errorf("invalid chunked checkpoint header: size=%d, checkPointID: %s", h.Size, id)
+	}
+
+	data := make([]byte, 0, h.Size)
+	for i := 0; i < h.Chunks; i++ {
+		chunk, existed, err := c.store.Get(ctx, chunkKey(id, i))
+		if err != nil {
+			return nil, fmt.Errorf("failed to get checkpoint chunk %d/%d: %w, checkPointID: %s",
+				i, h.Chunks, err, id)
+		}
+		if !existed {
+			return nil, fmt.Errorf("checkpoint chunk %d/%d missing: %s", i, h.Chunks, chunkKey(id, i))
+		}
+		data = append(data, chunk...)
+	}
+
+	if len(data) != h.Size {
+		return nil, fmt.Errorf("checkpoint chunk size mismatch: got %d, want %d, checkPointID: %s",
+			len(data), h.Size, id)
+	}
+
+	return data, nil
+}
+
 func (c *checkPointer) set(ctx context.Context, id string, cp *checkpoint) error {
 	normalizeCheckpointTypedNilInputs(cp)
 
@@ -236,7 +357,68 @@ func (c *checkPointer) set(ctx context.Context, id string, cp *checkpoint) error
 		return err
 	}
 
-	return c.store.Set(ctx, id, data)
+	if c.chunkSize <= 0 || len(data) <= c.chunkSize {
+		return c.store.Set(ctx, id, data)
+	}
+
+	return c.setChunked(ctx, id, data)
+}
+
+// setChunked splits data into <= chunkSize pieces and stores them under
+// <id>#N keys, with a header under <id>.
+func (c *checkPointer) setChunked(ctx context.Context, id string, data []byte) error {
+	chunks := (len(data) + c.chunkSize - 1) / c.chunkSize
+
+	for i := 0; i < chunks; i++ {
+		start := i * c.chunkSize
+		end := start + c.chunkSize
+		if end > len(data) {
+			end = len(data)
+		}
+		if err := c.store.Set(ctx, chunkKey(id, i), data[start:end]); err != nil {
+			return fmt.Errorf("failed to set checkpoint chunk %d/%d: %w, checkPointID: %s",
+				i, chunks, err, id)
+		}
+	}
+
+	h := chunkHeader{Chunks: chunks, Size: len(data)}
+	hb, err := json.Marshal(&h)
+	if err != nil {
+		return fmt.Errorf("failed to encode chunked checkpoint header: %w, checkPointID: %s", err, id)
+	}
+
+	// Overwrites any previous single-value or header payload under this id.
+	return c.store.Set(ctx, id, append([]byte(chunkedMagic), hb...))
+}
+
+// delete removes a checkpoint, including its chunks when chunking was used.
+// Best-effort: if the store does not implement CheckPointDeleter, only the
+// main key is left (chunks are cleaned when the store is a deleter).
+func (c *checkPointer) delete(ctx context.Context, id string) error {
+	d, ok := c.store.(CheckPointDeleter)
+	if !ok {
+		return nil
+	}
+
+	chunks := 0
+	if data, existed, err := c.store.Get(ctx, id); err == nil && existed &&
+		bytes.HasPrefix(data, []byte(chunkedMagic)) {
+		var h chunkHeader
+		if err := json.Unmarshal(data[len(chunkedMagic):], &h); err == nil {
+			chunks = h.Chunks
+		}
+	}
+
+	if err := d.Delete(ctx, id); err != nil {
+		return err
+	}
+	for i := 0; i < chunks; i++ {
+		if err := d.Delete(ctx, chunkKey(id, i)); err != nil {
+			return err
+		}
+	}
+
+	return nil
 }
 
 func normalizeCheckpointTypedNilInputs(cp *checkpoint) {

--- a/compose/checkpoint.go
+++ b/compose/checkpoint.go
@@ -119,6 +119,10 @@ func WithStateModifier(sm StateModifier) Option {
 // completes and the next tasks have been determined — while the run keeps
 // going (no interrupt is raised, no resume is needed to continue).
 //
+// A node-boundary snapshot is only persisted while the workflow still has
+// nodes pending to run; boundaries with no remaining tasks do not produce a
+// snapshot.
+//
 // This is useful for crash resilience: if the process dies mid-run, the last
 // node-boundary checkpoint can be used to resume from that point instead of
 // restarting from the beginning.

--- a/compose/component_checkpoint_test.go
+++ b/compose/component_checkpoint_test.go
@@ -203,6 +203,31 @@ func buildComponentCheckpointGraph() *Graph[string, string] {
 	return g
 }
 
+func TestComponentCheckpointSkipsSaveWhenNoPendingNodes(t *testing.T) {
+	store := newChunkTestStore()
+	ctx := context.Background()
+
+	r := &runner{
+		options:      graphCompileOptions{componentCheckpoint: true},
+		checkPointer: newCheckPointer(nil, nil, store, nil),
+	}
+
+	// no pending nodes: nothing to run at this boundary, must not persist
+	cpID := "run1"
+	err := r.saveComponentCheckpoint(ctx, nil, map[string]channel{}, false, false, &cpID)
+	require.NoError(t, err)
+	_, existed := store.m["run1"]
+	assert.False(t, existed, "no snapshot should be persisted without pending nodes")
+
+	// sanity check: with a pending node the snapshot is persisted
+	err = r.saveComponentCheckpoint(ctx, []*task{{nodeKey: "b", input: "in"}}, map[string]channel{}, false, false, &cpID)
+	require.NoError(t, err)
+	cp, existed, err := newCheckPointer(nil, nil, store, nil).get(ctx, "run1")
+	require.NoError(t, err)
+	require.True(t, existed)
+	assert.Equal(t, map[string]any{"b": "in"}, cp.Inputs)
+}
+
 func TestComponentCheckpointRunCompletes(t *testing.T) {
 	store := newChunkTestStore()
 	ctx := context.Background()

--- a/compose/component_checkpoint_test.go
+++ b/compose/component_checkpoint_test.go
@@ -1,0 +1,335 @@
+/*
+ * Copyright 2025 CloudWeGo Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package compose
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"io"
+	"strings"
+	"testing"
+
+	"github.com/cloudwego/eino/internal/serialization"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type chunkTestStore struct {
+	m map[string][]byte
+}
+
+func (s *chunkTestStore) Get(_ context.Context, checkPointID string) ([]byte, bool, error) {
+	v, ok := s.m[checkPointID]
+	return v, ok, nil
+}
+
+func (s *chunkTestStore) Set(_ context.Context, checkPointID string, checkPoint []byte) error {
+	s.m[checkPointID] = checkPoint
+	return nil
+}
+
+func (s *chunkTestStore) Delete(_ context.Context, checkPointID string) error {
+	delete(s.m, checkPointID)
+	return nil
+}
+
+func newChunkTestStore() *chunkTestStore {
+	return &chunkTestStore{m: make(map[string][]byte)}
+}
+
+func newChunkTestCheckpoint(inputs map[string]any) *checkpoint {
+	return &checkpoint{
+		Channels:       map[string]channel{},
+		Inputs:         inputs,
+		SkipPreHandler: map[string]bool{},
+	}
+}
+
+func TestCheckPointChunkingRoundTrip(t *testing.T) {
+	store := newChunkTestStore()
+	cpr := newCheckPointer(nil, nil, store, nil)
+	cpr.chunkSize = 16
+
+	payload := strings.Repeat("x", 100)
+	cp := newChunkTestCheckpoint(map[string]any{"node": payload})
+	serialized, err := cpr.serializer.Marshal(cp)
+	require.NoError(t, err)
+	require.NoError(t, cpr.set(context.Background(), "cp", cp))
+
+	// header under the main key with the magic prefix
+	header, ok := store.m["cp"]
+	require.True(t, ok)
+	require.True(t, bytes.HasPrefix(header, []byte(chunkedMagic)))
+
+	var h chunkHeader
+	require.NoError(t, json.Unmarshal(header[len(chunkedMagic):], &h))
+	assert.Equal(t, len(serialized), h.Size, "header size should match serialized checkpoint size")
+	assert.Equal(t, (len(serialized)+15)/16, h.Chunks)
+
+	// each chunk key exists and respects the size limit
+	for i := 0; i < h.Chunks; i++ {
+		chunk, ok := store.m[chunkKey("cp", i)]
+		require.True(t, ok, "chunk %d missing", i)
+		assert.LessOrEqual(t, len(chunk), 16)
+	}
+
+	// no extra chunk keys
+	_, ok = store.m[chunkKey("cp", h.Chunks)]
+	assert.False(t, ok)
+
+	// round trip
+	got, existed, err := cpr.get(context.Background(), "cp")
+	require.NoError(t, err)
+	require.True(t, existed)
+	assert.Equal(t, payload, got.Inputs["node"])
+}
+
+func TestCheckPointChunkingSmallPayloadStaysSingleValue(t *testing.T) {
+	store := newChunkTestStore()
+	cpr := newCheckPointer(nil, nil, store, nil)
+	cpr.chunkSize = 1024
+
+	cp := newChunkTestCheckpoint(map[string]any{"node": "small"})
+	require.NoError(t, cpr.set(context.Background(), "cp", cp))
+
+	// single value, no header, no chunk keys
+	data := store.m["cp"]
+	require.NotNil(t, data)
+	assert.False(t, bytes.HasPrefix(data, []byte(chunkedMagic)))
+	_, ok := store.m[chunkKey("cp", 0)]
+	assert.False(t, ok)
+
+	got, existed, err := cpr.get(context.Background(), "cp")
+	require.NoError(t, err)
+	require.True(t, existed)
+	assert.Equal(t, "small", got.Inputs["node"])
+}
+
+func TestCheckPointChunkingZeroSizeDisablesChunking(t *testing.T) {
+	store := newChunkTestStore()
+	cpr := newCheckPointer(nil, nil, store, nil)
+
+	payload := strings.Repeat("x", 4096)
+	cp := newChunkTestCheckpoint(map[string]any{"node": payload})
+	require.NoError(t, cpr.set(context.Background(), "cp", cp))
+
+	assert.False(t, bytes.HasPrefix(store.m["cp"], []byte(chunkedMagic)))
+
+	got, existed, err := cpr.get(context.Background(), "cp")
+	require.NoError(t, err)
+	require.True(t, existed)
+	assert.Equal(t, payload, got.Inputs["node"])
+}
+
+func TestCheckPointChunkingBackwardCompatibleRead(t *testing.T) {
+	store := newChunkTestStore()
+	cpr := newCheckPointer(nil, nil, store, nil)
+
+	// a checkpoint written by an older version as a single value is still readable
+	cp := newChunkTestCheckpoint(map[string]any{"node": "legacy"})
+	legacyData, err := cpr.serializer.Marshal(cp)
+	require.NoError(t, err)
+	store.m["cp"] = legacyData
+
+	got, existed, err := cpr.get(context.Background(), "cp")
+	require.NoError(t, err)
+	require.True(t, existed)
+	assert.Equal(t, "legacy", got.Inputs["node"])
+}
+
+func TestCheckPointChunkingRechunkOverwritesPreviousLayout(t *testing.T) {
+	store := newChunkTestStore()
+	cpr := newCheckPointer(nil, nil, store, nil)
+	cpr.chunkSize = 16
+
+	ctx := context.Background()
+
+	// first write: chunked
+	big := newChunkTestCheckpoint(map[string]any{"node": strings.Repeat("a", 100)})
+	require.NoError(t, cpr.set(ctx, "cp", big))
+	_, ok := store.m[chunkKey("cp", 3)]
+	require.True(t, ok)
+
+	// second write with chunking disabled: single value overwrites the chunked layout
+	cpr.chunkSize = 0
+	small := newChunkTestCheckpoint(map[string]any{"node": "tiny"})
+	require.NoError(t, cpr.set(ctx, "cp", small))
+	assert.False(t, bytes.HasPrefix(store.m["cp"], []byte(chunkedMagic)))
+
+	got, existed, err := cpr.get(ctx, "cp")
+	require.NoError(t, err)
+	require.True(t, existed)
+	assert.Equal(t, "tiny", got.Inputs["node"])
+}
+
+func TestCheckPointChunkingDelete(t *testing.T) {
+	store := newChunkTestStore()
+	cpr := newCheckPointer(nil, nil, store, nil)
+	cpr.chunkSize = 16
+
+	cp := newChunkTestCheckpoint(map[string]any{"node": strings.Repeat("a", 100)})
+	require.NoError(t, cpr.set(context.Background(), "cp", cp))
+
+	require.NoError(t, cpr.delete(context.Background(), "cp"))
+	assert.Empty(t, store.m)
+}
+
+func buildComponentCheckpointGraph() *Graph[string, string] {
+	g := NewGraph[string, string]()
+	_ = g.AddLambdaNode("a", InvokableLambda(func(ctx context.Context, in string) (string, error) {
+		return in + "a", nil
+	}))
+	_ = g.AddLambdaNode("b", InvokableLambda(func(ctx context.Context, in string) (string, error) {
+		return in + "b", nil
+	}))
+	_ = g.AddEdge(START, "a")
+	_ = g.AddEdge("a", "b")
+	_ = g.AddEdge("b", END)
+	return g
+}
+
+func TestComponentCheckpointRunCompletes(t *testing.T) {
+	store := newChunkTestStore()
+	ctx := context.Background()
+
+	r, err := buildComponentCheckpointGraph().Compile(ctx,
+		WithCheckPointStore(store), WithComponentCheckpoint())
+	require.NoError(t, err)
+
+	result, err := r.Invoke(ctx, "x", WithCheckPointID("run1"))
+	require.NoError(t, err)
+	assert.Equal(t, "xab", result)
+
+	// a node-boundary checkpoint was persisted without any interrupt
+	cpr := newCheckPointer(nil, nil, store, nil)
+	cp, existed, err := cpr.get(ctx, "run1")
+	require.NoError(t, err)
+	require.True(t, existed)
+	require.NotNil(t, cp)
+	assert.NotEmpty(t, cp.Inputs, "checkpoint should carry next-task inputs")
+	assert.Empty(t, cp.InterruptID2Addr, "no interrupt signals at node boundary")
+}
+
+func TestComponentCheckpointCrashRecovery(t *testing.T) {
+	store := newChunkTestStore()
+	ctx := context.Background()
+	g := buildComponentCheckpointGraph()
+
+	// run 1: completes normally while persisting node-boundary checkpoints
+	r1, err := g.Compile(ctx, WithCheckPointStore(store), WithComponentCheckpoint())
+	require.NoError(t, err)
+	result1, err := r1.Invoke(ctx, "x", WithCheckPointID("run1"))
+	require.NoError(t, err)
+	assert.Equal(t, "xab", result1)
+
+	// run 2: a fresh runner resumes from the last persisted boundary
+	// (simulating a crash followed by recovery)
+	r2, err := g.Compile(ctx, WithCheckPointStore(store), WithComponentCheckpoint())
+	require.NoError(t, err)
+	result2, err := r2.Invoke(ctx, "", WithCheckPointID("run1"))
+	require.NoError(t, err)
+	assert.Equal(t, result1, result2)
+}
+
+func TestComponentCheckpointStreamSkipped(t *testing.T) {
+	store := newChunkTestStore()
+	ctx := context.Background()
+
+	r, err := buildComponentCheckpointGraph().Compile(ctx,
+		WithCheckPointStore(store), WithComponentCheckpoint())
+	require.NoError(t, err)
+
+	out, err := r.Stream(ctx, "x", WithCheckPointID("run1"))
+	require.NoError(t, err)
+	got := ""
+	for {
+		chunk, err_ := out.Recv()
+		if err_ == io.EOF {
+			break
+		}
+		require.NoError(t, err_)
+		got += chunk
+	}
+	assert.Equal(t, "xab", got)
+
+	// streaming runs skip node-boundary checkpoints to avoid consuming streams
+	_, existed := store.m["run1"]
+	assert.False(t, existed)
+}
+
+func TestComponentCheckpointDisabledByDefault(t *testing.T) {
+	store := newChunkTestStore()
+	ctx := context.Background()
+
+	r, err := buildComponentCheckpointGraph().Compile(ctx, WithCheckPointStore(store))
+	require.NoError(t, err)
+
+	result, err := r.Invoke(ctx, "x", WithCheckPointID("run1"))
+	require.NoError(t, err)
+	assert.Equal(t, "xab", result)
+
+	_, existed := store.m["run1"]
+	assert.False(t, existed)
+}
+
+func TestComponentCheckpointWithChunking(t *testing.T) {
+	store := newChunkTestStore()
+	ctx := context.Background()
+
+	type bigState struct {
+		Padding string
+	}
+	require.NoError(t, serialization.GenericRegister[*bigState]("_eino_TestComponentCheckpointWithChunking_state"))
+
+	g := NewGraph[string, string](WithGenLocalState(func(ctx context.Context) *bigState {
+		return &bigState{}
+	}))
+	_ = g.AddLambdaNode("a", InvokableLambda(func(ctx context.Context, in string) (string, error) {
+		return in + "a", nil
+	}), WithStatePreHandler(func(ctx context.Context, in string, st *bigState) (string, error) {
+		st.Padding = strings.Repeat("p", 200)
+		return in, nil
+	}))
+	_ = g.AddLambdaNode("b", InvokableLambda(func(ctx context.Context, in string) (string, error) {
+		return in + "b", nil
+	}), WithStatePreHandler(func(ctx context.Context, in string, st *bigState) (string, error) {
+		return in, nil
+	}))
+	_ = g.AddEdge(START, "a")
+	_ = g.AddEdge("a", "b")
+	_ = g.AddEdge("b", END)
+
+	// chunk size small enough to force chunking of the state-bearing checkpoint
+	r, err := g.Compile(ctx, WithCheckPointStore(store), WithComponentCheckpoint(),
+		WithCheckpointChunkSize(64))
+	require.NoError(t, err)
+
+	result, err := r.Invoke(ctx, "x", WithCheckPointID("run1"))
+	require.NoError(t, err)
+	assert.Equal(t, "xab", result)
+
+	// the checkpoint was chunked and remains readable
+	assert.True(t, bytes.HasPrefix(store.m["run1"], []byte(chunkedMagic)))
+
+	r2, err := g.Compile(ctx, WithCheckPointStore(store), WithComponentCheckpoint(),
+		WithCheckpointChunkSize(64))
+	require.NoError(t, err)
+	result2, err := r2.Invoke(ctx, "", WithCheckPointID("run1"))
+	require.NoError(t, err)
+	assert.Equal(t, result, result2)
+}

--- a/compose/graph.go
+++ b/compose/graph.go
@@ -871,6 +871,7 @@ func (g *graph) compile(ctx context.Context, opt *graphCompileOptions) (*composa
 		inputPairs[END] = r.outputStreamConvertPair
 		outputPairs[START] = r.inputStreamConvertPair
 		r.checkPointer = newCheckPointer(inputPairs, outputPairs, opt.checkPointStore, opt.serializer)
+		r.checkPointer.chunkSize = opt.checkpointChunkSize
 
 		r.interruptBeforeNodes = opt.interruptBeforeNodes
 		r.interruptAfterNodes = opt.interruptAfterNodes

--- a/compose/graph_compile_options.go
+++ b/compose/graph_compile_options.go
@@ -30,6 +30,14 @@ type graphCompileOptions struct {
 	interruptBeforeNodes []string
 	interruptAfterNodes  []string
 
+	// componentCheckpoint enables checkpointing at node boundaries without
+	// interrupting the run. See WithComponentCheckpoint.
+	componentCheckpoint bool
+
+	// checkpointChunkSize is the max size of a single checkpoint value.
+	// <= 0 disables chunking. See WithCheckpointChunkSize.
+	checkpointChunkSize int
+
 	eagerDisabled bool
 
 	mergeConfigs map[string]FanInMergeConfig

--- a/compose/graph_run.go
+++ b/compose/graph_run.go
@@ -377,7 +377,76 @@ func (r *runner) run(ctx context.Context, isStream bool, input any, opts ...Opti
 				subGraphCheckpointPublisher,
 			)
 		}
+
+		// The current batch of nodes completed and the next tasks are determined.
+		// Persist progress without interrupting so a crash can be recovered from
+		// the last node boundary.
+		if err = r.saveComponentCheckpoint(ctx, nextTasks, cm.channels, isStream, isSubGraph, writeToCheckPointID); err != nil {
+			return nil, newGraphRunError(err)
+		}
 	}
+}
+
+// saveComponentCheckpoint persists the current progress at a node boundary
+// without raising an interrupt, so the run continues normally.
+//
+// It is a no-op unless enabled via WithComponentCheckpoint, a checkpoint store
+// and a write-to checkpoint id are configured, and the graph is not running as
+// a subgraph (whose checkpoints are published to the parent instead).
+//
+// Streaming runs are skipped: converting in-flight channel streams into
+// persisted values would consume the very streams the remaining execution
+// still needs.
+func (r *runner) saveComponentCheckpoint(
+	ctx context.Context,
+	nextTasks []*task,
+	channels map[string]channel,
+	isStream bool,
+	isSubGraph bool,
+	checkPointID *string,
+) error {
+	if !r.options.componentCheckpoint {
+		return nil
+	}
+	if isSubGraph || checkPointID == nil || r.checkPointer == nil {
+		return nil
+	}
+	if isStream {
+		// Persisting would consume in-flight streams needed by downstream nodes.
+		return nil
+	}
+
+	cp := &checkpoint{
+		Channels:       channels,
+		Inputs:         make(map[string]any),
+		SkipPreHandler: map[string]bool{},
+	}
+	if r.runCtx != nil {
+		// current graph has enabled state
+		if state, ok := ctx.Value(stateKey{}).(*internalState); ok {
+			state.mu.Lock()
+			copiedState, err := deepCopyState(state.state)
+			state.mu.Unlock()
+			if err != nil {
+				return fmt.Errorf("failed to copy state: %w", err)
+			}
+			cp.State = copiedState
+		}
+	}
+
+	for _, t := range nextTasks {
+		cp.Inputs[t.nodeKey] = t.input
+	}
+
+	if err := r.checkPointer.convertCheckPoint(cp, isStream); err != nil {
+		return fmt.Errorf("failed to convert checkpoint: %w", err)
+	}
+
+	if err := r.checkPointer.set(ctx, *checkPointID, cp); err != nil {
+		return fmt.Errorf("failed to set checkpoint: %w, checkPointID: %s", err, *checkPointID)
+	}
+
+	return nil
 }
 
 func (r *runner) resolveMaxSteps(maxSteps int, opts []Option) (int, error) {

--- a/compose/graph_run.go
+++ b/compose/graph_run.go
@@ -394,6 +394,11 @@ func (r *runner) run(ctx context.Context, isStream bool, input any, opts ...Opti
 // and a write-to checkpoint id are configured, and the graph is not running as
 // a subgraph (whose checkpoints are published to the parent instead).
 //
+// A snapshot is only meaningful while the workflow still has nodes to run: when
+// nextTasks is empty there is nothing left to execute (or the run is about to
+// fail with no pending work), so no snapshot is persisted and any previously
+// stored snapshot stays untouched.
+//
 // Streaming runs are skipped: converting in-flight channel streams into
 // persisted values would consume the very streams the remaining execution
 // still needs.
@@ -408,11 +413,28 @@ func (r *runner) saveComponentCheckpoint(
 	if !r.options.componentCheckpoint {
 		return nil
 	}
-	if isSubGraph || checkPointID == nil || r.checkPointer == nil {
+	if isSubGraph {
+		// A subgraph must not write the store directly: checkpoint IDs are
+		// run-scoped and owned by the root graph, and a subgraph snapshot is
+		// published to the parent (cp.SubGraphs) instead — see
+		// handleInterruptWithSubGraphAndRerunNodes. Writing here would
+		// overwrite the parent's checkpoint with subgraph-local state.
+		// This also keeps the same recovery behavior as the interrupt path:
+		// a subgraph's mid-run state is only persisted when it interrupts;
+		// otherwise a crash inside a running subgraph reruns the whole
+		// subgraph node from the parent's checkpoint.
+		return nil
+	}
+	if checkPointID == nil || r.checkPointer == nil {
 		return nil
 	}
 	if isStream {
 		// Persisting would consume in-flight streams needed by downstream nodes.
+		return nil
+	}
+	if len(nextTasks) == 0 {
+		// No pending nodes: the workflow has nothing left to run at this
+		// boundary, so persisting a snapshot would be meaningless.
 		return nil
 	}
 


### PR DESCRIPTION
## Why

eino currently persists checkpoints only on the interrupt path (`handleInterrupt`). Users who want crash-resilient runs are therefore forced to artificially raise an interrupt after every component, paying full interrupt-propagation plus resume-read costs each time and breaking the execution flow.

A second gap: real-world KV stores cap single-value size (e.g. etcd ~1.5MB). Serialized workflow state (session history, tool results) easily exceeds such limits, making checkpoint writes fail.

## What

- `WithComponentCheckpoint()`: persists progress after each node boundary while the run continues — no interrupt raised, no resume needed. Recovery after a crash reuses the existing resume path unchanged (same checkpoint struct as interrupts).
  - A snapshot is only created while the workflow still has pending nodes: the boundary after the **last** component completes (the batch that reaches `END`) does **not** produce a snapshot, so a completed workflow never leaves a "just finished" snapshot behind.
  - Safety guards: skipped for subgraphs (checkpoint IDs are run-scoped and owned by the root graph; a subgraph snapshot is published to the parent's `cp.SubGraphs` instead, matching the interrupt path's recovery behavior), missing store/ID, boundaries with no pending nodes, and streaming runs (persisting would consume in-flight streams needed downstream; `convertValues` mutates channel values in place).
- `WithCheckpointChunkSize(size)`: splits oversized checkpoints into chunks (`<id>#0..#N`) with a magic-prefixed header under `<id>`. Reads are transparent and backward compatible with legacy single-value checkpoints; deletion cleans up chunks.

## Tests

12 new cases: chunking round-trip, backward-compat reads, layout overwrite, chunk-aware delete, crash-recovery equivalence, streaming skip, default-off, chunked-state recovery, no-snapshot-when-no-pending-nodes. Full compose suite and adk checkpoint/interrupt/resume tests pass.
