### PR TITLE
fix(compose): drop untyped nil values before fan-in merge

### DIFF
--- a/compose/values_merge.go
+++ b/compose/values_merge.go
@@ -37,6 +37,22 @@ type mergeOptions struct {
 
 // the caller should ensure len(vs) > 1
 func mergeValues(vs []any, opts *mergeOptions) (any, error) {
+	// An untyped nil output carries no value: a fan-in predecessor returning
+	// (nil, nil) contributes nothing to the merge. Drop untyped nils so the
+	// outcome is deterministic — previously a nil landing at vs[0] panicked in
+	// reflect.Value.Type, while the same values in another order failed inside
+	// the type-specific merge func, and channel iteration order is random.
+	var nilFiltered bool
+	vs, opts, nilFiltered = dropNilMergeValues(vs, opts)
+	if nilFiltered {
+		if len(vs) == 0 {
+			return nil, nil
+		}
+		if len(vs) == 1 {
+			return vs[0], nil
+		}
+	}
+
 	v0 := reflect.ValueOf(vs[0])
 	t0 := v0.Type()
 
@@ -79,4 +95,40 @@ func mergeValues(vs []any, opts *mergeOptions) (any, error) {
 	}
 
 	return nil, fmt.Errorf("(mergeValues) unsupported type: %v", t0)
+}
+
+// dropNilMergeValues removes untyped nil values before merging, keeping
+// opts.names (when set) aligned with the surviving values. It reports whether
+// any value was dropped, so the caller can short-circuit empty/singleton
+// results without changing its contract for nil-free inputs.
+func dropNilMergeValues(vs []any, opts *mergeOptions) ([]any, *mergeOptions, bool) {
+	hasNil := false
+	for _, v := range vs {
+		if v == nil {
+			hasNil = true
+			break
+		}
+	}
+	if !hasNil {
+		return vs, opts, false
+	}
+
+	filtered := make([]any, 0, len(vs))
+	var filteredNames []string
+	if opts != nil && opts.names != nil {
+		filteredNames = make([]string, 0, len(opts.names))
+	}
+	for i, v := range vs {
+		if v == nil {
+			continue
+		}
+		filtered = append(filtered, v)
+		if filteredNames != nil && i < len(opts.names) {
+			filteredNames = append(filteredNames, opts.names[i])
+		}
+	}
+	if opts != nil {
+		opts.names = filteredNames
+	}
+	return filtered, opts, true
 }

--- a/compose/values_merge_test.go
+++ b/compose/values_merge_test.go
@@ -17,6 +17,7 @@
 package compose
 
 import (
+	"context"
 	"fmt"
 	"io"
 	"sort"
@@ -253,4 +254,73 @@ func Test_mergeValues(t *testing.T) {
 		assert.ErrorContains(t, err, "unsupported type")
 	})
 
+	t.Run("untyped nil values", func(t *testing.T) {
+		t.Run("nil first does not panic", func(t *testing.T) {
+			m := map[string]any{"k": "v"}
+			merged, err := mergeValues([]any{nil, m}, nil)
+			assert.NoError(t, err)
+			assert.Equal(t, m, merged)
+		})
+
+		t.Run("nil last", func(t *testing.T) {
+			m := map[string]any{"k": "v"}
+			merged, err := mergeValues([]any{m, nil}, nil)
+			assert.NoError(t, err)
+			assert.Equal(t, m, merged)
+		})
+
+		t.Run("all nil returns nil", func(t *testing.T) {
+			merged, err := mergeValues([]any{nil, nil}, nil)
+			assert.NoError(t, err)
+			assert.Nil(t, merged)
+		})
+
+		t.Run("nil between mergeable values", func(t *testing.T) {
+			m1 := map[string]any{"a": "1"}
+			m2 := map[string]any{"b": "2"}
+			merged, err := mergeValues([]any{m1, nil, m2}, nil)
+			assert.NoError(t, err)
+			assert.Equal(t, map[string]any{"a": "1", "b": "2"}, merged)
+		})
+
+		t.Run("names stay aligned after dropping nil", func(t *testing.T) {
+			opts := &mergeOptions{names: []string{"n0", "n1", "n2"}}
+			m := map[string]any{"k": "v"}
+			merged, err := mergeValues([]any{nil, m, nil}, opts)
+			assert.NoError(t, err)
+			assert.Equal(t, m, merged)
+			assert.Equal(t, []string{"n1"}, opts.names)
+		})
+	})
+
+}
+
+func TestFanInMergeWithNilNodeOutput(t *testing.T) {
+	// A fan-in predecessor returning (nil, nil) must not crash or fail the
+	// merge; the sink deterministically receives the remaining values.
+	// Run repeatedly to cover channel iteration orders.
+	for i := 0; i < 30; i++ {
+		g := NewGraph[string, any]()
+		assert.NoError(t, g.AddLambdaNode("nilnode", InvokableLambda(func(ctx context.Context, in string) (any, error) {
+			return nil, nil
+		})))
+		assert.NoError(t, g.AddLambdaNode("mapnode", InvokableLambda(func(ctx context.Context, in string) (any, error) {
+			return map[string]any{"k": "v"}, nil
+		})))
+		assert.NoError(t, g.AddLambdaNode("sink", InvokableLambda(func(ctx context.Context, in any) (any, error) {
+			return in, nil
+		})))
+		assert.NoError(t, g.AddEdge(START, "nilnode"))
+		assert.NoError(t, g.AddEdge(START, "mapnode"))
+		assert.NoError(t, g.AddEdge("nilnode", "sink"))
+		assert.NoError(t, g.AddEdge("mapnode", "sink"))
+		assert.NoError(t, g.AddEdge("sink", END))
+
+		r, err := g.Compile(context.Background())
+		require.NoError(t, err)
+
+		out, err := r.Invoke(context.Background(), "x")
+		require.NoError(t, err)
+		assert.Equal(t, map[string]any{"k": "v"}, out)
+	}
 }


### PR DESCRIPTION
Fixes #1263

## Problem

When a fan-in predecessor returns `(nil, nil)`, `mergeValues` receives the untyped nil among the values to merge. Channel `Values` live in a Go map, so iteration order is random and the same run either:

- **panicked** with `reflect: call of reflect.Value.Type on zero Value` whenever the nil landed at `vs[0]` (re-panicked out of `Invoke`), or
- failed inside the type-specific merge func (`field type mismatch ... got: '<nil>'`) otherwise.

Unit-level, both forms reproduce deterministically:

```go
mergeValues([]any{nil, map[string]any{"k": "v"}}, nil) // panic
mergeValues([]any{map[string]any{"k": "v"}, nil}, nil) // error
mergeValues([]any{nil, nil}, nil)                        // panic
```

## Fix

Drop untyped nils before merging: they carry no value, so the result deterministically equals the merge of the remaining values (all-nil merges to nil). `opts.names` for named stream merges stays aligned with the surviving values.

Behavior for nil-free inputs is fully preserved — including the `len(vs) > 1` contract: a single unregistered-type value still errors as before; the empty/singleton short-circuit only applies when nils were actually dropped.

Out of scope (intentionally unchanged): the runtime edge type check, where an `any`-typed predecessor's nil output flowing into a concretely-typed successor fails `assignableTypeMay` with a clear, deterministic error.

## Tests

- unit: nil-first no longer panics, nil-last merges, all-nil returns nil, nil between mergeable values, names alignment after dropping nils; the existing `unregistered type` single-element contract is unchanged;
- graph-level: fan-in with a `(nil, nil)` predecessor and a map predecessor, 30 iterations across channel iteration orders — previously panic/error at random, now deterministically `map[string]any{"k": "v"}`;
- verified the new tests fail (panic) without the fix; `go test -race ./compose/` is green.