### PR TITLE
fix(schema): correct field merging in agentic message concat

### DIFF
--- a/schema/agentic_message.go
+++ b/schema/agentic_message.go
@@ -1323,8 +1323,12 @@ func concatReasoning(reasons []*Reasoning) (ret *Reasoning, err error) {
 		if r.Text != "" {
 			ret.Text += r.Text
 		}
+		// Signature is an opaque integrity token for the reasoning text, not
+		// appendable content: when the same signature repeats across chunks,
+		// concatenating it corrupts verification. Keep the last non-empty one,
+		// matching mergeReasoningParts for *Message.
 		if r.Signature != "" {
-			ret.Signature += r.Signature
+			ret.Signature = r.Signature
 		}
 		if r.OpenAIExtension != nil {
 			openaiExtensions = append(openaiExtensions, r.OpenAIExtension)
@@ -1817,9 +1821,9 @@ func concatMCPToolResults(results []*MCPToolResult) (*MCPToolResult, error) {
 			continue
 		}
 
-		if r.Content != "" {
-			ret.Content = r.Content
-		}
+		// Content streams in chunks across messages, so append it like
+		// MCPToolCall.Arguments instead of overwriting previous chunks.
+		ret.Content += r.Content
 
 		if ret.ServerLabel == "" {
 			ret.ServerLabel = r.ServerLabel

--- a/schema/agentic_message_test.go
+++ b/schema/agentic_message_test.go
@@ -170,6 +170,119 @@ func TestConcatAgenticMessages(t *testing.T) {
 		assert.Equal(t, "Part1-Part3", result.ContentBlocks[0].Reasoning.Text)
 	})
 
+	t.Run("concat reasoning keeps last non-empty signature", func(t *testing.T) {
+		// The signature is an opaque integrity token, not appendable content:
+		// adapters commonly repeat the same signature in every chunk, and
+		// concatenating it corrupts verification. The last non-empty one wins,
+		// matching mergeReasoningParts for *Message.
+		msgs := []*AgenticMessage{
+			{
+				Role: AgenticRoleTypeAssistant,
+				ContentBlocks: []*ContentBlock{
+					{
+						Type: ContentBlockTypeReasoning,
+						Reasoning: &Reasoning{
+							Text:      "First ",
+							Signature: "sig-abc",
+						},
+						StreamingMeta: &StreamingMeta{Index: 0},
+					},
+				},
+			},
+			{
+				Role: AgenticRoleTypeAssistant,
+				ContentBlocks: []*ContentBlock{
+					{
+						Type: ContentBlockTypeReasoning,
+						Reasoning: &Reasoning{
+							Text:      "Second",
+							Signature: "sig-abc",
+						},
+						StreamingMeta: &StreamingMeta{Index: 0},
+					},
+				},
+			},
+		}
+
+		result, err := ConcatAgenticMessages(msgs)
+		assert.NoError(t, err)
+		assert.Len(t, result.ContentBlocks, 1)
+		assert.Equal(t, "First Second", result.ContentBlocks[0].Reasoning.Text)
+		assert.Equal(t, "sig-abc", result.ContentBlocks[0].Reasoning.Signature)
+	})
+
+	t.Run("concat reasoning signature falls back to later non-empty chunk", func(t *testing.T) {
+		msgs := []*AgenticMessage{
+			{
+				Role: AgenticRoleTypeAssistant,
+				ContentBlocks: []*ContentBlock{
+					{
+						Type: ContentBlockTypeReasoning,
+						Reasoning: &Reasoning{
+							Text:      "First ",
+							Signature: "sig-first",
+						},
+						StreamingMeta: &StreamingMeta{Index: 0},
+					},
+				},
+			},
+			{
+				Role: AgenticRoleTypeAssistant,
+				ContentBlocks: []*ContentBlock{
+					{
+						Type: ContentBlockTypeReasoning,
+						Reasoning: &Reasoning{
+							Text: "Second",
+						},
+						StreamingMeta: &StreamingMeta{Index: 0},
+					},
+				},
+			},
+		}
+
+		result, err := ConcatAgenticMessages(msgs)
+		assert.NoError(t, err)
+		assert.Equal(t, "sig-first", result.ContentBlocks[0].Reasoning.Signature)
+	})
+
+	t.Run("concat mcp tool result appends streamed content chunks", func(t *testing.T) {
+		// Streamed MCP tool results arrive in chunks; concatenation must append
+		// them (like MCPToolCall.Arguments) instead of keeping only the last one.
+		msgs := []*AgenticMessage{
+			{
+				Role: AgenticRoleTypeAssistant,
+				ContentBlocks: []*ContentBlock{
+					{
+						Type: ContentBlockTypeMCPToolResult,
+						MCPToolResult: &MCPToolResult{
+							CallID:  "mcp_call_1",
+							Name:    "mcp_func",
+							Content: `{"part1":`,
+						},
+						StreamingMeta: &StreamingMeta{Index: 0},
+					},
+				},
+			},
+			{
+				Role: AgenticRoleTypeAssistant,
+				ContentBlocks: []*ContentBlock{
+					{
+						Type: ContentBlockTypeMCPToolResult,
+						MCPToolResult: &MCPToolResult{
+							Content: `"value"}`,
+						},
+						StreamingMeta: &StreamingMeta{Index: 0},
+					},
+				},
+			},
+		}
+
+		result, err := ConcatAgenticMessages(msgs)
+		assert.NoError(t, err)
+		assert.Len(t, result.ContentBlocks, 1)
+		assert.Equal(t, `{"part1":"value"}`, result.ContentBlocks[0].MCPToolResult.Content)
+	})
+
 	t.Run("concat user input text", func(t *testing.T) {
 		msgs := []*AgenticMessage{
 			{
@@ -681,7 +794,7 @@ func TestConcatAgenticMessages(t *testing.T) {
 		assert.Equal(t, "mcp-server", result.ContentBlocks[0].MCPToolResult.ServerLabel)
 		assert.Equal(t, "mcp_call_1", result.ContentBlocks[0].MCPToolResult.CallID)
 		assert.Equal(t, "mcp_func", result.ContentBlocks[0].MCPToolResult.Name)
-		assert.Equal(t, `Second`, result.ContentBlocks[0].MCPToolResult.Content)
+		assert.Equal(t, `FirstSecond`, result.ContentBlocks[0].MCPToolResult.Content)
 	})
 
 	t.Run("concat mcp list tools", func(t *testing.T) {


### PR DESCRIPTION
Fixes #1261

## Problem

Two field-merge defects in `ConcatAgenticMessages` (`schema/agentic_message.go`):

1. **`concatMCPToolResults` kept only the last content chunk** — `ret.Content = r.Content` overwrote previous chunks, so a streamed MCP tool result lost everything but its final chunk. The sibling `concatMCPToolCalls` correctly accumulates (`ret.Arguments += c.Arguments`), and the existing test even asserted the buggy overwrite, confirming a copy-paste mistake.

2. **`concatReasoning` corrupted signatures** — `ret.Signature += r.Signature` treated the signature as appendable text. A reasoning `Signature` is an opaque integrity/encryption token: adapters commonly repeat the same signature across chunks, and concatenating it (e.g. `sig-abcsig-abc`) fails verification when the message is sent back to the model. The old `*Message` API (`mergeReasoningParts`) keeps the last non-empty signature, so the two message APIs also disagreed.

## Fix

- `concatMCPToolResults`: append `Content` chunks, matching `concatMCPToolCalls`.
- `concatReasoning`: keep the last non-empty `Signature`, matching `mergeReasoningParts` for `*Message`.

## Tests

- New regression tests: streamed MCP result chunks append into complete JSON; repeated signatures collapse to one; a signature from an earlier chunk survives a later empty chunk.
- Updated the existing `concat mcp tool result` test, which had asserted the buggy overwrite behavior.
- Verified the new/updated tests fail without the fix; full `go test ./schema/` is green.