### PR TITLE
feat(compose): support per-node trigger mode in AnyPredecessor graphs

### DIFF
--- a/compose/graph.go
+++ b/compose/graph.go
@@ -86,6 +86,10 @@ type graph struct {
 	handlerOnEdges   map[string]map[string][]handlerPair
 	handlerPreNode   map[string][]handlerPair
 	handlerPreBranch map[string][][]handlerPair
+
+	// nodeTriggerModes records per-node trigger mode overrides set via WithTriggerMode.
+	// Only nodes present in this map deviate from the graph-level trigger mode.
+	nodeTriggerModes map[string]NodeTriggerMode
 }
 
 type newGraphConfig struct {
@@ -193,6 +197,16 @@ func (g *graph) addNode(key string, node *graphNode, options *graphAddNodeOpts) 
 		if !isChain(g.cmp) {
 			return errors.New("only chain support node key option")
 		}
+	}
+
+	if options.nodeOptions.triggerMode != "" {
+		if options.nodeOptions.triggerMode != AnyPredecessor && options.nodeOptions.triggerMode != AllPredecessor {
+			return fmt.Errorf("node '%s' has invalid trigger mode: '%s'", key, options.nodeOptions.triggerMode)
+		}
+		if g.nodeTriggerModes == nil {
+			g.nodeTriggerModes = make(map[string]NodeTriggerMode)
+		}
+		g.nodeTriggerModes[key] = options.nodeOptions.triggerMode
 	}
 	// end: check options
 
@@ -683,10 +697,34 @@ func (g *graph) compile(ctx context.Context, opt *graphCompileOptions) (*composa
 		if opt != nil && opt.nodeTriggerMode != "" {
 			return nil, errors.New(fmt.Sprintf("%s doesn't support node trigger mode option", g.cmp))
 		}
+		if len(g.nodeTriggerModes) > 0 {
+			return nil, errors.New(fmt.Sprintf("%s doesn't support per-node trigger mode option", g.cmp))
+		}
 	}
 	if (opt != nil && opt.nodeTriggerMode == AllPredecessor) || isWorkflow(g.cmp) {
 		runType = runTypeDAG
 		cb = dagChannelBuilder
+	}
+
+	// Resolve per-node trigger mode overrides: a node marked AllPredecessor in an
+	// AnyPredecessor graph gets a dag-style channel so it only triggers after all
+	// of its predecessors finish. AnyPredecessor is the graph default in pregel
+	// mode (no-op), and redundant in dag mode where every node already waits for
+	// all predecessors.
+	var nodeChanBuilders map[string]chanBuilder
+	for nodeKey, mode := range g.nodeTriggerModes {
+		if runType == runTypeDAG {
+			if mode != AllPredecessor {
+				return nil, fmt.Errorf("node '%s' trigger mode '%s' is not supported in %s run mode: all nodes already wait for all predecessors", nodeKey, mode, runType)
+			}
+			continue
+		}
+		if mode == AllPredecessor {
+			if nodeChanBuilders == nil {
+				nodeChanBuilders = make(map[string]chanBuilder)
+			}
+			nodeChanBuilders[nodeKey] = dagChannelBuilder
+		}
 	}
 
 	// get eager type
@@ -820,7 +858,8 @@ func (g *graph) compile(ctx context.Context, opt *graphCompileOptions) (*composa
 
 		eager: eager,
 
-		chanBuilder: cb,
+		chanBuilder:      cb,
+		nodeChanBuilders: nodeChanBuilders,
 
 		inputType:     g.inputType(),
 		outputType:    g.outputType(),

--- a/compose/graph_add_node_options.go
+++ b/compose/graph_add_node_options.go
@@ -44,6 +44,8 @@ type nodeOptions struct {
 	outputKey string
 
 	graphCompileOption []GraphCompileOption // when this node is itself an AnyGraph, this option will be used to compile the node as a nested graph
+
+	triggerMode NodeTriggerMode // per-node trigger mode, empty means following the graph-level trigger mode
 }
 
 // WithNodeName sets the name of the node.
@@ -86,6 +88,33 @@ func WithOutputKey(k string) GraphAddNodeOpt {
 func WithGraphCompileOptions(opts ...GraphCompileOption) GraphAddNodeOpt {
 	return func(o *graphAddNodeOpts) {
 		o.nodeOptions.graphCompileOption = opts
+	}
+}
+
+// WithTriggerMode sets the trigger mode for this specific node, overriding the
+// graph-level trigger mode (see WithNodeTriggerMode) for this node only.
+//
+// The supported use case is marking selected nodes as AllPredecessor within an
+// AnyPredecessor (default) Graph: such a node is triggered only after ALL of its
+// predecessors have finished, instead of being triggered whenever ANY predecessor
+// finishes. This saves users from manually aligning super-step lengths with
+// passthrough nodes when only a few nodes need all-predecessor semantics.
+//
+// Notes:
+//   - Only Graph supports this option; Chain and Workflow reject it at compile time.
+//   - Setting AnyPredecessor on a node is a no-op when the graph runs in
+//     AnyPredecessor mode, and is rejected when the graph runs in AllPredecessor
+//     (DAG) mode, where every node already waits for all predecessors.
+//   - An AllPredecessor node inside a cycle waits for all of its predecessors in
+//     every super step; if one of them can only fire after the node itself, the
+//     graph run ends with a max-run-steps error instead of completing.
+//
+// e.g.
+//
+//	graph.AddNode("join", joiner, compose.WithTriggerMode(compose.AllPredecessor))
+func WithTriggerMode(triggerMode NodeTriggerMode) GraphAddNodeOpt {
+	return func(o *graphAddNodeOpts) {
+		o.nodeOptions.triggerMode = triggerMode
 	}
 }
 

--- a/compose/graph_run.go
+++ b/compose/graph_run.go
@@ -50,8 +50,12 @@ type runner struct {
 	inputChannels *chanCall
 
 	chanBuilder chanBuilder // could be nil
-	eager       bool
-	dag         bool
+	// nodeChanBuilders overrides chanBuilder for nodes with a per-node trigger
+	// mode (WithTriggerMode), e.g. an AllPredecessor node in an AnyPredecessor
+	// graph gets a dag-style channel while the rest keep pregel channels.
+	nodeChanBuilders map[string]chanBuilder
+	eager            bool
+	dag              bool
 
 	runCtx func(ctx context.Context) context.Context
 
@@ -1074,7 +1078,11 @@ func (r *runner) initChannelManager(isStream bool) *channelManager {
 
 	chs := make(map[string]channel)
 	for ch := range r.chanSubscribeTo {
-		chs[ch] = builder(r.controlPredecessors[ch], r.dataPredecessors[ch], r.chanSubscribeTo[ch].action.inputZeroValue, r.chanSubscribeTo[ch].action.inputEmptyStream)
+		nodeBuilder := builder
+		if b, ok := r.nodeChanBuilders[ch]; ok {
+			nodeBuilder = b
+		}
+		chs[ch] = nodeBuilder(r.controlPredecessors[ch], r.dataPredecessors[ch], r.chanSubscribeTo[ch].action.inputZeroValue, r.chanSubscribeTo[ch].action.inputEmptyStream)
 	}
 
 	chs[END] = builder(r.controlPredecessors[END], r.dataPredecessors[END], r.outputZeroValue, r.outputEmptyStream)

--- a/compose/graph_trigger_mode_test.go
+++ b/compose/graph_trigger_mode_test.go
@@ -1,0 +1,249 @@
+/*
+ * Copyright 2026 CloudWeGo Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package compose
+
+import (
+	"context"
+	"fmt"
+	"sync"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// buildTriggerModeProbeGraph builds the following graph:
+//
+//	START -> x -> z -> END
+//	START -> a -> y -> z
+//
+// x fires in super step 1, y fires in super step 2, so z's two predecessors
+// finish in different super steps.
+func buildTriggerModeProbeGraph(t *testing.T, zOpts ...GraphAddNodeOpt) (*Graph[string, string], *int, *[][]string) {
+	var mu sync.Mutex
+	zRuns := 0
+	var zInputs [][]string
+
+	g := NewGraph[string, string]()
+
+	err := g.AddLambdaNode("x", InvokableLambda(func(ctx context.Context, input string) (map[string]any, error) {
+		return map[string]any{"x": input}, nil
+	}))
+	assert.NoError(t, err)
+
+	err = g.AddLambdaNode("a", InvokableLambda(func(ctx context.Context, input string) (string, error) {
+		return input, nil
+	}))
+	assert.NoError(t, err)
+
+	err = g.AddLambdaNode("y", InvokableLambda(func(ctx context.Context, input string) (map[string]any, error) {
+		return map[string]any{"y": input}, nil
+	}))
+	assert.NoError(t, err)
+
+	err = g.AddLambdaNode("z", InvokableLambda(func(ctx context.Context, input map[string]any) (string, error) {
+		mu.Lock()
+		defer mu.Unlock()
+		zRuns++
+		keys := make([]string, 0, len(input))
+		for k := range input {
+			keys = append(keys, k)
+		}
+		zInputs = append(zInputs, keys)
+		return fmt.Sprintf("%v", input), nil
+	}), zOpts...)
+	assert.NoError(t, err)
+
+	assert.NoError(t, g.AddEdge(START, "x"))
+	assert.NoError(t, g.AddEdge(START, "a"))
+	assert.NoError(t, g.AddEdge("a", "y"))
+	assert.NoError(t, g.AddEdge("x", "z"))
+	assert.NoError(t, g.AddEdge("y", "z"))
+	assert.NoError(t, g.AddEdge("z", END))
+
+	return g, &zRuns, &zInputs
+}
+
+func TestPerNodeTriggerModeDefaultIsAnyPredecessor(t *testing.T) {
+	// Without WithTriggerMode, z keeps pregel semantics: it triggers as soon as
+	// its first predecessor (x, super step 1) finishes. y finishes one super
+	// step later, but by then END is already reachable through z, so the run
+	// ends and y's value never reaches z.
+	g, zRuns, zInputs := buildTriggerModeProbeGraph(t)
+
+	r, err := g.Compile(context.Background())
+	assert.NoError(t, err)
+
+	out, err := r.Invoke(context.Background(), "hello")
+	assert.NoError(t, err)
+	assert.Equal(t, 1, *zRuns)
+	assert.ElementsMatch(t, []string{"x"}, (*zInputs)[0])
+	assert.Contains(t, out, "x")
+	assert.NotContains(t, out, "y")
+}
+
+func TestPerNodeTriggerModeAllPredecessor(t *testing.T) {
+	// With WithTriggerMode(AllPredecessor), z waits for both predecessors and
+	// triggers exactly once with both values merged, even though they finish
+	// in different super steps.
+	g, zRuns, zInputs := buildTriggerModeProbeGraph(t, WithTriggerMode(AllPredecessor))
+
+	r, err := g.Compile(context.Background())
+	assert.NoError(t, err)
+
+	out, err := r.Invoke(context.Background(), "hello")
+	assert.NoError(t, err)
+	assert.Equal(t, 1, *zRuns)
+	assert.ElementsMatch(t, []string{"x", "y"}, (*zInputs)[0])
+	assert.Contains(t, out, "x")
+	assert.Contains(t, out, "y")
+
+	// stream mode goes through the same channel machinery.
+	*zRuns = 0
+	*zInputs = nil
+	sr, err := r.Stream(context.Background(), "hello")
+	assert.NoError(t, err)
+	for {
+		_, err = sr.Recv()
+		if err != nil {
+			break
+		}
+	}
+	sr.Close()
+	assert.Equal(t, 1, *zRuns)
+	assert.ElementsMatch(t, []string{"x", "y"}, (*zInputs)[0])
+}
+
+func TestPerNodeTriggerModeAllPredecessorWithBranchSkip(t *testing.T) {
+	// An AllPredecessor node whose other predecessor (b) is skipped by a branch
+	// still triggers, with only the completed predecessors' values. The skip
+	// report must propagate through b's own any-predecessor channel to reach z.
+	//
+	// Topology: START -> x -> z -> END
+	//           START -> branch -> b (skipped) -> z
+	//                            -> nowhere -> z
+	var zRuns int
+	var zInputKeys []string
+
+	g := NewGraph[string, string]()
+	assert.NoError(t, g.AddLambdaNode("x", InvokableLambda(func(ctx context.Context, input string) (map[string]any, error) {
+		return map[string]any{"x": input}, nil
+	})))
+	assert.NoError(t, g.AddLambdaNode("b", InvokableLambda(func(ctx context.Context, input string) (map[string]any, error) {
+		return map[string]any{"b": input}, nil
+	})))
+	assert.NoError(t, g.AddLambdaNode("nowhere", InvokableLambda(func(ctx context.Context, input string) (map[string]any, error) {
+		return map[string]any{"nw": input}, nil
+	})))
+	assert.NoError(t, g.AddLambdaNode("z", InvokableLambda(func(ctx context.Context, input map[string]any) (string, error) {
+		zRuns++
+		for k := range input {
+			zInputKeys = append(zInputKeys, k)
+		}
+		return "done", nil
+	}), WithTriggerMode(AllPredecessor)))
+
+	assert.NoError(t, g.AddEdge(START, "x"))
+	assert.NoError(t, g.AddEdge("x", "z"))
+	assert.NoError(t, g.AddBranch(START, NewGraphBranch(func(ctx context.Context, in string) (string, error) {
+		return "nowhere", nil // never selects "b", so "b" is skipped
+	}, map[string]bool{"b": true, "nowhere": true})))
+	assert.NoError(t, g.AddEdge("b", "z"))
+	assert.NoError(t, g.AddEdge("nowhere", "z"))
+	assert.NoError(t, g.AddEdge("z", END))
+
+	r, err := g.Compile(context.Background())
+	assert.NoError(t, err)
+
+	out, err := r.Invoke(context.Background(), "hello")
+	assert.NoError(t, err)
+	assert.Equal(t, "done", out)
+	assert.Equal(t, 1, zRuns)
+	assert.ElementsMatch(t, []string{"x", "nw"}, zInputKeys)
+}
+
+func TestPerNodeTriggerModeWithCheckpointResume(t *testing.T) {
+	// Hybrid channels (pregel + per-node dag channel) survive a checkpoint
+	// round trip: interrupt before z, resume, and z still fires exactly once
+	// with both predecessors' values.
+	g, zRuns, zInputs := buildTriggerModeProbeGraph(t, WithTriggerMode(AllPredecessor))
+
+	ctx := context.Background()
+	r, err := g.Compile(ctx,
+		WithCheckPointStore(newInMemoryStore()),
+		WithInterruptBeforeNodes([]string{"z"}),
+	)
+	assert.NoError(t, err)
+
+	_, err = r.Invoke(ctx, "hello", WithCheckPointID("cp-1"))
+	assert.Error(t, err) // interrupted before z
+	assert.Equal(t, 0, *zRuns)
+
+	info, ok := ExtractInterruptInfo(err)
+	assert.True(t, ok)
+
+	rCtx := Resume(ctx, info.InterruptContexts[0].ID)
+	out, err := r.Invoke(rCtx, "hello", WithCheckPointID("cp-1"))
+	assert.NoError(t, err)
+	assert.Contains(t, out, "x")
+	assert.Contains(t, out, "y")
+	assert.Equal(t, 1, *zRuns)
+	assert.ElementsMatch(t, []string{"x", "y"}, (*zInputs)[0])
+}
+
+func TestPerNodeTriggerModeCompileErrors(t *testing.T) {
+	t.Run("chain rejects per-node trigger mode", func(t *testing.T) {
+		c := NewChain[string, string]()
+		c.AppendLambda(InvokableLambda(func(ctx context.Context, input string) (string, error) {
+			return input, nil
+		}), WithTriggerMode(AllPredecessor))
+
+		_, err := c.Compile(context.Background())
+		assert.ErrorContains(t, err, "doesn't support per-node trigger mode option")
+	})
+
+	t.Run("dag graph rejects AnyPredecessor override", func(t *testing.T) {
+		g, _, _ := buildTriggerModeProbeGraph(t, WithTriggerMode(AnyPredecessor))
+
+		_, err := g.Compile(context.Background(), WithNodeTriggerMode(AllPredecessor))
+		assert.ErrorContains(t, err, "not supported in DAG run mode")
+	})
+
+	t.Run("dag graph accepts redundant AllPredecessor override", func(t *testing.T) {
+		g, zRuns, _ := buildTriggerModeProbeGraph(t, WithTriggerMode(AllPredecessor))
+
+		r, err := g.Compile(context.Background(), WithNodeTriggerMode(AllPredecessor))
+		assert.NoError(t, err)
+
+		_, err = r.Invoke(context.Background(), "hello")
+		assert.NoError(t, err)
+		assert.Equal(t, 1, *zRuns)
+	})
+
+	t.Run("invalid trigger mode", func(t *testing.T) {
+		g := NewGraph[string, string]()
+		assert.NoError(t, g.AddLambdaNode("n", InvokableLambda(func(ctx context.Context, input string) (string, error) {
+			return input, nil
+		})))
+		err := g.AddLambdaNode("bad", InvokableLambda(func(ctx context.Context, input string) (string, error) {
+			return input, nil
+		}), WithTriggerMode("not_a_mode"))
+		assert.ErrorContains(t, err, "invalid trigger mode")
+
+		_, err = g.Compile(context.Background())
+		assert.ErrorContains(t, err, "invalid trigger mode")
+	})
+}

--- a/compose/pregel.go
+++ b/compose/pregel.go
@@ -18,14 +18,24 @@ package compose
 
 import "fmt"
 
-func pregelChannelBuilder(_ []string, _ []string, _ func() any, _ func() streamReader) channel {
-	return &pregelChannel{Values: make(map[string]any)}
+func pregelChannelBuilder(controlDependencies []string, _ []string, _ func() any, _ func() streamReader) channel {
+	deps := make(map[string]dependencyState, len(controlDependencies))
+	for _, dep := range controlDependencies {
+		deps[dep] = dependencyStateWaiting
+	}
+	return &pregelChannel{Values: make(map[string]any), controlPredecessors: deps}
 }
 
 type pregelChannel struct {
 	Values map[string]any
 
 	mergeConfig FanInMergeConfig
+
+	// controlPredecessors only tracks branch-skip state, so that skip reports
+	// can propagate through this node to downstream nodes that wait for all
+	// predecessors (see WithTriggerMode). It never affects when this channel
+	// fires: any reported value still triggers the node immediately.
+	controlPredecessors map[string]dependencyState
 }
 
 func (ch *pregelChannel) setMergeConfig(cfg FanInMergeConfig) {
@@ -87,8 +97,25 @@ func (ch *pregelChannel) get(isStream bool, name string, edgeHandler *edgeHandle
 	return v, true, nil
 }
 
-func (ch *pregelChannel) reportSkip(_ []string) bool {
-	return false
+func (ch *pregelChannel) reportSkip(keys []string) bool {
+	for _, k := range keys {
+		if _, ok := ch.controlPredecessors[k]; ok {
+			ch.controlPredecessors[k] = dependencyStateSkipped
+		}
+	}
+
+	// Propagate the skip downstream only when every control predecessor has
+	// been skipped, i.e. this node can never fire. Nodes without control
+	// predecessors (e.g. reached through data-only edges) never propagate.
+	if len(ch.controlPredecessors) == 0 {
+		return false
+	}
+	for _, state := range ch.controlPredecessors {
+		if state != dependencyStateSkipped {
+			return false
+		}
+	}
+	return true
 }
 func (ch *pregelChannel) reportDependencies(_ []string) {
 	return


### PR DESCRIPTION
Implements #873

## Motivation

`NodeTriggerMode` is graph-level only, applied to all nodes at compile time. In an `AnyPredecessor` (pregel) graph, a join node fires as soon as **any** predecessor finishes — and when its remaining predecessors finish later, the run may already have ended through END, so their outputs never reach the join. Without first-class framework support, users have to align super-step lengths manually with passthrough nodes, which is costly and fragile.

## Design

- New node option `WithTriggerMode(mode NodeTriggerMode)` (`GraphAddNodeOpt`) that overrides the graph-level trigger mode for that node only.
- A node marked `AllPredecessor` in an `AnyPredecessor` graph gets a **dag-style channel** inside the pregel runtime: it triggers only after all of its predecessors have finished (or been skipped by branches), receiving their merged values in one firing. All other nodes keep pregel channels and semantics.
- **Skip propagation**: `pregelChannel` now records skip state for its control predecessors and propagates the skip downstream when all of them are skipped. Previously `reportSkip` was a no-op, which would have stranded an `AllPredecessor` node behind a branch-skipped predecessor. This bookkeeping never affects when a pregel channel fires.
- **Validation**: Chain/Workflow reject the option at compile time; in DAG mode `AnyPredecessor` is rejected while a redundant `AllPredecessor` is accepted; invalid mode values fail at `AddNode`.
- **Checkpoint**: hybrid channels round-trip through checkpoint/resume (both channel types were already gob-registered); verified by a resume test.

An `AllPredecessor` node inside a cycle waits for all of its predecessors in every super step; if one of them can only fire after the node itself, the run ends with a max-run-steps error (pregel's existing guard), never a hang. This is documented on the option.

## Tests

New `compose/graph_trigger_mode_test.go` covers:

- default `AnyPredecessor` behavior (join fires once with only the first predecessor's value — END short-circuits the rest) as the contrast baseline;
- `AllPredecessor` join fires exactly once with both predecessors' values merged, in both Invoke and Stream modes;
- branch-skip: a join whose other predecessor is skipped by a branch still fires with the completed predecessors' values (skip propagates through intermediate pregel channels);
- interrupt-before the join node, then resume: hybrid channels restore correctly and the join fires once with both values;
- compile-time validation for Chain, DAG graphs, and invalid mode values.

`go test -race ./compose/` and the full repo build are green.