### PR TITLE
fix(adk): preserve natural subagent completion during drain

### DIFF
--- a/adk/backgroundtask/executor.go
+++ b/adk/backgroundtask/executor.go
@@ -125,8 +125,9 @@ type Executor interface {
 	// ValidateExecution performs side-effect-free validation immediately before
 	// an attempt is claimed.
 	ValidateExecution(context.Context, *Task) error
-	// SupportsDrain reports whether Execute handles ControlDrain by returning a
-	// resumable suspended or yielded result.
+	// SupportsDrain reports whether Execute handles ControlDrain. When drain
+	// cancellation takes effect, Execute returns a resumable suspended or yielded
+	// result; a run that terminates first may preserve its own outcome.
 	SupportsDrain() bool
 	// Execute owns the attempt until it returns. It must observe ctx and runtime
 	// controls and return exactly one legal ExecutionResult variant.

--- a/adk/backgroundtask/subagent/subagent.go
+++ b/adk/backgroundtask/subagent/subagent.go
@@ -262,8 +262,9 @@ func (e *Executor[M]) ValidateExecution(_ context.Context, task *backgroundtask.
 	return e.ValidateSpec(task.Spec)
 }
 
-// SupportsDrain reports true because sub-agent drain captures an ADK Runner
-// checkpoint before returning a suspended result.
+// SupportsDrain reports true because an effective sub-agent drain captures an
+// ADK Runner checkpoint and returns a suspended result. If the run terminates
+// before drain cancellation takes effect, its own outcome is preserved.
 func (e *Executor[M]) SupportsDrain() bool { return true }
 
 func validateSpecPayload(spec backgroundtask.Spec) (*taskPayload, error) {
@@ -444,26 +445,16 @@ func (e *Executor[M]) Execute(
 	})
 	cancelOption, cancelRun := adk.WithCancel()
 	controlRequests := make(chan backgroundtask.ControlRequest, 1)
+	cancelOutcomes := make(chan error, 1)
 	controlWatchDone := make(chan struct{})
 	defer close(controlWatchDone)
 	go func() {
 		select {
 		case control := <-runtime.Controls():
 			controlRequests <- control
-			cancelOptions := []adk.AgentCancelOption{adk.WithRecursive()}
-			if control.Kind == backgroundtask.ControlDrain {
-				cancelOptions = append(cancelOptions,
-					adk.WithAgentCancelMode(adk.CancelAfterChatModel|adk.CancelAfterToolCalls))
-				if e.drainCancelTimeout > 0 {
-					cancelOptions = append(cancelOptions,
-						adk.WithAgentCancelTimeout(e.drainCancelTimeout))
-				}
-			} else {
-				cancelOptions = append(cancelOptions, adk.WithAgentCancelMode(adk.CancelImmediate))
-			}
-			if handle, accepted := cancelRun(cancelOptions...); accepted {
-				_ = handle.Wait()
-			}
+			cancelOutcomes <- requestCancelAndWait(
+				control, cancelRun, e.drainCancelTimeout,
+			)
 		case <-controlWatchDone:
 		case <-ctx.Done():
 		}
@@ -485,7 +476,9 @@ func (e *Executor[M]) Execute(
 			interrupted = event.Action.Interrupted
 		}
 		if event.Err != nil && interrupted == nil {
-			return e.handleRunError(ctx, iter, task, controlRequests, event.Err)
+			return e.handleRunError(
+				ctx, iter, task, controlRequests, cancelOutcomes, event.Err,
+			)
 		}
 		materialized := event
 		if event.Output != nil && event.Output.MessageOutput != nil {
@@ -495,7 +488,9 @@ func (e *Executor[M]) Execute(
 				if errors.As(messageErr, &retryErr) {
 					continue
 				}
-				return e.handleRunError(ctx, iter, task, controlRequests, messageErr)
+				return e.handleRunError(
+					ctx, iter, task, controlRequests, cancelOutcomes, messageErr,
+				)
 			}
 			materialized = materializedEvent(event, message)
 			final = agenttool.ExtractTextContent(message)
@@ -504,15 +499,49 @@ func (e *Executor[M]) Execute(
 			materialized, foregroundcoord.ProjectionDetached(ctx), copyMaterializedEvent[M],
 		)
 	}
-	if controlResult, controlErr, controlled := e.controlResult(ctx, task, pollControl(controlRequests)); controlled {
-		return controlResult, controlErr
+	control := pollControl(controlRequests)
+	cancelOutcome := waitForDrainCancelOutcome(ctx, control, cancelOutcomes)
+	return e.resolveRunOutcome(ctx, task, control, cancelOutcome, subagentRunOutcome{
+		final:       final,
+		interrupted: interrupted,
+	})
+}
+
+type subagentRunOutcome struct {
+	final       string
+	interrupted *adk.InterruptInfo
+	err         error
+}
+
+func (e *Executor[M]) resolveRunOutcome(
+	ctx context.Context,
+	task *backgroundtask.Task,
+	control backgroundtask.ControlRequest,
+	cancelOutcome error,
+	run subagentRunOutcome,
+) (*backgroundtask.ExecutionResult, error) {
+	drainLostRace := control.Kind == backgroundtask.ControlDrain &&
+		errors.Is(cancelOutcome, adk.ErrExecutionEnded)
+	if !drainLostRace {
+		if result, controlErr, controlled := e.controlResult(ctx, task, control); controlled {
+			return result, controlErr
+		}
 	}
-	if interrupted != nil {
-		return e.interruptResult(ctx, task, interrupted)
+	if run.err != nil {
+		if errors.Is(run.err, adk.ErrSessionBusy) {
+			return &backgroundtask.ExecutionResult{
+				Directive:  backgroundtask.ExecutionDirectiveYield,
+				Checkpoint: append([]byte(nil), task.Checkpoint...),
+			}, nil
+		}
+		return nil, run.err
+	}
+	if run.interrupted != nil {
+		return e.interruptResult(ctx, task, run.interrupted)
 	}
 	return &backgroundtask.ExecutionResult{
 		Status: backgroundtask.StatusCompleted,
-		Data:   []byte(final),
+		Data:   []byte(run.final),
 	}, nil
 }
 
@@ -604,6 +633,28 @@ func decodeResumeTargets(data []byte) (map[string]any, error) {
 	return targets, nil
 }
 
+func requestCancelAndWait(
+	control backgroundtask.ControlRequest,
+	cancelRun adk.AgentCancelFunc,
+	drainCancelTimeout time.Duration,
+) error {
+	cancelOptions := []adk.AgentCancelOption{adk.WithRecursive()}
+	if control.Kind == backgroundtask.ControlDrain {
+		cancelOptions = append(cancelOptions,
+			adk.WithAgentCancelMode(adk.CancelAfterChatModel|adk.CancelAfterToolCalls))
+		if drainCancelTimeout > 0 {
+			cancelOptions = append(cancelOptions,
+				adk.WithAgentCancelTimeout(drainCancelTimeout))
+		}
+	} else {
+		cancelOptions = append(cancelOptions, adk.WithAgentCancelMode(adk.CancelImmediate))
+	}
+	// accepted is intentionally ignored: a rejected cancellation still returns
+	// a handle whose Wait reports the terminal run outcome.
+	handle, _ := cancelRun(cancelOptions...)
+	return handle.Wait()
+}
+
 // handleRunError translates agent event and output materialization errors into
 // durable task lifecycle outcomes when a control request is active.
 func (e *Executor[M]) handleRunError(
@@ -611,6 +662,7 @@ func (e *Executor[M]) handleRunError(
 	iter *adk.AsyncIterator[*adk.TypedAgentEvent[M]],
 	task *backgroundtask.Task,
 	controlRequests <-chan backgroundtask.ControlRequest,
+	cancelOutcomes <-chan error,
 	err error,
 ) (*backgroundtask.ExecutionResult, error) {
 	control := pollControl(controlRequests)
@@ -628,16 +680,8 @@ func (e *Executor[M]) handleRunError(
 			}
 		}
 	}
-	if result, controlErr, controlled := e.controlResult(ctx, task, control); controlled {
-		return result, controlErr
-	}
-	if errors.Is(err, adk.ErrSessionBusy) {
-		return &backgroundtask.ExecutionResult{
-			Directive:  backgroundtask.ExecutionDirectiveYield,
-			Checkpoint: append([]byte(nil), task.Checkpoint...),
-		}, nil
-	}
-	return nil, err
+	cancelOutcome := waitForDrainCancelOutcome(ctx, control, cancelOutcomes)
+	return e.resolveRunOutcome(ctx, task, control, cancelOutcome, subagentRunOutcome{err: err})
 }
 
 func waitForControl(
@@ -651,6 +695,25 @@ func waitForControl(
 		return backgroundtask.ControlRequest{}
 	case <-time.After(100 * time.Millisecond):
 		return backgroundtask.ControlRequest{}
+	}
+}
+
+// waitForDrainCancelOutcome must be called only after the run iterator has been
+// fully drained. Draining closes the cancellation lifecycle and guarantees that
+// a pending CancelHandle.Wait can complete.
+func waitForDrainCancelOutcome(
+	ctx context.Context,
+	control backgroundtask.ControlRequest,
+	outcomes <-chan error,
+) error {
+	if control.Kind != backgroundtask.ControlDrain || outcomes == nil {
+		return nil
+	}
+	select {
+	case err := <-outcomes:
+		return err
+	case <-ctx.Done():
+		return ctx.Err()
 	}
 }
 

--- a/adk/backgroundtask/subagent/subagent_test.go
+++ b/adk/backgroundtask/subagent/subagent_test.go
@@ -987,6 +987,12 @@ func TestResumeControlHelpers(t *testing.T) {
 	require.Equal(t, backgroundtask.ControlStop,
 		waitForControl(context.Background(), controls).Kind)
 
+	require.NoError(t, waitForDrainCancelOutcome(
+		context.Background(),
+		backgroundtask.ControlRequest{Kind: backgroundtask.ControlDrain},
+		nil,
+	))
+
 	executor := newTestExecutor(t, nil)
 	task := &backgroundtask.Task{Spec: backgroundtask.Spec{ID: "task"}}
 	result, controlErr, controlled := executor.controlResult(
@@ -1024,7 +1030,7 @@ func TestHandleRunErrorControlOutcomes(t *testing.T) {
 		wantErr := errors.New("model failed")
 		result, err := executor.handleRunError(
 			context.Background(), iter, task,
-			make(chan backgroundtask.ControlRequest), wantErr,
+			make(chan backgroundtask.ControlRequest), nil, wantErr,
 		)
 		require.ErrorIs(t, err, wantErr)
 		require.Nil(t, result)
@@ -1038,6 +1044,7 @@ func TestHandleRunErrorControlOutcomes(t *testing.T) {
 			iter,
 			task,
 			make(chan backgroundtask.ControlRequest),
+			nil,
 			adk.ErrSessionBusy,
 		)
 		require.NoError(t, err)
@@ -1054,7 +1061,7 @@ func TestHandleRunErrorControlOutcomes(t *testing.T) {
 		controls := make(chan backgroundtask.ControlRequest, 1)
 		controls <- backgroundtask.ControlRequest{Kind: backgroundtask.ControlStop}
 		result, err := executor.handleRunError(
-			context.Background(), iter, task, controls, context.Canceled,
+			context.Background(), iter, task, controls, nil, context.Canceled,
 		)
 		require.NoError(t, err)
 		require.Equal(t, backgroundtask.StatusCanceled, result.Status)
@@ -1068,11 +1075,28 @@ func TestHandleRunErrorControlOutcomes(t *testing.T) {
 			Kind: backgroundtask.ControlTimeout, Reason: "deadline",
 		}
 		result, err := executor.handleRunError(
-			context.Background(), iter, task, controls, context.Canceled,
+			context.Background(), iter, task, controls, nil, context.Canceled,
 		)
 		require.NoError(t, err)
 		require.Equal(t, backgroundtask.StatusFailed, result.Status)
 		require.Equal(t, "deadline", result.Error)
+	})
+
+	t.Run("drain loses race to fatal error", func(t *testing.T) {
+		iter, generator := adk.NewAsyncIteratorPair[*adk.AgentEvent]()
+		generator.Close()
+		controls := make(chan backgroundtask.ControlRequest, 1)
+		controls <- backgroundtask.ControlRequest{Kind: backgroundtask.ControlDrain}
+		cancelOutcomes := make(chan error, 1)
+		cancelOutcomes <- adk.ErrExecutionEnded
+		wantErr := errors.New("model failed")
+
+		result, err := executor.handleRunError(
+			context.Background(), iter, task, controls, cancelOutcomes, wantErr,
+		)
+
+		require.ErrorIs(t, err, wantErr)
+		require.Nil(t, result)
 	})
 }
 
@@ -1084,7 +1108,7 @@ func TestAttack_StreamCanceledWithoutControlRemainsFailure(t *testing.T) {
 
 	result, err := executor.handleRunError(
 		context.Background(), iter, task,
-		make(chan backgroundtask.ControlRequest), adk.ErrStreamCanceled,
+		make(chan backgroundtask.ControlRequest), nil, adk.ErrStreamCanceled,
 	)
 
 	require.Nil(t, result)
@@ -1101,13 +1125,15 @@ func TestAttack_DrainControlAfterStreamCancellationSuspends(t *testing.T) {
 	iter, generator := adk.NewAsyncIteratorPair[*adk.AgentEvent]()
 	generator.Close()
 	controls := make(chan backgroundtask.ControlRequest)
+	cancelOutcomes := make(chan error, 1)
+	cancelOutcomes <- nil
 	go func() {
 		time.Sleep(10 * time.Millisecond)
 		controls <- backgroundtask.ControlRequest{Kind: backgroundtask.ControlDrain}
 	}()
 
 	result, err := executor.handleRunError(
-		context.Background(), iter, task, controls, adk.ErrStreamCanceled,
+		context.Background(), iter, task, controls, cancelOutcomes, adk.ErrStreamCanceled,
 	)
 
 	require.NoError(t, err)
@@ -1444,6 +1470,108 @@ func TestStopControlWinsOverLateFinalMessage_BitsUT(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, backgroundtask.StatusCanceled, canceled.Status)
 	assert.NotEqual(t, "late completion", string(canceled.ResultData))
+}
+
+func TestResolveRunOutcomeDrainLostRace_BitsUT(t *testing.T) {
+	store := adksession.NewInMemoryStore[*schema.Message](nil)
+	executor := newTestExecutor(t, store)
+	task := &backgroundtask.Task{Spec: backgroundtask.Spec{ID: "task"}}
+	agent := &cancelThenMessageAgent{
+		name: "worker", started: make(chan struct{}), release: make(chan struct{}),
+	}
+	cancelOption, cancelRun := adk.WithCancel()
+	runner := adk.NewRunner(context.Background(), adk.RunnerConfig{Agent: agent})
+	iter := runner.Run(context.Background(), nil, cancelOption)
+	<-agent.started
+	close(agent.release)
+
+	var final string
+	for {
+		event, open := iter.Next()
+		if !open {
+			break
+		}
+		require.NoError(t, event.Err)
+		if event.Output == nil || event.Output.MessageOutput == nil {
+			continue
+		}
+		message, messageErr := event.Output.MessageOutput.GetMessage()
+		require.NoError(t, messageErr)
+		final = message.Content
+	}
+
+	control := backgroundtask.ControlRequest{Kind: backgroundtask.ControlDrain}
+	cancelOutcome := requestCancelAndWait(control, cancelRun, time.Second)
+	require.ErrorIs(t, cancelOutcome, adk.ErrExecutionEnded)
+	result, err := executor.resolveRunOutcome(
+		context.Background(),
+		task,
+		control,
+		cancelOutcome,
+		subagentRunOutcome{final: final},
+	)
+
+	require.NoError(t, err)
+	require.Equal(t, backgroundtask.StatusCompleted, result.Status)
+	require.Equal(t, "late completion", string(result.Data))
+	_, checkpointExists, err := store.Get(
+		context.Background(),
+		checkpointID(task.Spec.ID),
+	)
+	require.NoError(t, err)
+	require.False(t, checkpointExists)
+}
+
+func TestDrainControlDefersToNaturalCompletionE2E_BitsUT(t *testing.T) {
+	store := adksession.NewInMemoryStore[*schema.Message](nil)
+	agent := &cancelThenMessageAgent{
+		name: "worker", started: make(chan struct{}), release: make(chan struct{}),
+	}
+	executor, err := NewExecutor(&ExecutorConfig[*schema.Message]{
+		SessionStore: store, CheckPointStore: store, DrainCancelTimeout: time.Second,
+	})
+	require.NoError(t, err)
+	require.NoError(t, executor.Register(
+		agent.name, &AgentRegistration[*schema.Message]{Agent: agent},
+	))
+	registry := backgroundtask.NewExecutorRegistry()
+	require.NoError(t, registry.Register(executor))
+	manager := mustNewBackgroundManager(
+		t, context.Background(), &backgroundtask.Config{Executors: registry},
+	)
+	task, err := Submit(context.Background(), manager, &SubmitRequest[*schema.Message]{
+		SubAgentName: agent.name, Input: textInput("work"), Description: "work",
+		SessionID: "parent",
+	})
+	require.NoError(t, err)
+
+	executeDone := make(chan error, 1)
+	go func() {
+		executeDone <- manager.Execute(context.Background(), task.Spec.ID)
+	}()
+	<-agent.started
+
+	closeDone := make(chan error, 1)
+	go func() {
+		closeCtx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+		defer cancel()
+		closeDone <- manager.Close(closeCtx)
+	}()
+	time.Sleep(20 * time.Millisecond)
+	close(agent.release)
+
+	require.NoError(t, <-executeDone)
+	require.NoError(t, <-closeDone)
+	completed, err := manager.Get(context.Background(), task.Spec.ID)
+	require.NoError(t, err)
+	require.Equal(t, backgroundtask.StatusCompleted, completed.Status)
+	require.Equal(t, "late completion", string(completed.ResultData))
+	_, checkpointExists, err := store.Get(
+		context.Background(),
+		checkpointID(task.Spec.ID),
+	)
+	require.NoError(t, err)
+	require.False(t, checkpointExists)
 }
 
 func TestExecutorDrainUsesDurableRunnerCheckpoint_BitsUT(t *testing.T) {


### PR DESCRIPTION
#### What type of PR is this?

fix

#### Check the PR title.

- [x] This PR title match the format: \<type\>(optional scope): \<description\>
- [x] The description of this PR title is user-oriented and clear enough for others to understand.
- [x] This PR does not require user-facing documentation updates.

#### (Optional) Translate the PR title into Chinese.

#### (Optional) More detailed description for this PR(en: English/zh: Chinese).

en:

When a drain request raced with a subagent's natural completion, the background task executor queued the drain control before cancellation completed and ignored the result of `CancelHandle.Wait`.

If the subagent completed before cancellation took effect, `CancelHandle.Wait` returned `ErrExecutionEnded`. However, the queued drain control still overrode the completed result and required a resumable checkpoint. Since natural completion does not produce a checkpoint, the executor returned `ErrDrainCheckpointUnavailable`, leaving the task running until lease recovery incorrectly marked it as failed.

This PR preserves the cancellation outcome and lets the natural completed result win when a drain loses the race with execution completion. Drains that take effect continue to require a resumable checkpoint and remain fail-closed if that checkpoint is unavailable.

A regression test verifies that the task is committed as completed, its final result is retained, and no checkpoint is required when execution completes naturally before drain cancellation takes effect.

zh(optional):

#### (Optional) Which issue(s) this PR fixes:

N/A

#### (optional) The PR that updates user documentation:

N/A