### PR TITLE
fix(adk): refresh topic memory for each user query

### DIFF
--- a/adk/middlewares/automemory/automemory.go
+++ b/adk/middlewares/automemory/automemory.go
@@ -204,6 +204,8 @@ type selectionFuture struct {
 	done chan struct{}
 	mu   sync.Mutex
 
+	queryKey string // Immutable query scope, also used when reusing a context.
+
 	// Store an immutable snapshot to avoid being mutated via shared pointers.
 	content string
 	err     error
@@ -213,7 +215,8 @@ type selectionFuture struct {
 type ctxKeySelectionFuture struct{}
 
 const (
-	memoryExtraKey = "__eino_automemory__"
+	memoryExtraKey           = "__eino_automemory__"
+	topicMemoryQueryExtraKey = "__eino_automemory_query__"
 )
 
 type memoryExtra struct {
@@ -329,7 +332,7 @@ func (m *middleware[M]) BeforeAgent(ctx context.Context, runCtx *adk.ChatModelAg
 		}
 	}
 
-	// 3) Topic memories: sync mode selects from the original user query.
+	// 3) Topic memories: select once per user query, not once per session.
 	if !hasTopicMemoryInjected(nRunCtx.AgentInput.Messages) &&
 		m.cfg.Read.Mode == ReadModeSync && m.topicSelectionEnabled() {
 		memMsg, err := m.selectAndBuildTopicMemoryMessage(ctx, nRunCtx.AgentInput)
@@ -349,8 +352,10 @@ func (m *middleware[M]) BeforeAgent(ctx context.Context, runCtx *adk.ChatModelAg
 	// 4) Topic memories: async mode starts selection here (cannot use RunLocalValue in BeforeAgent).
 	if !hasTopicMemoryInjected(nRunCtx.AgentInput.Messages) &&
 		m.cfg.Read.Mode == ReadModeAsync && m.topicSelectionEnabled() {
-		if existing, _ := ctx.Value(ctxKeySelectionFuture{}).(*selectionFuture); existing == nil {
-			fut := &selectionFuture{done: make(chan struct{})}
+		queryKey := topicMemoryQueryKey(nRunCtx.AgentInput.Messages)
+		if existing, _ := ctx.Value(ctxKeySelectionFuture{}).(*selectionFuture); queryKey != "" &&
+			(existing == nil || existing.queryKey != queryKey) {
+			fut := &selectionFuture{done: make(chan struct{}), queryKey: queryKey}
 			ctx = context.WithValue(ctx, ctxKeySelectionFuture{}, fut)
 
 			// Snapshot current messages for selection; async path is best-effort.
@@ -378,6 +383,10 @@ func (m *middleware[M]) BeforeModelRewriteState(ctx context.Context, state *adk.
 	if state == nil {
 		return ctx, state, nil
 	}
+	future, _ := ctx.Value(ctxKeySelectionFuture{}).(*selectionFuture)
+	if future != nil && future.queryKey != topicMemoryQueryKey(state.Messages) {
+		return ctx, state, nil
+	}
 	// Best-effort protection: if automemory content has been injected before and later
 	// mutated by other components, restore it using the immutable snapshot stored in the future.
 	if fut, _ := ctx.Value(ctxKeySelectionFuture{}).(*selectionFuture); fut != nil {
@@ -385,7 +394,7 @@ func (m *middleware[M]) BeforeModelRewriteState(ctx context.Context, state *adk.
 		expected := fut.content
 		fut.mu.Unlock()
 		if strings.TrimSpace(expected) != "" {
-			state = ensureMemoryMsgUnchanged(state, expected)
+			state = ensureMemoryMsgUnchanged(state, expected, fut.queryKey)
 		}
 	}
 	if m.cfg.Read.Mode != ReadModeAsync {
@@ -420,6 +429,7 @@ func (m *middleware[M]) BeforeModelRewriteState(ctx context.Context, state *adk.
 	var msgs []M
 	if strings.TrimSpace(content) != "" {
 		memMsg := newMemoryMessage[M](content)
+		copyAndSetMsgExtra(memMsg, topicMemoryQueryExtraKey, fut.queryKey)
 		m.sendTopicMemoryEvent(ctx, state.Messages, memMsg)
 		msgs = append(msgs, state.Messages...)
 		msgs = append(msgs, memMsg)
@@ -530,7 +540,9 @@ func (m *middleware[M]) selectAndBuildTopicMemoryMessage(ctx context.Context, ag
 		return nil, nil
 	}
 
-	return newMemoryMessage[M]("<!-- automemory -->\n" + buildTopicMemoryReminder(topics)), nil
+	msg := newMemoryMessage[M]("<!-- automemory -->\n" + buildTopicMemoryReminder(topics))
+	copyAndSetMsgExtra(msg, topicMemoryQueryExtraKey, topicMemoryQueryKey(agentIn.Messages))
+	return msg, nil
 }
 
 func (m *middleware[M]) listTopicCandidates(ctx context.Context) (map[string]topicCandidateBundle, []string, []string, error) {

--- a/adk/middlewares/automemory/automemory_test.go
+++ b/adk/middlewares/automemory/automemory_test.go
@@ -18,6 +18,7 @@ package automemory
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -1130,7 +1131,7 @@ func TestMiddleware_BeforeAgent_GenInstructionRendersAndIndexInjectedOnce(t *tes
 	require.Equal(t, 1, countMemoryIndexMessages(out3.AgentInput.Messages))
 }
 
-func TestMiddleware_BeforeAgent_TopicMemoryInjectedOncePerSession(t *testing.T) {
+func TestMiddleware_BeforeAgent_TopicMemoryInjectedOncePerQuery(t *testing.T) {
 	ctx := context.Background()
 	b := NewInMemoryBackend()
 	now := time.Now()
@@ -1167,9 +1168,9 @@ func TestMiddleware_BeforeAgent_TopicMemoryInjectedOncePerSession(t *testing.T) 
 		AgentInput:  &adk.AgentInput{Messages: nextMessages},
 	})
 	require.NoError(t, err)
-	require.EqualValues(t, 1, atomic.LoadInt32(&selModel.calls))
+	require.EqualValues(t, 2, atomic.LoadInt32(&selModel.calls))
 	require.Equal(t, 1, countMemoryIndexMessages(out2.AgentInput.Messages))
-	require.Equal(t, 1, countTopicMemoryMessages(out2.AgentInput.Messages))
+	require.Equal(t, 2, countTopicMemoryMessages(out2.AgentInput.Messages))
 }
 
 func TestMiddleware_LastUserMessageSkipsSystemReminderPrefix(t *testing.T) {
@@ -1575,4 +1576,121 @@ func TestMiddleware_AfterAgent_AsyncSetsPendingSnapshotWhenLockHeld(t *testing.T
 	topic, err := b.Read(ctx, &ReadRequest{FilePath: "/mem/topic.md"})
 	require.NoError(t, err)
 	require.Equal(t, "remember pending", topic.Content)
+}
+
+// topicRefreshModel returns different memories as the conversation progresses.
+type topicRefreshModel struct {
+	fixedModel
+	calls int32
+}
+
+func (m *topicRefreshModel) Stream(ctx context.Context, input []*schema.Message, opts ...model.Option) (*schema.StreamReader[*schema.Message], error) {
+	path := "appointment.md"
+	if atomic.AddInt32(&m.calls, 1) == 1 {
+		path = "refund.md"
+	}
+	selected := &fixedModel{out: fmt.Sprintf(`{"selected_memories":["%s"]}`, path)}
+	return selected.Stream(ctx, input, opts...)
+}
+
+func TestMiddleware_TopicMemoryRefreshesForNewQuery(t *testing.T) {
+	for _, mode := range []ReadMode{ReadModeSync, ReadModeAsync} {
+		t.Run(string(mode), func(t *testing.T) {
+			ctx := context.Background()
+			b := NewInMemoryBackend()
+			now := time.Now()
+			b.put("/mem/MEMORY.md", "refund.md\nappointment.md", now)
+			b.put("/mem/refund.md", "---\ndescription: refund rules\n---\nRefund within 7 days.", now)
+			b.put("/mem/appointment.md", "---\ndescription: change appointments\n---\nChange appointments 24 hours ahead.", now)
+			sel := &topicRefreshModel{}
+			mw, err := New(ctx, &Config[*schema.Message]{
+				MemoryDirectory: "/mem", MemoryBackend: b, Model: sel,
+				Read: &ReadConfig[*schema.Message]{Mode: mode},
+			})
+			require.NoError(t, err)
+			run := func(messages []*schema.Message) []*schema.Message {
+				t.Helper()
+				var out *adk.ChatModelAgentContext[*schema.Message]
+				ctx, out, err = mw.BeforeAgent(ctx, &adk.ChatModelAgentContext[*schema.Message]{
+					AgentInput: &adk.AgentInput{Messages: messages},
+				})
+				require.NoError(t, err)
+				st := &adk.ChatModelAgentState{Messages: out.AgentInput.Messages}
+				if mode == ReadModeAsync {
+					fut, _ := ctx.Value(ctxKeySelectionFuture{}).(*selectionFuture)
+					if fut != nil {
+						select {
+						case <-fut.done:
+						case <-time.After(5 * time.Second):
+							t.Fatal("topic selection did not complete")
+						}
+					}
+					_, st, err = mw.BeforeModelRewriteState(ctx, st, nil)
+					require.NoError(t, err)
+				}
+				return st.Messages
+			}
+			messages := run([]*schema.Message{schema.UserMessage("What are the refund rules?")})
+			require.EqualValues(t, 1, atomic.LoadInt32(&sel.calls))
+			require.Equal(t, 1, countTopicMemoryMessages(messages))
+			var originalMemory *schema.Message
+			for _, msg := range messages {
+				if isTopicMemoryMessage(msg) {
+					originalMemory = msg
+				}
+			}
+			require.NotNil(t, originalMemory)
+			originalContent := originalMemory.Content
+			require.Contains(t, originalContent, "Refund within 7 days.")
+			messages = run(messages)
+			require.EqualValues(t, 1, atomic.LoadInt32(&sel.calls), "same query must not select again")
+			messages = append(messages, schema.AssistantMessage("ack", nil), schema.UserMessage("How do I change my appointment?"))
+			messages = run(messages)
+			require.EqualValues(t, 2, atomic.LoadInt32(&sel.calls), "a new query must select again")
+			require.Equal(t, 2, countTopicMemoryMessages(messages))
+			require.Equal(t, 1, countMemoryIndexMessages(messages))
+			var latest *schema.Message
+			for _, msg := range messages {
+				if isTopicMemoryMessage(msg) {
+					latest = msg
+				}
+			}
+			require.Contains(t, latest.Content, "Change appointments 24 hours ahead.")
+			require.Equal(t, originalContent, originalMemory.Content)
+			messages = run(messages)
+			require.EqualValues(t, 2, atomic.LoadInt32(&sel.calls))
+			require.Equal(t, 2, countTopicMemoryMessages(messages))
+			var historyFound bool
+			for _, msg := range messages {
+				if msg.Content == originalContent {
+					historyFound = true
+				}
+			}
+			require.True(t, historyFound, "historical topic memory must not be rewritten")
+			// Persisted message extras must retain same-query deduplication without
+			// depending on the in-process future or pointer identity.
+			data, err := json.Marshal(messages)
+			require.NoError(t, err)
+			require.NoError(t, json.Unmarshal(data, &messages))
+			ctx = context.Background()
+			messages = run(messages)
+			require.EqualValues(t, 2, atomic.LoadInt32(&sel.calls))
+			require.Equal(t, 2, countTopicMemoryMessages(messages))
+
+			// Even identical query text in a later turn should read updated files.
+			b.put("/mem/appointment.md", "---\ndescription: change appointments\n---\nChange appointments 12 hours ahead.", now.Add(time.Minute))
+			messages = append(messages, schema.AssistantMessage("ack", nil), schema.UserMessage("How do I change my appointment?"))
+			messages = run(messages)
+			require.EqualValues(t, 3, atomic.LoadInt32(&sel.calls))
+			require.Equal(t, 3, countTopicMemoryMessages(messages))
+			var updatedFound bool
+			for _, msg := range messages {
+				if isTopicMemoryMessage(msg) && strings.Contains(msg.Content, "Change appointments 12 hours ahead.") {
+					updatedFound = true
+				}
+			}
+			require.True(t, updatedFound)
+
+		})
+	}
 }

--- a/adk/middlewares/automemory/utils.go
+++ b/adk/middlewares/automemory/utils.go
@@ -18,6 +18,7 @@ package automemory
 
 import (
 	"context"
+	"crypto/sha256"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -519,9 +520,51 @@ func messageToolNames[M adk.MessageType](msg M) []string {
 	}
 }
 
-func hasTopicMemoryInjected[M adk.MessageType](msgs []M) bool {
+// Agentic tool results also use the user role, but do not start a new query.
+func isUserQueryMessage[M adk.MessageType](msg M) bool {
+	if isNilMessage(msg) || !isUserRole(msg) || isAutomemoryReminderMessage(msg) {
+		return false
+	}
+	if agentic, ok := any(msg).(*schema.AgenticMessage); ok {
+		for _, block := range agentic.ContentBlocks {
+			if block != nil && (block.UserInputText != nil || block.UserInputImage != nil ||
+				block.UserInputAudio != nil || block.UserInputVideo != nil || block.UserInputFile != nil) {
+				return true
+			}
+		}
+		return false
+	}
+	return true
+}
+
+// topicMemoryQueryKey identifies the current occurrence of a user query. Include
+// preceding user queries so asking the same question in a later turn refreshes
+// memory too. Ignore reminders and model/tool messages, which can change within
+// a turn. Transcript truncation may cause a harmless fresh selection.
+func topicMemoryQueryKey[M adk.MessageType](msgs []M) string {
+	h := sha256.New()
+	found := false
 	for _, msg := range msgs {
-		if isTopicMemoryMessage(msg) {
+		if !isUserQueryMessage(msg) {
+			continue
+		}
+		content := userMessageTextContent(msg)
+		fmt.Fprintf(h, "%d:%s", len(content), content)
+		found = true
+	}
+	if !found {
+		return ""
+	}
+	return fmt.Sprintf("%x", h.Sum(nil))
+}
+
+func hasTopicMemoryInjected[M adk.MessageType](msgs []M) bool {
+	queryKey := topicMemoryQueryKey(msgs)
+	if queryKey == "" {
+		return false
+	}
+	for _, msg := range msgs {
+		if isTopicMemoryMessage(msg) && getMsgExtra(msg)[topicMemoryQueryExtraKey] == queryKey {
 			return true
 		}
 	}
@@ -555,7 +598,7 @@ func insertMessagesBeforeLastUserQuery[M adk.MessageType](msgs []M, inserts []M)
 func lastUserQueryMessageIndex[M adk.MessageType](msgs []M) int {
 	for i := len(msgs) - 1; i >= 0; i-- {
 		msg := msgs[i]
-		if isNilMessage(msg) || !isUserRole(msg) || isAutomemoryReminderMessage(msg) {
+		if !isUserQueryMessage(msg) {
 			continue
 		}
 		return i
@@ -638,7 +681,7 @@ func newMemoryIndexMessage[M adk.MessageType](content string) M {
 	return msg
 }
 
-func ensureMemoryMsgUnchanged[M adk.MessageType](state *adk.TypedChatModelAgentState[M], expectedContent string) *adk.TypedChatModelAgentState[M] {
+func ensureMemoryMsgUnchanged[M adk.MessageType](state *adk.TypedChatModelAgentState[M], expectedContent, queryKey string) *adk.TypedChatModelAgentState[M] {
 	if state == nil || strings.TrimSpace(expectedContent) == "" {
 		return state
 	}
@@ -647,12 +690,13 @@ func ensureMemoryMsgUnchanged[M adk.MessageType](state *adk.TypedChatModelAgentS
 	out.Messages = append([]M{}, state.Messages...)
 
 	for i, m := range out.Messages {
-		if !isTopicMemoryMessage(m) {
+		if !isTopicMemoryMessage(m) || getMsgExtra(m)[topicMemoryQueryExtraKey] != queryKey {
 			continue
 		}
 		extra := getMsgExtra(m)
 		if userMessageTextContent(m) != expectedContent || extra == nil || extra[memoryExtraKey] == nil {
 			out.Messages[i] = newMemoryMessage[M](expectedContent)
+			copyAndSetMsgExtra(out.Messages[i], topicMemoryQueryExtraKey, queryKey)
 			changed = true
 		}
 	}
@@ -869,7 +913,7 @@ func (m *middleware[M]) lastUserMessage(agentIn *adk.TypedAgentInput[M]) (M, boo
 	}
 	for i := len(agentIn.Messages) - 1; i >= 0; i-- {
 		msg := agentIn.Messages[i]
-		if isNilMessage(msg) || !isUserRole(msg) || isAutomemoryReminderMessage(msg) {
+		if !isUserQueryMessage(msg) {
 			continue
 		}
 		return msg, true

--- a/adk/middlewares/automemory/utils_test.go
+++ b/adk/middlewares/automemory/utils_test.go
@@ -17,11 +17,13 @@
 package automemory
 
 import (
+	"encoding/json"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"github.com/cloudwego/eino/adk"
 	"github.com/cloudwego/eino/schema"
 )
 
@@ -87,4 +89,53 @@ func TestConcatMessageStream_WithToolCalls(t *testing.T) {
 	assert.Equal(t, "thinking...", msg.Content)
 	require.Len(t, msg.ToolCalls, 1)
 	assert.Equal(t, "search", msg.ToolCalls[0].Function.Name)
+}
+
+func TestTopicMemoryQueryScope(t *testing.T) {
+	t.Run("message", testTopicMemoryQueryScope[*schema.Message])
+	t.Run("agentic_message", testTopicMemoryQueryScope[*schema.AgenticMessage])
+}
+
+func testTopicMemoryQueryScope[M adk.MessageType](t *testing.T) {
+	query := makeUserMsg[M]("refund rules")
+	key := topicMemoryQueryKey([]M{query})
+	topic := newMemoryMessage[M]("<!-- automemory -->refund notes")
+	copyAndSetMsgExtra(topic, topicMemoryQueryExtraKey, key)
+	index := newMemoryIndexMessage[M]("<!-- automemory:index -->index")
+	reminder := makeUserMsg[M]("<system-reminder>other middleware</system-reminder>")
+	var nilMsg M
+	for _, messages := range [][]M{
+		{index, topic, query}, // Sync inserts before the query.
+		{index, query, topic}, // Async appends after the query.
+		{nilMsg, index, query, topic, reminder},
+	} {
+		require.True(t, hasTopicMemoryInjected(messages))
+		data, err := json.Marshal(messages)
+		require.NoError(t, err)
+		var restored []M
+		require.NoError(t, json.Unmarshal(data, &restored))
+		require.True(t, hasTopicMemoryInjected(restored))
+		// A consecutive query must not inherit an earlier async reminder,
+		// even when there is no assistant response between the two queries.
+		require.False(t, hasTopicMemoryInjected(append(restored, makeUserMsg[M]("change appointment"))))
+		require.False(t, hasTopicMemoryInjected(append(messages, makeUserMsg[M]("refund rules"))))
+	}
+	require.False(t, hasTopicMemoryInjected([]M{nilMsg, index, topic}))
+	require.False(t, hasTopicMemoryInjected([]M{newMemoryMessage[M]("legacy topic"), query}))
+}
+
+func TestTopicMemoryQueryScopeIgnoresAgenticToolResults(t *testing.T) {
+	query := schema.UserAgenticMessage("refund rules")
+	key := topicMemoryQueryKey([]*schema.AgenticMessage{query})
+	topic := newMemoryMessage[*schema.AgenticMessage]("<!-- automemory -->refund notes")
+	copyAndSetMsgExtra(topic, topicMemoryQueryExtraKey, key)
+	result := &schema.AgenticMessage{
+		Role: schema.AgenticRoleTypeUser,
+		ContentBlocks: []*schema.ContentBlock{
+			schema.NewContentBlock(&schema.FunctionToolResult{CallID: "call-1", Name: "lookup"}),
+		},
+	}
+	messages := []*schema.AgenticMessage{topic, query, result}
+	require.True(t, hasTopicMemoryInjected(messages))
+	require.Equal(t, 1, lastUserQueryMessageIndex(messages))
 }


### PR DESCRIPTION
#### What type of PR is this?
fix

#### Check the PR title.
- [x] This PR title matches the format: <type>(optional scope): <description>
- [x] The description of this PR title is user-oriented and clear enough for others to understand.
- [ ] Attach the PR updating the user documentation if required.

#### (Optional) Translate the PR title into Chinese.
修复 AutoMemory 在同一会话的新提问中不刷新主题记忆的问题。

#### (Optional) More detailed description for this PR(en: English/zh: Chinese).
en:
After AutoMemory injects refund-related memory, a later question about rescheduling in the same session currently skips topic selection because any historical topic reminder satisfies the session-wide guard. Scope successful topic-memory injection to the current user-query occurrence instead, for both sync and async reads. A later occurrence of the same question also reads updated memory files.

Persist a query fingerprint in reminder extras, derived from the sequence of business user-query text with length framing. This keeps deduplication stable across reminder insertion, model/tool messages, and JSON round-trips, without mutating user messages. Agentic tool-result messages use the user role but do not count as new queries. Legacy reminders without a query scope allow a fresh selection; transcript truncation can also trigger a fresh selection. MEMORY.md reminder behavior remains session-scoped.

Scope async futures and immutable-content restoration to their originating query so a reused context can start a new selection without rewriting historical topic reminders. This change does not introduce semantic-topic caching or polling for memory updates during the same query. It may perform additional topic-selection calls on later user queries, which is necessary to refresh relevant memory.

Validation (Go 1.26.0, darwin/arm64):
- Confirmed the new sync/async multi-query regression fails against unmodified alpha/10 at 60ad5c6f8f00ce7324c3cea6096495bde0a2a5a6: expected 2 model calls, got 1.
- `go test -race ./...` passed after the fix.
- `golangci-lint run --timeout 5m --new-from-rev=HEAD` passed with v2.8.0, 0 new issues (HEAD is the unchanged alpha/10 base).
- Regression coverage includes same-query deduplication, topic switching, updated memory on repeated query text, JSON persistence, both message types, Agentic tool results, and preservation of historical reminders.

#### (Optional) Which issue(s) this PR fixes:
Fixes #1130

#### (optional) The PR that updates user documentation:
No separate documentation PR included; no public configuration/API changes.
