### PR TITLE
fix(adk): avoid recursive read lock deadlock in InMemoryBackend.GrepRaw

### DIFF
--- a/adk/filesystem/backend_inmemory.go
+++ b/adk/filesystem/backend_inmemory.go
@@ -496,6 +496,10 @@ func matchFileType(ext, fileType string) bool {
 }
 
 // applyContext adds context lines around matches.
+// Locking: it must only be called with b.mu already held for reading (GrepRaw
+// does this for its whole duration). It must not acquire b.mu itself: a nested
+// RLock deadlocks once a writer is queued behind the outer read lock, because
+// sync.RWMutex blocks new readers when a writer is waiting.
 func (b *InMemoryBackend) applyContext(matches []GrepMatch, req *GrepRequest) []GrepMatch {
 	if len(matches) == 0 {
 		return matches
@@ -534,10 +538,8 @@ func (b *InMemoryBackend) applyContext(matches []GrepMatch, req *GrepRequest) []
 	for _, filePath := range fileOrder {
 		fileMatches := matchesByFile[filePath]
 
-		// Get file content once per file
-		b.mu.RLock()
+		// Get file content once per file; b.mu is already held by GrepRaw.
 		entry, exists := b.files[filePath]
-		b.mu.RUnlock()
 
 		if !exists {
 			// If file doesn't exist, keep original matches

--- a/adk/filesystem/backend_inmemory_test.go
+++ b/adk/filesystem/backend_inmemory_test.go
@@ -2034,6 +2034,66 @@ func TestInMemoryBackend_GrepRaw_Concurrent(t *testing.T) {
 	})
 }
 
+func TestInMemoryBackend_GrepRaw_NoDeadlockWithConcurrentWriter(t *testing.T) {
+	// Regression test: GrepRaw holds b.mu for reading and applyContext used to
+	// re-acquire it. A writer queued between the two read locks wedged the
+	// mutex permanently (sync.RWMutex forbids recursive read locking).
+	ctx := context.Background()
+
+	for _, files := range []int{1, 20} { // single-file and multi-file grep paths
+		backend := NewInMemoryBackend()
+		for i := 0; i < files; i++ {
+			err := backend.Write(ctx, &WriteRequest{
+				FilePath: fmt.Sprintf("/dir/file%d.txt", i),
+				Content:  "hello\nworld\nhello again\n",
+			})
+			if err != nil {
+				t.Fatalf("Write failed: %v", err)
+			}
+		}
+
+		stop := make(chan struct{})
+		writerDone := make(chan struct{})
+		go func() {
+			defer close(writerDone)
+			for {
+				select {
+				case <-stop:
+					return
+				default:
+					_ = backend.Edit(ctx, &EditRequest{
+						FilePath:  "/dir/file0.txt",
+						OldString: "world",
+						NewString: "world",
+					})
+				}
+			}
+		}()
+
+		grepDone := make(chan struct{})
+		go func() {
+			defer close(grepDone)
+			_, err := backend.GrepRaw(ctx, &GrepRequest{
+				Pattern:    "hello",
+				Path:       "/dir",
+				AfterLines: 1,
+			})
+			if err != nil {
+				t.Errorf("GrepRaw failed: %v", err)
+			}
+		}()
+
+		select {
+		case <-grepDone:
+		case <-time.After(10 * time.Second):
+			t.Fatalf("GrepRaw with %d file(s) deadlocked against a concurrent writer", files)
+		}
+
+		close(stop)
+		<-writerDone
+	}
+}
+
 func BenchmarkInMemoryBackend_GrepRaw(b *testing.B) {
 	backend := NewInMemoryBackend()
 	ctx := context.Background()


### PR DESCRIPTION
Fixes #1254

## Problem

`GrepRaw` holds `b.mu.RLock()` for its entire duration, but `applyContext` (reached whenever the grep request asks for context lines) acquired `b.mu.RLock()` again:

- multi-file path: `GrepRaw` → `applyContext` directly;
- single-file path: `GrepRaw` → `collector.buildResults` → `buildContentResult` → `applyContext`.

`sync.RWMutex` forbids recursive read locking: once a writer (`Write`/`Edit` → `b.mu.Lock()`) queues behind the outer read lock, the nested `RLock` blocks behind the pending writer while the writer waits for the outer reader. The mutex wedges **permanently** — all subsequent Reads/Writes/Edits/Greps block too, and no context cancellation can unblock a mutex.

Any `grep -A/-B/-C` racing a concurrent `write_file`/`edit_file` on the same backend could trigger it. LLMs use grep context flags constantly and the DeepAgent task prompt explicitly encourages parallel tool calls, so the interleaving is routine.

## Fix

`applyContext` is only ever called under `GrepRaw`'s read lock (verified all call sites), so drop the nested `RLock`/`RUnlock` and document the locking contract on the function.

## Tests

Added `TestInMemoryBackend_GrepRaw_NoDeadlockWithConcurrentWriter`: a watchdog test that greps with `AfterLines` while a writer loops on the same backend, covering both the single-file and multi-file grep paths.

- Without the fix: deadlocks, test fails at the 10s timeout (reproduces on the first round).
- With the fix: passes; `go test -race ./adk/filesystem/ ./adk/middlewares/filesystem/` is green.