### PR TITLE
docs(readme): fix ChatModelAgent quickstart example

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,8 @@ for {
     if !ok {
         break
     }
-    fmt.Println(event.Message.Content)
+    msg, _ := event.Output.MessageOutput.GetMessage()
+    fmt.Println(msg.Content)
 }
 ```
 

--- a/README.zh_CN.md
+++ b/README.zh_CN.md
@@ -47,7 +47,8 @@ for {
     if !ok {
         break
     }
-    fmt.Println(event.Message.Content)
+    msg, _ := event.Output.MessageOutput.GetMessage()
+    fmt.Println(msg.Content)
 }
 ```
 


### PR DESCRIPTION
#### What type of PR is this?
docs: Documentation only changes

More detailed description for this PR(en: English/zh: Chinese).
  en:
  This PR updates the ChatModelAgent quickstart in `README.md` and `README.zh_CN.md` to use the current ADK event API.The outdated `event.Message.Content` access is replaced with `event.Output.MessageOutput.GetMessage()` so the example matches the current code.

  zh(optional):
  本 PR 更新 `README.md` 和 `README.zh_CN.md` 中的 ChatModelAgent quickstart 示例，改为使用当前的 ADK event API。将过期的 `event.Message.Content` 改为 `event.Output.MessageOutput.GetMessage()`，保证示例与当前代码一致。

Which issue(s) this PR fixes:
  Fixes #1265