### PR TITLE
fix(compose): close sibling tool streams on errors

### DIFF
--- a/compose/tool_node.go
+++ b/compose/tool_node.go
@@ -970,6 +970,21 @@ func runToolCallTaskByStream(ctx context.Context, task *toolCallTask, opts ...to
 	}
 }
 
+func closeToolCallTaskStreams(tasks []toolCallTask) {
+	for i := range tasks {
+		if !tasks[i].executed {
+			continue
+		}
+		if tasks[i].useEnhanced {
+			if tasks[i].enhancedSOutput != nil {
+				tasks[i].enhancedSOutput.Close()
+			}
+		} else if tasks[i].sOutput != nil {
+			tasks[i].sOutput.Close()
+		}
+	}
+}
+
 func sequentialRunToolCall(ctx context.Context,
 	run func(ctx2 context.Context, callTask *toolCallTask, opts ...tool.Option),
 	tasks []toolCallTask, opts ...tool.Option) {
@@ -1200,6 +1215,7 @@ func (tn *ToolsNode) Stream(ctx context.Context, input *schema.Message,
 		if tasks[i].err != nil {
 			info, ok := IsInterruptRerunError(tasks[i].err)
 			if !ok {
+				closeToolCallTaskStreams(tasks)
 				return nil, fmt.Errorf("failed to stream tool call %s: %w", tasks[i].callID, tasks[i].err)
 			}
 
@@ -1217,11 +1233,13 @@ func (tn *ToolsNode) Stream(ctx context.Context, input *schema.Message,
 
 	if len(errs) > 0 {
 		// concat and save tool output
-		for _, t := range tasks {
+		for i := range tasks {
+			t := &tasks[i]
 			if t.executed {
 				if t.useEnhanced {
 					eo, err_ := concatStreamReader(t.enhancedSOutput)
 					if err_ != nil {
+						closeToolCallTaskStreams(tasks[i+1:])
 						return nil, fmt.Errorf("failed to concat enhanced tool[name:%s id:%s]'s stream output: %w", t.name, t.callID, err_)
 					}
 					rerunExtra.ExecutedEnhancedTools[t.callID] = eo
@@ -1230,6 +1248,7 @@ func (tn *ToolsNode) Stream(ctx context.Context, input *schema.Message,
 				} else {
 					o, err_ := concatStreamReader(t.sOutput)
 					if err_ != nil {
+						closeToolCallTaskStreams(tasks[i+1:])
 						return nil, fmt.Errorf("failed to concat tool[name:%s id:%s]'s stream output: %w", t.name, t.callID, err_)
 					}
 					rerunExtra.ExecutedTools[t.callID] = o

--- a/compose/tool_node_test.go
+++ b/compose/tool_node_test.go
@@ -18,11 +18,13 @@ package compose
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"io"
 	"strconv"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/bytedance/sonic"
 	"github.com/stretchr/testify/assert"
@@ -33,6 +35,185 @@ import (
 	"github.com/cloudwego/eino/internal/generic"
 	"github.com/cloudwego/eino/schema"
 )
+
+var errStreamTool = errors.New("stream tool failed")
+
+type blockingStreamTool struct {
+	reader       *schema.StreamReader[string]
+	producerDone chan struct{}
+}
+
+func (t *blockingStreamTool) Info(context.Context) (*schema.ToolInfo, error) {
+	return &schema.ToolInfo{Name: "blocking_stream"}, nil
+}
+
+func (t *blockingStreamTool) StreamableRun(context.Context, string, ...tool.Option) (*schema.StreamReader[string], error) {
+	reader, writer := schema.Pipe[string](0)
+	t.reader = reader
+	t.producerDone = make(chan struct{})
+	go func() {
+		defer close(t.producerDone)
+		defer writer.Close()
+		writer.Send("blocked until reader is closed", nil)
+	}()
+	return reader, nil
+}
+
+type blockingEnhancedStreamTool struct {
+	reader       *schema.StreamReader[*schema.ToolResult]
+	producerDone chan struct{}
+}
+
+func (t *blockingEnhancedStreamTool) Info(context.Context) (*schema.ToolInfo, error) {
+	return &schema.ToolInfo{Name: "blocking_enhanced_stream"}, nil
+}
+
+func (t *blockingEnhancedStreamTool) StreamableRun(context.Context, *schema.ToolArgument, ...tool.Option) (*schema.StreamReader[*schema.ToolResult], error) {
+	reader, writer := schema.Pipe[*schema.ToolResult](0)
+	t.reader = reader
+	t.producerDone = make(chan struct{})
+	go func() {
+		defer close(t.producerDone)
+		defer writer.Close()
+		writer.Send(&schema.ToolResult{}, nil)
+	}()
+	return reader, nil
+}
+
+type failingStreamTool struct{}
+
+func (failingStreamTool) Info(context.Context) (*schema.ToolInfo, error) {
+	return &schema.ToolInfo{Name: "failing_stream"}, nil
+}
+
+func (failingStreamTool) StreamableRun(context.Context, string, ...tool.Option) (*schema.StreamReader[string], error) {
+	return nil, errStreamTool
+}
+
+type interruptingStreamTool struct{}
+
+func (interruptingStreamTool) Info(context.Context) (*schema.ToolInfo, error) {
+	return &schema.ToolInfo{Name: "interrupting_stream"}, nil
+}
+
+func (interruptingStreamTool) StreamableRun(ctx context.Context, _ string, _ ...tool.Option) (*schema.StreamReader[string], error) {
+	return nil, tool.Interrupt(ctx, "rerun")
+}
+
+type emptyStreamTool struct{}
+
+func (emptyStreamTool) Info(context.Context) (*schema.ToolInfo, error) {
+	return &schema.ToolInfo{Name: "empty_stream"}, nil
+}
+
+func (emptyStreamTool) StreamableRun(context.Context, string, ...tool.Option) (*schema.StreamReader[string], error) {
+	return schema.StreamReaderFromArray([]string{}), nil
+}
+
+type emptyEnhancedStreamTool struct{}
+
+func (emptyEnhancedStreamTool) Info(context.Context) (*schema.ToolInfo, error) {
+	return &schema.ToolInfo{Name: "empty_enhanced_stream"}, nil
+}
+
+func (emptyEnhancedStreamTool) StreamableRun(context.Context, *schema.ToolArgument, ...tool.Option) (*schema.StreamReader[*schema.ToolResult], error) {
+	return schema.StreamReaderFromArray([]*schema.ToolResult{}), nil
+}
+
+func assertProducerDone(t *testing.T, readerClose func(), producerDone <-chan struct{}) {
+	t.Helper()
+	t.Cleanup(func() {
+		select {
+		case <-producerDone:
+		default:
+			readerClose()
+		}
+	})
+	assert.Eventually(t, func() bool {
+		select {
+		case <-producerDone:
+			return true
+		default:
+			return false
+		}
+	}, time.Second, 10*time.Millisecond)
+}
+
+func TestToolsNodeStreamClosesSuccessfulStreamsOnError(t *testing.T) {
+	ctx := context.Background()
+
+	for _, sequential := range []bool{false, true} {
+		mode := "parallel"
+		if sequential {
+			mode = "sequential"
+		}
+		t.Run("standard/"+mode, func(t *testing.T) {
+			blockingTool := &blockingStreamTool{}
+			node, err := NewToolNode(ctx, &ToolsNodeConfig{
+				Tools: []tool.BaseTool{blockingTool, failingStreamTool{}}, ExecuteSequentially: sequential,
+			})
+			assert.NoError(t, err)
+
+			_, err = node.Stream(ctx, schema.AssistantMessage("", []schema.ToolCall{
+				{ID: "blocking", Function: schema.FunctionCall{Name: "blocking_stream", Arguments: "{}"}},
+				{ID: "failing", Function: schema.FunctionCall{Name: "failing_stream", Arguments: "{}"}},
+			}))
+			assert.ErrorIs(t, err, errStreamTool)
+			assertProducerDone(t, blockingTool.reader.Close, blockingTool.producerDone)
+		})
+
+		t.Run("enhanced/"+mode, func(t *testing.T) {
+			blockingTool := &blockingEnhancedStreamTool{}
+			node, err := NewToolNode(ctx, &ToolsNodeConfig{
+				Tools: []tool.BaseTool{blockingTool, failingStreamTool{}}, ExecuteSequentially: sequential,
+			})
+			assert.NoError(t, err)
+
+			_, err = node.Stream(ctx, schema.AssistantMessage("", []schema.ToolCall{
+				{ID: "blocking", Function: schema.FunctionCall{Name: "blocking_enhanced_stream", Arguments: "{}"}},
+				{ID: "failing", Function: schema.FunctionCall{Name: "failing_stream", Arguments: "{}"}},
+			}))
+			assert.ErrorIs(t, err, errStreamTool)
+			assertProducerDone(t, blockingTool.reader.Close, blockingTool.producerDone)
+		})
+	}
+}
+
+func TestToolsNodeStreamClosesPendingStreamsOnInterruptConcatError(t *testing.T) {
+	tests := []struct {
+		name           string
+		concatTool     tool.BaseTool
+		concatToolName string
+		sequential     bool
+	}{
+		{name: "standard/parallel", concatTool: emptyStreamTool{}, concatToolName: "empty_stream"},
+		{name: "enhanced/parallel", concatTool: emptyEnhancedStreamTool{}, concatToolName: "empty_enhanced_stream"},
+		{name: "standard/sequential", concatTool: emptyStreamTool{}, concatToolName: "empty_stream", sequential: true},
+		{name: "enhanced/sequential", concatTool: emptyEnhancedStreamTool{}, concatToolName: "empty_enhanced_stream", sequential: true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctx := context.Background()
+			blockingTool := &blockingStreamTool{}
+			blockingEnhancedTool := &blockingEnhancedStreamTool{}
+			node, err := NewToolNode(ctx, &ToolsNodeConfig{
+				Tools:               []tool.BaseTool{interruptingStreamTool{}, tt.concatTool, blockingTool, blockingEnhancedTool},
+				ExecuteSequentially: tt.sequential,
+			})
+			assert.NoError(t, err)
+
+			_, err = node.Stream(ctx, schema.AssistantMessage("", []schema.ToolCall{
+				{ID: "interrupting", Function: schema.FunctionCall{Name: "interrupting_stream", Arguments: "{}"}},
+				{ID: "empty", Function: schema.FunctionCall{Name: tt.concatToolName, Arguments: "{}"}},
+				{ID: "blocking", Function: schema.FunctionCall{Name: "blocking_stream", Arguments: "{}"}},
+				{ID: "blocking_enhanced", Function: schema.FunctionCall{Name: "blocking_enhanced_stream", Arguments: "{}"}},
+			}))
+			assert.ErrorContains(t, err, "failed to concat")
+			assertProducerDone(t, blockingTool.reader.Close, blockingTool.producerDone)
+			assertProducerDone(t, blockingEnhancedTool.reader.Close, blockingEnhancedTool.producerDone)
+		})
+	}
+}
 
 const (
 	toolNameOfUserCompany = "user_company"


### PR DESCRIPTION
#### What type of PR is this?

fix

#### Check the PR title.

- [x] This PR title matches the required `<type>(optional scope): <description>` format.
- [x] The description is user-oriented and clear.
- [x] No user documentation update is required because this only fixes error-path resource cleanup.

#### More detailed description

en:

`ToolsNode.Stream` owns every reader returned by a successful tool until ownership is transferred to the caller or the reader is consumed. Two error paths could abandon readers that the caller can no longer access:

1. A regular tool error returned before successful sibling readers were merged.
2. During interrupt/rerun handling, concatenating one successful stream failed and returned before later successful readers were consumed.

This change closes all successful readers before the regular-error return. For interrupt/rerun concat failures, the current reader is already closed by `concatStreamReader`, previous readers were consumed and closed, and the change closes only the not-yet-consumed suffix. This avoids both leaks and double-close while preserving successful execution and normal interrupt/rerun state semantics.

Regression tests use unbuffered pipes and cover:

- regular tool errors and interrupt/rerun concat errors;
- standard and enhanced streams;
- parallel and sequential tool execution;
- multiple pending sibling streams after the concat failure.

Validation:

- Final regression matrix against the previous PR head: regular-error cases passed, while all four interrupt concat cases failed because both pending producers remained blocked
- `go test -race ./compose -run 'TestToolsNodeStreamCloses(Successful|Pending)Streams' -count=20`
- `go test -race ./compose`
- `go test ./...`
- `go test -race ./...`
- `git diff --check`
- Multiple independent reviews found no P0-P2 defects in the final diff

`golangci-lint` was not available locally and was not installed globally; the repository CI lint check remains authoritative.

#### Which issue(s) this PR fixes:

Fixes #1256