### PR TITLE
fix(compose): stop receiveWithDeadline writing its results from the goroutine

### DIFF
--- a/compose/graph_manager.go
+++ b/compose/graph_manager.go
@@ -506,19 +506,25 @@ func receiveWithDeadline(recv func() (*task, bool), deadline time.Time) (ta *tas
 
 	timeout := deadline.Sub(now)
 
-	resultCh := make(chan struct{}, 1)
+	type pair struct {
+		ta     *task
+		closed bool
+	}
+	resultCh := make(chan pair, 1)
 
 	go func() {
-		ta, closed = recv()
-		resultCh <- struct{}{}
+		ta, closed := recv()
+		resultCh <- pair{ta: ta, closed: closed}
 	}()
 
-	timeoutCh := time.After(timeout)
+	// NewTimer over time.After so the timer is released when recv wins.
+	timer := time.NewTimer(timeout)
+	defer timer.Stop()
 
 	select {
-	case <-resultCh:
-		return ta, closed, false
-	case <-timeoutCh:
+	case p := <-resultCh:
+		return p.ta, p.closed, false
+	case <-timer.C:
 		return nil, false, true
 	}
 }

--- a/compose/graph_manager_test.go
+++ b/compose/graph_manager_test.go
@@ -238,3 +238,50 @@ func TestReceiveWithListening_PositiveTimeout_DeadlineExpiresFirst(t *testing.T)
 	assert.Nil(t, ta)
 	assert.NotNil(t, deadline)
 }
+
+// TestReceiveWithDeadline_TaskFinishesBeforeDeadline verifies the deadline form
+// still returns the task's real result when it arrives in time.
+func TestReceiveWithDeadline_TaskFinishesBeforeDeadline(t *testing.T) {
+	recvReleased := make(chan struct{})
+	want := &task{nodeKey: "n"}
+	recv := func() (*task, bool) {
+		<-recvReleased
+		return want, true
+	}
+
+	go func() {
+		time.Sleep(20 * time.Millisecond)
+		close(recvReleased)
+	}()
+
+	ta, closed, canceled := receiveWithDeadline(recv, time.Now().Add(time.Second))
+
+	assert.False(t, canceled)
+	assert.True(t, closed)
+	assert.Same(t, want, ta)
+}
+
+// TestReceiveWithDeadline_DeadlineExpiresFirst verifies the deadline discards a
+// task that has not completed in time, and that the abandoned goroutine cannot
+// write back into the returned values once it does complete.
+//
+// The second half is a `-race` regression: receiveWithDeadline used to capture
+// its named results in the goroutine (`ta, closed = recv()`), so a task
+// finishing after the deadline raced with the timeout return.
+func TestReceiveWithDeadline_DeadlineExpiresFirst(t *testing.T) {
+	recvReleased := make(chan struct{})
+	recv := func() (*task, bool) {
+		<-recvReleased
+		return &task{nodeKey: "n"}, true
+	}
+
+	ta, closed, canceled := receiveWithDeadline(recv, time.Now().Add(20*time.Millisecond))
+
+	assert.True(t, canceled)
+	assert.Nil(t, ta)
+	assert.False(t, closed)
+
+	// Let the abandoned goroutine run to completion after we already returned.
+	close(recvReleased)
+	time.Sleep(100 * time.Millisecond)
+}


### PR DESCRIPTION
#### What type of PR is this?

fix: A bug fix

#### Check the PR title.

- [x] This PR title match the format: \<type\>(optional scope): \<description\>
- [x] The description of this PR title is user-oriented and clear enough for others to understand.
- [ ] Attach the PR updating the user documentation if the current PR requires user awareness at the usage level.
  - Not applicable: internal fix, no user-facing API or behaviour change.

#### (Optional) Translate the PR title into Chinese.

fix(compose): 修复 receiveWithDeadline 在超时返回后仍由 goroutine 写回结果的数据竞争

#### (Optional) More detailed description for this PR(en: English/zh: Chinese).

en:

`receiveWithDeadline` captured its own named return values in the goroutine it spawns:

```go
go func() {
	ta, closed = recv()          // writes the caller-visible results
	resultCh <- struct{}{}
}()
```

When the deadline fires first, the function returns through `case <-timeoutCh` while the abandoned goroutine is still running. If the pending receive then completes, the goroutine writes `ta`/`closed` with no happens-before edge to that return (nor to the caller's read of the results) — a data race on every deadline expiry where the task finishes after the deadline.

Fix: send the result through a buffered channel, exactly as the sibling `receiveWithListening` in the same file already does, so the deadline path shares nothing with the abandoned goroutine. `time.After` is replaced with a stopped `time.NewTimer` so the timer is released on the `recv`-wins path too.

Tests: `receiveWithDeadline` had no coverage (its sibling has four `TestReceiveWithListening_*` cases). This adds both outcomes. The expiry case completes the pending task *after* the return, which is the interleaving the race detector flags on the previous implementation.

Verification I ran:

- `go test ./compose/...` — ok (26.5s)
- `go vet ./compose/` — clean
- `gofmt -l` on the touched files — clean

The race itself needs the detector, which CI runs (`go test -race`):

```
go test -race -count=1 -run TestReceiveWithDeadline ./compose/
```

I could not run `-race` on this machine (Windows without a C toolchain, and the detector requires cgo), so please rely on CI for that confirmation; the added test is the reproduction.

zh(optional):

`receiveWithDeadline` 在派生的 goroutine 中直接写入自己的具名返回值。当截止时间先到、任务随后完成时，被遗弃的 goroutine 与该函数的超时 return 之间没有任何 happens-before 关系，构成数据竞争。修复方式是像同文件的 `receiveWithListening` 一样用带缓冲 channel 传结果，并把 `time.After` 换成会停止的 `time.NewTimer`。同时补上该函数此前完全缺失的测试（超时先到的那条用例会在旧实现上被 `-race` 报告为竞争）。

#### (Optional) Which issue(s) this PR fixes:

Fixes #1279
