### PR TITLE
perf(adk): skip transcript files when bash cannot run in background

### DIFF
--- a/adk/middlewares/filesystem/bash_run.go
+++ b/adk/middlewares/filesystem/bash_run.go
@@ -92,11 +92,11 @@ type toolDefinition struct {
 }
 
 // bashOutputWriter tees a managed execute task's output to a file via a
-// filesystem.AppendOpener. It is built per invocation: when both an AppendOpener
-// and an outputDir are configured it reserves outputDir/<uuid>.output (created empty
-// up front) and opens an append stream when the work starts; otherwise it is
-// disabled and every method is a no-op, so the task has no output file. There is no
-// rewrite fallback — output files require an AppendOpener.
+// filesystem.AppendOpener. It is built per invocation: eligible runs with both an
+// AppendOpener and an outputDir reserve outputDir/<uuid>.output (created empty up
+// front) and open an append stream when the work starts; otherwise it is disabled
+// and every method is a no-op, so the task has no output file. There is no rewrite
+// fallback — output files require an AppendOpener.
 //
 // The execute tool — not the Manager — owns writing, so streaming runs tee interim
 // output as chunks arrive. It is single-consumer: append is called serially on
@@ -139,6 +139,21 @@ func reserveBashOutput(ctx context.Context, sink outputSink) *bashOutputWriter {
 		store: sink.store,
 		path:  path,
 	}
+}
+
+// prepareBashOutput skips transcript materialization only when the backend owns
+// the timeout for a foreground run. That mode disables the Manager's foreground
+// timer, so the run cannot be handed off to the background. Explicit background
+// runs and foreground runs that may be auto-backgrounded still reserve output.
+func prepareBashOutput(
+	ctx context.Context,
+	sink outputSink,
+	backendOwnsTimeout bool,
+) *bashOutputWriter {
+	if backendOwnsTimeout {
+		return &bashOutputWriter{}
+	}
+	return reserveBashOutput(ctx, sink)
 }
 
 func (w *bashOutputWriter) fail(err error) error {
@@ -475,7 +490,7 @@ func newManagedBufferedExecuteTool(
 			return "", err
 		}
 		req := managedExecuteRequest(input, backendOwnsTimeout)
-		w := reserveBashOutput(ctx, sink)
+		w := prepareBashOutput(ctx, sink, backendOwnsTimeout)
 		runInput, err := managedRunInput(input, w, parentSessionID, backendOwnsTimeout)
 		if err != nil {
 			return "", err
@@ -534,7 +549,7 @@ func newManagedStreamingExecuteTool(
 			return nil, err
 		}
 		req := managedExecuteRequest(input, backendOwnsTimeout)
-		w := reserveBashOutput(ctx, sink)
+		w := prepareBashOutput(ctx, sink, backendOwnsTimeout)
 		runInput, err := managedRunInput(input, w, parentSessionID, backendOwnsTimeout)
 		if err != nil {
 			return nil, err

--- a/adk/middlewares/filesystem/bash_run_test.go
+++ b/adk/middlewares/filesystem/bash_run_test.go
@@ -434,6 +434,33 @@ func TestManagedExecuteTool_BackendOwnsCommandTimeoutUsesCommandExecutionTimeout
 	assert.Equal(t, 10*time.Second, *shell.req.Timeout)
 }
 
+func TestManagedExecuteTool_BackendOwnsCommandTimeoutForegroundSkipsOutputFile(t *testing.T) {
+	backend := setupTestBackend()
+	output := &countingAppendOpener{backend: backend}
+	mgr := newTestManager(t, context.Background())
+	defer func() {
+		ctx, cancel := context.WithTimeout(context.Background(), 100*time.Millisecond)
+		defer cancel()
+		_ = mgr.Close(ctx)
+	}()
+
+	executeTool, err := newManagedExecuteTool(
+		mustLocalRunner(t, mgr),
+		&mockShellBackend{resp: &filesystem.ExecuteResponse{Output: "done"}},
+		nil,
+		testNotificationSessionID,
+		outputSink{store: output, outputDir: "/tasks"},
+		toolDefinition{backendOwnsCommandTimeout: true},
+	)
+	require.NoError(t, err)
+
+	result, err := invokeTool(t, executeTool, `{"command":"echo hi","timeout":10}`)
+	require.NoError(t, err)
+	assert.Equal(t, "done", result)
+	assert.Zero(t, atomic.LoadInt32(&output.opens))
+	assert.Zero(t, atomic.LoadInt32(&output.closes))
+}
+
 func TestManagedExecuteTool_BackendOwnsCommandTimeoutExplicitBackgroundIgnoresTimeout(t *testing.T) {
 	mgr := newTestManager(t, context.Background())
 	defer func() {
@@ -442,19 +469,23 @@ func TestManagedExecuteTool_BackendOwnsCommandTimeoutExplicitBackgroundIgnoresTi
 		_ = mgr.Close(ctx)
 	}()
 
+	backend := setupTestBackend()
+	output := &countingAppendOpener{backend: backend}
 	release := make(chan struct{})
 	shell := &gatedShell{release: release, out: "done"}
 	tools, err := getFilesystemTools(context.Background(), &MiddlewareConfig{
-		Shell: shell,
+		Backend: backend,
+		Shell:   shell,
 		Background: &BackgroundConfig{Local: &LocalBackgroundConfig{
 			Runner: mustLocalRunner(t, mgr), BackendOwnsCommandTimeout: true,
+			OutputStore: output, OutputDir: "/tasks",
 		}},
 		notificationSessionID: testNotificationSessionID,
 	})
 	require.NoError(t, err)
 
 	result, err := invokeTool(
-		t, tools[0], `{"command":"sleep","run_in_background":true,"timeout":10}`,
+		t, findExecuteTool(t, tools), `{"command":"sleep","run_in_background":true,"timeout":10}`,
 	)
 	require.NoError(t, err)
 	assert.Contains(t, result, "Command running in background with ID:")
@@ -462,6 +493,8 @@ func TestManagedExecuteTool_BackendOwnsCommandTimeoutExplicitBackgroundIgnoresTi
 	_ = waitTerminalTask(t, mgr)
 	require.NotNil(t, shell.req)
 	assert.Nil(t, shell.req.Timeout)
+	assert.Positive(t, atomic.LoadInt32(&output.opens))
+	assert.Equal(t, atomic.LoadInt32(&output.opens), atomic.LoadInt32(&output.closes))
 }
 
 func TestManagedExecuteTool_BackgroundWithoutNotificationSession(t *testing.T) {
@@ -564,6 +597,7 @@ func TestManagedExecuteTool_Background(t *testing.T) {
 // A foreground command that outlives its timeout is moved to the background
 // (kept running) when the Manager's ShouldAutoBackground hook permits it.
 func TestManagedExecuteTool_TimeoutMovesToBackground(t *testing.T) {
+	backend := setupTestBackend()
 	mgr := newTestManager(t, context.Background())
 	defer func() {
 		ctx, cancel := context.WithTimeout(context.Background(), time.Second)
@@ -572,7 +606,8 @@ func TestManagedExecuteTool_TimeoutMovesToBackground(t *testing.T) {
 	}()
 
 	tools, err := getFilesystemTools(context.Background(), &MiddlewareConfig{
-		Shell: &slowShell{delay: 1200 * time.Millisecond, out: "slow done"},
+		Backend: backend,
+		Shell:   &slowShell{delay: 1200 * time.Millisecond, out: "slow done"},
 		Background: &BackgroundConfig{
 			Local: &LocalBackgroundConfig{
 				Runner: mustLocalRunner(t, mgr, func(config *backgroundlocal.Config) {
@@ -580,6 +615,7 @@ func TestManagedExecuteTool_TimeoutMovesToBackground(t *testing.T) {
 						return true
 					}
 				}),
+				OutputStore: backend, OutputDir: "/tasks",
 			},
 		},
 		notificationSessionID: testNotificationSessionID,
@@ -587,13 +623,16 @@ func TestManagedExecuteTool_TimeoutMovesToBackground(t *testing.T) {
 	require.NoError(t, err)
 
 	// timeout=1s < 1.2s command → moved to background.
-	result, err := invokeTool(t, tools[0], `{"command":"sleep","timeout":1}`)
+	result, err := invokeTool(t, findExecuteTool(t, tools), `{"command":"sleep","timeout":1}`)
 	require.NoError(t, err)
 	assert.Contains(t, result, "Command running in background with ID:")
 
 	task := waitTerminalTask(t, mgr)
 	assert.Equal(t, backgroundtask.StatusCompleted, task.Status)
 	assert.Equal(t, "slow done", string(task.ResultData))
+	path, found := filesystemOutput(t, backend)
+	require.True(t, found)
+	assert.Equal(t, task.Spec.OutputFile, path)
 }
 
 // Without a ShouldAutoBackground hook, a command that outlives its timeout is
@@ -817,6 +856,34 @@ func TestManagedExecuteTool_StreamingBackendOwnsCommandTimeoutUsesCommandExecuti
 	require.NotNil(t, shell.req)
 	require.NotNil(t, shell.req.Timeout)
 	assert.Equal(t, 10*time.Second, *shell.req.Timeout)
+}
+
+func TestManagedExecuteTool_StreamingBackendOwnsCommandTimeoutForegroundSkipsOutputFile(t *testing.T) {
+	backend := setupTestBackend()
+	output := &countingAppendOpener{backend: backend}
+	mgr := newTestManager(t, context.Background())
+	defer func() {
+		ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+		defer cancel()
+		_ = mgr.Close(ctx)
+	}()
+
+	executeTool, err := newManagedExecuteTool(
+		mustLocalRunner(t, mgr),
+		nil,
+		&mockStreamingShellMultiChunk{},
+		testNotificationSessionID,
+		outputSink{store: output, outputDir: "/tasks"},
+		toolDefinition{backendOwnsCommandTimeout: true},
+	)
+	require.NoError(t, err)
+
+	stream := executeTool.(tool.StreamableTool)
+	result, err := stream.StreamableRun(context.Background(), `{"command":"echo hi","timeout":10}`)
+	require.NoError(t, err)
+	assert.Contains(t, drainToolStream(t, result), "chunk3")
+	assert.Zero(t, atomic.LoadInt32(&output.opens))
+	assert.Zero(t, atomic.LoadInt32(&output.closes))
 }
 
 // An explicit background launch on a streaming managed tool exposes the bounded


### PR DESCRIPTION
#### What type of PR is this?

perf

#### Check the PR title.

- [x] This PR title match the format: \<type\>(optional scope): \<description\>
- [x] The description of this PR title is user-oriented and clear enough for others to understand.
- [x] Attach the PR updating the user documentation if the current PR requires user awareness at the usage level. `https://github.com/cloudwego/cloudwego.github.io` (Not required)

#### (Optional) Translate the PR title into Chinese.

perf(adk): 当 Bash 不会转入后台时跳过 transcript 文件

#### (Optional) More detailed description for this PR(en: English/zh: Chinese).

en:

When `BackendOwnsCommandTimeout` is enabled for a foreground Bash command, the Manager's foreground timer is disabled, so the command cannot be automatically handed off to the background.

Previously, these synchronous commands still reserved and wrote a transcript file through `OutputStore`. This introduced unnecessary filesystem RPCs and could delay command execution when the remote filesystem was slow.

This PR skips transcript materialization for this specific foreground execution mode. Explicit background commands and foreground commands that may be automatically moved to the background continue to reserve and write transcript files.

Both buffered and streaming Bash execution paths are covered by regression tests. Tests also verify that explicit background execution and automatic background handoff retain their existing output-file behavior.

In one 30-minute production sample, these redundant foreground reservations accounted for approximately 79.5% of all `WriteFile` RPCs and 88.6% of `WriteFile` timeouts.

zh(optional):

#### (Optional) Which issue(s) this PR fixes:

#### (optional) The PR that updates user documentation:

Not required. This change only removes redundant internal transcript writes and does not change the public API.