### PR TITLE
fix(compose): validate indirect edges in Workflow compile

### DIFF
--- a/compose/workflow.go
+++ b/compose/workflow.go
@@ -506,9 +506,92 @@ func (wf *Workflow[I, O]) compile(ctx context.Context, options *graphCompileOpti
 		}
 	}
 
-	// TODO: check indirect edges are legal
+	if err := wf.validateIndirectEdges(); err != nil {
+		return nil, err
+	}
 
 	return wf.g.compile(ctx, options)
+}
+
+// validateIndirectEdges checks that every noDirectDependency (indirect) edge has a valid
+// execution path from its source node to its target node through direct control edges
+// and branch edges in the underlying graph.
+//
+// An indirect edge (created via WithNoDirectDependency) only establishes a data mapping
+// without a direct execution dependency. The source node must still complete before the
+// target node executes, which requires an execution path through other nodes.
+//
+// The adjacency list is built from the graph's actual control edges (g.controlEdges)
+// and branch edges (g.branches), rather than wf.dependencies, because a single (from, to)
+// pair may have both a branch dependency and a noDirectDependency data mapping, and the
+// latter would overwrite the former in wf.dependencies.
+func (wf *Workflow[I, O]) validateIndirectEdges() error {
+	adjacency := wf.buildControlAdjacency()
+
+	for toNode, deps := range wf.dependencies {
+		for fromNode, depType := range deps {
+			if depType != noDirectDependency {
+				continue
+			}
+
+			if !wf.isReachable(fromNode, toNode, adjacency) {
+				return fmt.Errorf(
+					"illegal indirect edge: node '%s' declares a no-direct-dependency on node '%s', "+
+						"but no execution path exists from '%s' to '%s' through direct control edges",
+					toNode, fromNode, fromNode, toNode,
+				)
+			}
+		}
+	}
+
+	return nil
+}
+
+// buildControlAdjacency builds an adjacency list from the graph's control edges and branch edges.
+// These represent the actual execution dependencies in the compiled graph.
+func (wf *Workflow[I, O]) buildControlAdjacency() map[string][]string {
+	adjacency := make(map[string][]string)
+
+	for from, tos := range wf.g.controlEdges {
+		adjacency[from] = append(adjacency[from], tos...)
+	}
+
+	for from, branches := range wf.g.branches {
+		for _, branch := range branches {
+			for endNode := range branch.endNodes {
+				adjacency[from] = append(adjacency[from], endNode)
+			}
+		}
+	}
+
+	return adjacency
+}
+
+func (wf *Workflow[I, O]) isReachable(start, target string, adjacency map[string][]string) bool {
+	if start == target {
+		return true
+	}
+
+	visited := make(map[string]bool)
+	queue := []string{start}
+	visited[start] = true
+
+	for len(queue) > 0 {
+		current := queue[0]
+		queue = queue[1:]
+
+		for _, next := range adjacency[current] {
+			if next == target {
+				return true
+			}
+			if !visited[next] {
+				visited[next] = true
+				queue = append(queue, next)
+			}
+		}
+	}
+
+	return false
 }
 
 func (wf *Workflow[I, O]) initNode(key string) *WorkflowNode {

--- a/compose/workflow_indirect_edge_test.go
+++ b/compose/workflow_indirect_edge_test.go
@@ -1,0 +1,109 @@
+/*
+ * Copyright 2024 CloudWeGo Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package compose
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestIndirectEdgeIllegal(t *testing.T) {
+	t.Run("no path from source to target", func(t *testing.T) {
+		// Graph: START -> A, START -> B
+		// B declares noDirectDependency on A, but there is no control path A -> B.
+		wf := NewWorkflow[string, map[string]any]()
+
+		wf.AddLambdaNode("A", InvokableLambda(func(ctx context.Context, in string) (output string, err error) {
+			return in + "_A", nil
+		})).AddInput(START)
+
+		wf.AddLambdaNode("B", InvokableLambda(func(ctx context.Context, in map[string]string) (output string, err error) {
+			return in["A"] + "_" + in[START], nil
+		})).AddInput(START, ToField(START)).
+			AddInputWithOptions("A", []*FieldMapping{ToField("A")}, WithNoDirectDependency())
+
+		wf.End().AddInput("B", ToField("B"))
+
+		_, err := wf.Compile(context.Background())
+		assert.Error(t, err)
+		assert.ErrorContains(t, err, "illegal indirect edge")
+	})
+
+	t.Run("disconnected nodes", func(t *testing.T) {
+		// Graph: START -> A, START -> B, B -> END
+		// END declares noDirectDependency on A, but A has no path to END (A is disconnected).
+		wf := NewWorkflow[string, map[string]any]()
+
+		wf.AddLambdaNode("A", InvokableLambda(func(ctx context.Context, in string) (output string, err error) {
+			return in + "_A", nil
+		})).AddInput(START)
+
+		wf.AddLambdaNode("B", InvokableLambda(func(ctx context.Context, in string) (output string, err error) {
+			return in + "_B", nil
+		})).AddInput(START)
+
+		wf.End().AddInput("B", ToField("B")).
+			AddInputWithOptions("A", []*FieldMapping{ToField("A")}, WithNoDirectDependency())
+
+		_, err := wf.Compile(context.Background())
+		assert.Error(t, err)
+		assert.ErrorContains(t, err, "illegal indirect edge")
+	})
+
+	t.Run("valid indirect edge through branch", func(t *testing.T) {
+		// Graph: START -> branch_node, branch -> A, branch -> END
+		// A declares noDirectDependency on START, which is valid because START -> branch_node -> A.
+		wf := NewWorkflow[map[string]any, map[string]any]()
+
+		wf.AddLambdaNode("A", InvokableLambda(func(ctx context.Context, in map[string]any) (output map[string]any, err error) {
+			return in, nil
+		})).AddInputWithOptions(START, nil, WithNoDirectDependency())
+
+		wf.AddPassthroughNode("branch_node").AddInput(START)
+
+		wf.AddBranch("branch_node", NewGraphBranch(func(ctx context.Context, in map[string]any) (string, error) {
+			return "A", nil
+		}, map[string]bool{"A": true, END: true}))
+
+		wf.End().AddInput("A", ToField("A"))
+
+		_, err := wf.Compile(context.Background())
+		assert.NoError(t, err)
+	})
+
+	t.Run("valid indirect edge through chain", func(t *testing.T) {
+		// Graph: START -> A -> B -> END
+		// END declares noDirectDependency on A, which is valid because A -> B -> END.
+		wf := NewWorkflow[string, map[string]any]()
+
+		wf.AddLambdaNode("A", InvokableLambda(func(ctx context.Context, in string) (output string, err error) {
+			return in + "_A", nil
+		})).AddInput(START)
+
+		wf.AddLambdaNode("B", InvokableLambda(func(ctx context.Context, in string) (output string, err error) {
+			return in + "_B", nil
+		})).AddInput("A")
+
+		wf.End().AddInput("B", ToField("B")).
+			AddInputWithOptions("A", []*FieldMapping{ToField("A")}, WithNoDirectDependency())
+
+		_, err := wf.Compile(context.Background())
+		assert.NoError(t, err)
+	})
+}


### PR DESCRIPTION
#### What type of PR is this?
<!--
fix: A bug fix
-->

fix

#### Check the PR title.
- [x] This PR title match the format: <type>(optional scope): <description>
- [x] The description of this PR title is user-oriented and clear enough for others to understand.
- [ ] Attach the PR updating the user documentation if the current PR requires user awareness at the usage level.

#### (Optional) Translate the PR title into Chinese.

fix(compose): 在 Workflow 编译时校验间接边的合法性

#### (Optional) More detailed description for this PR(en: English/zh: Chinese).
en:
Add validation for noDirectDependency (indirect) edges during Workflow compilation.

There was a TODO at compose/workflow.go:509: "check indirect edges are legal". Edges created via WithNoDirectDependency() only establish data mappings without direct execution dependencies. Without validation, an illegal graph where no execution path exists from source to target could compile successfully and cause undefined behavior at runtime.

Changes:
- Add validateIndirectEdges() called before graph compilation
- Build control adjacency from g.controlEdges + g.branches (not wf.dependencies, because branchDependency can be overwritten by noDirectDependency for the same node pair)
- BFS reachability check for each noDirectDependency edge
- Clear error message for illegal configurations
- 4 test cases: 2 illegal scenarios + 2 valid scenarios (including branch paths)

zh(optional):
在 Workflow 编译阶段增加对间接边（noDirectDependency）的合法性校验。

compose/workflow.go:509 处原有 TODO 标注 "check indirect edges are legal"。通过 WithNoDirectDependency() 创建的边仅建立数据映射而无直接执行依赖。若不校验，源节点到目标节点不存在执行路径的非法图也能编译通过，运行时产生不可预期行为。

主要改动：
- 新增 validateIndirectEdges()，在图编译前调用
- 从 g.controlEdges 和 g.branches 构建控制邻接表（不使用 wf.dependencies，因为同一节点对的 branchDependency 可能被 noDirectDependency 覆盖）
- 对每条间接边执行 BFS 可达性检查
- 非法配置返回清晰的错误信息
- 新增 4 个测试用例：2 个非法场景 + 2 个合法场景（含分支路径）

#### (Optional) Which issue(s) this PR fixes:

N/A (resolves internal TODO)

#### (optional) The PR that updates user documentation:

N/A
