### PR TITLE
docs: point README diagrams at existing image files

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Eino provides:
 - **Composition**: connect components into graphs and workflows that can run standalone or be exposed as tools for agents.
 - **[Examples](https://github.com/cloudwego/eino-examples)**: working code for common patterns and real-world use cases.
 
-![](.github/static/img/eino/eino_concept.jpeg)
+![](.github/static/img/eino/eino_project_structure_and_modules.png)
 
 # Quick Start
 
@@ -157,7 +157,7 @@ Any agent or tool can pause execution for human input and resume from checkpoint
 
 # Framework Structure
 
-![](.github/static/img/eino/eino_framework.jpeg)
+![](.github/static/img/eino/eino_architecture_overview.png)
 
 The Eino framework consists of:
 

--- a/README.zh_CN.md
+++ b/README.zh_CN.md
@@ -22,7 +22,7 @@ Eino 提供：
 - **编排**：把组件组装成图或工作流，既能独立运行，也能作为工具给智能体调用
 - **[示例](https://github.com/cloudwego/eino-examples)**：常见模式和实际场景的可运行代码
 
-![](.github/static/img/eino/eino_concept.jpeg)
+![](.github/static/img/eino/eino_project_structure_and_modules.png)
 
 # 快速上手
 
@@ -157,7 +157,7 @@ Eino 在编排中自动处理流式：拼接、装箱、合并、复制。组件
 
 # 框架结构
 
-![](.github/static/img/eino/eino_framework.jpeg)
+![](.github/static/img/eino/eino_architecture_overview.png)
 
 Eino 框架包含：
 


### PR DESCRIPTION
## Problem

`README.md` and `README.zh_CN.md` embed two diagram paths that no longer exist on `main`:

- `.github/static/img/eino/eino_concept.jpeg`
- `.github/static/img/eino/eino_framework.jpeg`

Both images were deleted when the current PNG diagrams landed, so the concept and framework diagrams render as broken images on the repository landing page (both languages).

## Fix

Point the references at the existing replacements:

- `eino_concept.jpeg` → `eino_project_structure_and_modules.png`
- `eino_framework.jpeg` → `eino_architecture_overview.png`

## Checklist

- [x] Paths verified to exist in the tree at `.github/static/img/eino/`
- [x] No code changes

Fixes #1208
