### PR TITLE
fix(adk): encode automatic transfer arguments as JSON

### DIFF
--- a/adk/agent_tool_test.go
+++ b/adk/agent_tool_test.go
@@ -325,7 +325,7 @@ func TestGetReactHistory(t *testing.T) {
 		schema.UserMessage("user query"),
 		schema.UserMessage("For context: [MyAgent] called tool: `tool1` with arguments: arguments1."),
 		schema.UserMessage("For context: [MyAgent] `tool1` tool returned result: tool result 1."),
-		schema.UserMessage("For context: [MyAgent] called tool: `transfer_to_agent` with arguments: DestAgentName."),
+		schema.UserMessage("For context: [MyAgent] called tool: `transfer_to_agent` with arguments: {\"agent_name\":\"DestAgentName\"}."),
 		schema.UserMessage("For context: [MyAgent] `transfer_to_agent` tool returned result: successfully transferred to agent [DestAgentName]."),
 	}, result)
 }
@@ -430,7 +430,7 @@ func TestAgentToolWithOptions(t *testing.T) {
 		assert.Len(t, mockAgent.capturedInput, 4) // 2 from history + 2 transfer messages
 		assert.Equal(t, "first user message", mockAgent.capturedInput[0].Content)
 		assert.Equal(t, "For context: [react-agent] said: first assistant response.", mockAgent.capturedInput[1].Content)
-		assert.Equal(t, "For context: [react-agent] called tool: `transfer_to_agent` with arguments: test-agent.", mockAgent.capturedInput[2].Content)
+		assert.Equal(t, "For context: [react-agent] called tool: `transfer_to_agent` with arguments: {\"agent_name\":\"test-agent\"}.", mockAgent.capturedInput[2].Content)
 		assert.Equal(t, "For context: [react-agent] `transfer_to_agent` tool returned result: successfully transferred to agent [test-agent].", mockAgent.capturedInput[3].Content)
 	})
 
@@ -600,7 +600,7 @@ func TestAgentToolWithOptions(t *testing.T) {
 		assert.Len(t, mockAgent.capturedInput, 4) // 2 history + 2 transfer messages
 		assert.Equal(t, "previous conversation", mockAgent.capturedInput[0].Content)
 		assert.Equal(t, "For context: [react-agent] said: previous response.", mockAgent.capturedInput[1].Content)
-		assert.Equal(t, "For context: [react-agent] called tool: `transfer_to_agent` with arguments: combined-agent.", mockAgent.capturedInput[2].Content)
+		assert.Equal(t, "For context: [react-agent] called tool: `transfer_to_agent` with arguments: {\"agent_name\":\"combined-agent\"}.", mockAgent.capturedInput[2].Content)
 		assert.Equal(t, "For context: [react-agent] `transfer_to_agent` tool returned result: successfully transferred to agent [combined-agent].", mockAgent.capturedInput[3].Content)
 	})
 }

--- a/adk/prebuilt/supervisor/supervisor_test.go
+++ b/adk/prebuilt/supervisor/supervisor_test.go
@@ -18,23 +18,108 @@ package supervisor
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"strings"
 	"sync"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"go.uber.org/mock/gomock"
 
 	"github.com/cloudwego/eino/adk"
 	"github.com/cloudwego/eino/callbacks"
 	"github.com/cloudwego/eino/components"
+	"github.com/cloudwego/eino/components/model"
 	"github.com/cloudwego/eino/components/tool"
 	"github.com/cloudwego/eino/compose"
 	mockAdk "github.com/cloudwego/eino/internal/mock/adk"
 	mockModel "github.com/cloudwego/eino/internal/mock/components/model"
 	"github.com/cloudwego/eino/schema"
 )
+
+func TestSupervisorTransferHistoryJSONArguments(t *testing.T) {
+	ctx := context.Background()
+	ctrl := gomock.NewController(t)
+	mainModel := mockModel.NewMockToolCallingChatModel(ctrl)
+	subModel := mockModel.NewMockToolCallingChatModel(ctrl)
+	mainModel.EXPECT().WithTools(gomock.Any()).Return(mainModel, nil).AnyTimes()
+	subModel.EXPECT().WithTools(gomock.Any()).Return(subModel, nil).AnyTimes()
+
+	mainModel.EXPECT().Generate(gomock.Any(), gomock.Any(), gomock.Any()).Return(
+		schema.AssistantMessage("", []schema.ToolCall{{
+			ID: "transfer", Type: "function",
+			Function: schema.FunctionCall{
+				Name: adk.TransferToAgentToolName, Arguments: `{"agent_name":"SubAgent"}`,
+			},
+		}}), nil)
+	subModel.EXPECT().Generate(gomock.Any(), gomock.Any(), gomock.Any()).
+		Return(schema.AssistantMessage("subagent finished", nil), nil)
+	mainModel.EXPECT().Generate(gomock.Any(), gomock.Any(), gomock.Any()).
+		Return(schema.AssistantMessage("done", nil), nil)
+
+	mainAgent, err := adk.NewChatModelAgent(ctx, &adk.ChatModelAgentConfig{
+		Name: "MainAgent", Description: "Supervisor", Model: mainModel,
+	})
+	require.NoError(t, err)
+	subAgent, err := adk.NewChatModelAgent(ctx, &adk.ChatModelAgentConfig{
+		Name: "SubAgent", Description: "Worker", Model: subModel,
+	})
+	require.NoError(t, err)
+	agent, err := New(ctx, &Config{Supervisor: mainAgent, SubAgents: []adk.Agent{subAgent}})
+	require.NoError(t, err)
+	runner := adk.NewRunner(ctx, adk.RunnerConfig{Agent: agent})
+
+	// Applications can collect the emitted messages and replay them next turn.
+	history := []*schema.Message{schema.UserMessage("delegate")}
+	iter := runner.Run(ctx, history)
+	for {
+		event, ok := iter.Next()
+		if !ok {
+			break
+		}
+		require.NoError(t, event.Err)
+		if event.Output != nil && event.Output.MessageOutput != nil {
+			message, getErr := event.Output.MessageOutput.GetMessage()
+			require.NoError(t, getErr)
+			history = append(history, message)
+		}
+	}
+
+	// Model adapters that decode arguments as a JSON object must also accept
+	// the framework-generated transfer back to MainAgent (issue #786).
+	mainModel.EXPECT().Generate(gomock.Any(), gomock.Any(), gomock.Any()).
+		DoAndReturn(func(_ context.Context, messages []*schema.Message, _ ...model.Option) (*schema.Message, error) {
+			var destinations []string
+			for _, message := range messages {
+				for _, call := range message.ToolCalls {
+					var args map[string]string
+					if err := json.Unmarshal([]byte(call.Function.Arguments), &args); err != nil {
+						return nil, fmt.Errorf("invalid tool arguments: %w", err)
+					}
+					destinations = append(destinations, args["agent_name"])
+				}
+			}
+			assert.Equal(t, []string{"SubAgent", "MainAgent"}, destinations)
+			return schema.AssistantMessage("next turn", nil), nil
+		})
+	iter = runner.Run(ctx, append(history, schema.UserMessage("hello again")))
+	var responses []string
+	for {
+		event, ok := iter.Next()
+		if !ok {
+			break
+		}
+		require.NoError(t, event.Err)
+		if event.Output != nil && event.Output.MessageOutput != nil {
+			message, getErr := event.Output.MessageOutput.GetMessage()
+			require.NoError(t, getErr)
+			responses = append(responses, message.Content)
+		}
+	}
+	assert.Contains(t, responses, "next turn")
+}
 
 // TestNewSupervisor tests the New function
 func TestNewSupervisor(t *testing.T) {

--- a/adk/utils.go
+++ b/adk/utils.go
@@ -18,6 +18,7 @@ package adk
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"io"
 	"strings"
@@ -95,7 +96,10 @@ func concatInstructions(instructions ...string) string {
 // or DeepAgent instead for most multi-agent scenarios.
 func GenTransferMessages(_ context.Context, destAgentName string) (Message, Message) {
 	toolCallID := uuid.NewString()
-	tooCall := schema.ToolCall{ID: toolCallID, Function: schema.FunctionCall{Name: TransferToAgentToolName, Arguments: destAgentName}}
+	// Match the transfer tool's object schema, including when these messages
+	// are replayed as conversation history. Marshaling strings cannot fail.
+	arguments, _ := json.Marshal(map[string]string{"agent_name": destAgentName})
+	tooCall := schema.ToolCall{ID: toolCallID, Function: schema.FunctionCall{Name: TransferToAgentToolName, Arguments: string(arguments)}}
 	assistantMessage := schema.AssistantMessage("", []schema.ToolCall{tooCall})
 	msg := transferToAgentToolOutput(destAgentName)
 	toolMessage := schema.ToolMessage(msg, toolCallID, schema.WithToolName(TransferToAgentToolName))

--- a/adk/utils_test.go
+++ b/adk/utils_test.go
@@ -18,7 +18,9 @@ package adk
 
 import (
 	"bytes"
+	"context"
 	"encoding/gob"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"sync"
@@ -26,9 +28,26 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"github.com/cloudwego/eino/schema"
 )
+
+func TestGenTransferMessagesJSONArguments(t *testing.T) {
+	for _, name := range []string{"MainAgent", "", "agent\"\\\n\t", "助手"} {
+		t.Run(name, func(t *testing.T) {
+			assistant, result := GenTransferMessages(context.Background(), name)
+			require.Len(t, assistant.ToolCalls, 1)
+			call := assistant.ToolCalls[0]
+			var args map[string]string
+			require.NoError(t, json.Unmarshal([]byte(call.Function.Arguments), &args))
+			assert.Equal(t, map[string]string{"agent_name": name}, args)
+			assert.Equal(t, TransferToAgentToolName, call.Function.Name)
+			assert.Equal(t, call.ID, result.ToolCallID)
+			assert.Equal(t, transferToAgentToolOutput(name), result.Content)
+		})
+	}
+}
 
 func TestAsyncIteratorPair_Basic(t *testing.T) {
 	// Create a new iterator-generator pair


### PR DESCRIPTION
#### What type of PR is this?
fix

#### Check the PR title.
- [x] This PR title matches the format: <type>(optional scope): <description>
- [x] The title describes the user-visible fix.

#### Description
When an application collects supervisor runner events and sends those messages back in the next turn, the automatic transfer-back tool call contains a bare agent name (`MainAgent`) in `Function.Arguments`. Model adapters that decode arguments as a JSON object reject that history with `invalid character 'M' looking for beginning of value`, as reported in #786.

Encode generated transfer arguments as `{"agent_name":"MainAgent"}`, matching the existing transfer tool schema. JSON marshaling also handles quotes, backslashes, control characters, and Unicode names. Update the existing history assertions to reflect the encoded arguments.

The supervisor regression test collects the actual first-turn events, replays them in a second runner invocation, and uses a mock model that parses all historical tool arguments as JSON objects. Both this integration test and the new argument round-trip test fail before the fix and pass afterward; no external model credentials are required.

Related prior work: #741 proposed the same argument-format correction and was closed without merging. This PR ties the correction to the concrete two-turn failure in #786 and includes a regression for that path.

#### Validation
- Linux amd64, Go 1.25.9: `go test -race ./adk/...` — all 16 packages passed.
- Windows amd64, Go 1.24.1: `go test -race ./adk ./adk/prebuilt/...` — passed.
- golangci-lint v2.8.0, checked against the base revision for this change: 0 new issues.
- Full `golangci-lint run --timeout 5m ./adk/...` reports three gci formatting findings in unchanged files: `adk/agent_tool.go`, `adk/call_option.go`, and `adk/callback.go`.
- `git diff --check` — passed.

#### Which issue(s) this PR fixes
Fixes #786
