### PR TITLE
feat(adk): add standard tool policy and human approval middleware

### DIFF
--- a/adk/middlewares/toolpolicy/toolpolicy.go
+++ b/adk/middlewares/toolpolicy/toolpolicy.go
@@ -1,0 +1,315 @@
+/*
+ * Copyright 2026 CloudWeGo Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// Package toolpolicy provides a standard ADK middleware for tool-call policy
+// control and human approval.
+//
+// A Policy decides for every tool call whether it may run (optionally with
+// rewritten arguments), is denied (the model receives a safe tool result
+// instead), or requires human approval. Approval requests ride on ADK's
+// existing interrupt/resume machinery: the tool call interrupts with the
+// policy's ApprovalInfo, and the approver resumes the run with an *Approval
+// as resume data. No second checkpoint or approval storage mechanism is
+// introduced; decision auditing can be layered on through the existing
+// callback handlers.
+//
+// Usage:
+//
+//	mw, err := toolpolicy.New(ctx, &toolpolicy.Config{Policy: myPolicy})
+//	if err != nil { ... }
+//	agent, err := adk.NewChatModelAgent(ctx, &adk.ChatModelAgentConfig{
+//	    ...
+//	    Handlers: []adk.ChatModelAgentMiddleware{mw},
+//	})
+//
+//	resume with:
+//	runner.ResumeWithParams(ctx, checkPointID, &adk.ResumeParams{
+//	    Targets: map[string]any{interruptID: &toolpolicy.Approval{Approved: true}},
+//	})
+package toolpolicy
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	"github.com/cloudwego/eino/adk"
+	"github.com/cloudwego/eino/components/tool"
+	"github.com/cloudwego/eino/schema"
+)
+
+// Decision is the policy verdict for a single tool call.
+type Decision string
+
+const (
+	// DecisionAllow lets the tool call execute, optionally with rewritten arguments.
+	DecisionAllow Decision = "allow"
+	// DecisionDeny blocks the tool call; the model receives Result.Message as the tool result.
+	DecisionDeny Decision = "deny"
+	// DecisionRequireApproval interrupts the run until a human approves or rejects the call.
+	DecisionRequireApproval Decision = "require_approval"
+)
+
+// Request describes a single tool call awaiting a policy decision.
+type Request struct {
+	// ToolName is the name of the tool being called.
+	ToolName string
+	// CallID is the unique identifier of this specific tool call.
+	CallID string
+	// Arguments is the raw JSON argument string produced by the model.
+	Arguments string
+}
+
+// Result is the policy verdict for one tool call.
+type Result struct {
+	// Decision tells the middleware what to do with the call.
+	Decision Decision
+
+	// RewrittenArguments optionally replaces the arguments before execution.
+	// It applies to DecisionAllow, and to an approval grant (see Approval).
+	// Empty keeps the original arguments. Must be valid tool arguments.
+	RewrittenArguments string
+
+	// Message is returned to the model as the tool result when the call is
+	// denied. Empty falls back to a default denial message containing the
+	// tool name.
+	Message string
+
+	// ApprovalInfo is surfaced to the user through the interrupt event when
+	// Decision is DecisionRequireApproval, so approvers can see what they are
+	// approving. It is persisted in the checkpoint and therefore must be
+	// gob-serializable (register custom types with schema.RegisterName).
+	ApprovalInfo any
+}
+
+// Policy decides whether a tool call may proceed.
+// Implementations must be safe for concurrent use: an agent may execute
+// several tool calls in parallel.
+type Policy interface {
+	Decide(ctx context.Context, req *Request) (*Result, error)
+}
+
+// PolicyFunc adapts an ordinary function to a Policy.
+type PolicyFunc func(ctx context.Context, req *Request) (*Result, error)
+
+// Decide implements Policy.
+func (f PolicyFunc) Decide(ctx context.Context, req *Request) (*Result, error) {
+	return f(ctx, req)
+}
+
+// Approval is the resume data the middleware expects for an approval interrupt.
+// Pass it as the interrupt target's value when resuming, e.g. via
+// Runner.ResumeWithParams: Targets: map[string]any{interruptID: &toolpolicy.Approval{...}}.
+type Approval struct {
+	// Approved executes the tool call; otherwise the call is denied.
+	Approved bool
+	// Message optionally overrides the denial message returned to the model
+	// when Approved is false.
+	Message string
+	// RewrittenArguments optionally replaces the call arguments before
+	// execution when Approved is true. Empty keeps the original arguments.
+	RewrittenArguments string
+}
+
+// approvalState is persisted in the checkpoint for a pending approval so that
+// re-interrupts (when a sibling tool call is resumed instead) carry the same
+// user-facing info, and so the original arguments survive the round trip.
+type approvalState struct {
+	Info      any
+	Arguments string
+}
+
+func init() {
+	schema.RegisterName[*approvalState]("_eino_adk_toolpolicy_approval_state")
+	schema.RegisterName[*Approval]("_eino_adk_toolpolicy_approval")
+}
+
+// Config configures the tool policy middleware.
+type Config struct {
+	// Policy is required; the middleware fails closed (returns an error for
+	// every wrapped tool call) if it is nil.
+	Policy Policy
+}
+
+// NewTyped creates a new generic tool policy middleware.
+func NewTyped[M adk.MessageType](_ context.Context, cfg *Config) (adk.TypedChatModelAgentMiddleware[M], error) {
+	if cfg == nil || cfg.Policy == nil {
+		return nil, errors.New("toolpolicy: Policy is required")
+	}
+	return &typedMiddleware[M]{
+		TypedBaseChatModelAgentMiddleware: &adk.TypedBaseChatModelAgentMiddleware[M]{},
+		policy:                            cfg.Policy,
+	}, nil
+}
+
+// New creates a new tool policy middleware for *schema.Message agents.
+func New(ctx context.Context, cfg *Config) (adk.ChatModelAgentMiddleware, error) {
+	return NewTyped[*schema.Message](ctx, cfg)
+}
+
+type typedMiddleware[M adk.MessageType] struct {
+	*adk.TypedBaseChatModelAgentMiddleware[M]
+	policy Policy
+}
+
+// WrapInvokableToolCall implements adk.TypedChatModelAgentMiddleware.
+func (m *typedMiddleware[M]) WrapInvokableToolCall(_ context.Context, endpoint adk.InvokableToolCallEndpoint, tCtx *adk.ToolContext) (adk.InvokableToolCallEndpoint, error) {
+	return func(ctx context.Context, argumentsInJSON string, opts ...tool.Option) (string, error) {
+		action, err := m.gate(ctx, tCtx, argumentsInJSON)
+		if err != nil {
+			return "", err
+		}
+		if action.execute {
+			return endpoint(ctx, action.arguments, opts...)
+		}
+		return action.denyMessage, nil
+	}, nil
+}
+
+// WrapStreamableToolCall implements adk.TypedChatModelAgentMiddleware.
+func (m *typedMiddleware[M]) WrapStreamableToolCall(_ context.Context, endpoint adk.StreamableToolCallEndpoint, tCtx *adk.ToolContext) (adk.StreamableToolCallEndpoint, error) {
+	return func(ctx context.Context, argumentsInJSON string, opts ...tool.Option) (*schema.StreamReader[string], error) {
+		action, err := m.gate(ctx, tCtx, argumentsInJSON)
+		if err != nil {
+			return nil, err
+		}
+		if action.execute {
+			return endpoint(ctx, action.arguments, opts...)
+		}
+		return schema.StreamReaderFromArray([]string{action.denyMessage}), nil
+	}, nil
+}
+
+// WrapEnhancedInvokableToolCall implements adk.TypedChatModelAgentMiddleware.
+func (m *typedMiddleware[M]) WrapEnhancedInvokableToolCall(_ context.Context, endpoint adk.EnhancedInvokableToolCallEndpoint, tCtx *adk.ToolContext) (adk.EnhancedInvokableToolCallEndpoint, error) {
+	return func(ctx context.Context, toolArgument *schema.ToolArgument, opts ...tool.Option) (*schema.ToolResult, error) {
+		action, err := m.gate(ctx, tCtx, toolArgumentText(toolArgument))
+		if err != nil {
+			return nil, err
+		}
+		if action.execute {
+			return endpoint(ctx, &schema.ToolArgument{Text: action.arguments}, opts...)
+		}
+		return textToolResult(action.denyMessage), nil
+	}, nil
+}
+
+// WrapEnhancedStreamableToolCall implements adk.TypedChatModelAgentMiddleware.
+func (m *typedMiddleware[M]) WrapEnhancedStreamableToolCall(_ context.Context, endpoint adk.EnhancedStreamableToolCallEndpoint, tCtx *adk.ToolContext) (adk.EnhancedStreamableToolCallEndpoint, error) {
+	return func(ctx context.Context, toolArgument *schema.ToolArgument, opts ...tool.Option) (*schema.StreamReader[*schema.ToolResult], error) {
+		action, err := m.gate(ctx, tCtx, toolArgumentText(toolArgument))
+		if err != nil {
+			return nil, err
+		}
+		if action.execute {
+			return endpoint(ctx, &schema.ToolArgument{Text: action.arguments}, opts...)
+		}
+		return schema.StreamReaderFromArray([]*schema.ToolResult{textToolResult(action.denyMessage)}), nil
+	}, nil
+}
+
+// gateAction is the outcome of the policy gate for one tool call: either
+// execute the endpoint with the given arguments, or short-circuit with a
+// denial message as the tool result.
+type gateAction struct {
+	execute     bool
+	arguments   string
+	denyMessage string
+}
+
+// gate evaluates the policy for one tool call, handling the first-run,
+// pending-approval, and resumed-approval paths.
+func (m *typedMiddleware[M]) gate(ctx context.Context, tCtx *adk.ToolContext, argumentsInJSON string) (gateAction, error) {
+	wasInterrupted, hasState, state := tool.GetInterruptState[*approvalState](ctx)
+	if wasInterrupted {
+		return resumeGate(ctx, tCtx, hasState, state)
+	}
+
+	result, err := m.policy.Decide(ctx, &Request{
+		ToolName:  tCtx.Name,
+		CallID:    tCtx.CallID,
+		Arguments: argumentsInJSON,
+	})
+	if err != nil {
+		return gateAction{}, fmt.Errorf("toolpolicy: policy decide failed for tool '%s': %w", tCtx.Name, err)
+	}
+	if result == nil {
+		return gateAction{}, fmt.Errorf("toolpolicy: policy returned nil result for tool '%s'", tCtx.Name)
+	}
+
+	switch result.Decision {
+	case DecisionAllow, "":
+		return gateAction{execute: true, arguments: orDefault(result.RewrittenArguments, argumentsInJSON)}, nil
+	case DecisionDeny:
+		return gateAction{denyMessage: denialMessage(tCtx.Name, result.Message)}, nil
+	case DecisionRequireApproval:
+		st := &approvalState{Info: result.ApprovalInfo, Arguments: argumentsInJSON}
+		return gateAction{}, tool.StatefulInterrupt(ctx, result.ApprovalInfo, st)
+	default:
+		return gateAction{}, fmt.Errorf("toolpolicy: unknown decision '%s' for tool '%s'", result.Decision, tCtx.Name)
+	}
+}
+
+// resumeGate handles a tool call that was previously interrupted for approval.
+func resumeGate(ctx context.Context, tCtx *adk.ToolContext, hasState bool, state *approvalState) (gateAction, error) {
+	if !hasState || state == nil {
+		return gateAction{}, fmt.Errorf("toolpolicy: approval interrupt state missing for tool '%s'", tCtx.Name)
+	}
+
+	isTarget, hasData, approval := tool.GetResumeContext[*Approval](ctx)
+	if !isTarget {
+		// A sibling interrupt was resumed instead; this call still waits for
+		// its own approval, so interrupt again with the same info.
+		return gateAction{}, tool.StatefulInterrupt(ctx, state.Info, state)
+	}
+	if !hasData || approval == nil {
+		return gateAction{}, fmt.Errorf("toolpolicy: approval for tool '%s' requires resume data of type *toolpolicy.Approval", tCtx.Name)
+	}
+
+	if approval.Approved {
+		return gateAction{execute: true, arguments: orDefault(approval.RewrittenArguments, state.Arguments)}, nil
+	}
+	return gateAction{denyMessage: denialMessage(tCtx.Name, approval.Message)}, nil
+}
+
+func denialMessage(toolName, custom string) string {
+	if custom != "" {
+		return custom
+	}
+	return fmt.Sprintf("Tool call '%s' was denied by policy.", toolName)
+}
+
+func orDefault(rewritten, original string) string {
+	if rewritten != "" {
+		return rewritten
+	}
+	return original
+}
+
+func toolArgumentText(arg *schema.ToolArgument) string {
+	if arg == nil {
+		return ""
+	}
+	return arg.Text
+}
+
+func textToolResult(text string) *schema.ToolResult {
+	return &schema.ToolResult{
+		Parts: []schema.ToolOutputPart{
+			{Type: schema.ToolPartTypeText, Text: text},
+		},
+	}
+}

--- a/adk/middlewares/toolpolicy/toolpolicy_test.go
+++ b/adk/middlewares/toolpolicy/toolpolicy_test.go
@@ -1,0 +1,626 @@
+/*
+ * Copyright 2026 CloudWeGo Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package toolpolicy
+
+import (
+	"context"
+	"errors"
+	"io"
+	"strings"
+	"sync"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/cloudwego/eino/adk"
+	"github.com/cloudwego/eino/components/model"
+	"github.com/cloudwego/eino/components/tool"
+	"github.com/cloudwego/eino/compose"
+	"github.com/cloudwego/eino/schema"
+)
+
+// --- endpoint-level unit tests ---
+
+type recordingTool struct {
+	called    bool
+	gotArgs   string
+	result    string
+	callError error
+}
+
+func (t *recordingTool) Info(_ context.Context) (*schema.ToolInfo, error) {
+	return &schema.ToolInfo{Name: "rec", Desc: "recording tool"}, nil
+}
+
+func (t *recordingTool) InvokableRun(_ context.Context, argumentsInJSON string, _ ...tool.Option) (string, error) {
+	t.called = true
+	t.gotArgs = argumentsInJSON
+	if t.callError != nil {
+		return "", t.callError
+	}
+	return t.result, nil
+}
+
+func allowPolicy(ctx context.Context, req *Request) (*Result, error) {
+	return &Result{Decision: DecisionAllow}, nil
+}
+
+func newInvokableMiddleware(t *testing.T, policy Policy) (adk.ChatModelAgentMiddleware, *recordingTool) {
+	t.Helper()
+	mw, err := New(context.Background(), &Config{Policy: policy})
+	require.NoError(t, err)
+	rt := &recordingTool{result: "tool-output"}
+	return mw, rt
+}
+
+func TestNilPolicyRejected(t *testing.T) {
+	_, err := New(context.Background(), &Config{})
+	assert.Error(t, err)
+	_, err = New(context.Background(), nil)
+	assert.Error(t, err)
+}
+
+func TestAllowExecutesTool(t *testing.T) {
+	mw, rt := newInvokableMiddleware(t, PolicyFunc(allowPolicy))
+
+	ep, err := mw.WrapInvokableToolCall(context.Background(), rt.InvokableRun, &adk.ToolContext{Name: "rec", CallID: "c1"})
+	require.NoError(t, err)
+
+	out, err := ep(context.Background(), `{"a":1}`)
+	require.NoError(t, err)
+	assert.True(t, rt.called)
+	assert.Equal(t, `{"a":1}`, rt.gotArgs)
+	assert.Equal(t, "tool-output", out)
+}
+
+func TestAllowWithRewrittenArguments(t *testing.T) {
+	mw, rt := newInvokableMiddleware(t, PolicyFunc(func(ctx context.Context, req *Request) (*Result, error) {
+		return &Result{Decision: DecisionAllow, RewrittenArguments: `{"sanitized":true}`}, nil
+	}))
+
+	ep, err := mw.WrapInvokableToolCall(context.Background(), rt.InvokableRun, &adk.ToolContext{Name: "rec", CallID: "c1"})
+	require.NoError(t, err)
+
+	_, err = ep(context.Background(), `{"a":1}`)
+	require.NoError(t, err)
+	assert.Equal(t, `{"sanitized":true}`, rt.gotArgs)
+}
+
+func TestDenyShortCircuits(t *testing.T) {
+	mw, rt := newInvokableMiddleware(t, PolicyFunc(func(ctx context.Context, req *Request) (*Result, error) {
+		assert.Equal(t, "rec", req.ToolName)
+		assert.Equal(t, "c1", req.CallID)
+		assert.Equal(t, `{"a":1}`, req.Arguments)
+		return &Result{Decision: DecisionDeny}, nil
+	}))
+
+	ep, err := mw.WrapInvokableToolCall(context.Background(), rt.InvokableRun, &adk.ToolContext{Name: "rec", CallID: "c1"})
+	require.NoError(t, err)
+
+	out, err := ep(context.Background(), `{"a":1}`)
+	require.NoError(t, err)
+	assert.False(t, rt.called, "denied tool must not execute")
+	assert.Contains(t, out, "denied")
+	assert.Contains(t, out, "rec")
+}
+
+func TestDenyWithCustomMessage(t *testing.T) {
+	mw, rt := newInvokableMiddleware(t, PolicyFunc(func(ctx context.Context, req *Request) (*Result, error) {
+		return &Result{Decision: DecisionDeny, Message: "no destructive ops on Fridays"}, nil
+	}))
+
+	ep, err := mw.WrapInvokableToolCall(context.Background(), rt.InvokableRun, &adk.ToolContext{Name: "rec", CallID: "c1"})
+	require.NoError(t, err)
+
+	out, err := ep(context.Background(), `{}`)
+	require.NoError(t, err)
+	assert.False(t, rt.called)
+	assert.Equal(t, "no destructive ops on Fridays", out)
+}
+
+func TestRequireApprovalInterrupts(t *testing.T) {
+	mw, rt := newInvokableMiddleware(t, PolicyFunc(func(ctx context.Context, req *Request) (*Result, error) {
+		return &Result{Decision: DecisionRequireApproval, ApprovalInfo: "needs admin sign-off"}, nil
+	}))
+
+	ep, err := mw.WrapInvokableToolCall(context.Background(), rt.InvokableRun, &adk.ToolContext{Name: "rec", CallID: "c1"})
+	require.NoError(t, err)
+
+	_, err = ep(context.Background(), `{}`)
+	require.Error(t, err)
+	assert.False(t, rt.called)
+
+	info, ok := compose.IsInterruptRerunError(err)
+	assert.True(t, ok, "expected an interrupt error, got: %v", err)
+	assert.Equal(t, "needs admin sign-off", info)
+}
+
+func TestPolicyErrorPropagates(t *testing.T) {
+	mw, rt := newInvokableMiddleware(t, PolicyFunc(func(ctx context.Context, req *Request) (*Result, error) {
+		return nil, errors.New("policy backend down")
+	}))
+
+	ep, err := mw.WrapInvokableToolCall(context.Background(), rt.InvokableRun, &adk.ToolContext{Name: "rec", CallID: "c1"})
+	require.NoError(t, err)
+
+	_, err = ep(context.Background(), `{}`)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "policy backend down")
+	assert.False(t, rt.called)
+}
+
+func TestNilPolicyResultRejected(t *testing.T) {
+	mw, rt := newInvokableMiddleware(t, PolicyFunc(func(ctx context.Context, req *Request) (*Result, error) {
+		return nil, nil
+	}))
+
+	ep, err := mw.WrapInvokableToolCall(context.Background(), rt.InvokableRun, &adk.ToolContext{Name: "rec", CallID: "c1"})
+	require.NoError(t, err)
+
+	_, err = ep(context.Background(), `{}`)
+	require.Error(t, err)
+	assert.False(t, rt.called)
+}
+
+func TestUnknownDecisionRejected(t *testing.T) {
+	mw, rt := newInvokableMiddleware(t, PolicyFunc(func(ctx context.Context, req *Request) (*Result, error) {
+		return &Result{Decision: "maybe"}, nil
+	}))
+
+	ep, err := mw.WrapInvokableToolCall(context.Background(), rt.InvokableRun, &adk.ToolContext{Name: "rec", CallID: "c1"})
+	require.NoError(t, err)
+
+	_, err = ep(context.Background(), `{}`)
+	require.ErrorContains(t, err, "unknown decision")
+	assert.False(t, rt.called)
+}
+
+type recordingStreamTool struct {
+	called bool
+}
+
+func (t *recordingStreamTool) Info(_ context.Context) (*schema.ToolInfo, error) {
+	return &schema.ToolInfo{Name: "recs", Desc: "recording stream tool"}, nil
+}
+
+func (t *recordingStreamTool) StreamableRun(_ context.Context, _ string, _ ...tool.Option) (*schema.StreamReader[string], error) {
+	t.called = true
+	return schema.StreamReaderFromArray([]string{"chunk1", "chunk2"}), nil
+}
+
+func TestStreamableDenyReturnsMessageStream(t *testing.T) {
+	mw, err := New(context.Background(), &Config{Policy: PolicyFunc(func(ctx context.Context, req *Request) (*Result, error) {
+		return &Result{Decision: DecisionDeny, Message: "stream denied"}, nil
+	})})
+	require.NoError(t, err)
+
+	st := &recordingStreamTool{}
+	ep, err := mw.WrapStreamableToolCall(context.Background(), st.StreamableRun, &adk.ToolContext{Name: "recs", CallID: "c1"})
+	require.NoError(t, err)
+
+	sr, err := ep(context.Background(), `{}`)
+	require.NoError(t, err)
+	defer sr.Close()
+
+	var sb strings.Builder
+	for {
+		chunk, err := sr.Recv()
+		if err == io.EOF {
+			break
+		}
+		require.NoError(t, err)
+		sb.WriteString(chunk)
+	}
+	assert.False(t, st.called)
+	assert.Equal(t, "stream denied", sb.String())
+}
+
+func TestStreamableAllowExecutes(t *testing.T) {
+	mw, err := New(context.Background(), &Config{Policy: PolicyFunc(allowPolicy)})
+	require.NoError(t, err)
+
+	st := &recordingStreamTool{}
+	ep, err := mw.WrapStreamableToolCall(context.Background(), st.StreamableRun, &adk.ToolContext{Name: "recs", CallID: "c1"})
+	require.NoError(t, err)
+
+	sr, err := ep(context.Background(), `{}`)
+	require.NoError(t, err)
+	defer sr.Close()
+
+	var chunks []string
+	for {
+		chunk, err := sr.Recv()
+		if err == io.EOF {
+			break
+		}
+		require.NoError(t, err)
+		chunks = append(chunks, chunk)
+	}
+	assert.True(t, st.called)
+	assert.Equal(t, []string{"chunk1", "chunk2"}, chunks)
+}
+
+func TestEnhancedInvokableDenyReturnsTextResult(t *testing.T) {
+	mw, err := New(context.Background(), &Config{Policy: PolicyFunc(func(ctx context.Context, req *Request) (*Result, error) {
+		return &Result{Decision: DecisionDeny, Message: "enhanced denied"}, nil
+	})})
+	require.NoError(t, err)
+
+	called := false
+	var endpoint adk.EnhancedInvokableToolCallEndpoint = func(ctx context.Context, arg *schema.ToolArgument, opts ...tool.Option) (*schema.ToolResult, error) {
+		called = true
+		return &schema.ToolResult{Parts: []schema.ToolOutputPart{{Type: schema.ToolPartTypeText, Text: "real"}}}, nil
+	}
+
+	ep, err := mw.WrapEnhancedInvokableToolCall(context.Background(), endpoint, &adk.ToolContext{Name: "en", CallID: "c1"})
+	require.NoError(t, err)
+
+	res, err := ep(context.Background(), &schema.ToolArgument{Text: `{"x":1}`})
+	require.NoError(t, err)
+	assert.False(t, called)
+	require.Len(t, res.Parts, 1)
+	assert.Equal(t, "enhanced denied", res.Parts[0].Text)
+}
+
+func TestEnhancedStreamableDenyReturnsTextResultStream(t *testing.T) {
+	mw, err := New(context.Background(), &Config{Policy: PolicyFunc(func(ctx context.Context, req *Request) (*Result, error) {
+		return &Result{Decision: DecisionDeny, Message: "enhanced stream denied"}, nil
+	})})
+	require.NoError(t, err)
+
+	called := false
+	var endpoint adk.EnhancedStreamableToolCallEndpoint = func(ctx context.Context, arg *schema.ToolArgument, opts ...tool.Option) (*schema.StreamReader[*schema.ToolResult], error) {
+		called = true
+		return schema.StreamReaderFromArray([]*schema.ToolResult{}), nil
+	}
+
+	ep, err := mw.WrapEnhancedStreamableToolCall(context.Background(), endpoint, &adk.ToolContext{Name: "ens", CallID: "c1"})
+	require.NoError(t, err)
+
+	sr, err := ep(context.Background(), &schema.ToolArgument{Text: `{}`})
+	require.NoError(t, err)
+	defer sr.Close()
+
+	res, err := sr.Recv()
+	require.NoError(t, err)
+	assert.False(t, called)
+	require.Len(t, res.Parts, 1)
+	assert.Equal(t, "enhanced stream denied", res.Parts[0].Text)
+}
+
+// --- end-to-end approval flow through ChatModelAgent + Runner ---
+
+type scriptedModel struct {
+	mu       sync.Mutex
+	messages []*schema.Message
+	calls    int
+}
+
+func (m *scriptedModel) next() *schema.Message {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	msg := m.messages[m.calls]
+	m.calls++
+	return msg
+}
+
+func (m *scriptedModel) Generate(_ context.Context, _ []*schema.Message, _ ...model.Option) (*schema.Message, error) {
+	return m.next(), nil
+}
+
+func (m *scriptedModel) Stream(_ context.Context, _ []*schema.Message, _ ...model.Option) (*schema.StreamReader[*schema.Message], error) {
+	msg := m.next()
+	return schema.StreamReaderFromArray([]*schema.Message{msg}), nil
+}
+
+func (m *scriptedModel) WithTools(_ []*schema.ToolInfo) (model.ToolCallingChatModel, error) {
+	return m, nil
+}
+
+type memoryStore struct {
+	mu sync.Mutex
+	m  map[string][]byte
+}
+
+func newMemoryStore() *memoryStore { return &memoryStore{m: map[string][]byte{}} }
+
+func (s *memoryStore) Set(_ context.Context, key string, value []byte) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.m[key] = value
+	return nil
+}
+
+func (s *memoryStore) Get(_ context.Context, key string) ([]byte, bool, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	v, ok := s.m[key]
+	return v, ok, nil
+}
+
+type e2eTool struct {
+	name   string
+	called int
+	lastIn string
+	output string
+}
+
+func (t *e2eTool) Info(_ context.Context) (*schema.ToolInfo, error) {
+	return &schema.ToolInfo{
+		Name: t.name,
+		Desc: "e2e tool " + t.name,
+		ParamsOneOf: schema.NewParamsOneOfByParams(map[string]*schema.ParameterInfo{
+			"query": {Type: schema.String, Desc: "query"},
+		}),
+	}, nil
+}
+
+func (t *e2eTool) InvokableRun(_ context.Context, argumentsInJSON string, _ ...tool.Option) (string, error) {
+	t.called++
+	t.lastIn = argumentsInJSON
+	return t.output, nil
+}
+
+func toolCallMessage(id, name, args string) *schema.Message {
+	return schema.AssistantMessage("", []schema.ToolCall{
+		{ID: id, Function: schema.FunctionCall{Name: name, Arguments: args}},
+	})
+}
+
+// collectEvents drains an event iterator, returning all events.
+func collectEvents(iter *adk.AsyncIterator[*adk.AgentEvent]) []*adk.AgentEvent {
+	var events []*adk.AgentEvent
+	for {
+		event, ok := iter.Next()
+		if !ok {
+			break
+		}
+		events = append(events, event)
+	}
+	return events
+}
+
+func findInterruptEvent(events []*adk.AgentEvent) *adk.AgentEvent {
+	for _, e := range events {
+		if e.Action != nil && e.Action.Interrupted != nil {
+			return e
+		}
+	}
+	return nil
+}
+
+func rootCauseInterruptID(t *testing.T, event *adk.AgentEvent) string {
+	t.Helper()
+	for _, ic := range event.Action.Interrupted.InterruptContexts {
+		if ic.IsRootCause {
+			return ic.ID
+		}
+	}
+	t.Fatal("no root-cause interrupt context found")
+	return ""
+}
+
+func setupApprovalAgent(t *testing.T, policy Policy, e2eTools ...*e2eTool) (adk.Agent, *scriptedModel) {
+	t.Helper()
+	ctx := context.Background()
+
+	var tools []tool.BaseTool
+	for _, et := range e2eTools {
+		tools = append(tools, et)
+	}
+
+	var script []*schema.Message
+	if len(e2eTools) == 1 {
+		script = []*schema.Message{
+			toolCallMessage("call-1", e2eTools[0].name, `{"query":"q1"}`),
+			schema.AssistantMessage("final answer", nil),
+		}
+	} else {
+		var calls []schema.ToolCall
+		for i, et := range e2eTools {
+			calls = append(calls, schema.ToolCall{
+				ID:       "call-" + string(rune('1'+i)),
+				Function: schema.FunctionCall{Name: et.name, Arguments: `{"query":"q"}`},
+			})
+		}
+		script = []*schema.Message{
+			schema.AssistantMessage("", calls),
+			schema.AssistantMessage("final answer", nil),
+		}
+	}
+
+	mdl := &scriptedModel{messages: script}
+
+	mw, err := New(ctx, &Config{Policy: policy})
+	require.NoError(t, err)
+
+	agent, err := adk.NewChatModelAgent(ctx, &adk.ChatModelAgentConfig{
+		Name:        "tester",
+		Description: "test agent",
+		Model:       mdl,
+		ToolsConfig: adk.ToolsConfig{
+			ToolsNodeConfig: compose.ToolsNodeConfig{Tools: tools},
+		},
+		Handlers: []adk.ChatModelAgentMiddleware{mw},
+	})
+	require.NoError(t, err)
+	return agent, mdl
+}
+
+func TestApprovalGrantedEndToEnd(t *testing.T) {
+	ctx := context.Background()
+	risky := &e2eTool{name: "risky_op", output: "op done"}
+
+	policy := PolicyFunc(func(ctx context.Context, req *Request) (*Result, error) {
+		return &Result{
+			Decision:     DecisionRequireApproval,
+			ApprovalInfo: "approve risky_op?",
+		}, nil
+	})
+
+	agent, _ := setupApprovalAgent(t, policy, risky)
+	runner := adk.NewRunner(ctx, adk.RunnerConfig{Agent: agent, CheckPointStore: newMemoryStore()})
+
+	events := collectEvents(runner.Query(ctx, "do it", adk.WithCheckPointID("cp-1")))
+	interrupt := findInterruptEvent(events)
+	require.NotNil(t, interrupt, "expected an interrupt event")
+	assert.Equal(t, 0, risky.called, "tool must not run before approval")
+
+	interruptID := rootCauseInterruptID(t, interrupt)
+
+	iter, err := runner.ResumeWithParams(ctx, "cp-1", &adk.ResumeParams{
+		Targets: map[string]any{interruptID: &Approval{Approved: true}},
+	})
+	require.NoError(t, err)
+	events = collectEvents(iter)
+
+	assert.Equal(t, 1, risky.called)
+	assert.Equal(t, `{"query":"q1"}`, risky.lastIn)
+	last := events[len(events)-1]
+	require.NotNil(t, last.Output)
+	require.NotNil(t, last.Output.MessageOutput)
+	assert.Equal(t, "final answer", last.Output.MessageOutput.Message.Content)
+}
+
+func TestApprovalRejectedEndToEnd(t *testing.T) {
+	ctx := context.Background()
+	risky := &e2eTool{name: "risky_op", output: "op done"}
+
+	policy := PolicyFunc(func(ctx context.Context, req *Request) (*Result, error) {
+		return &Result{Decision: DecisionRequireApproval, ApprovalInfo: "approve?"}, nil
+	})
+
+	agent, mdl := setupApprovalAgent(t, policy, risky)
+	// The model must see the denial as the tool result, then answer.
+	runner := adk.NewRunner(ctx, adk.RunnerConfig{Agent: agent, CheckPointStore: newMemoryStore()})
+
+	events := collectEvents(runner.Query(ctx, "do it", adk.WithCheckPointID("cp-2")))
+	interrupt := findInterruptEvent(events)
+	require.NotNil(t, interrupt)
+	interruptID := rootCauseInterruptID(t, interrupt)
+
+	iter, err := runner.ResumeWithParams(ctx, "cp-2", &adk.ResumeParams{
+		Targets: map[string]any{interruptID: &Approval{Approved: false, Message: "user said no"}},
+	})
+	require.NoError(t, err)
+	events = collectEvents(iter)
+
+	assert.Equal(t, 0, risky.called, "rejected tool must not run")
+	_ = mdl
+	last := events[len(events)-1]
+	assert.Equal(t, "final answer", last.Output.MessageOutput.Message.Content)
+}
+
+func TestApprovalWithRewrittenArgumentsEndToEnd(t *testing.T) {
+	ctx := context.Background()
+	risky := &e2eTool{name: "risky_op", output: "op done"}
+
+	policy := PolicyFunc(func(ctx context.Context, req *Request) (*Result, error) {
+		return &Result{Decision: DecisionRequireApproval, ApprovalInfo: "approve?"}, nil
+	})
+
+	agent, _ := setupApprovalAgent(t, policy, risky)
+	runner := adk.NewRunner(ctx, adk.RunnerConfig{Agent: agent, CheckPointStore: newMemoryStore()})
+
+	events := collectEvents(runner.Query(ctx, "do it", adk.WithCheckPointID("cp-3")))
+	interrupt := findInterruptEvent(events)
+	require.NotNil(t, interrupt)
+	interruptID := rootCauseInterruptID(t, interrupt)
+
+	iter, err := runner.ResumeWithParams(ctx, "cp-3", &adk.ResumeParams{
+		Targets: map[string]any{interruptID: &Approval{Approved: true, RewrittenArguments: `{"query":"rewritten"}`}},
+	})
+	require.NoError(t, err)
+	collectEvents(iter)
+
+	assert.Equal(t, 1, risky.called)
+	assert.Equal(t, `{"query":"rewritten"}`, risky.lastIn)
+}
+
+func TestParallelApprovalsReInterruptEndToEnd(t *testing.T) {
+	ctx := context.Background()
+	toolA := &e2eTool{name: "op_a", output: "a done"}
+	toolB := &e2eTool{name: "op_b", output: "b done"}
+
+	policy := PolicyFunc(func(ctx context.Context, req *Request) (*Result, error) {
+		return &Result{
+			Decision:     DecisionRequireApproval,
+			ApprovalInfo: "approve " + req.ToolName + "?",
+		}, nil
+	})
+
+	agent, _ := setupApprovalAgent(t, policy, toolA, toolB)
+	runner := adk.NewRunner(ctx, adk.RunnerConfig{Agent: agent, CheckPointStore: newMemoryStore()})
+
+	// First run: both tool calls require approval and interrupt.
+	events := collectEvents(runner.Query(ctx, "do both", adk.WithCheckPointID("cp-4")))
+	interrupt := findInterruptEvent(events)
+	require.NotNil(t, interrupt)
+	assert.Equal(t, 0, toolA.called)
+	assert.Equal(t, 0, toolB.called)
+
+	var ids []string
+	for _, ic := range interrupt.Action.Interrupted.InterruptContexts {
+		if ic.IsRootCause {
+			ids = append(ids, ic.ID)
+		}
+	}
+	require.NotEmpty(t, ids)
+
+	// Approve only the first pending call; the other must re-interrupt.
+	iter, err := runner.ResumeWithParams(ctx, "cp-4", &adk.ResumeParams{
+		Targets: map[string]any{ids[0]: &Approval{Approved: true}},
+	})
+	require.NoError(t, err)
+	events = collectEvents(iter)
+
+	secondInterrupt := findInterruptEvent(events)
+	require.NotNil(t, secondInterrupt, "the unapproved sibling must re-interrupt")
+	assert.Equal(t, 1, toolA.called+toolB.called, "exactly one tool should have run")
+
+	secondID := rootCauseInterruptID(t, secondInterrupt)
+
+	// Approve the remaining call; the agent completes.
+	iter, err = runner.ResumeWithParams(ctx, "cp-4", &adk.ResumeParams{
+		Targets: map[string]any{secondID: &Approval{Approved: true}},
+	})
+	require.NoError(t, err)
+	events = collectEvents(iter)
+
+	assert.Nil(t, findInterruptEvent(events))
+	assert.Equal(t, 1, toolA.called)
+	assert.Equal(t, 1, toolB.called)
+	last := events[len(events)-1]
+	assert.Equal(t, "final answer", last.Output.MessageOutput.Message.Content)
+}
+
+func TestTypedMiddlewareWorksForAgenticMessage(t *testing.T) {
+	mw, err := NewTyped[*schema.AgenticMessage](context.Background(), &Config{Policy: PolicyFunc(func(ctx context.Context, req *Request) (*Result, error) {
+		return &Result{Decision: DecisionDeny, Message: "agentic denied"}, nil
+	})})
+	require.NoError(t, err)
+
+	rt := &recordingTool{result: "x"}
+	ep, err := mw.WrapInvokableToolCall(context.Background(), rt.InvokableRun, &adk.ToolContext{Name: "rec", CallID: "c1"})
+	require.NoError(t, err)
+
+	out, err := ep(context.Background(), `{}`)
+	require.NoError(t, err)
+	assert.False(t, rt.called)
+	assert.Equal(t, "agentic denied", out)
+}


### PR DESCRIPTION
Implements #996

## Motivation

Eino has powerful primitives (tool middleware, interrupt/resume), but application developers still hand-roll a policy layer for deciding whether a tool call should be allowed, denied, rewritten, audited, or interrupted for human approval. This PR adds the standard, reusable abstraction proposed in #996, following the thin-hook direction that converged in the issue discussion: the middleware owns only the invocation seam and lifecycle integration; policy storage, approval storage, and audit persistence stay deployment-specific (audit can plug into existing callback handlers).

## Design

New `adk/middlewares/toolpolicy` package:

- **`Policy` interface** — `Decide(ctx, *Request) (*Result, error)`; `Request` carries tool name, call ID, and raw JSON arguments. A `PolicyFunc` adapter is provided.
- **Three verdicts** —
  - `allow`: execute, optionally with rewritten/sanitized arguments;
  - `deny`: the model receives a safe tool result (default or custom message) without executing the tool;
  - `require_approval`: the run interrupts with the policy's `ApprovalInfo` and waits.
- **Approval via existing interrupt/resume** — no second checkpoint mechanism: approval state is persisted in the checkpoint, and the approver resumes with `*toolpolicy.Approval` as resume data (`Approved`, optional denial `Message`, optional `RewrittenArguments`). Unapproved sibling calls re-interrupt with the same user-facing info.
- **Full coverage of the invocation seam** — all four tool-call kinds are wrapped (invokable, streamable, enhanced invokable, enhanced streamable), for both `Message` and `AgenticMessage` agents.
- **Fails closed** — policy errors, nil results, and unknown decisions surface as errors; a missing `Policy` is rejected at construction.

## Example

```go
mw, _ := toolpolicy.New(ctx, &toolpolicy.Config{Policy: toolpolicy.PolicyFunc(
    func(ctx context.Context, req *toolpolicy.Request) (*toolpolicy.Result, error) {
        if req.ToolName == "delete_database" {
            return &toolpolicy.Result{
                Decision:     toolpolicy.DecisionRequireApproval,
                ApprovalInfo: fmt.Sprintf("approve %s(%s)?", req.ToolName, req.Arguments),
            }, nil
        }
        return &toolpolicy.Result{Decision: toolpolicy.DecisionAllow}, nil
    })})

agent, _ := adk.NewChatModelAgent(ctx, &adk.ChatModelAgentConfig{
    ...
    Handlers: []adk.ChatModelAgentMiddleware{mw},
})

// after the run interrupts:
runner.ResumeWithParams(ctx, checkPointID, &adk.ResumeParams{
    Targets: map[string]any{interruptID: &toolpolicy.Approval{Approved: true}},
})
```

## Tests

18 tests, all green with `-race`:

- endpoint-level: allow / rewritten args / deny (default & custom message) / approval interrupt / policy error / nil result / unknown decision, across all four tool-call kinds;
- end-to-end through ChatModelAgent + Runner + checkpoint store: approval granted (tool runs with original args), rejected (denial message reaches the model), granted with rewritten arguments, and two parallel approvals where the unapproved sibling re-interrupts before the run completes;
- genericity: the same middleware serves `*schema.AgenticMessage` agents.