### PR TITLE
fix(schema): avoid panic and data loss when concatenating streamed audio parts

### DIFF
--- a/schema/message.go
+++ b/schema/message.go
@@ -1410,7 +1410,11 @@ func canMergeOutputParts(current, next MessageOutputPart) bool {
 		return false
 	}
 
-	if !isMergeableOutputPartType(current) {
+	// Both parts must be mergeable: a group headed by a mergeable part must not
+	// absorb a trailing part that cannot be merged (e.g. a base64 audio group
+	// absorbing a URL audio part would silently drop the URL, and absorbing a
+	// part with a nil payload would panic during the merge).
+	if !isMergeableOutputPartType(current) || !isMergeableOutputPartType(next) {
 		return false
 	}
 
@@ -1523,6 +1527,9 @@ func mergeAudioParts(group []MessageOutputPart) (MessageOutputPart, error) {
 
 	for _, part := range group {
 		audioPart := part.Audio
+		if !isBase64MessageOutputAudioPart(part) {
+			return MessageOutputPart{}, fmt.Errorf("cannot merge non-base64 audio part into an audio stream group")
+		}
 		if audioPart.Base64Data != nil {
 			b64Builder.WriteString(*audioPart.Base64Data)
 		}

--- a/schema/message_test.go
+++ b/schema/message_test.go
@@ -571,6 +571,125 @@ func TestConcatMessage(t *testing.T) {
 		assert.Equal(t, expectedContent, mergedMsg.AssistantGenMultiContent)
 	})
 
+	t.Run("concat audio stream followed by nil audio part does not panic", func(t *testing.T) {
+		base64Audio := "dGVzdF9hdWRpb18x"
+
+		msgs := []*Message{
+			{
+				Role: Assistant,
+				AssistantGenMultiContent: []MessageOutputPart{
+					{Type: ChatMessagePartTypeAudioURL, Audio: &MessageOutputAudio{MessagePartCommon: MessagePartCommon{Base64Data: &base64Audio}}},
+				},
+			},
+			{
+				Role: Assistant,
+				AssistantGenMultiContent: []MessageOutputPart{
+					{Type: ChatMessagePartTypeAudioURL, Audio: nil},
+				},
+			},
+		}
+
+		mergedMsg, err := ConcatMessages(msgs)
+		assert.NoError(t, err)
+
+		expectedContent := []MessageOutputPart{
+			{Type: ChatMessagePartTypeAudioURL, Audio: &MessageOutputAudio{MessagePartCommon: MessagePartCommon{Base64Data: &base64Audio}}},
+			{Type: ChatMessagePartTypeAudioURL, Audio: nil},
+		}
+
+		assert.Equal(t, expectedContent, mergedMsg.AssistantGenMultiContent)
+	})
+
+	t.Run("concat base64 audio stream does not swallow trailing url audio part", func(t *testing.T) {
+		base64Audio := "dGVzdF9hdWRpb18x"
+		audioURL := "https://example.com/audio.wav"
+
+		msgs := []*Message{
+			{
+				Role: Assistant,
+				AssistantGenMultiContent: []MessageOutputPart{
+					{Type: ChatMessagePartTypeAudioURL, Audio: &MessageOutputAudio{MessagePartCommon: MessagePartCommon{Base64Data: &base64Audio, MIMEType: "audio/wav"}}},
+				},
+			},
+			{
+				Role: Assistant,
+				AssistantGenMultiContent: []MessageOutputPart{
+					{Type: ChatMessagePartTypeAudioURL, Audio: &MessageOutputAudio{MessagePartCommon: MessagePartCommon{URL: &audioURL, MIMEType: "audio/wav"}}},
+				},
+			},
+		}
+
+		mergedMsg, err := ConcatMessages(msgs)
+		assert.NoError(t, err)
+
+		expectedContent := []MessageOutputPart{
+			{Type: ChatMessagePartTypeAudioURL, Audio: &MessageOutputAudio{MessagePartCommon: MessagePartCommon{Base64Data: &base64Audio, MIMEType: "audio/wav"}}},
+			{Type: ChatMessagePartTypeAudioURL, Audio: &MessageOutputAudio{MessagePartCommon: MessagePartCommon{URL: &audioURL, MIMEType: "audio/wav"}}},
+		}
+
+		assert.Equal(t, expectedContent, mergedMsg.AssistantGenMultiContent)
+	})
+
+	t.Run("concat url audio stream followed by base64 audio part keeps both", func(t *testing.T) {
+		base64Audio := "dGVzdF9hdWRpb18x"
+		audioURL := "https://example.com/audio.wav"
+
+		msgs := []*Message{
+			{
+				Role: Assistant,
+				AssistantGenMultiContent: []MessageOutputPart{
+					{Type: ChatMessagePartTypeAudioURL, Audio: &MessageOutputAudio{MessagePartCommon: MessagePartCommon{URL: &audioURL}}},
+				},
+			},
+			{
+				Role: Assistant,
+				AssistantGenMultiContent: []MessageOutputPart{
+					{Type: ChatMessagePartTypeAudioURL, Audio: &MessageOutputAudio{MessagePartCommon: MessagePartCommon{Base64Data: &base64Audio}}},
+				},
+			},
+		}
+
+		mergedMsg, err := ConcatMessages(msgs)
+		assert.NoError(t, err)
+
+		expectedContent := []MessageOutputPart{
+			{Type: ChatMessagePartTypeAudioURL, Audio: &MessageOutputAudio{MessagePartCommon: MessagePartCommon{URL: &audioURL}}},
+			{Type: ChatMessagePartTypeAudioURL, Audio: &MessageOutputAudio{MessagePartCommon: MessagePartCommon{Base64Data: &base64Audio}}},
+		}
+
+		assert.Equal(t, expectedContent, mergedMsg.AssistantGenMultiContent)
+	})
+
+	t.Run("concat audio stream interrupted by distinct streaming indexes", func(t *testing.T) {
+		base64Audio1 := "dGVzdF9hdWRpb18x"
+		base64Audio2 := "dGVzdF9hdWRpb18y"
+
+		msgs := []*Message{
+			{
+				Role: Assistant,
+				AssistantGenMultiContent: []MessageOutputPart{
+					{Type: ChatMessagePartTypeAudioURL, Audio: &MessageOutputAudio{MessagePartCommon: MessagePartCommon{Base64Data: &base64Audio1}}, StreamingMeta: &MessageStreamingMeta{Index: 0}},
+				},
+			},
+			{
+				Role: Assistant,
+				AssistantGenMultiContent: []MessageOutputPart{
+					{Type: ChatMessagePartTypeAudioURL, Audio: &MessageOutputAudio{MessagePartCommon: MessagePartCommon{Base64Data: &base64Audio2}}, StreamingMeta: &MessageStreamingMeta{Index: 1}},
+				},
+			},
+		}
+
+		mergedMsg, err := ConcatMessages(msgs)
+		assert.NoError(t, err)
+
+		expectedContent := []MessageOutputPart{
+			{Type: ChatMessagePartTypeAudioURL, Audio: &MessageOutputAudio{MessagePartCommon: MessagePartCommon{Base64Data: &base64Audio1}}, StreamingMeta: &MessageStreamingMeta{Index: 0}},
+			{Type: ChatMessagePartTypeAudioURL, Audio: &MessageOutputAudio{MessagePartCommon: MessagePartCommon{Base64Data: &base64Audio2}}, StreamingMeta: &MessageStreamingMeta{Index: 1}},
+		}
+
+		assert.Equal(t, expectedContent, mergedMsg.AssistantGenMultiContent)
+	})
+
 	t.Run("concat text parts with extra", func(t *testing.T) {
 		msgs := []*Message{
 			{


### PR DESCRIPTION
Fixes #1252

## Problem

`groupOutputParts` calls `canMergeOutputParts(currentGroup[0], parts[i])`, but mergeability was only validated for the group head — never for the part being appended. A group headed by a base64 audio part therefore absorbed **any** later `audio_url` part with the same streaming index:

1. **Panic**: a trailing part with `Audio == nil` crashed `mergeAudioParts` with a nil pointer dereference during stream aggregation.
2. **Silent data loss**: a trailing URL-referenced audio part was merged into the base64 group; its URL was dropped entirely and MIME metadata was mixed across chunks.

Both reproduce on current `main` (`9d983b36`) with plain `schema.ConcatMessages`.

## Fix

- `canMergeOutputParts` now requires **both** parts to be mergeable before grouping them. A nil-payload or URL-referenced audio part no longer joins a base64 merge group and is preserved as its own part.
- `mergeAudioParts` returns an error for non-base64 parts defensively instead of dereferencing a nil `Audio` payload.

Text and reasoning mergeability is type-only, so their grouping behavior is unchanged.

## Tests

Added four regression tests to `TestConcatMessage`:

- base64 audio stream followed by a nil audio part — previously panicked, now preserved as separate parts;
- base64 audio stream followed by a URL audio part — previously swallowed, now preserved;
- URL audio part followed by a base64 audio part — both preserved;
- audio streams with distinct streaming indexes stay separate.

Verified the new tests fail (panic) without the fix and pass with it; full `go test ./schema/...` is green.