### PR TITLE
feat(adk): tolerate transient heartbeat failures

### DIFF
--- a/adk/backgroundtask/conformance_test.go
+++ b/adk/backgroundtask/conformance_test.go
@@ -140,7 +140,8 @@ func TestSimplifiedPublicModelHasNoOverlappingStateFields_BitsUT(t *testing.T) {
 		"TaskID", "Cursor", "Limit", "NewestFirst")
 	assertFieldsPresent(t, reflect.TypeOf(ListTaskEventsResult{}), "Events", "NextCursor")
 	assertFieldsPresent(t, reflect.TypeOf(Config{}),
-		"Tasks", "TaskEvents", "Executors", "SendTaskCreatedEvent", "IDGen", "ContextSnapshotter")
+		"Tasks", "TaskEvents", "Executors", "HeartbeatInterval", "LeaseDuration",
+		"TolerateTransientHeartbeatErrors", "SendTaskCreatedEvent", "IDGen", "ContextSnapshotter")
 	assertFieldsAbsent(t, reflect.TypeOf(Config{}), "Store", "NotificationWriter")
 	assertMethodsAbsent(t, reflect.TypeOf((*TaskStore)(nil)).Elem(),
 		"AppendTaskEvent", "ListTaskEvents", "ReadRecentTaskEvents", "ReportOutputFailure",
@@ -177,6 +178,7 @@ func TestSimplifiedPublicModelHasNoOverlappingStateFields_BitsUT(t *testing.T) {
 		"TaskID", "AppendTaskEvent", "ReportOutputFailure", "CommitStart")
 	assertMethodsPresent(t, reflect.TypeOf((*ExecutionRuntime)(nil)).Elem(),
 		"EmitProgress", "ReportTranscriptFailure")
+	assertMethodsPresent(t, reflect.TypeOf((*LeaseGateRuntime)(nil)).Elem(), "WaitForLease")
 	assertMethodsPresent(t, reflect.TypeOf((*StartCommitRuntime)(nil)).Elem(),
 		"CommitStart")
 	assertFieldsPresent(t, reflect.TypeOf(CommitStartRequest{}),

--- a/adk/backgroundtask/executor.go
+++ b/adk/backgroundtask/executor.go
@@ -28,6 +28,7 @@ import (
 	"github.com/google/uuid"
 
 	"github.com/cloudwego/eino/adk/internal/taskcontrol"
+	"github.com/cloudwego/eino/internal/core"
 	"github.com/cloudwego/eino/internal/safe"
 )
 
@@ -112,6 +113,15 @@ type ExecutionRuntime interface {
 // compatibility for custom executors and test doubles.
 type StartCommitRuntime interface {
 	CommitStart(context.Context, []byte) error
+}
+
+// LeaseGateRuntime is an optional execution capability that waits until the
+// Manager has confirmed that the current attempt still owns a safe lease.
+// Built-in agent tool dispatch observes this gate automatically. Custom
+// executors should call it before starting a new external side effect. Calls
+// return promptly when transient-heartbeat tolerance is disabled.
+type LeaseGateRuntime interface {
+	WaitForLease(context.Context) error
 }
 
 // Executor reconstructs and runs durable work from a task Spec.
@@ -212,18 +222,31 @@ func (a *activeAttempt) signalReady() {
 }
 
 type taskRuntime struct {
-	mu                 sync.Mutex
-	controlMu          sync.Mutex
-	tasks              TaskStore
-	taskEvents         TaskEventStore
-	notificationWriter NotificationWriter
-	taskID             string
-	attempt            int64
-	version            int64
-	controls           chan ControlRequest
-	poison             error
-	cancelRequested    bool
-	cancelReason       string
+	mu                      sync.Mutex
+	controlMu               sync.Mutex
+	tasks                   TaskStore
+	taskEvents              TaskEventStore
+	notificationWriter      NotificationWriter
+	taskID                  string
+	attempt                 int64
+	version                 int64
+	controls                chan ControlRequest
+	poison                  error
+	cancelRequested         bool
+	cancelReason            string
+	stateChanged            chan struct{}
+	heartbeatAbort          chan struct{}
+	heartbeatAborted        bool
+	versionWriteActive      bool
+	heartbeatPending        bool
+	heartbeatToken          uint64
+	heartbeatSequence       uint64
+	leaseUncertain          bool
+	unconfirmedAt           time.Time
+	leaseExpiresAt          time.Time
+	leaseDuration           time.Duration
+	leaseSafetyMargin       time.Duration
+	tolerateHeartbeatErrors bool
 }
 
 // detachedCtx preserves values while detaching worker execution from the
@@ -239,7 +262,17 @@ func (detachedCtx) Done() <-chan struct{}       { return nil }
 func (detachedCtx) Err() error                  { return nil }
 func (c detachedCtx) Value(key any) any         { return c.parent.Value(key) }
 
-var errHeartbeatStopped = errors.New("backgroundtask: heartbeat stopped")
+var (
+	errHeartbeatRetry   = errors.New("backgroundtask: heartbeat retry at regular interval")
+	errHeartbeatStopped = errors.New("backgroundtask: heartbeat stopped")
+)
+
+type taskRuntimeLeaseConfig struct {
+	confirmedAt             time.Time
+	duration                time.Duration
+	safetyMargin            time.Duration
+	tolerateHeartbeatErrors bool
+}
 
 func newTaskRuntime(
 	tasks TaskStore,
@@ -247,16 +280,327 @@ func newTaskRuntime(
 	taskID string,
 	attempt, version int64,
 	notificationWriter NotificationWriter,
+	leaseConfigs ...taskRuntimeLeaseConfig,
 ) *taskRuntime {
-	return &taskRuntime{
+	runtime := &taskRuntime{
 		tasks: tasks, taskEvents: taskEvents,
 		notificationWriter: notificationWriter,
 		taskID:             taskID, attempt: attempt, version: version,
-		controls: make(chan ControlRequest, 1),
+		controls:       make(chan ControlRequest, 1),
+		stateChanged:   make(chan struct{}),
+		heartbeatAbort: make(chan struct{}),
 	}
+	if len(leaseConfigs) > 0 {
+		config := leaseConfigs[0]
+		runtime.leaseDuration = config.duration
+		runtime.leaseSafetyMargin = config.safetyMargin
+		runtime.tolerateHeartbeatErrors = config.tolerateHeartbeatErrors
+		if config.tolerateHeartbeatErrors {
+			runtime.leaseExpiresAt = config.confirmedAt.Add(config.duration)
+		}
+	}
+	return runtime
 }
 
 func (r *taskRuntime) Controls() <-chan ControlRequest { return r.controls }
+
+func (r *taskRuntime) signalStateChangedLocked() {
+	close(r.stateChanged)
+	r.stateChanged = make(chan struct{})
+}
+
+func (r *taskRuntime) abortHeartbeatLocked() {
+	if !r.heartbeatAborted {
+		close(r.heartbeatAbort)
+		r.heartbeatAborted = true
+	}
+}
+
+// WaitForLease blocks new side effects while a heartbeat result is uncertain.
+func (r *taskRuntime) WaitForLease(ctx context.Context) error {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	for {
+		if err := ctx.Err(); err != nil {
+			return err
+		}
+		r.mu.Lock()
+		if r.poison != nil {
+			err := r.poison
+			r.mu.Unlock()
+			return err
+		}
+		if r.cancelRequested {
+			r.mu.Unlock()
+			return ErrLeaseLost
+		}
+		if !r.tolerateHeartbeatErrors ||
+			(!r.heartbeatPending && r.heartbeatToken == 0 && !r.leaseUncertain) {
+			r.mu.Unlock()
+			return nil
+		}
+		changed := r.stateChanged
+		r.mu.Unlock()
+		select {
+		case <-changed:
+		case <-ctx.Done():
+			return ctx.Err()
+		}
+	}
+}
+
+func (r *taskRuntime) beginVersionWrite(
+	ctx context.Context,
+	allowCanceled bool,
+) (int64, error) {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	for {
+		if err := ctx.Err(); err != nil {
+			return 0, err
+		}
+		r.mu.Lock()
+		if r.poison != nil {
+			err := r.poison
+			r.mu.Unlock()
+			return 0, err
+		}
+		if r.cancelRequested && !allowCanceled {
+			r.mu.Unlock()
+			return 0, ErrLeaseLost
+		}
+		leaseBlocked := r.heartbeatPending || r.heartbeatToken != 0 ||
+			(r.tolerateHeartbeatErrors && r.leaseUncertain)
+		if !r.versionWriteActive && !leaseBlocked {
+			r.versionWriteActive = true
+			version := r.version
+			r.mu.Unlock()
+			return version, nil
+		}
+		changed := r.stateChanged
+		r.mu.Unlock()
+		select {
+		case <-changed:
+		case <-ctx.Done():
+			return 0, ctx.Err()
+		}
+	}
+}
+
+func (r *taskRuntime) finishVersionWrite(task *Task) {
+	r.mu.Lock()
+	if task != nil && r.poison == nil && task.Version > r.version {
+		r.version = task.Version
+	}
+	r.versionWriteActive = false
+	r.signalStateChangedLocked()
+	r.mu.Unlock()
+}
+
+func (r *taskRuntime) beginHeartbeat(
+	ctx context.Context,
+	startedAt time.Time,
+) (uint64, int64, time.Time, error) {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	if err := ctx.Err(); err != nil {
+		return 0, 0, time.Time{}, err
+	}
+	r.mu.Lock()
+	if r.poison != nil {
+		err := r.poison
+		r.mu.Unlock()
+		return 0, 0, time.Time{}, err
+	}
+	if r.cancelRequested {
+		r.mu.Unlock()
+		return 0, 0, time.Time{}, errHeartbeatStopped
+	}
+	r.heartbeatPending = true
+	r.signalStateChangedLocked()
+	for r.versionWriteActive || r.heartbeatToken != 0 {
+		changed := r.stateChanged
+		r.mu.Unlock()
+		select {
+		case <-changed:
+		case <-ctx.Done():
+			r.mu.Lock()
+			r.heartbeatPending = false
+			r.signalStateChangedLocked()
+			r.mu.Unlock()
+			return 0, 0, time.Time{}, ctx.Err()
+		}
+		r.mu.Lock()
+		if r.poison != nil {
+			err := r.poison
+			r.heartbeatPending = false
+			r.signalStateChangedLocked()
+			r.mu.Unlock()
+			return 0, 0, time.Time{}, err
+		}
+		if r.cancelRequested {
+			r.heartbeatPending = false
+			r.signalStateChangedLocked()
+			r.mu.Unlock()
+			return 0, 0, time.Time{}, errHeartbeatStopped
+		}
+	}
+	r.heartbeatSequence++
+	token := r.heartbeatSequence
+	r.heartbeatToken = token
+	r.heartbeatPending = false
+	unconfirmedAt := time.Time{}
+	if r.tolerateHeartbeatErrors {
+		if r.leaseUncertain {
+			unconfirmedAt = r.unconfirmedAt
+		} else {
+			r.unconfirmedAt = startedAt
+		}
+		r.leaseUncertain = true
+	}
+	version := r.version
+	r.signalStateChangedLocked()
+	r.mu.Unlock()
+	return token, version, unconfirmedAt, nil
+}
+
+func definitiveHeartbeatError(err error) bool {
+	return errors.Is(err, ErrLeaseLost) ||
+		errors.Is(err, ErrNotFound) ||
+		errors.Is(err, ErrIllegalTransition) ||
+		errors.Is(err, ErrAlreadyTerminal)
+}
+
+func (r *taskRuntime) finishHeartbeatError(token uint64, heartbeatErr error) error {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	if token != r.heartbeatToken {
+		return errHeartbeatStopped
+	}
+	r.heartbeatToken = 0
+	if r.tolerateHeartbeatErrors && !definitiveHeartbeatError(heartbeatErr) {
+		r.leaseUncertain = true
+		r.signalStateChangedLocked()
+		return errHeartbeatRetry
+	}
+	r.poison = heartbeatErr
+	r.leaseUncertain = false
+	r.unconfirmedAt = time.Time{}
+	r.signalStateChangedLocked()
+	return heartbeatErr
+}
+
+func (r *taskRuntime) confirmHeartbeat(
+	token uint64,
+	expectedVersion int64,
+	confirmedAt time.Time,
+	task *Task,
+) error {
+	if task == nil || task.Status != StatusRunning || task.Attempt != r.attempt ||
+		task.CancelRequestedAt != nil || task.Version != expectedVersion+1 {
+		return r.finishHeartbeatError(token, ErrLeaseLost)
+	}
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	if token != r.heartbeatToken {
+		return errHeartbeatStopped
+	}
+	if r.tolerateHeartbeatErrors &&
+		!time.Now().Before(r.leaseExpiresAt.Add(-r.leaseSafetyMargin)) {
+		r.poison = ErrLeaseLost
+		r.heartbeatToken = 0
+		r.leaseUncertain = false
+		r.unconfirmedAt = time.Time{}
+		r.signalStateChangedLocked()
+		return ErrLeaseLost
+	}
+	r.version = task.Version
+	r.heartbeatToken = 0
+	r.leaseUncertain = false
+	r.unconfirmedAt = time.Time{}
+	r.leaseExpiresAt = confirmedAt.Add(r.leaseDuration)
+	r.signalStateChangedLocked()
+	return nil
+}
+
+func (r *taskRuntime) acceptCancellation(task *Task, expectedVersion int64) error {
+	if task == nil || task.Status != StatusRunning || task.Attempt != r.attempt ||
+		task.CancelRequestedAt == nil ||
+		(expectedVersion > 0 && task.Version != expectedVersion) {
+		r.loseLease(ErrLeaseLost)
+		return ErrLeaseLost
+	}
+	r.mu.Lock()
+	if r.poison != nil {
+		err := r.poison
+		r.mu.Unlock()
+		return err
+	}
+	if task.Version < r.version {
+		r.mu.Unlock()
+		r.loseLease(ErrLeaseLost)
+		return ErrLeaseLost
+	}
+	r.version = task.Version
+	r.cancelRequested = true
+	r.cancelReason = task.CancelReason
+	r.heartbeatToken = 0
+	r.heartbeatPending = false
+	r.leaseUncertain = false
+	r.unconfirmedAt = time.Time{}
+	r.abortHeartbeatLocked()
+	r.signalStateChangedLocked()
+	r.mu.Unlock()
+	r.requestControlWithReason(ControlStop, task.CancelReason)
+	return nil
+}
+
+func (r *taskRuntime) loseLease(cause error) {
+	if cause == nil {
+		cause = ErrLeaseLost
+	}
+	r.mu.Lock()
+	if r.poison == nil {
+		r.poison = cause
+	}
+	r.heartbeatSequence++
+	r.heartbeatToken = 0
+	r.heartbeatPending = false
+	r.leaseUncertain = false
+	r.unconfirmedAt = time.Time{}
+	r.signalStateChangedLocked()
+	r.mu.Unlock()
+}
+
+func (r *taskRuntime) stopHeartbeat() {
+	r.mu.Lock()
+	r.heartbeatSequence++
+	r.heartbeatToken = 0
+	r.heartbeatPending = false
+	r.leaseUncertain = false
+	r.unconfirmedAt = time.Time{}
+	r.signalStateChangedLocked()
+	r.mu.Unlock()
+}
+
+func (r *taskRuntime) leaseSafetyDeadline() (time.Time, bool) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	if !r.tolerateHeartbeatErrors || r.leaseExpiresAt.IsZero() ||
+		r.poison != nil || r.cancelRequested {
+		return time.Time{}, false
+	}
+	return r.leaseExpiresAt.Add(-r.leaseSafetyMargin), true
+}
+
+func (r *taskRuntime) leaseNeedsConfirmation() bool {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return r.heartbeatPending || r.heartbeatToken != 0 || r.leaseUncertain
+}
 
 // NotifyParent emits one idempotent application notification using authority
 // bound to the current managed attempt context. It returns
@@ -283,19 +627,24 @@ func (r *taskRuntime) notifyParent(
 	req *NotifyParentRequest,
 ) error {
 	r.mu.Lock()
-	defer r.mu.Unlock()
 	if r.poison != nil {
-		return r.poison
+		err := r.poison
+		r.mu.Unlock()
+		return err
 	}
-	if r.notificationWriter == nil {
+	writer := r.notificationWriter
+	taskID := r.taskID
+	attempt := r.attempt
+	r.mu.Unlock()
+	if writer == nil {
 		return ErrNotificationUnavailable
 	}
 	cloned := *req
 	cloned.Data = cloneBytes(req.Data)
-	return r.notificationWriter.EnqueueTaskNotification(
+	return writer.EnqueueTaskNotification(
 		ctx,
-		r.taskID,
-		r.attempt,
+		taskID,
+		attempt,
 		&cloned,
 	)
 }
@@ -306,15 +655,20 @@ func (r *taskRuntime) EmitProgress(
 	data []byte,
 ) (ProgressEmission, error) {
 	r.mu.Lock()
-	defer r.mu.Unlock()
 	if r.poison != nil {
-		return ProgressEmission{}, r.poison
+		err := r.poison
+		r.mu.Unlock()
+		return ProgressEmission{}, err
 	}
+	taskEvents := r.taskEvents
+	taskID := r.taskID
+	attempt := r.attempt
+	r.mu.Unlock()
 	if eventID == "" {
 		eventID = uuid.NewString()
 	}
-	result, err := r.taskEvents.AppendTaskEvent(ctx, &AppendTaskEventRequest{
-		TaskID: r.taskID, Attempt: r.attempt, EventID: eventID, Data: cloneBytes(data),
+	result, err := taskEvents.AppendTaskEvent(ctx, &AppendTaskEventRequest{
+		TaskID: taskID, Attempt: attempt, EventID: eventID, Data: cloneBytes(data),
 	})
 	if err != nil {
 		return ProgressEmission{}, err
@@ -368,18 +722,17 @@ func controlPriority(kind ControlKind) int {
 }
 
 func (r *taskRuntime) ReportTranscriptFailure(ctx context.Context, cause error) error {
-	r.mu.Lock()
-	defer r.mu.Unlock()
-	if r.poison != nil {
-		return r.poison
-	}
-	task, err := r.tasks.ReportTranscriptFailure(ctx, &ReportTranscriptFailureRequest{
-		TaskID: r.taskID, ExpectedVersion: r.version, Error: boundedError(cause),
-	})
+	version, err := r.beginVersionWrite(ctx, false)
 	if err != nil {
 		return err
 	}
-	r.version = task.Version
+	task, err := r.tasks.ReportTranscriptFailure(ctx, &ReportTranscriptFailureRequest{
+		TaskID: r.taskID, ExpectedVersion: version, Error: boundedError(cause),
+	})
+	r.finishVersionWrite(task)
+	if err != nil {
+		return err
+	}
 	return nil
 }
 
@@ -387,103 +740,121 @@ func (r *taskRuntime) CommitStart(
 	ctx context.Context,
 	checkpoint []byte,
 ) error {
-	r.mu.Lock()
-	defer r.mu.Unlock()
-	if r.poison != nil {
-		return r.poison
-	}
-	task, err := r.tasks.CommitStart(ctx, &CommitStartRequest{
-		TaskID: r.taskID, ExpectedVersion: r.version,
-		Checkpoint: cloneBytes(checkpoint),
-	})
+	version, err := r.beginVersionWrite(ctx, false)
 	if err != nil {
 		return err
 	}
-	r.version = task.Version
+	task, err := r.tasks.CommitStart(ctx, &CommitStartRequest{
+		TaskID: r.taskID, ExpectedVersion: version,
+		Checkpoint: cloneBytes(checkpoint),
+	})
+	r.finishVersionWrite(task)
+	if err != nil {
+		return err
+	}
 	return nil
 }
 
 func (r *taskRuntime) heartbeat(ctx context.Context) error {
-	r.mu.Lock()
-	defer r.mu.Unlock()
-	if r.poison != nil {
-		return r.poison
-	}
-	if r.cancelRequested {
-		return errHeartbeatStopped
+	requestStartedAt := time.Now()
+	token, version, unconfirmedAt, err := r.beginHeartbeat(ctx, requestStartedAt)
+	if err != nil {
+		return err
 	}
 	task, err := r.tasks.Heartbeat(ctx, &HeartbeatRequest{
-		TaskID: r.taskID, ExpectedVersion: r.version,
+		TaskID: r.taskID, ExpectedVersion: version,
 	})
-	if err != nil {
-		if errors.Is(err, ErrVersionConflict) {
-			if reconcileErr := r.reconcileCancellationLocked(ctx); reconcileErr != nil {
-				return reconcileErr
+	if err == nil {
+		return r.confirmHeartbeat(token, version, requestStartedAt, task)
+	}
+	if errors.Is(err, ErrVersionConflict) {
+		current, getErr := r.tasks.Get(ctx, r.taskID)
+		if getErr != nil {
+			return r.finishHeartbeatError(token, getErr)
+		}
+		if current != nil && current.Status == StatusRunning &&
+			current.Attempt == r.attempt &&
+			current.CancelRequestedAt != nil {
+			expectedCancellationVersion := version + 1
+			if r.tolerateHeartbeatErrors {
+				expectedCancellationVersion = 0
+			}
+			if acceptErr := r.acceptCancellation(
+				current,
+				expectedCancellationVersion,
+			); acceptErr != nil {
+				return acceptErr
 			}
 			return errHeartbeatStopped
 		}
-		r.poison = err
-		return err
+		if current != nil && r.tolerateHeartbeatErrors && !unconfirmedAt.IsZero() &&
+			current.Status == StatusRunning &&
+			current.Attempt == r.attempt && current.CancelRequestedAt == nil &&
+			current.Version == version+1 {
+			return r.confirmHeartbeat(token, version, unconfirmedAt, current)
+		}
+		return r.finishHeartbeatError(token, ErrLeaseLost)
 	}
-	r.version = task.Version
-	return nil
+	return r.finishHeartbeatError(token, err)
 }
 
-func (r *taskRuntime) reconcileCancellationLocked(ctx context.Context) error {
+func (r *taskRuntime) reconcileCancellation(ctx context.Context, expectedVersion int64) error {
 	task, err := r.tasks.Get(ctx, r.taskID)
 	if err != nil {
-		r.poison = err
+		r.loseLease(err)
 		return err
 	}
-	if task.Status != StatusRunning || task.CancelRequestedAt == nil ||
-		task.Version != r.version+1 {
-		r.poison = ErrLeaseLost
-		return r.poison
-	}
-	r.version = task.Version
-	r.cancelRequested = true
-	r.cancelReason = task.CancelReason
-	r.requestControlWithReason(ControlStop, r.cancelReason)
-	return nil
+	return r.acceptCancellation(task, expectedVersion+1)
 }
 
 func (r *taskRuntime) commit(ctx context.Context, result *ExecutionResult) (*Task, error) {
-	r.mu.Lock()
-	defer r.mu.Unlock()
-	if r.poison != nil {
-		return nil, r.poison
-	}
 	if result == nil {
 		return nil, errors.New("backgroundtask: executor returned nil result")
 	}
+	version, err := r.beginVersionWrite(ctx, true)
+	if err != nil {
+		return nil, err
+	}
+	var committed *Task
+	defer func() { r.finishVersionWrite(committed) }()
+	r.mu.Lock()
 	if r.cancelRequested {
 		result = &ExecutionResult{Status: StatusCanceled, Error: r.cancelReason}
 	}
-	task, err := r.commitResult(ctx, result)
+	r.mu.Unlock()
+	task, err := r.commitResult(ctx, version, result)
 	if errors.Is(err, ErrVersionConflict) {
-		if reconcileErr := r.reconcileCancellationLocked(ctx); reconcileErr != nil {
+		if reconcileErr := r.reconcileCancellation(ctx, version); reconcileErr != nil {
 			return nil, reconcileErr
 		}
-		task, err = r.commitResult(ctx, &ExecutionResult{
-			Status: StatusCanceled, Error: r.cancelReason,
+		r.mu.Lock()
+		version = r.version
+		cancelReason := r.cancelReason
+		r.mu.Unlock()
+		task, err = r.commitResult(ctx, version, &ExecutionResult{
+			Status: StatusCanceled, Error: cancelReason,
 		})
 	}
 	if err != nil {
-		r.poison = err
+		r.loseLease(err)
 		return nil, err
 	}
-	r.version = task.Version
+	committed = task
 	return task, nil
 }
 
-func (r *taskRuntime) commitResult(ctx context.Context, result *ExecutionResult) (*Task, error) {
+func (r *taskRuntime) commitResult(
+	ctx context.Context,
+	version int64,
+	result *ExecutionResult,
+) (*Task, error) {
 	if result.Directive != "" {
 		if result.Directive != ExecutionDirectiveYield || result.Status != "" ||
 			len(result.Data) != 0 || result.Error != "" {
 			return nil, fmt.Errorf("%w: conflicting executor directive and lifecycle result", ErrInvalidExecutionResult)
 		}
 		return r.tasks.Yield(ctx, &YieldTaskRequest{
-			TaskID: r.taskID, ExpectedVersion: r.version,
+			TaskID: r.taskID, ExpectedVersion: version,
 			Checkpoint: cloneBytes(result.Checkpoint),
 		})
 	}
@@ -493,35 +864,35 @@ func (r *taskRuntime) commitResult(ctx context.Context, result *ExecutionResult)
 			return nil, fmt.Errorf("%w: completed result contains checkpoint or error", ErrInvalidExecutionResult)
 		}
 		return r.tasks.Complete(ctx, &CompleteTaskRequest{
-			TaskID: r.taskID, ExpectedVersion: r.version, Data: cloneBytes(result.Data),
+			TaskID: r.taskID, ExpectedVersion: version, Data: cloneBytes(result.Data),
 		})
 	case StatusFailed:
 		if len(result.Checkpoint) != 0 || len(result.Data) != 0 {
 			return nil, fmt.Errorf("%w: failed result contains checkpoint or data", ErrInvalidExecutionResult)
 		}
 		return r.tasks.Fail(ctx, &FailTaskRequest{
-			TaskID: r.taskID, ExpectedVersion: r.version, Error: result.Error,
+			TaskID: r.taskID, ExpectedVersion: version, Error: result.Error,
 		})
 	case StatusCanceled:
 		if len(result.Checkpoint) != 0 || len(result.Data) != 0 {
 			return nil, fmt.Errorf("%w: canceled result contains checkpoint or data", ErrInvalidExecutionResult)
 		}
 		return r.tasks.AckCancel(ctx, &AckCancelRequest{
-			TaskID: r.taskID, ExpectedVersion: r.version, Reason: result.Error,
+			TaskID: r.taskID, ExpectedVersion: version, Reason: result.Error,
 		})
 	case StatusWaitingInput:
 		if len(result.Data) != 0 || result.Error != "" {
 			return nil, fmt.Errorf("%w: waiting-input result contains data or error", ErrInvalidExecutionResult)
 		}
 		return r.tasks.WaitInput(ctx, &WaitInputTaskRequest{
-			TaskID: r.taskID, ExpectedVersion: r.version, Checkpoint: cloneBytes(result.Checkpoint),
+			TaskID: r.taskID, ExpectedVersion: version, Checkpoint: cloneBytes(result.Checkpoint),
 		})
 	case StatusSuspended:
 		if len(result.Data) != 0 || result.Error != "" {
 			return nil, fmt.Errorf("%w: suspended result contains data or error", ErrInvalidExecutionResult)
 		}
 		return r.tasks.Suspend(ctx, &SuspendTaskRequest{
-			TaskID: r.taskID, ExpectedVersion: r.version, Checkpoint: cloneBytes(result.Checkpoint),
+			TaskID: r.taskID, ExpectedVersion: version, Checkpoint: cloneBytes(result.Checkpoint),
 		})
 	default:
 		return nil, fmt.Errorf("%w: unsupported executor result status %q", ErrInvalidExecutionResult, result.Status)
@@ -754,12 +1125,7 @@ func (m *Manager) RequestCancel(
 			return result, ctx.Err()
 		}
 		if attempt.runtime != nil {
-			attempt.runtime.mu.Lock()
-			if !attempt.runtime.cancelRequested {
-				err = attempt.runtime.reconcileCancellationLocked(ctx)
-			}
-			attempt.runtime.mu.Unlock()
-			if err != nil {
+			if err = attempt.runtime.acceptCancellation(result, 0); err != nil {
 				return result, err
 			}
 		}
@@ -904,6 +1270,7 @@ func (m *Manager) execute(
 	if err = executor.ValidateExecution(ctx, cloneTask(task)); err != nil {
 		return fmt.Errorf("backgroundtask: validate execution: %w", err)
 	}
+	leaseConfirmedAt := time.Now()
 	started, err := m.tasks.Start(ctx, &StartTaskRequest{
 		TaskID: taskID, ExpectedVersion: task.Version,
 	})
@@ -917,13 +1284,22 @@ func (m *Manager) execute(
 		started.Attempt,
 		started.Version,
 		m.notificationWriter,
+		taskRuntimeLeaseConfig{
+			confirmedAt:             leaseConfirmedAt,
+			duration:                m.leaseDuration,
+			safetyMargin:            m.heartbeatSafetyMargin,
+			tolerateHeartbeatErrors: m.tolerateHeartbeatErrors,
+		},
 	)
 	if started.CancelRequestedAt != nil {
-		runtime.cancelRequested = true
-		runtime.cancelReason = started.CancelReason
-		runtime.requestControlWithReason(ControlStop, runtime.cancelReason)
+		if err = runtime.acceptCancellation(started, 0); err != nil {
+			return err
+		}
 	}
 	runCtx, cancel := context.WithCancel(ctx)
+	if m.tolerateHeartbeatErrors {
+		runCtx = core.WithExecutionGate(runCtx, runtime.WaitForLease)
+	}
 	runCtx = context.WithValue(
 		runCtx,
 		notifyParentContextKey{},
@@ -1002,6 +1378,103 @@ func (m *Manager) heartbeat(
 	done chan<- struct{},
 ) {
 	defer close(done)
+	if !runtime.tolerateHeartbeatErrors {
+		m.heartbeatLegacy(ctx, cancel, runtime, stop)
+		return
+	}
+	interval := m.heartbeatEvery
+	if interval <= 0 {
+		interval = time.Nanosecond
+	}
+	heartbeatTimer := time.NewTimer(interval)
+	defer heartbeatTimer.Stop()
+	heartbeatC := heartbeatTimer.C
+	var resultC <-chan error
+	stopC := stop
+	stopRequested := false
+	for {
+		var safetyTimer *time.Timer
+		var safetyC <-chan time.Time
+		if deadline, ok := runtime.leaseSafetyDeadline(); ok {
+			delay := time.Until(deadline)
+			if delay < 0 {
+				delay = 0
+			}
+			safetyTimer = time.NewTimer(delay)
+			safetyC = safetyTimer.C
+		}
+		select {
+		case <-heartbeatC:
+			heartbeatC = nil
+			result := make(chan error, 1)
+			resultC = result
+			go func() {
+				result <- runtime.heartbeat(ctx)
+			}()
+		case err := <-resultC:
+			resultC = nil
+			switch {
+			case err == nil:
+				if stopRequested {
+					if safetyTimer != nil {
+						safetyTimer.Stop()
+					}
+					return
+				}
+			case errors.Is(err, errHeartbeatRetry):
+			case errors.Is(err, errHeartbeatStopped):
+				if safetyTimer != nil {
+					safetyTimer.Stop()
+				}
+				return
+			default:
+				if !errors.Is(err, context.Canceled) {
+					cancel()
+				}
+				if safetyTimer != nil {
+					safetyTimer.Stop()
+				}
+				return
+			}
+			heartbeatTimer.Reset(interval)
+			heartbeatC = heartbeatTimer.C
+		case <-ctx.Done():
+			runtime.stopHeartbeat()
+			if safetyTimer != nil {
+				safetyTimer.Stop()
+			}
+			return
+		case <-runtime.heartbeatAbort:
+			if safetyTimer != nil {
+				safetyTimer.Stop()
+			}
+			return
+		case <-stopC:
+			stopRequested = true
+			stopC = nil
+			if resultC == nil && !runtime.leaseNeedsConfirmation() {
+				if safetyTimer != nil {
+					safetyTimer.Stop()
+				}
+				return
+			}
+		case <-safetyC:
+			runtime.loseLease(ErrLeaseLost)
+			cancel()
+			return
+		}
+		if safetyTimer != nil {
+			safetyTimer.Stop()
+		}
+	}
+}
+
+func (m *Manager) heartbeatLegacy(
+	ctx context.Context,
+	cancel context.CancelFunc,
+	runtime *taskRuntime,
+	stop <-chan struct{},
+) {
 	interval := m.heartbeatEvery
 	if interval <= 0 {
 		interval = time.Nanosecond
@@ -1054,5 +1527,6 @@ func boundedError(err error) string {
 
 var (
 	_ ExecutionRuntime   = (*taskRuntime)(nil)
+	_ LeaseGateRuntime   = (*taskRuntime)(nil)
 	_ StartCommitRuntime = (*taskRuntime)(nil)
 )

--- a/adk/backgroundtask/executor.go
+++ b/adk/backgroundtask/executor.go
@@ -274,30 +274,46 @@ type taskRuntimeLeaseConfig struct {
 	tolerateHeartbeatErrors bool
 }
 
+type taskRuntimeConfig struct {
+	tasks              TaskStore
+	taskEvents         TaskEventStore
+	notificationWriter NotificationWriter
+	taskID             string
+	attempt            int64
+	version            int64
+	lease              taskRuntimeLeaseConfig
+}
+
 func newTaskRuntime(
 	tasks TaskStore,
 	taskEvents TaskEventStore,
 	taskID string,
 	attempt, version int64,
 	notificationWriter NotificationWriter,
-	leaseConfigs ...taskRuntimeLeaseConfig,
 ) *taskRuntime {
-	runtime := &taskRuntime{
+	return newTaskRuntimeWithConfig(taskRuntimeConfig{
 		tasks: tasks, taskEvents: taskEvents,
 		notificationWriter: notificationWriter,
 		taskID:             taskID, attempt: attempt, version: version,
-		controls:       make(chan ControlRequest, 1),
-		stateChanged:   make(chan struct{}),
-		heartbeatAbort: make(chan struct{}),
+	})
+}
+
+func newTaskRuntimeWithConfig(config taskRuntimeConfig) *taskRuntime {
+	runtime := &taskRuntime{
+		tasks: config.tasks, taskEvents: config.taskEvents,
+		notificationWriter: config.notificationWriter,
+		taskID:             config.taskID,
+		attempt:            config.attempt,
+		version:            config.version,
+		controls:           make(chan ControlRequest, 1),
+		stateChanged:       make(chan struct{}),
+		heartbeatAbort:     make(chan struct{}),
 	}
-	if len(leaseConfigs) > 0 {
-		config := leaseConfigs[0]
-		runtime.leaseDuration = config.duration
-		runtime.leaseSafetyMargin = config.safetyMargin
-		runtime.tolerateHeartbeatErrors = config.tolerateHeartbeatErrors
-		if config.tolerateHeartbeatErrors {
-			runtime.leaseExpiresAt = config.confirmedAt.Add(config.duration)
-		}
+	runtime.leaseDuration = config.lease.duration
+	runtime.leaseSafetyMargin = config.lease.safetyMargin
+	runtime.tolerateHeartbeatErrors = config.lease.tolerateHeartbeatErrors
+	if config.lease.tolerateHeartbeatErrors {
+		runtime.leaseExpiresAt = config.lease.confirmedAt.Add(config.lease.duration)
 	}
 	return runtime
 }
@@ -1277,20 +1293,20 @@ func (m *Manager) execute(
 	if err != nil {
 		return err
 	}
-	runtime := newTaskRuntime(
-		m.tasks,
-		m.taskEvents,
-		taskID,
-		started.Attempt,
-		started.Version,
-		m.notificationWriter,
-		taskRuntimeLeaseConfig{
+	runtime := newTaskRuntimeWithConfig(taskRuntimeConfig{
+		tasks:              m.tasks,
+		taskEvents:         m.taskEvents,
+		taskID:             taskID,
+		attempt:            started.Attempt,
+		version:            started.Version,
+		notificationWriter: m.notificationWriter,
+		lease: taskRuntimeLeaseConfig{
 			confirmedAt:             leaseConfirmedAt,
 			duration:                m.leaseDuration,
 			safetyMargin:            m.heartbeatSafetyMargin,
 			tolerateHeartbeatErrors: m.tolerateHeartbeatErrors,
 		},
-	)
+	})
 	if started.CancelRequestedAt != nil {
 		if err = runtime.acceptCancellation(started, 0); err != nil {
 			return err

--- a/adk/backgroundtask/heartbeat_tolerance_test.go
+++ b/adk/backgroundtask/heartbeat_tolerance_test.go
@@ -77,20 +77,19 @@ func tolerantRuntime(
 	interval time.Duration,
 	leaseDuration time.Duration,
 ) *taskRuntime {
-	return newTaskRuntime(
-		tasks,
-		events,
-		started.Spec.ID,
-		started.Attempt,
-		started.Version,
-		nil,
-		taskRuntimeLeaseConfig{
+	return newTaskRuntimeWithConfig(taskRuntimeConfig{
+		tasks:      tasks,
+		taskEvents: events,
+		taskID:     started.Spec.ID,
+		attempt:    started.Attempt,
+		version:    started.Version,
+		lease: taskRuntimeLeaseConfig{
 			confirmedAt:             confirmedAt,
 			duration:                leaseDuration,
 			safetyMargin:            interval / 2,
 			tolerateHeartbeatErrors: true,
 		},
-	)
+	})
 }
 
 func TestHeartbeatResponseLossConfirmsSameAttemptAndReleasesWrites(t *testing.T) {
@@ -169,15 +168,16 @@ func TestHeartbeatTransientFailuresUseRegularCadenceAndSafetyDeadline(t *testing
 		return nil, errors.New("temporary storage failure")
 	}
 	confirmedAt := time.Now()
-	runtime := newTaskRuntime(
-		store, base, started.Spec.ID, started.Attempt, started.Version, nil,
-		taskRuntimeLeaseConfig{
+	runtime := newTaskRuntimeWithConfig(taskRuntimeConfig{
+		tasks: store, taskEvents: base,
+		taskID: started.Spec.ID, attempt: started.Attempt, version: started.Version,
+		lease: taskRuntimeLeaseConfig{
 			confirmedAt:             confirmedAt,
 			duration:                leaseDuration,
 			safetyMargin:            safetyMargin,
 			tolerateHeartbeatErrors: true,
 		},
-	)
+	})
 	manager := &Manager{heartbeatEvery: interval}
 	runCtx, cancel := context.WithCancel(context.Background())
 	defer cancel()
@@ -255,15 +255,16 @@ func TestHeartbeatSafetyDeadlineCancelsBlockedStoreRequest(t *testing.T) {
 		<-release
 		return base.Heartbeat(ctx, req)
 	}
-	runtime := newTaskRuntime(
-		store, base, started.Spec.ID, started.Attempt, started.Version, nil,
-		taskRuntimeLeaseConfig{
+	runtime := newTaskRuntimeWithConfig(taskRuntimeConfig{
+		tasks: store, taskEvents: base,
+		taskID: started.Spec.ID, attempt: started.Attempt, version: started.Version,
+		lease: taskRuntimeLeaseConfig{
 			confirmedAt:             time.Now(),
 			duration:                leaseDuration,
 			safetyMargin:            safetyMargin,
 			tolerateHeartbeatErrors: true,
 		},
-	)
+	})
 	manager := &Manager{heartbeatEvery: interval}
 	runCtx, cancel := context.WithCancel(context.Background())
 	defer cancel()

--- a/adk/backgroundtask/heartbeat_tolerance_test.go
+++ b/adk/backgroundtask/heartbeat_tolerance_test.go
@@ -1,0 +1,604 @@
+/*
+ * Copyright 2026 CloudWeGo Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package backgroundtask
+
+import (
+	"context"
+	"errors"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+type heartbeatTestStore struct {
+	TaskStore
+	mu          sync.Mutex
+	callTimes   []time.Time
+	inFlight    int
+	maxInFlight int
+	heartbeat   func(int, context.Context, *HeartbeatRequest) (*Task, error)
+	get         func(context.Context, string) (*Task, error)
+}
+
+func (s *heartbeatTestStore) Heartbeat(
+	ctx context.Context,
+	req *HeartbeatRequest,
+) (*Task, error) {
+	s.mu.Lock()
+	call := len(s.callTimes) + 1
+	s.callTimes = append(s.callTimes, time.Now())
+	s.inFlight++
+	if s.inFlight > s.maxInFlight {
+		s.maxInFlight = s.inFlight
+	}
+	s.mu.Unlock()
+	defer func() {
+		s.mu.Lock()
+		s.inFlight--
+		s.mu.Unlock()
+	}()
+	return s.heartbeat(call, ctx, req)
+}
+
+func (s *heartbeatTestStore) Get(ctx context.Context, taskID string) (*Task, error) {
+	if s.get != nil {
+		return s.get(ctx, taskID)
+	}
+	return s.TaskStore.Get(ctx, taskID)
+}
+
+func (s *heartbeatTestStore) snapshotCalls() ([]time.Time, int) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return append([]time.Time(nil), s.callTimes...), s.maxInFlight
+}
+
+func tolerantRuntime(
+	tasks TaskStore,
+	events TaskEventStore,
+	started *Task,
+	confirmedAt time.Time,
+	interval time.Duration,
+	leaseDuration time.Duration,
+) *taskRuntime {
+	return newTaskRuntime(
+		tasks,
+		events,
+		started.Spec.ID,
+		started.Attempt,
+		started.Version,
+		nil,
+		taskRuntimeLeaseConfig{
+			confirmedAt:             confirmedAt,
+			duration:                leaseDuration,
+			safetyMargin:            interval / 2,
+			tolerateHeartbeatErrors: true,
+		},
+	)
+}
+
+func TestHeartbeatResponseLossConfirmsSameAttemptAndReleasesWrites(t *testing.T) {
+	base := NewInMemoryStore(&InMemoryStoreConfig{
+		ActiveAttemptTimeout: time.Second,
+	})
+	started := createAndStart(t, base, "heartbeat-response-loss")
+	temporaryErr := errors.New("response lost")
+	store := &heartbeatTestStore{TaskStore: base}
+	store.heartbeat = func(
+		call int,
+		ctx context.Context,
+		req *HeartbeatRequest,
+	) (*Task, error) {
+		task, err := base.Heartbeat(ctx, req)
+		if call == 1 && err == nil {
+			return nil, temporaryErr
+		}
+		return task, err
+	}
+	runtime := tolerantRuntime(
+		store, base, started, started.UpdatedAt, 20*time.Millisecond, time.Second,
+	)
+	initialExpiry := runtime.leaseExpiresAt
+
+	require.ErrorIs(t, runtime.heartbeat(context.Background()), errHeartbeatRetry)
+	require.Equal(t, initialExpiry, runtime.leaseExpiresAt)
+	waitCtx, cancelWait := context.WithTimeout(context.Background(), 5*time.Millisecond)
+	require.ErrorIs(t, runtime.WaitForLease(waitCtx), context.DeadlineExceeded)
+	cancelWait()
+
+	writeDone := make(chan error, 1)
+	go func() {
+		writeDone <- runtime.CommitStart(context.Background(), []byte("checkpoint"))
+	}()
+	select {
+	case err := <-writeDone:
+		t.Fatalf("versioned write returned while lease was uncertain: %v", err)
+	case <-time.After(10 * time.Millisecond):
+	}
+
+	require.NoError(t, runtime.heartbeat(context.Background()))
+	require.NoError(t, <-writeDone)
+	current, err := base.Get(context.Background(), started.Spec.ID)
+	require.NoError(t, err)
+	require.Equal(t, started.Attempt, current.Attempt)
+	require.Equal(t, started.Version+2, current.Version)
+	require.Greater(t, runtime.leaseExpiresAt, initialExpiry)
+	calls, _ := store.snapshotCalls()
+	require.Len(t, calls, 2)
+	require.True(
+		t,
+		runtime.leaseExpiresAt.Before(calls[1].Add(time.Second-5*time.Millisecond)),
+		"reconciliation must retain the first unconfirmed heartbeat's lease deadline",
+	)
+}
+
+func TestHeartbeatTransientFailuresUseRegularCadenceAndSafetyDeadline(t *testing.T) {
+	const (
+		interval       = 20 * time.Millisecond
+		leaseDuration  = 120 * time.Millisecond
+		safetyMargin   = 10 * time.Millisecond
+		timingSlack    = 8 * time.Millisecond
+		completionWait = time.Second
+	)
+	base := NewInMemoryStore(&InMemoryStoreConfig{
+		ActiveAttemptTimeout: leaseDuration,
+	})
+	started := createAndStart(t, base, "heartbeat-transient")
+	store := &heartbeatTestStore{TaskStore: base}
+	store.heartbeat = func(
+		_ int,
+		_ context.Context,
+		_ *HeartbeatRequest,
+	) (*Task, error) {
+		return nil, errors.New("temporary storage failure")
+	}
+	confirmedAt := time.Now()
+	runtime := newTaskRuntime(
+		store, base, started.Spec.ID, started.Attempt, started.Version, nil,
+		taskRuntimeLeaseConfig{
+			confirmedAt:             confirmedAt,
+			duration:                leaseDuration,
+			safetyMargin:            safetyMargin,
+			tolerateHeartbeatErrors: true,
+		},
+	)
+	manager := &Manager{heartbeatEvery: interval}
+	runCtx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	done := make(chan struct{})
+	go manager.heartbeat(runCtx, cancel, runtime, make(chan struct{}), done)
+
+	select {
+	case <-done:
+	case <-time.After(completionWait):
+		t.Fatal("heartbeat loop did not stop at the lease safety deadline")
+	}
+	require.ErrorIs(t, runCtx.Err(), context.Canceled)
+	runtime.mu.Lock()
+	require.ErrorIs(t, runtime.poison, ErrLeaseLost)
+	runtime.mu.Unlock()
+	calls, maxInFlight := store.snapshotCalls()
+	require.GreaterOrEqual(t, len(calls), 4)
+	require.Equal(t, 1, maxInFlight)
+	for i := 1; i < len(calls); i++ {
+		require.GreaterOrEqual(t, calls[i].Sub(calls[i-1]), interval-timingSlack)
+	}
+	elapsed := time.Since(confirmedAt)
+	require.GreaterOrEqual(t, elapsed, leaseDuration-safetyMargin-timingSlack)
+}
+
+func TestHeartbeatToleranceIsOptIn(t *testing.T) {
+	base := NewInMemoryStore(nil)
+	started := createAndStart(t, base, "heartbeat-opt-in")
+	store := &heartbeatTestStore{TaskStore: base}
+	store.heartbeat = func(
+		_ int,
+		_ context.Context,
+		_ *HeartbeatRequest,
+	) (*Task, error) {
+		return nil, errors.New("temporary storage failure")
+	}
+	runtime := newTaskRuntime(
+		store, base, started.Spec.ID, started.Attempt, started.Version, nil,
+	)
+	manager := &Manager{heartbeatEvery: time.Nanosecond}
+	runCtx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	done := make(chan struct{})
+	go manager.heartbeat(runCtx, cancel, runtime, make(chan struct{}), done)
+
+	select {
+	case <-done:
+	case <-time.After(time.Second):
+		t.Fatal("legacy heartbeat handling did not stop after the first error")
+	}
+	require.ErrorIs(t, runCtx.Err(), context.Canceled)
+	calls, _ := store.snapshotCalls()
+	require.Len(t, calls, 1)
+}
+
+func TestHeartbeatSafetyDeadlineCancelsBlockedStoreRequest(t *testing.T) {
+	const (
+		interval      = 10 * time.Millisecond
+		leaseDuration = 100 * time.Millisecond
+		safetyMargin  = 20 * time.Millisecond
+	)
+	base := NewInMemoryStore(&InMemoryStoreConfig{
+		ActiveAttemptTimeout: leaseDuration,
+	})
+	started := createAndStart(t, base, "heartbeat-blocked")
+	entered := make(chan struct{})
+	release := make(chan struct{})
+	store := &heartbeatTestStore{TaskStore: base}
+	store.heartbeat = func(
+		_ int,
+		ctx context.Context,
+		req *HeartbeatRequest,
+	) (*Task, error) {
+		close(entered)
+		<-release
+		return base.Heartbeat(ctx, req)
+	}
+	runtime := newTaskRuntime(
+		store, base, started.Spec.ID, started.Attempt, started.Version, nil,
+		taskRuntimeLeaseConfig{
+			confirmedAt:             time.Now(),
+			duration:                leaseDuration,
+			safetyMargin:            safetyMargin,
+			tolerateHeartbeatErrors: true,
+		},
+	)
+	manager := &Manager{heartbeatEvery: interval}
+	runCtx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	done := make(chan struct{})
+	go manager.heartbeat(runCtx, cancel, runtime, make(chan struct{}), done)
+
+	<-entered
+	gateDone := make(chan error, 1)
+	go func() {
+		gateDone <- runtime.WaitForLease(context.Background())
+	}()
+	select {
+	case err := <-gateDone:
+		t.Fatalf("lease gate returned while heartbeat was blocked: %v", err)
+	case <-time.After(10 * time.Millisecond):
+	}
+	select {
+	case <-done:
+	case <-time.After(time.Second):
+		t.Fatal("blocked heartbeat prevented lease safety cancellation")
+	}
+	require.ErrorIs(t, runCtx.Err(), context.Canceled)
+	require.ErrorIs(t, <-gateDone, ErrLeaseLost)
+	_, maxInFlight := store.snapshotCalls()
+	require.Equal(t, 1, maxInFlight)
+
+	time.Sleep(leaseDuration)
+	close(release)
+	require.Eventually(t, func() bool {
+		store.mu.Lock()
+		defer store.mu.Unlock()
+		return store.inFlight == 0
+	}, time.Second, time.Millisecond)
+	current, err := base.Get(context.Background(), started.Spec.ID)
+	require.NoError(t, err)
+	require.Equal(t, StatusPending, current.Status)
+	require.Equal(t, started.Attempt, current.Attempt)
+}
+
+func TestManagerExecutionStopsWhenHeartbeatRequestHangs(t *testing.T) {
+	const (
+		interval      = 10 * time.Millisecond
+		leaseDuration = 100 * time.Millisecond
+	)
+	base := NewInMemoryStore(&InMemoryStoreConfig{
+		ActiveAttemptTimeout: leaseDuration,
+	})
+	entered := make(chan struct{})
+	release := make(chan struct{})
+	store := &heartbeatTestStore{TaskStore: base}
+	store.heartbeat = func(
+		_ int,
+		ctx context.Context,
+		req *HeartbeatRequest,
+	) (*Task, error) {
+		renewed, err := base.Heartbeat(ctx, req)
+		close(entered)
+		<-release
+		return renewed, err
+	}
+	executionStarted := make(chan struct{})
+	executor := &scriptedExecutor{
+		execute: func(
+			ctx context.Context,
+			_ *Task,
+			_ ExecutionRuntime,
+		) (*ExecutionResult, error) {
+			close(executionStarted)
+			<-ctx.Done()
+			return nil, ctx.Err()
+		},
+	}
+	registry := NewExecutorRegistry()
+	require.NoError(t, registry.Register(executor))
+	manager := mustNewManager(t, context.Background(), &Config{
+		Tasks:                            store,
+		TaskEvents:                       base,
+		Executors:                        registry,
+		HeartbeatInterval:                interval,
+		LeaseDuration:                    leaseDuration,
+		TolerateTransientHeartbeatErrors: true,
+	})
+	spec := validSpec("heartbeat-blocked-execution")
+	spec.SessionID = ""
+	spec.NotifySession = false
+	task, err := manager.Submit(context.Background(), &SubmitRequest{Spec: spec})
+	require.NoError(t, err)
+	executeDone := make(chan error, 1)
+	go func() {
+		executeDone <- manager.Execute(context.Background(), task.Spec.ID)
+	}()
+
+	<-executionStarted
+	<-entered
+	select {
+	case err = <-executeDone:
+		require.ErrorIs(t, err, ErrLeaseLost)
+	case <-time.After(time.Second):
+		t.Fatal("blocked heartbeat prevented execution cancellation")
+	}
+
+	time.Sleep(leaseDuration)
+	close(release)
+	require.Eventually(t, func() bool {
+		store.mu.Lock()
+		defer store.mu.Unlock()
+		return store.inFlight == 0
+	}, time.Second, time.Millisecond)
+	current, err := base.Get(context.Background(), task.Spec.ID)
+	require.NoError(t, err)
+	require.Equal(t, StatusPending, current.Status)
+	require.Equal(t, int64(1), current.Attempt)
+}
+
+func TestHeartbeatCancellationWinsBlockedRenewal(t *testing.T) {
+	base := NewInMemoryStore(&InMemoryStoreConfig{
+		ActiveAttemptTimeout: time.Second,
+	})
+	started := createAndStart(t, base, "heartbeat-cancel-race")
+	entered := make(chan struct{})
+	release := make(chan struct{})
+	store := &heartbeatTestStore{TaskStore: base}
+	store.heartbeat = func(
+		_ int,
+		ctx context.Context,
+		req *HeartbeatRequest,
+	) (*Task, error) {
+		renewed, err := base.Heartbeat(ctx, req)
+		close(entered)
+		<-release
+		return renewed, err
+	}
+	runtime := tolerantRuntime(
+		store, base, started, time.Now(), 10*time.Millisecond, time.Second,
+	)
+	ready := make(chan struct{})
+	close(ready)
+	manager := &Manager{
+		tasks: store,
+		activeAttempts: map[string]*activeAttempt{
+			started.Spec.ID: {runtime: runtime, ready: ready},
+		},
+	}
+	runCtx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	done := make(chan struct{})
+	go (&Manager{heartbeatEvery: 10 * time.Millisecond}).heartbeat(
+		runCtx, cancel, runtime, make(chan struct{}), done,
+	)
+
+	<-entered
+	gateDone := make(chan error, 1)
+	go func() {
+		gateDone <- runtime.WaitForLease(context.Background())
+	}()
+	writeDone := make(chan error, 1)
+	go func() {
+		writeDone <- runtime.CommitStart(context.Background(), []byte("checkpoint"))
+	}()
+	requested, err := manager.RequestCancel(
+		context.Background(),
+		started.Spec.ID,
+		WithCancellationReason("operator request"),
+	)
+	require.NoError(t, err)
+	require.Equal(t, "operator request", requested.CancelReason)
+	require.Equal(t, ControlRequest{
+		Kind: ControlStop, Reason: "operator request",
+	}, <-runtime.Controls())
+	require.ErrorIs(t, <-gateDone, ErrLeaseLost)
+	require.ErrorIs(t, <-writeDone, ErrLeaseLost)
+	committed, err := runtime.commit(context.Background(), &ExecutionResult{
+		Status: StatusCanceled,
+	})
+	require.NoError(t, err)
+	require.Equal(t, StatusCanceled, committed.Status)
+	select {
+	case <-done:
+	case <-time.After(time.Second):
+		t.Fatal("heartbeat loop did not stop after explicit cancellation")
+	}
+	require.NoError(t, runCtx.Err())
+	close(release)
+	require.Eventually(t, func() bool {
+		store.mu.Lock()
+		defer store.mu.Unlock()
+		return store.inFlight == 0
+	}, time.Second, time.Millisecond)
+}
+
+func TestHeartbeatRejectsTakeoverImmediately(t *testing.T) {
+	base := NewInMemoryStore(nil)
+	started := createAndStart(t, base, "heartbeat-takeover")
+	store := &heartbeatTestStore{
+		TaskStore: base,
+		heartbeat: func(
+			_ int,
+			_ context.Context,
+			_ *HeartbeatRequest,
+		) (*Task, error) {
+			return nil, ErrVersionConflict
+		},
+		get: func(context.Context, string) (*Task, error) {
+			takenOver := cloneTask(started)
+			takenOver.Attempt++
+			takenOver.Version++
+			return takenOver, nil
+		},
+	}
+	runtime := tolerantRuntime(
+		store, base, started, time.Now(), 10*time.Millisecond, time.Second,
+	)
+
+	require.ErrorIs(t, runtime.heartbeat(context.Background()), ErrLeaseLost)
+	runtime.mu.Lock()
+	require.ErrorIs(t, runtime.poison, ErrLeaseLost)
+	runtime.mu.Unlock()
+}
+
+func TestHeartbeatRejectsDefinitiveLeaseStatesImmediately(t *testing.T) {
+	tests := []struct {
+		name         string
+		heartbeatErr error
+		current      func(*Task) *Task
+	}{
+		{name: "lease lost", heartbeatErr: ErrLeaseLost},
+		{
+			name:         "terminal",
+			heartbeatErr: ErrVersionConflict,
+			current: func(started *Task) *Task {
+				task := cloneTask(started)
+				task.Status = StatusCompleted
+				task.Version++
+				return task
+			},
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			base := NewInMemoryStore(nil)
+			started := createAndStart(t, base, "heartbeat-definitive-"+test.name)
+			store := &heartbeatTestStore{
+				TaskStore: base,
+				heartbeat: func(
+					_ int,
+					_ context.Context,
+					_ *HeartbeatRequest,
+				) (*Task, error) {
+					return nil, test.heartbeatErr
+				},
+			}
+			if test.current != nil {
+				store.get = func(context.Context, string) (*Task, error) {
+					return test.current(started), nil
+				}
+			}
+			runtime := tolerantRuntime(
+				store, base, started, time.Now(), 10*time.Millisecond, time.Second,
+			)
+
+			require.ErrorIs(t, runtime.heartbeat(context.Background()), ErrLeaseLost)
+			runtime.mu.Lock()
+			require.ErrorIs(t, runtime.poison, ErrLeaseLost)
+			runtime.mu.Unlock()
+		})
+	}
+}
+
+func TestHeartbeatShutdownWaitsForLeaseConfirmation(t *testing.T) {
+	const interval = 20 * time.Millisecond
+	base := NewInMemoryStore(&InMemoryStoreConfig{
+		ActiveAttemptTimeout: time.Second,
+	})
+	started := createAndStart(t, base, "heartbeat-shutdown")
+	firstStarted := make(chan struct{})
+	firstRelease := make(chan struct{})
+	secondStarted := make(chan struct{})
+	store := &heartbeatTestStore{TaskStore: base}
+	store.heartbeat = func(
+		call int,
+		ctx context.Context,
+		req *HeartbeatRequest,
+	) (*Task, error) {
+		if call == 1 {
+			close(firstStarted)
+			<-firstRelease
+			return nil, errors.New("temporary storage failure")
+		}
+		close(secondStarted)
+		return base.Heartbeat(ctx, req)
+	}
+	runtime := tolerantRuntime(
+		store, base, started, time.Now(), interval, time.Second,
+	)
+	manager := &Manager{heartbeatEvery: interval}
+	runCtx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	stop := make(chan struct{})
+	done := make(chan struct{})
+	go manager.heartbeat(runCtx, cancel, runtime, stop, done)
+
+	<-firstStarted
+	close(stop)
+	time.Sleep(2 * interval)
+	firstReleasedAt := time.Now()
+	close(firstRelease)
+	select {
+	case <-done:
+		t.Fatal("heartbeat loop stopped before the uncertain lease was confirmed")
+	case <-time.After(interval / 2):
+	}
+	select {
+	case <-secondStarted:
+	case <-time.After(time.Second):
+		t.Fatal("heartbeat loop did not perform the next scheduled renewal")
+	}
+	secondStartedAt := time.Now()
+	require.GreaterOrEqual(
+		t,
+		secondStartedAt.Sub(firstReleasedAt),
+		interval-5*time.Millisecond,
+	)
+	select {
+	case <-done:
+	case <-time.After(time.Second):
+		t.Fatal("heartbeat loop did not stop after lease confirmation")
+	}
+	require.NoError(t, runCtx.Err())
+	committed, err := runtime.commit(context.Background(), &ExecutionResult{
+		Status: StatusCompleted,
+		Data:   []byte("done"),
+	})
+	require.NoError(t, err)
+	require.Equal(t, StatusCompleted, committed.Status)
+	calls, maxInFlight := store.snapshotCalls()
+	require.Len(t, calls, 2)
+	require.Equal(t, 1, maxInFlight)
+}

--- a/adk/backgroundtask/in_memory_store.go
+++ b/adk/backgroundtask/in_memory_store.go
@@ -48,9 +48,8 @@ type memoryActiveAttempt struct {
 }
 
 const (
-	defaultActiveAttemptTimeout = 30 * time.Second
-	defaultTaskEventPageSize    = 100
-	maxTaskEventPageSize        = 1000
+	defaultTaskEventPageSize = 100
+	maxTaskEventPageSize     = 1000
 )
 
 type taskEventCursor struct {
@@ -96,7 +95,7 @@ func NewInMemoryStore(config *InMemoryStoreConfig) *InMemoryStore {
 		customNotifications: make(map[string]map[string]Notification),
 		notify:              make(chan struct{}),
 		now:                 time.Now,
-		activeTimeout:       defaultActiveAttemptTimeout,
+		activeTimeout:       defaultLeaseDuration,
 		maxValue:            1 << 20,
 	}
 	if config != nil {

--- a/adk/backgroundtask/in_memory_store.go
+++ b/adk/backgroundtask/in_memory_store.go
@@ -48,8 +48,9 @@ type memoryActiveAttempt struct {
 }
 
 const (
-	defaultTaskEventPageSize = 100
-	maxTaskEventPageSize     = 1000
+	defaultActiveAttemptTimeout = 30 * time.Second
+	defaultTaskEventPageSize    = 100
+	maxTaskEventPageSize        = 1000
 )
 
 type taskEventCursor struct {
@@ -95,7 +96,7 @@ func NewInMemoryStore(config *InMemoryStoreConfig) *InMemoryStore {
 		customNotifications: make(map[string]map[string]Notification),
 		notify:              make(chan struct{}),
 		now:                 time.Now,
-		activeTimeout:       30 * time.Second,
+		activeTimeout:       defaultActiveAttemptTimeout,
 		maxValue:            1 << 20,
 	}
 	if config != nil {

--- a/adk/backgroundtask/manager.go
+++ b/adk/backgroundtask/manager.go
@@ -38,7 +38,10 @@ import (
 	"time"
 )
 
-const defaultHeartbeatInterval = 10 * time.Second
+const (
+	defaultHeartbeatInterval = 10 * time.Second
+	defaultLeaseDuration     = 30 * time.Second
+)
 
 // Status represents the durable lifecycle status of a task.
 type Status string
@@ -144,10 +147,21 @@ type Config struct {
 	// lease. It should be shorter than the task store's active-attempt timeout.
 	// Non-positive values default to 10 seconds.
 	HeartbeatInterval time.Duration
-	// ActiveAttemptTimeout controls lease expiry for the default in-memory task
-	// store. Non-positive values default to 30 seconds. This field is ignored
-	// when Tasks is supplied.
-	ActiveAttemptTimeout time.Duration
+	// LeaseDuration is the active-attempt lease duration used to derive the
+	// local safety deadline. It also configures the default in-memory task store.
+	// When transient-heartbeat tolerance is enabled, custom task stores must use
+	// the same duration. Non-positive values default to 30 seconds.
+	LeaseDuration time.Duration
+	// TolerateTransientHeartbeatErrors keeps an attempt running after an
+	// unclassified heartbeat storage error while its last confirmed lease is
+	// still safe. The Manager does not retry faster than HeartbeatInterval and
+	// cancels execution with a safety margin of half HeartbeatInterval before
+	// LeaseDuration expires. LeaseDuration must leave room for at least two
+	// heartbeat intervals plus that margin. The zero value preserves the legacy
+	// behavior of canceling on the first heartbeat error. ErrLeaseLost,
+	// ErrNotFound, ErrIllegalTransition, ErrAlreadyTerminal, and an unverified
+	// version conflict always terminate immediately.
+	TolerateTransientHeartbeatErrors bool
 	// SendTaskCreatedEvent emits a TaskCreated timeline event after a task is
 	// durably created. It may be called concurrently. Tasks without a parent
 	// SessionID do not emit this event. Use TaskCreatedSessionEventSender so the
@@ -198,18 +212,21 @@ func WithCancellationReason(reason string) RequestCancelOption {
 
 // Manager owns TaskStore-backed lifecycle and worker coordination.
 type Manager struct {
-	tasks                TaskStore
-	taskEvents           TaskEventStore
-	notificationWriter   NotificationWriter
-	executors            *ExecutorRegistry
-	heartbeatEvery       time.Duration
-	attemptsMu           sync.Mutex
-	activeAttempts       map[string]*activeAttempt
-	mu                   sync.Mutex
-	closed               bool
-	idGen                IDGenerator
-	sendTaskCreatedEvent func(context.Context, *Task) error
-	contextSnapshotter   ContextSnapshotter
+	tasks                   TaskStore
+	taskEvents              TaskEventStore
+	notificationWriter      NotificationWriter
+	executors               *ExecutorRegistry
+	heartbeatEvery          time.Duration
+	leaseDuration           time.Duration
+	heartbeatSafetyMargin   time.Duration
+	tolerateHeartbeatErrors bool
+	attemptsMu              sync.Mutex
+	activeAttempts          map[string]*activeAttempt
+	mu                      sync.Mutex
+	closed                  bool
+	idGen                   IDGenerator
+	sendTaskCreatedEvent    func(context.Context, *Task) error
+	contextSnapshotter      ContextSnapshotter
 }
 
 // New creates a Manager. A nil Config installs the in-memory reference stores
@@ -217,20 +234,41 @@ type Manager struct {
 // must also implement TaskEventStore. The context is reserved for constructor
 // symmetry; Manager does not retain it or derive task lifetime from it.
 func New(_ context.Context, conf *Config) (*Manager, error) {
-	defaultStoreConfig := &InMemoryStoreConfig{}
 	heartbeatInterval := defaultHeartbeatInterval
+	leaseDuration := defaultLeaseDuration
+	tolerateHeartbeatErrors := false
 	if conf != nil {
-		defaultStoreConfig.ActiveAttemptTimeout = conf.ActiveAttemptTimeout
 		if conf.HeartbeatInterval > 0 {
 			heartbeatInterval = conf.HeartbeatInterval
 		}
+		if conf.LeaseDuration > 0 {
+			leaseDuration = conf.LeaseDuration
+		}
+		tolerateHeartbeatErrors = conf.TolerateTransientHeartbeatErrors
 	}
-	defaults := NewInMemoryStore(defaultStoreConfig)
+	defaults := NewInMemoryStore(&InMemoryStoreConfig{
+		ActiveAttemptTimeout: leaseDuration,
+	})
+	safetyMargin := heartbeatInterval / 2
+	if safetyMargin <= 0 {
+		safetyMargin = time.Nanosecond
+	}
+	safeWindow := leaseDuration - safetyMargin
+	if tolerateHeartbeatErrors &&
+		(safeWindow <= heartbeatInterval ||
+			safeWindow-heartbeatInterval <= heartbeatInterval) {
+		return nil, errors.New(
+			"backgroundtask: lease duration must cover two heartbeat intervals plus the safety margin",
+		)
+	}
 	m := &Manager{
-		heartbeatEvery: heartbeatInterval,
-		activeAttempts: make(map[string]*activeAttempt),
-		tasks:          defaults,
-		taskEvents:     defaults,
+		heartbeatEvery:          heartbeatInterval,
+		leaseDuration:           leaseDuration,
+		heartbeatSafetyMargin:   safetyMargin,
+		tolerateHeartbeatErrors: tolerateHeartbeatErrors,
+		activeAttempts:          make(map[string]*activeAttempt),
+		tasks:                   defaults,
+		taskEvents:              defaults,
 	}
 	m.executors = NewExecutorRegistry()
 	if conf != nil {

--- a/adk/backgroundtask/manager.go
+++ b/adk/backgroundtask/manager.go
@@ -38,6 +38,8 @@ import (
 	"time"
 )
 
+const defaultHeartbeatInterval = 10 * time.Second
+
 // Status represents the durable lifecycle status of a task.
 type Status string
 
@@ -138,6 +140,14 @@ type Config struct {
 	TaskEvents TaskEventStore
 	// Executors resolves serialized task intent to local implementations.
 	Executors *ExecutorRegistry
+	// HeartbeatInterval controls how often Manager renews an active attempt
+	// lease. It should be shorter than the task store's active-attempt timeout.
+	// Non-positive values default to 10 seconds.
+	HeartbeatInterval time.Duration
+	// ActiveAttemptTimeout controls lease expiry for the default in-memory task
+	// store. Non-positive values default to 30 seconds. This field is ignored
+	// when Tasks is supplied.
+	ActiveAttemptTimeout time.Duration
 	// SendTaskCreatedEvent emits a TaskCreated timeline event after a task is
 	// durably created. It may be called concurrently. Tasks without a parent
 	// SessionID do not emit this event. Use TaskCreatedSessionEventSender so the
@@ -207,9 +217,17 @@ type Manager struct {
 // must also implement TaskEventStore. The context is reserved for constructor
 // symmetry; Manager does not retain it or derive task lifetime from it.
 func New(_ context.Context, conf *Config) (*Manager, error) {
-	defaults := NewInMemoryStore(nil)
+	defaultStoreConfig := &InMemoryStoreConfig{}
+	heartbeatInterval := defaultHeartbeatInterval
+	if conf != nil {
+		defaultStoreConfig.ActiveAttemptTimeout = conf.ActiveAttemptTimeout
+		if conf.HeartbeatInterval > 0 {
+			heartbeatInterval = conf.HeartbeatInterval
+		}
+	}
+	defaults := NewInMemoryStore(defaultStoreConfig)
 	m := &Manager{
-		heartbeatEvery: 10 * time.Second,
+		heartbeatEvery: heartbeatInterval,
 		activeAttempts: make(map[string]*activeAttempt),
 		tasks:          defaults,
 		taskEvents:     defaults,

--- a/adk/backgroundtask/manager_test.go
+++ b/adk/backgroundtask/manager_test.go
@@ -67,6 +67,50 @@ type firstReleaseConflictStore struct {
 	once sync.Once
 }
 
+func TestManagerConfiguresLifecycleIntervals(t *testing.T) {
+	tests := []struct {
+		name              string
+		config            *Config
+		heartbeatInterval time.Duration
+		activeTimeout     time.Duration
+	}{
+		{
+			name:              "defaults",
+			heartbeatInterval: defaultHeartbeatInterval,
+			activeTimeout:     defaultActiveAttemptTimeout,
+		},
+		{
+			name: "configured",
+			config: &Config{
+				HeartbeatInterval:    2 * time.Second,
+				ActiveAttemptTimeout: 7 * time.Second,
+			},
+			heartbeatInterval: 2 * time.Second,
+			activeTimeout:     7 * time.Second,
+		},
+		{
+			name: "non-positive values use defaults",
+			config: &Config{
+				HeartbeatInterval:    -time.Second,
+				ActiveAttemptTimeout: -time.Second,
+			},
+			heartbeatInterval: defaultHeartbeatInterval,
+			activeTimeout:     defaultActiveAttemptTimeout,
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			manager := mustNewManager(t, context.Background(), test.config)
+			defer closeWithTimeout(manager)
+
+			require.Equal(t, test.heartbeatInterval, manager.heartbeatEvery)
+			store, ok := manager.tasks.(*InMemoryStore)
+			require.True(t, ok)
+			require.Equal(t, test.activeTimeout, store.activeTimeout)
+		})
+	}
+}
+
 func (s *firstReleaseConflictStore) ReleaseSuspension(
 	ctx context.Context,
 	req *ReleaseSuspensionRequest,
@@ -709,8 +753,9 @@ func (s heartbeatErrorStore) Heartbeat(context.Context, *HeartbeatRequest) (*Tas
 }
 
 func TestManagerHeartbeatStopsAndCancelsOnLeaseError(t *testing.T) {
-	manager := mustNewManager(t, context.Background(), nil)
-	manager.heartbeatEvery = time.Nanosecond
+	manager := mustNewManager(t, context.Background(), &Config{
+		HeartbeatInterval: time.Nanosecond,
+	})
 	events := NewInMemoryStore(nil)
 	runtime := newTaskRuntime(
 		heartbeatErrorStore{TaskStore: NewInMemoryStore(nil), err: ErrLeaseLost},

--- a/adk/backgroundtask/manager_test.go
+++ b/adk/backgroundtask/manager_test.go
@@ -73,29 +73,32 @@ func TestManagerConfiguresLifecycleIntervals(t *testing.T) {
 		config            *Config
 		heartbeatInterval time.Duration
 		activeTimeout     time.Duration
+		tolerateErrors    bool
 	}{
 		{
 			name:              "defaults",
 			heartbeatInterval: defaultHeartbeatInterval,
-			activeTimeout:     defaultActiveAttemptTimeout,
+			activeTimeout:     defaultLeaseDuration,
 		},
 		{
 			name: "configured",
 			config: &Config{
-				HeartbeatInterval:    2 * time.Second,
-				ActiveAttemptTimeout: 7 * time.Second,
+				HeartbeatInterval:                30 * time.Second,
+				LeaseDuration:                    90 * time.Second,
+				TolerateTransientHeartbeatErrors: true,
 			},
-			heartbeatInterval: 2 * time.Second,
-			activeTimeout:     7 * time.Second,
+			heartbeatInterval: 30 * time.Second,
+			activeTimeout:     90 * time.Second,
+			tolerateErrors:    true,
 		},
 		{
 			name: "non-positive values use defaults",
 			config: &Config{
-				HeartbeatInterval:    -time.Second,
-				ActiveAttemptTimeout: -time.Second,
+				HeartbeatInterval: -time.Second,
+				LeaseDuration:     -time.Second,
 			},
 			heartbeatInterval: defaultHeartbeatInterval,
-			activeTimeout:     defaultActiveAttemptTimeout,
+			activeTimeout:     defaultLeaseDuration,
 		},
 	}
 	for _, test := range tests {
@@ -104,11 +107,27 @@ func TestManagerConfiguresLifecycleIntervals(t *testing.T) {
 			defer closeWithTimeout(manager)
 
 			require.Equal(t, test.heartbeatInterval, manager.heartbeatEvery)
+			require.Equal(t, test.heartbeatInterval/2, manager.heartbeatSafetyMargin)
+			require.Equal(t, test.activeTimeout, manager.leaseDuration)
+			require.Equal(t, test.tolerateErrors, manager.tolerateHeartbeatErrors)
 			store, ok := manager.tasks.(*InMemoryStore)
 			require.True(t, ok)
 			require.Equal(t, test.activeTimeout, store.activeTimeout)
 		})
 	}
+}
+
+func TestManagerRejectsUnsafeHeartbeatToleranceWindow(t *testing.T) {
+	_, err := New(context.Background(), &Config{
+		HeartbeatInterval:                30 * time.Second,
+		LeaseDuration:                    60 * time.Second,
+		TolerateTransientHeartbeatErrors: true,
+	})
+	require.EqualError(
+		t,
+		err,
+		"backgroundtask: lease duration must cover two heartbeat intervals plus the safety margin",
+	)
 }
 
 func (s *firstReleaseConflictStore) ReleaseSuspension(
@@ -806,7 +825,7 @@ func TestRuntimeCancellationReconciliationRejectsInvalidState(t *testing.T) {
 	store := NewInMemoryStore(nil)
 	runtime := newTaskRuntime(store, store, "missing", 1, 1, nil)
 	require.ErrorIs(
-		t, runtime.reconcileCancellationLocked(context.Background()), ErrNotFound,
+		t, runtime.reconcileCancellation(context.Background(), 1), ErrNotFound,
 	)
 	require.ErrorIs(t, runtime.poison, ErrNotFound)
 
@@ -815,7 +834,7 @@ func TestRuntimeCancellationReconciliationRejectsInvalidState(t *testing.T) {
 		store, store, started.Spec.ID, started.Attempt, started.Version, nil,
 	)
 	require.ErrorIs(
-		t, runtime.reconcileCancellationLocked(context.Background()), ErrLeaseLost,
+		t, runtime.reconcileCancellation(context.Background(), started.Version), ErrLeaseLost,
 	)
 	require.ErrorIs(t, runtime.poison, ErrLeaseLost)
 }

--- a/compose/execution_gate_test.go
+++ b/compose/execution_gate_test.go
@@ -1,0 +1,123 @@
+/*
+ * Copyright 2026 CloudWeGo Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package compose
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/cloudwego/eino/internal/core"
+	"github.com/cloudwego/eino/schema"
+)
+
+func TestToolCallExecutionWaitsForContextGate(t *testing.T) {
+	tests := []struct {
+		name string
+		run  func(context.Context, *toolCallTask)
+	}{
+		{
+			name: "invoke",
+			run: func(ctx context.Context, task *toolCallTask) {
+				runToolCallTaskByInvoke(ctx, task)
+			},
+		},
+		{
+			name: "stream",
+			run: func(ctx context.Context, task *toolCallTask) {
+				runToolCallTaskByStream(ctx, task)
+			},
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			gateEntered := make(chan struct{})
+			gateRelease := make(chan struct{})
+			called := make(chan struct{})
+			ctx := core.WithExecutionGate(
+				context.Background(),
+				func(ctx context.Context) error {
+					close(gateEntered)
+					select {
+					case <-gateRelease:
+						return nil
+					case <-ctx.Done():
+						return ctx.Err()
+					}
+				},
+			)
+			task := &toolCallTask{
+				meta: &executorMeta{},
+				endpoint: func(context.Context, *ToolInput) (*ToolOutput, error) {
+					close(called)
+					return &ToolOutput{Result: "ok"}, nil
+				},
+				streamEndpoint: func(context.Context, *ToolInput) (*StreamToolOutput, error) {
+					close(called)
+					return &StreamToolOutput{
+						Result: schema.StreamReaderFromArray([]string{"ok"}),
+					}, nil
+				},
+			}
+			done := make(chan struct{})
+			go func() {
+				test.run(ctx, task)
+				close(done)
+			}()
+
+			<-gateEntered
+			select {
+			case <-called:
+				t.Fatal("tool call started before the execution gate opened")
+			case <-time.After(10 * time.Millisecond):
+			}
+			close(gateRelease)
+			select {
+			case <-done:
+			case <-time.After(time.Second):
+				t.Fatal("tool call did not resume after the execution gate opened")
+			}
+			require.NoError(t, task.err)
+			require.True(t, task.executed)
+		})
+	}
+}
+
+func TestToolCallExecutionStopsWhenContextGateFails(t *testing.T) {
+	gateErr := errors.New("execution gate closed")
+	ctx := core.WithExecutionGate(
+		context.Background(),
+		func(context.Context) error {
+			return gateErr
+		},
+	)
+	task := &toolCallTask{
+		meta: &executorMeta{},
+		endpoint: func(context.Context, *ToolInput) (*ToolOutput, error) {
+			t.Fatal("tool call started after the execution gate failed")
+			return nil, nil
+		},
+	}
+
+	runToolCallTaskByInvoke(ctx, task)
+
+	require.ErrorIs(t, task.err, gateErr)
+	require.False(t, task.executed)
+}

--- a/compose/tool_node.go
+++ b/compose/tool_node.go
@@ -1138,6 +1138,10 @@ func runToolCallTaskByInvoke(ctx context.Context, task *toolCallTask, opts ...to
 	if task.executed {
 		return
 	}
+	if err := core.WaitExecutionGate(ctx); err != nil {
+		task.err = err
+		return
+	}
 	ctx = callbacks.ReuseHandlers(ctx, &callbacks.RunInfo{
 		Name:      task.name,
 		Type:      task.meta.componentImplType,
@@ -1177,6 +1181,13 @@ func runToolCallTaskByInvoke(ctx context.Context, task *toolCallTask, opts ...to
 }
 
 func runToolCallTaskByStream(ctx context.Context, task *toolCallTask, opts ...tool.Option) {
+	if task.executed {
+		return
+	}
+	if err := core.WaitExecutionGate(ctx); err != nil {
+		task.err = err
+		return
+	}
 	ctx = callbacks.ReuseHandlers(ctx, &callbacks.RunInfo{
 		Name:      task.name,
 		Type:      task.meta.componentImplType,

--- a/internal/core/execution_gate.go
+++ b/internal/core/execution_gate.go
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2026 CloudWeGo Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package core
+
+import "context"
+
+type executionGateKey struct{}
+
+// ExecutionGate waits until a new side effect may start.
+type ExecutionGate func(context.Context) error
+
+// WithExecutionGate attaches a side-effect admission gate to ctx.
+func WithExecutionGate(ctx context.Context, gate ExecutionGate) context.Context {
+	if ctx == nil || gate == nil {
+		return ctx
+	}
+	return context.WithValue(ctx, executionGateKey{}, gate)
+}
+
+// WaitExecutionGate waits for the gate attached to ctx, if any.
+func WaitExecutionGate(ctx context.Context) error {
+	if ctx == nil {
+		return nil
+	}
+	gate, _ := ctx.Value(executionGateKey{}).(ExecutionGate)
+	if gate == nil {
+		return nil
+	}
+	return gate(ctx)
+}

--- a/internal/core/execution_gate_test.go
+++ b/internal/core/execution_gate_test.go
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2026 CloudWeGo Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package core
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestExecutionGateContext(t *testing.T) {
+	require.NoError(t, WaitExecutionGate(context.Background()))
+	require.NoError(t, WaitExecutionGate(nil))
+
+	want := errors.New("blocked")
+	ctx := WithExecutionGate(context.Background(), func(context.Context) error {
+		return want
+	})
+	require.ErrorIs(t, WaitExecutionGate(ctx), want)
+	require.Same(t, ctx, WithExecutionGate(ctx, nil))
+	require.Nil(t, WithExecutionGate(nil, func(context.Context) error { return nil }))
+}


### PR DESCRIPTION
## Problem

A background task currently loses its execution context after the first heartbeat storage error, even when the last confirmed lease is still valid. Retrying immediately would increase storage pressure, while continuing without fencing new side effects could let work run after ownership becomes uncertain.

## Solution

Add opt-in transient-heartbeat tolerance to `backgroundtask.Config`:

```go
&backgroundtask.Config{
    HeartbeatInterval:                 30 * time.Second,
    LeaseDuration:                     90 * time.Second,
    TolerateTransientHeartbeatErrors: true,
}
```

With the option enabled, heartbeat attempts remain single-flight and are scheduled one full `HeartbeatInterval` after the previous attempt finishes. A transient error keeps the attempt alive but closes an execution gate: new tool calls and version-dependent writes wait until ownership is confirmed, canceled, or timed out. Operations already admitted may finish.

The Manager tracks a conservative local lease deadline from the start of the last confirmed renewal and cancels before expiry with a safety margin of half the heartbeat interval. This watchdog remains effective even if the storage request ignores context cancellation.

On a version conflict after an uncertain response, the Manager reads authoritative task state. It accepts only the same running `Attempt` with exactly one version advancement as a lost successful heartbeat response. Cancellation, takeover, terminal state, expired lease, and other explicit fencing errors terminate immediately; the Manager never calls `Start` during reconciliation.

The zero-value behavior is unchanged: transient-heartbeat tolerance is disabled, with the existing 10-second heartbeat and 30-second lease defaults.

## Key Insight

A failed heartbeat response does not prove that renewal failed. Safety requires separating confirmed lease time from response status: pause new side effects while uncertain, reconcile the same attempt on the next normal cadence, and never extend the local deadline until the renewal is proven.

## Validation

- `golangci-lint run --new-from-rev=alpha/10 ./...`
- `go test -race ./...`
- `go test -race -count=30 ./adk/backgroundtask -run 'TestHeartbeat|TestManagerExecutionStops|TestManagerConfigures|TestManagerRejects'`
- `GOTOOLCHAIN=go1.18.10 go test ./adk/backgroundtask/... ./compose ./internal/core`
- `go test -coverprofile=/tmp/eino2-heartbeat-tolerance.coverage.out ./...` (83.0% total)

---

## 问题

后台任务当前遇到第一次 heartbeat 存储错误就会取消执行，即使最后一次确认的租约仍然有效。立即重试会增加存储压力；如果不限制新的副作用，则可能在所有权不确定后继续执行任务。

## 解决方案

在 `backgroundtask.Config` 中增加显式开启的临时 heartbeat 错误容忍能力：

```go
&backgroundtask.Config{
    HeartbeatInterval:                 30 * time.Second,
    LeaseDuration:                     90 * time.Second,
    TolerateTransientHeartbeatErrors: true,
}
```

开启后，heartbeat 保持单飞，并在上一次请求结束一个完整 `HeartbeatInterval` 后再发起下一次请求。临时错误不会立即取消 attempt，但会关闭 execution gate：新的工具调用和依赖版本号的写入等待租约确认、取消或超时；已经准入的操作可以正常返回。

Manager 从最后一次确认续租的请求开始时间计算保守的本地租约截止时间，并在租约过期前预留半个 heartbeat interval 的安全余量后取消执行。即使存储请求不响应 context 取消，本地 watchdog 仍会生效。

不确定状态下再次续租遇到版本冲突时，Manager 会读取权威任务状态。只有仍处于 running、`Attempt` 相同且版本恰好推进一次时，才认定上次续租已提交但响应丢失。明确取消、接管、终态、租约失效及其他 fencing 错误仍立即终止；对账过程不会调用 `Start` 或复活任务。

默认行为保持不变：未显式开启容错时，第一次 heartbeat 错误仍会取消执行，heartbeat 和租约默认值仍分别为 10 秒和 30 秒。

## 关键认知

heartbeat 响应失败不等于续租提交失败。安全做法是将“最后确认的租约时间”与“本次响应状态”分开：不确定期间暂停新副作用，按正常周期确认同一 attempt，并且在续租被证明成功前绝不延长本地截止时间。

## 验证

- `golangci-lint run --new-from-rev=alpha/10 ./...`
- `go test -race ./...`
- `go test -race -count=30 ./adk/backgroundtask -run 'TestHeartbeat|TestManagerExecutionStops|TestManagerConfigures|TestManagerRejects'`
- `GOTOOLCHAIN=go1.18.10 go test ./adk/backgroundtask/... ./compose ./internal/core`
- `go test -coverprofile=/tmp/eino2-heartbeat-tolerance.coverage.out ./...`（总覆盖率 83.0%）