### PR TITLE
fix(compose): legacy interrupt wrapping with BatchResumeWithData

### DIFF
--- a/compose/interrupt.go
+++ b/compose/interrupt.go
@@ -21,8 +21,6 @@ import (
 	"errors"
 	"fmt"
 
-	"github.com/google/uuid"
-
 	"github.com/cloudwego/eino/internal/core"
 	"github.com/cloudwego/eino/schema"
 )
@@ -182,7 +180,7 @@ func CompositeInterrupt(ctx context.Context, info any, state any, errs ...error)
 		if errors.As(err, &wrapped) {
 			inner := wrapped.Unwrap()
 			if errors.Is(inner, deprecatedInterruptAndRerun) {
-				id := uuid.NewString()
+				id := wrapped.ps.String()
 				cErrs = append(cErrs, &core.InterruptSignal{
 					ID:      id,
 					Address: wrapped.ps,
@@ -196,7 +194,7 @@ func CompositeInterrupt(ctx context.Context, info any, state any, errs ...error)
 
 			ire := &core.InterruptSignal{}
 			if errors.As(err, &ire) {
-				id := uuid.NewString()
+				id := wrapped.ps.String()
 				cErrs = append(cErrs, &core.InterruptSignal{
 					ID:      id,
 					Address: wrapped.ps,

--- a/compose/resume_test.go
+++ b/compose/resume_test.go
@@ -1086,17 +1086,26 @@ func TestLegacyInterrupt(t *testing.T) {
 	assert.True(t, isInterrupt2)
 	assert.Len(t, info2.InterruptContexts, 3, "Should have the same number of interrupts on re-run")
 
+	// Collect the latest interrupt IDs from the second invocation.
+	// Legacy interrupts have deterministic address-based IDs (stable across runs),
+	// but modern interrupts (Interrupt()) use random UUIDs that change on each run.
+	// We must use the IDs from the most recent invocation to match the checkpoint state.
+	addrToID2 := make(map[string]string)
+	for _, iCtx := range info2.InterruptContexts {
+		addrToID2[iCtx.Address.String()] = iCtx.ID
+	}
+
 	// 7. Third invocation - Resume all three interrupt points with specific data
 	resumeData := map[string]any{
-		addrToID[expectedID1]: "output1",
-		addrToID[expectedID2]: "output2",
-		addrToID[expectedID3]: "output3",
+		addrToID2[expectedID1]: "output1",
+		addrToID2[expectedID2]: "output2",
+		addrToID2[expectedID3]: "output3",
 	}
 	resumeCtx := BatchResumeWithData(context.Background(), resumeData)
-	// TODO: The legacy interrupt wrapping does not currently work correctly with BatchResumeWithData.
-	// The graph re-interrupts instead of completing. This should be fixed in the core framework.
-	_, err = compiledGraph.Invoke(resumeCtx, "input", WithCheckPointID(checkPointID))
-	assert.Error(t, err)
+	finalOutput, err := compiledGraph.Invoke(resumeCtx, "input", WithCheckPointID(checkPointID))
+	assert.NoError(t, err)
+	// Each sub-process returns its resume data, and the composite lambda appends " " + its own data (empty).
+	assert.Equal(t, "output1output2output3 ", finalOutput)
 }
 
 type wrapperToolForTest struct {


### PR DESCRIPTION
#### What type of PR is this?
<!--
fix: A bug fix
-->

fix

#### Check the PR title.
- [x] This PR title match the format: <type>(optional scope): <description>
- [x] The description of this PR title is user-oriented and clear enough for others to understand.
- [ ] Attach the PR updating the user documentation if the current PR requires user awareness at the usage level.

#### (Optional) Translate the PR title into Chinese.

fix(compose): 修复 legacy interrupt 与 BatchResumeWithData 不兼容的问题

#### (Optional) More detailed description for this PR(en: English/zh: Chinese).
en:
Fix the incompatibility between legacy interrupt errors (InterruptAndRerun, NewInterruptAndRerunErr) wrapped via WrapInterruptAndRerunIfNeeded and the BatchResumeWithData resume mechanism.

There was a TODO at compose/resume_test.go:1096 noting that legacy interrupt wrapping does not work correctly with BatchResumeWithData - the graph re-interrupts instead of completing.

Root cause: CompositeInterrupt generated a new random UUID for each legacy interrupt on every invocation. Since BatchResumeWithData matches resume data by interrupt ID, the IDs from the first invocation no longer matched after a re-run.

Fix: Use the deterministic address string (wrapped.ps.String()) as the ID for legacy interrupts instead of uuid.NewString(). Addresses are stable across re-runs, ensuring resume data correctly matches the interrupt point.

Also updated the test to use IDs from the most recent invocation (modern Interrupt() still uses random UUIDs), and removed the unused uuid import.

zh(optional):
修复通过 WrapInterruptAndRerunIfNeeded 包装的 legacy 中断错误（InterruptAndRerun、NewInterruptAndRerunErr）与 BatchResumeWithData 恢复机制不兼容的问题。

compose/resume_test.go:1096 处原有 TODO 标注 legacy interrupt wrapping 与 BatchResumeWithData 不能正常工作——图会重新中断而非完成执行。

根本原因：CompositeInterrupt 每次调用都为每个 legacy 中断生成新的随机 UUID。由于 BatchResumeWithData 按中断 ID 匹配恢复数据，重新运行后第一次调用的 ID 不再匹配。

修复方案：使用确定性的地址字符串（wrapped.ps.String()）作为 legacy 中断的 ID，替代 uuid.NewString()。地址在多次运行间保持稳定，确保恢复数据能正确匹配到中断点。

同时更新了测试以使用最近一次调用的 ID（现代 Interrupt() 仍使用随机 UUID），并移除了未使用的 uuid 导入。

#### (Optional) Which issue(s) this PR fixes:

N/A (resolves internal TODO)

#### (optional) The PR that updates user documentation:

N/A
