### PR TITLE
feat(skill): support preloading skills into the agent instruction

### DIFF
--- a/adk/middlewares/skill/doc.go
+++ b/adk/middlewares/skill/doc.go
@@ -33,6 +33,14 @@
 //   - fork: runs the skill with a new sub-agent without parent message history
 //   - fork_with_context: runs the skill with a new sub-agent carrying parent message history
 //
+// # Preloading
+//
+// By default, a skill's full instructions are loaded on demand: the model calls the
+// skill tool, and the content is returned as the tool result. Config.PreloadSkills
+// preloads the listed skills instead: their full content is inlined into the system
+// instruction when the middleware is created, so the model starts with them without
+// a tool call. Skills running in fork or fork_with_context modes cannot be preloaded.
+//
 // # Extension points
 //
 //   - CustomToolParams customizes the tool parameter schema.

--- a/adk/middlewares/skill/preload_test.go
+++ b/adk/middlewares/skill/preload_test.go
@@ -1,0 +1,187 @@
+/*
+ * Copyright 2025 CloudWeGo Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package skill
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/cloudwego/eino/adk"
+	"github.com/cloudwego/eino/adk/internal"
+)
+
+func newPreloadBackend() *inMemoryBackend {
+	return &inMemoryBackend{m: []Skill{
+		{
+			FrontMatter: FrontMatter{
+				Name:        "name1",
+				Description: "desc1",
+			},
+			Content:       "content1",
+			BaseDirectory: "basedir1",
+		},
+		{
+			FrontMatter: FrontMatter{
+				Name:        "name2",
+				Description: "desc2",
+			},
+			Content:       "content2",
+			BaseDirectory: "basedir2",
+		},
+		{
+			FrontMatter: FrontMatter{
+				Name:        "fork-skill",
+				Description: "desc3",
+				Context:     ContextModeFork,
+			},
+			Content:       "content3",
+			BaseDirectory: "basedir3",
+		},
+	}}
+}
+
+func TestPreloadSkills(t *testing.T) {
+	ctx := context.Background()
+	backend := newPreloadBackend()
+
+	mw, err := NewMiddleware(ctx, &Config{
+		Backend:       backend,
+		PreloadSkills: []string{"name1"},
+	})
+	assert.NoError(t, err)
+
+	_, runCtx, err := mw.BeforeAgent(ctx, &adk.ChatModelAgentContext{})
+	assert.NoError(t, err)
+	assert.Contains(t, runCtx.Instruction, "# Preloaded Skills")
+	assert.Contains(t, runCtx.Instruction, "name1")
+	assert.Contains(t, runCtx.Instruction, "content1")
+	assert.Contains(t, runCtx.Instruction, "basedir1")
+	assert.NotContains(t, runCtx.Instruction, "content2")
+}
+
+func TestPreloadSkills_Multiple(t *testing.T) {
+	ctx := context.Background()
+	backend := newPreloadBackend()
+
+	mw, err := NewMiddleware(ctx, &Config{
+		Backend:       backend,
+		PreloadSkills: []string{"name1", "name2"},
+	})
+	assert.NoError(t, err)
+
+	_, runCtx, err := mw.BeforeAgent(ctx, &adk.ChatModelAgentContext{})
+	assert.NoError(t, err)
+	assert.Contains(t, runCtx.Instruction, "content1")
+	assert.Contains(t, runCtx.Instruction, "content2")
+}
+
+func TestPreloadSkills_Chinese(t *testing.T) {
+	internal.SetLanguage(internal.LanguageChinese)
+	defer internal.SetLanguage(internal.LanguageEnglish)
+
+	ctx := context.Background()
+	backend := newPreloadBackend()
+
+	mw, err := NewMiddleware(ctx, &Config{
+		Backend:       backend,
+		PreloadSkills: []string{"name1"},
+	})
+	assert.NoError(t, err)
+
+	_, runCtx, err := mw.BeforeAgent(ctx, &adk.ChatModelAgentContext{})
+	assert.NoError(t, err)
+	assert.Contains(t, runCtx.Instruction, "# 预加载 Skill")
+	assert.Contains(t, runCtx.Instruction, "content1")
+}
+
+func TestPreloadSkills_UnknownSkill(t *testing.T) {
+	ctx := context.Background()
+	backend := newPreloadBackend()
+
+	_, err := NewMiddleware(ctx, &Config{
+		Backend:       backend,
+		PreloadSkills: []string{"missing"},
+	})
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to preload skill 'missing'")
+}
+
+func TestPreloadSkills_ForkSkill(t *testing.T) {
+	ctx := context.Background()
+	backend := newPreloadBackend()
+
+	_, err := NewMiddleware(ctx, &Config{
+		Backend:       backend,
+		PreloadSkills: []string{"fork-skill"},
+	})
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "cannot be preloaded")
+}
+
+func TestPreloadSkills_ToolStillListsAllSkills(t *testing.T) {
+	ctx := context.Background()
+	backend := newPreloadBackend()
+
+	mw, err := NewMiddleware(ctx, &Config{
+		Backend:       backend,
+		PreloadSkills: []string{"name1"},
+	})
+	assert.NoError(t, err)
+
+	_, runCtx, err := mw.BeforeAgent(ctx, &adk.ChatModelAgentContext{})
+	assert.NoError(t, err)
+	assert.Len(t, runCtx.Tools, 1)
+
+	info, err := runCtx.Tools[0].Info(ctx)
+	assert.NoError(t, err)
+	assert.Contains(t, info.Desc, "name1")
+	assert.Contains(t, info.Desc, "name2")
+}
+
+func TestPreloadSkills_DeprecatedNew(t *testing.T) {
+	ctx := context.Background()
+	backend := newPreloadBackend()
+
+	m, err := New(ctx, &Config{
+		Backend:       backend,
+		PreloadSkills: []string{"name1"},
+	})
+	assert.NoError(t, err)
+	assert.Contains(t, m.AdditionalInstruction, "# Preloaded Skills")
+	assert.Contains(t, m.AdditionalInstruction, "content1")
+}
+
+func TestPreloadSkills_CustomSystemPromptStillPreloads(t *testing.T) {
+	ctx := context.Background()
+	backend := newPreloadBackend()
+
+	mw, err := NewMiddleware(ctx, &Config{
+		Backend:       backend,
+		PreloadSkills: []string{"name1"},
+		CustomSystemPrompt: func(_ context.Context, _ string) string {
+			return "custom prompt"
+		},
+	})
+	assert.NoError(t, err)
+
+	_, runCtx, err := mw.BeforeAgent(ctx, &adk.ChatModelAgentContext{})
+	assert.NoError(t, err)
+	assert.Contains(t, runCtx.Instruction, "custom prompt")
+	assert.Contains(t, runCtx.Instruction, "content1")
+}

--- a/adk/middlewares/skill/prompt.go
+++ b/adk/middlewares/skill/prompt.go
@@ -139,6 +139,47 @@ Important:
 {{- end }}
 </available_skills>
 `
+
+	preloadTemplate = `
+# Preloaded Skills
+
+The skills below are preloaded: their full instructions are already included here, so do not call the '{{.ToolName}}' tool for them. Follow their instructions directly when they are relevant to the task.
+
+{{- range .Skills }}
+<preloaded_skill>
+<name>
+{{ .Name }}
+</name>
+<base_directory>
+{{ .BaseDirectory }}
+</base_directory>
+<content>
+{{ .Content }}
+</content>
+</preloaded_skill>
+{{- end }}
+`
+
+	preloadTemplateChinese = `
+# 预加载 Skill
+
+以下 Skill 已预加载：完整说明已包含在此，无需为它们调用 '{{.ToolName}}' 工具。当它们与任务相关时，请直接遵循其说明。
+
+{{- range .Skills }}
+<preloaded_skill>
+<name>
+{{ .Name }}
+</name>
+<base_directory>
+{{ .BaseDirectory }}
+</base_directory>
+<content>
+{{ .Content }}
+</content>
+</preloaded_skill>
+{{- end }}
+`
+
 	toolResult        = "Launching skill: %s\n"
 	toolResultChinese = "正在启动 Skill：%s\n"
 	userContent       = `Base directory for this skill: %s

--- a/adk/middlewares/skill/skill.go
+++ b/adk/middlewares/skill/skill.go
@@ -154,6 +154,18 @@ type TypedConfig[M adk.MessageType] struct {
 	// or return an error in context mode.
 	ModelHub TypedModelHub[M]
 
+	// PreloadSkills lists the names of skills whose full content is preloaded into
+	// the agent's system instruction when the middleware is created, so the model
+	// starts with their instructions without calling the skill tool.
+	// Each name must exist in the Backend, and the skill must not use
+	// "context: fork" or "context: fork_with_context", which are executed by
+	// sub-agents and cannot be preloaded.
+	// The "model" frontmatter field of preloaded skills has no effect: it only
+	// applies when the skill is loaded through the skill tool.
+	// Skills not listed here keep the default on-demand behavior via the skill tool.
+	// optional
+	PreloadSkills []string
+
 	// CustomSystemPrompt allows customizing the system prompt injected into the agent.
 	// If nil, the default system prompt is used.
 	// The function receives the skill tool name as a parameter.
@@ -218,6 +230,14 @@ func NewTyped[M adk.MessageType](ctx context.Context, config *TypedConfig[M]) (a
 		if err != nil {
 			return nil, err
 		}
+	}
+
+	if len(config.PreloadSkills) > 0 {
+		section, err := buildPreloadSection(ctx, config.Backend, config.PreloadSkills, name, config.UseChinese)
+		if err != nil {
+			return nil, err
+		}
+		instruction += section
 	}
 
 	return &typedSkillHandler[M]{
@@ -331,6 +351,14 @@ func New(ctx context.Context, config *Config) (adk.AgentMiddleware, error) {
 		}
 	}
 
+	if len(config.PreloadSkills) > 0 {
+		section, err := buildPreloadSection(ctx, config.Backend, config.PreloadSkills, name, config.UseChinese)
+		if err != nil {
+			return adk.AgentMiddleware{}, err
+		}
+		sp += section
+	}
+
 	return adk.AgentMiddleware{
 		AdditionalInstruction: sp,
 		AdditionalTools: []tool.BaseTool{&typedSkillTool[*schema.Message]{
@@ -355,6 +383,49 @@ func buildSystemPrompt(skillToolName string, useChinese bool) (string, error) {
 	return pyfmt.Fmt(prompt, map[string]string{
 		"tool_name": skillToolName,
 	})
+}
+
+type preloadTemplateHelper struct {
+	ToolName string
+	Skills   []Skill
+}
+
+// buildPreloadSection loads the skills to preload from the backend and renders
+// the instruction section that inlines their full content.
+func buildPreloadSection(ctx context.Context, backend Backend, names []string, toolName string, useChinese bool) (string, error) {
+	skills := make([]Skill, 0, len(names))
+	for _, name := range names {
+		skill, err := backend.Get(ctx, name)
+		if err != nil {
+			return "", fmt.Errorf("failed to preload skill '%s': %w", name, err)
+		}
+		switch skill.Context {
+		case ContextModeFork, ContextModeForkWithContext:
+			return "", fmt.Errorf("failed to preload skill '%s': context mode %q runs in a sub-agent and cannot be preloaded", name, skill.Context)
+		}
+		skills = append(skills, skill)
+	}
+
+	tplStr := internal.SelectPrompt(internal.I18nPrompts{
+		English: preloadTemplate,
+		Chinese: preloadTemplateChinese,
+	})
+	if useChinese {
+		tplStr = preloadTemplateChinese
+	}
+
+	tpl, err := template.New("preloaded_skills").Parse(tplStr)
+	if err != nil {
+		return "", fmt.Errorf("failed to parse preload template: %w", err)
+	}
+
+	var buf bytes.Buffer
+	err = tpl.Execute(&buf, preloadTemplateHelper{ToolName: toolName, Skills: skills})
+	if err != nil {
+		return "", fmt.Errorf("failed to render preload section: %w", err)
+	}
+
+	return buf.String(), nil
 }
 
 type typedSkillTool[M adk.MessageType] struct {


### PR DESCRIPTION
#### What type of PR is this?

feat

#### Check the PR title.

- [x] This PR title match the format: \<type\>(optional scope): \<description\>
- [x] The description of this PR title is user-oriented and clear enough for others to understand.
- [ ] Attach the PR updating the user documentation if the current PR requires user awareness at the usage level. [User docs repo](https://github.com/cloudwego/cloudwego.github.io)

#### (Optional) Translate the PR title into Chinese.

feat(skill): 支持将指定 Skill 预加载进 Agent 系统指令

#### (Optional) More detailed description for this PR(en: English/zh: Chinese).

en:
Skills are currently loaded on demand: the model has to call the skill tool and the content comes back as a tool result. This adds `Config.PreloadSkills` to the skill middleware so that the listed skills are loaded from the Backend at middleware creation and their full content is inlined into the system instruction (bilingual prompt sections included), saving a tool round-trip for skills that should always be active.

Details:
- Unknown skill names fail fast at creation.
- Skills using `context: fork` / `fork_with_context` are rejected: they run in sub-agents and cannot be inlined.
- The `"model"` frontmatter override does not apply to preloaded skills (it only takes effect via the skill tool), documented on the field.
- The skill tool keeps its on-demand behavior and still lists every skill.
- Covered by new unit tests (English/Chinese prompt, unknown skill, fork rejection, deprecated `New`, custom system prompt).

zh(optional):
当前 Skill 为按需加载：模型需要先调用 skill 工具才能拿到完整说明。本 PR 为 skill 中间件新增 `Config.PreloadSkills`，在创建中间件时即从 Backend 加载指定 Skill 并将其完整内容注入系统指令（含中英文提示词模板），省去一次工具调用。未列出的 Skill 保持原有按需行为；fork / fork_with_context 模式的 Skill 不允许预加载；未知名称在创建时报错。

#### (Optional) Which issue(s) this PR fixes:

Implements #867

#### (optional) The PR that updates user documentation:

Not yet — will add to the user docs repo if maintainers want this documented there.