### PR TITLE
fix(adk): treat virtual filesystem paths as slash-separated on every platform

### DIFF
--- a/adk/filesystem/backend_inmemory.go
+++ b/adk/filesystem/backend_inmemory.go
@@ -19,7 +19,7 @@ package filesystem
 import (
 	"context"
 	"fmt"
-	"path/filepath"
+	"path"
 	"regexp"
 	"strings"
 	"sync"
@@ -53,7 +53,7 @@ func (b *InMemoryBackend) LsInfo(ctx context.Context, req *LsInfoRequest) ([]Fil
 	defer b.mu.RUnlock()
 
 	// Normalize path
-	path := normalizePath(req.Path)
+	dir := normalizePath(req.Path)
 
 	var result []FileInfo
 	seen := make(map[string]bool)
@@ -63,16 +63,16 @@ func (b *InMemoryBackend) LsInfo(ctx context.Context, req *LsInfoRequest) ([]Fil
 		normalizedFilePath := normalizePath(filePath)
 
 		// Check if file is under the given path
-		if path == "/" || strings.HasPrefix(normalizedFilePath, path+"/") || normalizedFilePath == path {
+		if dir == "/" || strings.HasPrefix(normalizedFilePath, dir+"/") || normalizedFilePath == dir {
 			// For directory listing, we want to show immediate children
-			relativePath := strings.TrimPrefix(normalizedFilePath, path)
+			relativePath := strings.TrimPrefix(normalizedFilePath, dir)
 			relativePath = strings.TrimPrefix(relativePath, "/")
 
 			if relativePath == "" {
 				// The path itself is a file
 				if !seen[normalizedFilePath] {
 					result = append(result, FileInfo{
-						Path:       filepath.Base(normalizedFilePath),
+						Path:       path.Base(normalizedFilePath),
 						IsDir:      false,
 						Size:       int64(len(entry.content)),
 						ModifiedAt: entry.modifiedAt.Format(time.RFC3339Nano),
@@ -85,8 +85,8 @@ func (b *InMemoryBackend) LsInfo(ctx context.Context, req *LsInfoRequest) ([]Fil
 			// Get the first segment (immediate child)
 			parts := strings.SplitN(relativePath, "/", 2)
 			if len(parts) > 0 {
-				childPath := path
-				if path != "/" {
+				childPath := dir
+				if dir != "/" {
 					childPath += "/"
 				}
 				childPath += parts[0]
@@ -378,7 +378,7 @@ func (b *InMemoryBackend) filterByGlob(files []string, searchPath string, globPa
 				matchPath = strings.TrimPrefix(filePath, searchPath+"/")
 			}
 		} else {
-			matchPath = filepath.Base(filePath)
+			matchPath = path.Base(filePath)
 		}
 
 		matched, err := doublestar.Match(globPattern, matchPath)
@@ -397,7 +397,7 @@ func (b *InMemoryBackend) filterByFileType(files []string, fileType string) []st
 	var result []string
 
 	for _, filePath := range files {
-		ext := strings.TrimPrefix(filepath.Ext(filePath), ".")
+		ext := strings.TrimPrefix(path.Ext(filePath), ".")
 		if matchFileType(ext, fileType) {
 			result = append(result, filePath)
 		}
@@ -687,17 +687,22 @@ func (b *InMemoryBackend) Edit(ctx context.Context, req *EditRequest) error {
 }
 
 // normalizePath normalizes a file path by ensuring it starts with "/" and removing trailing slashes.
-func normalizePath(path string) string {
-	if path == "" {
+//
+// Paths in this backend are virtual and slash-separated, so they are cleaned
+// with the slash-only path package: filepath.Clean would rewrite them with the
+// host separator (e.g. backslashes on Windows) and every glob/prefix match that
+// assumes "/" would then miss.
+func normalizePath(p string) string {
+	if p == "" {
 		return "/"
 	}
 
 	// Ensure path starts with "/"
-	if !strings.HasPrefix(path, "/") {
-		path = "/" + path
+	if !strings.HasPrefix(p, "/") {
+		p = "/" + p
 	}
 
-	return filepath.Clean(path)
+	return path.Clean(p)
 }
 
 type grepCollector struct {

--- a/adk/filesystem/backend_inmemory_test.go
+++ b/adk/filesystem/backend_inmemory_test.go
@@ -19,7 +19,7 @@ package filesystem
 import (
 	"context"
 	"fmt"
-	"path/filepath"
+	"path"
 	"strconv"
 	"strings"
 	"testing"
@@ -2209,7 +2209,7 @@ func TestInMemoryBackend_GrepRaw_ComplexScenarios(t *testing.T) {
 			t.Fatalf("GrepRaw failed: %v", err)
 		}
 		for _, match := range matches {
-			if filepath.Base(match.Path) != "main.go" {
+			if path.Base(match.Path) != "main.go" {
 				t.Errorf("Expected filename 'main.go', got: %s", match.Path)
 			}
 		}

--- a/adk/middlewares/agentsmd/agentsmd_test.go
+++ b/adk/middlewares/agentsmd/agentsmd_test.go
@@ -627,14 +627,14 @@ func TestLoader_RelativeTopLevelWithDotDotImport(t *testing.T) {
 	if !strings.Contains(content, "SHARED X") {
 		t.Fatalf("expected imported content, got %q", content)
 	}
-	// filepath.Clean should normalize "sub/../shared/x.md" to "shared/x.md"
+	// path.Clean should normalize "sub/../shared/x.md" to "shared/x.md"
 	if !strings.Contains(content, "Contents of shared/x.md") {
 		t.Fatalf("expected normalized path in section header, got %q", content)
 	}
 }
 
 func TestLoader_RelativeTopLevelDedup(t *testing.T) {
-	// Two top-level relative paths that resolve to the same file via filepath.Clean
+	// Two top-level relative paths that resolve to the same file via path.Clean
 	// should be deduped (loaded only once).
 	b := newMemBackend()
 	b.set("sub/a.md", "CONTENT A")
@@ -683,7 +683,7 @@ func TestLoader_AbsoluteTopLevelWithDotDotImport(t *testing.T) {
 	if !strings.Contains(content, "SHARED") {
 		t.Fatalf("expected imported content, got %q", content)
 	}
-	// filepath.Clean normalizes "/project/sub/../shared/x.md" to "/project/shared/x.md"
+	// path.Clean normalizes "/project/sub/../shared/x.md" to "/project/shared/x.md"
 	if !strings.Contains(content, "Contents of /project/shared/x.md") {
 		t.Fatalf("expected normalized path in section header, got %q", content)
 	}
@@ -691,7 +691,7 @@ func TestLoader_AbsoluteTopLevelWithDotDotImport(t *testing.T) {
 
 func TestLoader_RelativeImportDedup(t *testing.T) {
 	// Two different relative @import paths that resolve to the same file
-	// should be deduped via filepath.Clean.
+	// should be deduped via path.Clean.
 	b := newMemBackend()
 	b.set("/a/main.md", "first @/a/b/shared.md second @../a/b/shared.md end")
 	b.set("/a/b/shared.md", "SHARED ONCE")

--- a/adk/middlewares/agentsmd/loader.go
+++ b/adk/middlewares/agentsmd/loader.go
@@ -22,7 +22,7 @@ import (
 	"fmt"
 	"log"
 	"os"
-	"path/filepath"
+	"path"
 	"regexp"
 	"strings"
 	"unicode/utf8"
@@ -130,7 +130,7 @@ func (cfg *loaderConfig) load(ctx context.Context) (string, error) {
 		if l.stopped {
 			// The budget was exhausted by an earlier file; the rest never load.
 			for _, p := range l.files[i:] {
-				omitted = append(omitted, filepath.Clean(p))
+				omitted = append(omitted, path.Clean(p))
 			}
 			break
 		}
@@ -144,7 +144,7 @@ func (cfg *loaderConfig) load(ctx context.Context) (string, error) {
 
 		// This file crossed the budget and was dropped whole (truncated files stay in parts).
 		if l.stopped && len(parts) == before {
-			omitted = append(omitted, filepath.Clean(filePath))
+			omitted = append(omitted, path.Clean(filePath))
 		}
 	}
 
@@ -157,7 +157,7 @@ func (cfg *loaderConfig) load(ctx context.Context) (string, error) {
 // visited tracks the current ancestor chain to detect circular imports.
 // seen tracks globally loaded files to avoid duplicate reads and byte counting.
 func (l *loader) loadFile(ctx context.Context, filePath string, depth int, visited map[string]bool, seen map[string]bool) ([]loadedFile, error) {
-	filePath = filepath.Clean(filePath)
+	filePath = path.Clean(filePath)
 
 	if depth > maxImportDepth {
 		l.onWarning(filePath, fmt.Errorf("@import depth exceeds maximum of %d", maxImportDepth))
@@ -270,7 +270,7 @@ func (l *loader) applyBudget(filePath, content string) (string, bool) {
 // Non-fatal errors (file not found, depth exceeded, circular import) are reported
 // via onWarning and skipped. Fatal errors (e.g. I/O) are returned.
 func (l *loader) collectImports(ctx context.Context, hostPath, content string, depth int, visited map[string]bool, seen map[string]bool) ([]loadedFile, error) {
-	dir := filepath.Dir(hostPath)
+	dir := path.Dir(hostPath)
 	var imports []loadedFile
 
 	matches := importRegex.FindAllStringSubmatch(content, -1)
@@ -282,13 +282,13 @@ func (l *loader) collectImports(ctx context.Context, hostPath, content string, d
 
 		// Only treat as import if path contains "/" or ends with an allowed extension.
 		// This avoids false positives on email addresses and social mentions.
-		if !strings.Contains(rawPath, "/") && !allowedImportExts[filepath.Ext(rawPath)] {
+		if !strings.Contains(rawPath, "/") && !allowedImportExts[path.Ext(rawPath)] {
 			continue
 		}
 
 		importPath := rawPath
-		if !filepath.IsAbs(importPath) {
-			importPath = filepath.Join(dir, importPath)
+		if !path.IsAbs(importPath) {
+			importPath = path.Join(dir, importPath)
 		}
 
 		if seen[importPath] {

--- a/adk/middlewares/filesystem/filesystem.go
+++ b/adk/middlewares/filesystem/filesystem.go
@@ -22,7 +22,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"path/filepath"
+	"path"
 	"runtime/debug"
 	"sort"
 	"strconv"
@@ -955,7 +955,7 @@ func newGrepTool(fs filesystem.Backend, name string, desc string) (tool.BaseTool
 	}
 	return utils.InferTool(toolName, d, func(ctx context.Context, input grepArgs) (string, error) {
 		// Extract string parameters
-		path := valueOrDefault(input.Path, "")
+		filePath := valueOrDefault(input.Path, "")
 		glob := valueOrDefault(input.Glob, "")
 		fileType := valueOrDefault(input.FileType, "")
 		var beforeLines, afterLines int
@@ -979,7 +979,7 @@ func newGrepTool(fs filesystem.Backend, name string, desc string) (tool.BaseTool
 
 		matches, err := fs.GrepRaw(ctx, &filesystem.GrepRequest{
 			Pattern:         input.Pattern,
-			Path:            path,
+			Path:            filePath,
 			Glob:            glob,
 			FileType:        fileType,
 			CaseInsensitive: caseInsensitive,
@@ -992,7 +992,7 @@ func newGrepTool(fs filesystem.Backend, name string, desc string) (tool.BaseTool
 		}
 
 		sort.SliceStable(matches, func(i, j int) bool {
-			return filepath.Base(matches[i].Path) < filepath.Base(matches[j].Path)
+			return path.Base(matches[i].Path) < path.Base(matches[j].Path)
 		})
 
 		switch input.OutputMode {

--- a/adk/middlewares/plantask/backend_test.go
+++ b/adk/middlewares/plantask/backend_test.go
@@ -19,7 +19,7 @@ package plantask
 import (
 	"context"
 	"errors"
-	"path/filepath"
+	"path"
 	"strings"
 	"sync"
 
@@ -43,10 +43,10 @@ func (b *inMemoryBackend) LsInfo(ctx context.Context, req *LsInfoRequest) ([]Fil
 
 	reqPath := strings.TrimSuffix(req.Path, "/")
 	var result []FileInfo
-	for path := range b.files {
-		dir := filepath.Dir(path)
+	for p := range b.files {
+		dir := path.Dir(p)
 		if dir == reqPath {
-			result = append(result, FileInfo{Path: path})
+			result = append(result, FileInfo{Path: p})
 		}
 	}
 	return result, nil

--- a/adk/middlewares/plantask/task_create.go
+++ b/adk/middlewares/plantask/task_create.go
@@ -19,7 +19,7 @@ package plantask
 import (
 	"context"
 	"fmt"
-	"path/filepath"
+	"path"
 	"sync"
 
 	"github.com/bytedance/sonic"
@@ -104,7 +104,7 @@ func (t *taskCreateTool) InvokableRun(ctx context.Context, argumentsInJSON strin
 
 	highwatermark := int64(0)
 	for _, file := range files {
-		fileName := filepath.Base(file.Path)
+		fileName := path.Base(file.Path)
 		if fileName == highWatermarkFileName {
 			content, readErr := t.Backend.Read(ctx, &ReadRequest{
 				FilePath: file.Path,
@@ -126,7 +126,7 @@ func (t *taskCreateTool) InvokableRun(ctx context.Context, argumentsInJSON strin
 	taskFileName := fmt.Sprintf("%d.json", taskID)
 
 	for _, file := range files {
-		fileName := filepath.Base(file.Path)
+		fileName := path.Base(file.Path)
 		if fileName == taskFileName {
 			return "", fmt.Errorf("task #%d already exists", taskID)
 		}
@@ -149,7 +149,7 @@ func (t *taskCreateTool) InvokableRun(ctx context.Context, argumentsInJSON strin
 	}
 
 	//  Write highwatermark file first
-	highwatermarkPath := filepath.Join(t.BaseDir, highWatermarkFileName)
+	highwatermarkPath := path.Join(t.BaseDir, highWatermarkFileName)
 	err = t.Backend.Write(ctx, &WriteRequest{
 		FilePath: highwatermarkPath,
 		Content:  fmt.Sprintf("%d", taskID),
@@ -158,7 +158,7 @@ func (t *taskCreateTool) InvokableRun(ctx context.Context, argumentsInJSON strin
 		return "", fmt.Errorf("%s update highwatermark file %s failed, err: %w", TaskCreateToolName, highwatermarkPath, err)
 	}
 
-	taskFilePath := filepath.Join(t.BaseDir, taskFileName)
+	taskFilePath := path.Join(t.BaseDir, taskFileName)
 	err = t.Backend.Write(ctx, &WriteRequest{
 		FilePath: taskFilePath,
 		Content:  taskData,

--- a/adk/middlewares/plantask/task_create_test.go
+++ b/adk/middlewares/plantask/task_create_test.go
@@ -18,7 +18,7 @@ package plantask
 
 import (
 	"context"
-	"path/filepath"
+	"path"
 	"sync"
 	"testing"
 
@@ -43,7 +43,7 @@ func TestTaskCreateTool(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Equal(t, `{"result":"Task #1 created successfully: Test Task"}`, result)
 
-	content, err := backend.Read(ctx, &ReadRequest{FilePath: filepath.Join(baseDir, "1.json")})
+	content, err := backend.Read(ctx, &ReadRequest{FilePath: path.Join(baseDir, "1.json")})
 	assert.NoError(t, err)
 
 	var taskData task
@@ -55,7 +55,7 @@ func TestTaskCreateTool(t *testing.T) {
 	assert.Equal(t, taskStatusPending, taskData.Status)
 	assert.Equal(t, "Testing", taskData.ActiveForm)
 
-	hwContent, err := backend.Read(ctx, &ReadRequest{FilePath: filepath.Join(baseDir, highWatermarkFileName)})
+	hwContent, err := backend.Read(ctx, &ReadRequest{FilePath: path.Join(baseDir, highWatermarkFileName)})
 	assert.NoError(t, err)
 	assert.Equal(t, "1", hwContent.Content)
 
@@ -63,7 +63,7 @@ func TestTaskCreateTool(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Equal(t, `{"result":"Task #2 created successfully: Second Task"}`, result)
 
-	hwContent, err = backend.Read(ctx, &ReadRequest{FilePath: filepath.Join(baseDir, highWatermarkFileName)})
+	hwContent, err = backend.Read(ctx, &ReadRequest{FilePath: path.Join(baseDir, highWatermarkFileName)})
 	assert.NoError(t, err)
 	assert.Equal(t, "2", hwContent.Content)
 }
@@ -80,7 +80,7 @@ func TestTaskCreateToolWithMetadata(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Contains(t, result, "Task #1 created successfully")
 
-	content, err := backend.Read(ctx, &ReadRequest{FilePath: filepath.Join(baseDir, "1.json")})
+	content, err := backend.Read(ctx, &ReadRequest{FilePath: path.Join(baseDir, "1.json")})
 	assert.NoError(t, err)
 
 	var taskData task

--- a/adk/middlewares/plantask/task_get.go
+++ b/adk/middlewares/plantask/task_get.go
@@ -19,7 +19,7 @@ package plantask
 import (
 	"context"
 	"fmt"
-	"path/filepath"
+	"path"
 	"strings"
 	"sync"
 
@@ -78,7 +78,7 @@ func (t *taskGetTool) InvokableRun(ctx context.Context, argumentsInJSON string, 
 	}
 
 	taskFileName := fmt.Sprintf("%s.json", params.TaskID)
-	taskFilePath := filepath.Join(t.BaseDir, taskFileName)
+	taskFilePath := path.Join(t.BaseDir, taskFileName)
 
 	content, err := t.Backend.Read(ctx, &ReadRequest{
 		FilePath: taskFilePath,

--- a/adk/middlewares/plantask/task_get_test.go
+++ b/adk/middlewares/plantask/task_get_test.go
@@ -18,7 +18,7 @@ package plantask
 
 import (
 	"context"
-	"path/filepath"
+	"path"
 	"sync"
 	"testing"
 
@@ -41,7 +41,7 @@ func TestTaskGetTool(t *testing.T) {
 		BlockedBy:   []string{"4"},
 	}
 	taskJSON, _ := sonic.MarshalString(taskData)
-	_ = backend.Write(ctx, &WriteRequest{FilePath: filepath.Join(baseDir, "1.json"), Content: taskJSON})
+	_ = backend.Write(ctx, &WriteRequest{FilePath: path.Join(baseDir, "1.json"), Content: taskJSON})
 
 	tool := newTaskGetTool(backend, baseDir, lock)
 

--- a/adk/middlewares/plantask/task_list.go
+++ b/adk/middlewares/plantask/task_list.go
@@ -19,7 +19,7 @@ package plantask
 import (
 	"context"
 	"fmt"
-	"path/filepath"
+	"path"
 	"sort"
 	"strings"
 	"sync"
@@ -64,7 +64,7 @@ func listTasks(ctx context.Context, backend Backend, baseDir string) ([]*task, e
 
 	var tasks []*task
 	for _, file := range files {
-		fileName := filepath.Base(file.Path)
+		fileName := path.Base(file.Path)
 		if !strings.HasSuffix(fileName, ".json") {
 			continue
 		}

--- a/adk/middlewares/plantask/task_list_test.go
+++ b/adk/middlewares/plantask/task_list_test.go
@@ -18,7 +18,7 @@ package plantask
 
 import (
 	"context"
-	"path/filepath"
+	"path"
 	"sync"
 	"testing"
 
@@ -45,11 +45,11 @@ func TestTaskListTool(t *testing.T) {
 
 	task1 := &task{ID: "1", Subject: "Task 1", Status: taskStatusPending, BlockedBy: []string{"2"}}
 	task1JSON, _ := sonic.MarshalString(task1)
-	_ = backend.Write(ctx, &WriteRequest{FilePath: filepath.Join(baseDir, "1.json"), Content: task1JSON})
+	_ = backend.Write(ctx, &WriteRequest{FilePath: path.Join(baseDir, "1.json"), Content: task1JSON})
 
 	task2 := &task{ID: "2", Subject: "Task 2", Status: taskStatusInProgress, Owner: "agent1"}
 	task2JSON, _ := sonic.MarshalString(task2)
-	_ = backend.Write(ctx, &WriteRequest{FilePath: filepath.Join(baseDir, "2.json"), Content: task2JSON})
+	_ = backend.Write(ctx, &WriteRequest{FilePath: path.Join(baseDir, "2.json"), Content: task2JSON})
 
 	result, err = tool.InvokableRun(ctx, `{}`)
 	assert.NoError(t, err)

--- a/adk/middlewares/plantask/task_update.go
+++ b/adk/middlewares/plantask/task_update.go
@@ -19,7 +19,7 @@ package plantask
 import (
 	"context"
 	"fmt"
-	"path/filepath"
+	"path"
 	"strings"
 	"sync"
 
@@ -134,7 +134,7 @@ func (t *taskUpdateTool) InvokableRun(ctx context.Context, argumentsInJSON strin
 	}
 
 	taskFileName := fmt.Sprintf("%s.json", params.TaskID)
-	taskFilePath := filepath.Join(t.BaseDir, taskFileName)
+	taskFilePath := path.Join(t.BaseDir, taskFileName)
 
 	if params.Status == taskStatusDeleted {
 		if removeErr := t.removeTaskFromDependencies(ctx, params.TaskID); removeErr != nil {
@@ -322,7 +322,7 @@ func (t *taskUpdateTool) removeTaskFromDependencies(ctx context.Context, deleted
 				return fmt.Errorf("failed to marshal task #%s: %w", taskData.ID, err)
 			}
 
-			taskFilePath := filepath.Join(t.BaseDir, fmt.Sprintf("%s.json", taskData.ID))
+			taskFilePath := path.Join(t.BaseDir, fmt.Sprintf("%s.json", taskData.ID))
 			if err := t.Backend.Write(ctx, &WriteRequest{FilePath: taskFilePath, Content: updatedContent}); err != nil {
 				return fmt.Errorf("failed to write task #%s: %w", taskData.ID, err)
 			}
@@ -333,7 +333,7 @@ func (t *taskUpdateTool) removeTaskFromDependencies(ctx context.Context, deleted
 }
 
 func (t *taskUpdateTool) addBlockedByToTask(ctx context.Context, targetTaskID, blockerTaskID string) error {
-	taskFilePath := filepath.Join(t.BaseDir, fmt.Sprintf("%s.json", targetTaskID))
+	taskFilePath := path.Join(t.BaseDir, fmt.Sprintf("%s.json", targetTaskID))
 
 	content, err := t.Backend.Read(ctx, &ReadRequest{FilePath: taskFilePath})
 	if err != nil {
@@ -360,7 +360,7 @@ func (t *taskUpdateTool) addBlockedByToTask(ctx context.Context, targetTaskID, b
 }
 
 func (t *taskUpdateTool) addBlocksToTask(ctx context.Context, targetTaskID, blockedTaskID string) error {
-	taskFilePath := filepath.Join(t.BaseDir, fmt.Sprintf("%s.json", targetTaskID))
+	taskFilePath := path.Join(t.BaseDir, fmt.Sprintf("%s.json", targetTaskID))
 
 	content, err := t.Backend.Read(ctx, &ReadRequest{FilePath: taskFilePath})
 	if err != nil {
@@ -401,7 +401,7 @@ func (t *taskUpdateTool) checkIfNeedDeleteAllTasks(ctx context.Context) error {
 
 	for _, task := range tasks {
 		err := t.Backend.Delete(ctx, &DeleteRequest{
-			FilePath: filepath.Join(t.BaseDir, task.ID+".json"),
+			FilePath: path.Join(t.BaseDir, task.ID+".json"),
 		})
 		if err != nil {
 			return err

--- a/adk/middlewares/plantask/task_update_test.go
+++ b/adk/middlewares/plantask/task_update_test.go
@@ -18,7 +18,7 @@ package plantask
 
 import (
 	"context"
-	"path/filepath"
+	"path"
 	"sync"
 	"testing"
 
@@ -41,7 +41,7 @@ func TestTaskUpdateTool(t *testing.T) {
 		BlockedBy:   []string{},
 	}
 	taskJSON, _ := sonic.MarshalString(taskData)
-	_ = backend.Write(ctx, &WriteRequest{FilePath: filepath.Join(baseDir, "1.json"), Content: taskJSON})
+	_ = backend.Write(ctx, &WriteRequest{FilePath: path.Join(baseDir, "1.json"), Content: taskJSON})
 
 	tool := newTaskUpdateTool(backend, baseDir, lock)
 
@@ -55,7 +55,7 @@ func TestTaskUpdateTool(t *testing.T) {
 	assert.Contains(t, result, "Updated task #1")
 	assert.Contains(t, result, "status")
 
-	content, err := backend.Read(ctx, &ReadRequest{FilePath: filepath.Join(baseDir, "1.json")})
+	content, err := backend.Read(ctx, &ReadRequest{FilePath: path.Join(baseDir, "1.json")})
 	assert.NoError(t, err)
 	var updated task
 	_ = sonic.UnmarshalString(content.Content, &updated)
@@ -66,7 +66,7 @@ func TestTaskUpdateTool(t *testing.T) {
 	assert.Contains(t, result, "subject")
 	assert.Contains(t, result, "description")
 
-	content, _ = backend.Read(ctx, &ReadRequest{FilePath: filepath.Join(baseDir, "1.json")})
+	content, _ = backend.Read(ctx, &ReadRequest{FilePath: path.Join(baseDir, "1.json")})
 	_ = sonic.UnmarshalString(content.Content, &updated)
 	assert.Equal(t, "New Subject", updated.Subject)
 	assert.Equal(t, "New description", updated.Description)
@@ -87,7 +87,7 @@ func TestTaskUpdateToolOwnerAndMetadata(t *testing.T) {
 		BlockedBy:   []string{},
 	}
 	taskJSON, _ := sonic.MarshalString(taskData)
-	_ = backend.Write(ctx, &WriteRequest{FilePath: filepath.Join(baseDir, "1.json"), Content: taskJSON})
+	_ = backend.Write(ctx, &WriteRequest{FilePath: path.Join(baseDir, "1.json"), Content: taskJSON})
 
 	tool := newTaskUpdateTool(backend, baseDir, lock)
 
@@ -95,7 +95,7 @@ func TestTaskUpdateToolOwnerAndMetadata(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Contains(t, result, "owner")
 
-	content, _ := backend.Read(ctx, &ReadRequest{FilePath: filepath.Join(baseDir, "1.json")})
+	content, _ := backend.Read(ctx, &ReadRequest{FilePath: path.Join(baseDir, "1.json")})
 	var updated task
 	_ = sonic.UnmarshalString(content.Content, &updated)
 	assert.Equal(t, "agent1", updated.Owner)
@@ -104,7 +104,7 @@ func TestTaskUpdateToolOwnerAndMetadata(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Contains(t, result, "metadata")
 
-	content, _ = backend.Read(ctx, &ReadRequest{FilePath: filepath.Join(baseDir, "1.json")})
+	content, _ = backend.Read(ctx, &ReadRequest{FilePath: path.Join(baseDir, "1.json")})
 	_ = sonic.UnmarshalString(content.Content, &updated)
 	assert.Equal(t, "value1", updated.Metadata["key1"])
 	assert.Equal(t, "value2", updated.Metadata["key2"])
@@ -112,7 +112,7 @@ func TestTaskUpdateToolOwnerAndMetadata(t *testing.T) {
 	_, err = tool.InvokableRun(ctx, `{"taskId": "1", "metadata": {"key1": null, "key3": "value3"}}`)
 	assert.NoError(t, err)
 
-	content, _ = backend.Read(ctx, &ReadRequest{FilePath: filepath.Join(baseDir, "1.json")})
+	content, _ = backend.Read(ctx, &ReadRequest{FilePath: path.Join(baseDir, "1.json")})
 	var updated2 task
 	_ = sonic.UnmarshalString(content.Content, &updated2)
 	_, key1Exists := updated2.Metadata["key1"]
@@ -136,7 +136,7 @@ func TestTaskUpdateToolBlocks(t *testing.T) {
 		BlockedBy:   []string{},
 	}
 	task1JSON, _ := sonic.MarshalString(task1)
-	_ = backend.Write(ctx, &WriteRequest{FilePath: filepath.Join(baseDir, "1.json"), Content: task1JSON})
+	_ = backend.Write(ctx, &WriteRequest{FilePath: path.Join(baseDir, "1.json"), Content: task1JSON})
 
 	task2 := &task{
 		ID:          "2",
@@ -147,7 +147,7 @@ func TestTaskUpdateToolBlocks(t *testing.T) {
 		BlockedBy:   []string{},
 	}
 	task2JSON, _ := sonic.MarshalString(task2)
-	_ = backend.Write(ctx, &WriteRequest{FilePath: filepath.Join(baseDir, "2.json"), Content: task2JSON})
+	_ = backend.Write(ctx, &WriteRequest{FilePath: path.Join(baseDir, "2.json"), Content: task2JSON})
 
 	task3 := &task{
 		ID:          "3",
@@ -158,7 +158,7 @@ func TestTaskUpdateToolBlocks(t *testing.T) {
 		BlockedBy:   []string{},
 	}
 	task3JSON, _ := sonic.MarshalString(task3)
-	_ = backend.Write(ctx, &WriteRequest{FilePath: filepath.Join(baseDir, "3.json"), Content: task3JSON})
+	_ = backend.Write(ctx, &WriteRequest{FilePath: path.Join(baseDir, "3.json"), Content: task3JSON})
 
 	task4 := &task{
 		ID:          "4",
@@ -169,7 +169,7 @@ func TestTaskUpdateToolBlocks(t *testing.T) {
 		BlockedBy:   []string{},
 	}
 	task4JSON, _ := sonic.MarshalString(task4)
-	_ = backend.Write(ctx, &WriteRequest{FilePath: filepath.Join(baseDir, "4.json"), Content: task4JSON})
+	_ = backend.Write(ctx, &WriteRequest{FilePath: path.Join(baseDir, "4.json"), Content: task4JSON})
 
 	tool := newTaskUpdateTool(backend, baseDir, lock)
 
@@ -177,7 +177,7 @@ func TestTaskUpdateToolBlocks(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Contains(t, result, "blocks")
 
-	content, _ := backend.Read(ctx, &ReadRequest{FilePath: filepath.Join(baseDir, "1.json")})
+	content, _ := backend.Read(ctx, &ReadRequest{FilePath: path.Join(baseDir, "1.json")})
 	var updated task
 	_ = sonic.UnmarshalString(content.Content, &updated)
 	assert.Equal(t, []string{"2", "3"}, updated.Blocks)
@@ -186,7 +186,7 @@ func TestTaskUpdateToolBlocks(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Contains(t, result, "blockedBy")
 
-	content, _ = backend.Read(ctx, &ReadRequest{FilePath: filepath.Join(baseDir, "1.json")})
+	content, _ = backend.Read(ctx, &ReadRequest{FilePath: path.Join(baseDir, "1.json")})
 	_ = sonic.UnmarshalString(content.Content, &updated)
 	assert.Equal(t, []string{"4"}, updated.BlockedBy)
 }
@@ -204,7 +204,7 @@ func TestTaskUpdateToolDelete(t *testing.T) {
 		Status:      taskStatusPending,
 	}
 	taskJSON, _ := sonic.MarshalString(taskData)
-	_ = backend.Write(ctx, &WriteRequest{FilePath: filepath.Join(baseDir, "1.json"), Content: taskJSON})
+	_ = backend.Write(ctx, &WriteRequest{FilePath: path.Join(baseDir, "1.json"), Content: taskJSON})
 
 	tool := newTaskUpdateTool(backend, baseDir, lock)
 
@@ -212,7 +212,7 @@ func TestTaskUpdateToolDelete(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Contains(t, result, "deleted")
 
-	_, err = backend.Read(ctx, &ReadRequest{FilePath: filepath.Join(baseDir, "1.json")})
+	_, err = backend.Read(ctx, &ReadRequest{FilePath: path.Join(baseDir, "1.json")})
 	assert.Error(t, err)
 }
 
@@ -245,7 +245,7 @@ func TestTaskUpdateToolInvalidTaskID(t *testing.T) {
 		BlockedBy:   []string{},
 	}
 	task1JSON, _ := sonic.MarshalString(task1)
-	_ = backend.Write(ctx, &WriteRequest{FilePath: filepath.Join(baseDir, "1.json"), Content: task1JSON})
+	_ = backend.Write(ctx, &WriteRequest{FilePath: path.Join(baseDir, "1.json"), Content: task1JSON})
 
 	_, err = tool.InvokableRun(ctx, `{"taskId": "1", "addBlocks": ["invalid"]}`)
 	assert.Error(t, err)
@@ -271,7 +271,7 @@ func TestTaskUpdateToolBlocksDeduplication(t *testing.T) {
 		BlockedBy:   []string{},
 	}
 	task1JSON, _ := sonic.MarshalString(task1)
-	_ = backend.Write(ctx, &WriteRequest{FilePath: filepath.Join(baseDir, "1.json"), Content: task1JSON})
+	_ = backend.Write(ctx, &WriteRequest{FilePath: path.Join(baseDir, "1.json"), Content: task1JSON})
 
 	task2 := &task{
 		ID:          "2",
@@ -282,7 +282,7 @@ func TestTaskUpdateToolBlocksDeduplication(t *testing.T) {
 		BlockedBy:   []string{"1"},
 	}
 	task2JSON, _ := sonic.MarshalString(task2)
-	_ = backend.Write(ctx, &WriteRequest{FilePath: filepath.Join(baseDir, "2.json"), Content: task2JSON})
+	_ = backend.Write(ctx, &WriteRequest{FilePath: path.Join(baseDir, "2.json"), Content: task2JSON})
 
 	task3 := &task{
 		ID:          "3",
@@ -293,7 +293,7 @@ func TestTaskUpdateToolBlocksDeduplication(t *testing.T) {
 		BlockedBy:   []string{},
 	}
 	task3JSON, _ := sonic.MarshalString(task3)
-	_ = backend.Write(ctx, &WriteRequest{FilePath: filepath.Join(baseDir, "3.json"), Content: task3JSON})
+	_ = backend.Write(ctx, &WriteRequest{FilePath: path.Join(baseDir, "3.json"), Content: task3JSON})
 
 	task4 := &task{
 		ID:          "4",
@@ -304,7 +304,7 @@ func TestTaskUpdateToolBlocksDeduplication(t *testing.T) {
 		BlockedBy:   []string{},
 	}
 	task4JSON, _ := sonic.MarshalString(task4)
-	_ = backend.Write(ctx, &WriteRequest{FilePath: filepath.Join(baseDir, "4.json"), Content: task4JSON})
+	_ = backend.Write(ctx, &WriteRequest{FilePath: path.Join(baseDir, "4.json"), Content: task4JSON})
 
 	task5 := &task{
 		ID:          "5",
@@ -315,14 +315,14 @@ func TestTaskUpdateToolBlocksDeduplication(t *testing.T) {
 		BlockedBy:   []string{},
 	}
 	task5JSON, _ := sonic.MarshalString(task5)
-	_ = backend.Write(ctx, &WriteRequest{FilePath: filepath.Join(baseDir, "5.json"), Content: task5JSON})
+	_ = backend.Write(ctx, &WriteRequest{FilePath: path.Join(baseDir, "5.json"), Content: task5JSON})
 
 	tool := newTaskUpdateTool(backend, baseDir, lock)
 
 	_, err := tool.InvokableRun(ctx, `{"taskId": "1", "addBlocks": ["2", "4", "4"]}`)
 	assert.NoError(t, err)
 
-	content, _ := backend.Read(ctx, &ReadRequest{FilePath: filepath.Join(baseDir, "1.json")})
+	content, _ := backend.Read(ctx, &ReadRequest{FilePath: path.Join(baseDir, "1.json")})
 	var updated task
 	_ = sonic.UnmarshalString(content.Content, &updated)
 	assert.Equal(t, []string{"2", "4"}, updated.Blocks)
@@ -330,7 +330,7 @@ func TestTaskUpdateToolBlocksDeduplication(t *testing.T) {
 	_, err = tool.InvokableRun(ctx, `{"taskId": "1", "addBlockedBy": ["3", "5", "5"]}`)
 	assert.NoError(t, err)
 
-	content, _ = backend.Read(ctx, &ReadRequest{FilePath: filepath.Join(baseDir, "1.json")})
+	content, _ = backend.Read(ctx, &ReadRequest{FilePath: path.Join(baseDir, "1.json")})
 	_ = sonic.UnmarshalString(content.Content, &updated)
 	assert.Equal(t, []string{"3", "5"}, updated.BlockedBy)
 }
@@ -350,7 +350,7 @@ func TestTaskUpdateToolBidirectionalBlocks(t *testing.T) {
 		BlockedBy:   []string{},
 	}
 	task1JSON, _ := sonic.MarshalString(task1)
-	_ = backend.Write(ctx, &WriteRequest{FilePath: filepath.Join(baseDir, "1.json"), Content: task1JSON})
+	_ = backend.Write(ctx, &WriteRequest{FilePath: path.Join(baseDir, "1.json"), Content: task1JSON})
 
 	task2 := &task{
 		ID:          "2",
@@ -361,7 +361,7 @@ func TestTaskUpdateToolBidirectionalBlocks(t *testing.T) {
 		BlockedBy:   []string{},
 	}
 	task2JSON, _ := sonic.MarshalString(task2)
-	_ = backend.Write(ctx, &WriteRequest{FilePath: filepath.Join(baseDir, "2.json"), Content: task2JSON})
+	_ = backend.Write(ctx, &WriteRequest{FilePath: path.Join(baseDir, "2.json"), Content: task2JSON})
 
 	task3 := &task{
 		ID:          "3",
@@ -372,26 +372,26 @@ func TestTaskUpdateToolBidirectionalBlocks(t *testing.T) {
 		BlockedBy:   []string{},
 	}
 	task3JSON, _ := sonic.MarshalString(task3)
-	_ = backend.Write(ctx, &WriteRequest{FilePath: filepath.Join(baseDir, "3.json"), Content: task3JSON})
+	_ = backend.Write(ctx, &WriteRequest{FilePath: path.Join(baseDir, "3.json"), Content: task3JSON})
 
 	tool := newTaskUpdateTool(backend, baseDir, lock)
 
 	_, err := tool.InvokableRun(ctx, `{"taskId": "1", "addBlocks": ["2", "3"]}`)
 	assert.NoError(t, err)
 
-	content1, _ := backend.Read(ctx, &ReadRequest{FilePath: filepath.Join(baseDir, "1.json")})
+	content1, _ := backend.Read(ctx, &ReadRequest{FilePath: path.Join(baseDir, "1.json")})
 	var updatedTask1 task
 	_ = sonic.UnmarshalString(content1.Content, &updatedTask1)
 	assert.Equal(t, []string{"2", "3"}, updatedTask1.Blocks)
 	assert.Empty(t, updatedTask1.BlockedBy)
 
-	content2, _ := backend.Read(ctx, &ReadRequest{FilePath: filepath.Join(baseDir, "2.json")})
+	content2, _ := backend.Read(ctx, &ReadRequest{FilePath: path.Join(baseDir, "2.json")})
 	var updatedTask2 task
 	_ = sonic.UnmarshalString(content2.Content, &updatedTask2)
 	assert.Empty(t, updatedTask2.Blocks)
 	assert.Equal(t, []string{"1"}, updatedTask2.BlockedBy)
 
-	content3, _ := backend.Read(ctx, &ReadRequest{FilePath: filepath.Join(baseDir, "3.json")})
+	content3, _ := backend.Read(ctx, &ReadRequest{FilePath: path.Join(baseDir, "3.json")})
 	var updatedTask3 task
 	_ = sonic.UnmarshalString(content3.Content, &updatedTask3)
 	assert.Empty(t, updatedTask3.Blocks)
@@ -413,7 +413,7 @@ func TestTaskUpdateToolBidirectionalBlockedBy(t *testing.T) {
 		BlockedBy:   []string{},
 	}
 	task1JSON, _ := sonic.MarshalString(task1)
-	_ = backend.Write(ctx, &WriteRequest{FilePath: filepath.Join(baseDir, "1.json"), Content: task1JSON})
+	_ = backend.Write(ctx, &WriteRequest{FilePath: path.Join(baseDir, "1.json"), Content: task1JSON})
 
 	task2 := &task{
 		ID:          "2",
@@ -424,7 +424,7 @@ func TestTaskUpdateToolBidirectionalBlockedBy(t *testing.T) {
 		BlockedBy:   []string{},
 	}
 	task2JSON, _ := sonic.MarshalString(task2)
-	_ = backend.Write(ctx, &WriteRequest{FilePath: filepath.Join(baseDir, "2.json"), Content: task2JSON})
+	_ = backend.Write(ctx, &WriteRequest{FilePath: path.Join(baseDir, "2.json"), Content: task2JSON})
 
 	task3 := &task{
 		ID:          "3",
@@ -435,26 +435,26 @@ func TestTaskUpdateToolBidirectionalBlockedBy(t *testing.T) {
 		BlockedBy:   []string{},
 	}
 	task3JSON, _ := sonic.MarshalString(task3)
-	_ = backend.Write(ctx, &WriteRequest{FilePath: filepath.Join(baseDir, "3.json"), Content: task3JSON})
+	_ = backend.Write(ctx, &WriteRequest{FilePath: path.Join(baseDir, "3.json"), Content: task3JSON})
 
 	tool := newTaskUpdateTool(backend, baseDir, lock)
 
 	_, err := tool.InvokableRun(ctx, `{"taskId": "3", "addBlockedBy": ["1", "2"]}`)
 	assert.NoError(t, err)
 
-	content3, _ := backend.Read(ctx, &ReadRequest{FilePath: filepath.Join(baseDir, "3.json")})
+	content3, _ := backend.Read(ctx, &ReadRequest{FilePath: path.Join(baseDir, "3.json")})
 	var updatedTask3 task
 	_ = sonic.UnmarshalString(content3.Content, &updatedTask3)
 	assert.Empty(t, updatedTask3.Blocks)
 	assert.Equal(t, []string{"1", "2"}, updatedTask3.BlockedBy)
 
-	content1, _ := backend.Read(ctx, &ReadRequest{FilePath: filepath.Join(baseDir, "1.json")})
+	content1, _ := backend.Read(ctx, &ReadRequest{FilePath: path.Join(baseDir, "1.json")})
 	var updatedTask1 task
 	_ = sonic.UnmarshalString(content1.Content, &updatedTask1)
 	assert.Equal(t, []string{"3"}, updatedTask1.Blocks)
 	assert.Empty(t, updatedTask1.BlockedBy)
 
-	content2, _ := backend.Read(ctx, &ReadRequest{FilePath: filepath.Join(baseDir, "2.json")})
+	content2, _ := backend.Read(ctx, &ReadRequest{FilePath: path.Join(baseDir, "2.json")})
 	var updatedTask2 task
 	_ = sonic.UnmarshalString(content2.Content, &updatedTask2)
 	assert.Equal(t, []string{"3"}, updatedTask2.Blocks)
@@ -476,7 +476,7 @@ func TestTaskUpdateToolBidirectionalWithNonExistentTask(t *testing.T) {
 		BlockedBy:   []string{},
 	}
 	task1JSON, _ := sonic.MarshalString(task1)
-	_ = backend.Write(ctx, &WriteRequest{FilePath: filepath.Join(baseDir, "1.json"), Content: task1JSON})
+	_ = backend.Write(ctx, &WriteRequest{FilePath: path.Join(baseDir, "1.json"), Content: task1JSON})
 
 	tool := newTaskUpdateTool(backend, baseDir, lock)
 
@@ -504,7 +504,7 @@ func TestTaskUpdateToolCyclicDependencyDetection(t *testing.T) {
 		BlockedBy:   []string{},
 	}
 	task1JSON, _ := sonic.MarshalString(task1)
-	_ = backend.Write(ctx, &WriteRequest{FilePath: filepath.Join(baseDir, "1.json"), Content: task1JSON})
+	_ = backend.Write(ctx, &WriteRequest{FilePath: path.Join(baseDir, "1.json"), Content: task1JSON})
 
 	task2 := &task{
 		ID:          "2",
@@ -515,7 +515,7 @@ func TestTaskUpdateToolCyclicDependencyDetection(t *testing.T) {
 		BlockedBy:   []string{},
 	}
 	task2JSON, _ := sonic.MarshalString(task2)
-	_ = backend.Write(ctx, &WriteRequest{FilePath: filepath.Join(baseDir, "2.json"), Content: task2JSON})
+	_ = backend.Write(ctx, &WriteRequest{FilePath: path.Join(baseDir, "2.json"), Content: task2JSON})
 
 	task3 := &task{
 		ID:          "3",
@@ -526,7 +526,7 @@ func TestTaskUpdateToolCyclicDependencyDetection(t *testing.T) {
 		BlockedBy:   []string{},
 	}
 	task3JSON, _ := sonic.MarshalString(task3)
-	_ = backend.Write(ctx, &WriteRequest{FilePath: filepath.Join(baseDir, "3.json"), Content: task3JSON})
+	_ = backend.Write(ctx, &WriteRequest{FilePath: path.Join(baseDir, "3.json"), Content: task3JSON})
 
 	tool := newTaskUpdateTool(backend, baseDir, lock)
 
@@ -560,19 +560,19 @@ func TestTaskUpdateToolCyclicDependencyDetection(t *testing.T) {
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "cyclic dependency")
 
-	content1, _ := backend.Read(ctx, &ReadRequest{FilePath: filepath.Join(baseDir, "1.json")})
+	content1, _ := backend.Read(ctx, &ReadRequest{FilePath: path.Join(baseDir, "1.json")})
 	var updatedTask1 task
 	_ = sonic.UnmarshalString(content1.Content, &updatedTask1)
 	assert.Equal(t, []string{"2"}, updatedTask1.Blocks)
 	assert.Empty(t, updatedTask1.BlockedBy)
 
-	content2, _ := backend.Read(ctx, &ReadRequest{FilePath: filepath.Join(baseDir, "2.json")})
+	content2, _ := backend.Read(ctx, &ReadRequest{FilePath: path.Join(baseDir, "2.json")})
 	var updatedTask2 task
 	_ = sonic.UnmarshalString(content2.Content, &updatedTask2)
 	assert.Equal(t, []string{"3"}, updatedTask2.Blocks)
 	assert.Equal(t, []string{"1"}, updatedTask2.BlockedBy)
 
-	content3, _ := backend.Read(ctx, &ReadRequest{FilePath: filepath.Join(baseDir, "3.json")})
+	content3, _ := backend.Read(ctx, &ReadRequest{FilePath: path.Join(baseDir, "3.json")})
 	var updatedTask3 task
 	_ = sonic.UnmarshalString(content3.Content, &updatedTask3)
 	assert.Empty(t, updatedTask3.Blocks)
@@ -594,7 +594,7 @@ func TestTaskUpdateToolDeleteCleansDependencies(t *testing.T) {
 		BlockedBy:   []string{},
 	}
 	task1JSON, _ := sonic.MarshalString(task1)
-	_ = backend.Write(ctx, &WriteRequest{FilePath: filepath.Join(baseDir, "1.json"), Content: task1JSON})
+	_ = backend.Write(ctx, &WriteRequest{FilePath: path.Join(baseDir, "1.json"), Content: task1JSON})
 
 	task2 := &task{
 		ID:          "2",
@@ -605,7 +605,7 @@ func TestTaskUpdateToolDeleteCleansDependencies(t *testing.T) {
 		BlockedBy:   []string{"1"},
 	}
 	task2JSON, _ := sonic.MarshalString(task2)
-	_ = backend.Write(ctx, &WriteRequest{FilePath: filepath.Join(baseDir, "2.json"), Content: task2JSON})
+	_ = backend.Write(ctx, &WriteRequest{FilePath: path.Join(baseDir, "2.json"), Content: task2JSON})
 
 	task3 := &task{
 		ID:          "3",
@@ -616,7 +616,7 @@ func TestTaskUpdateToolDeleteCleansDependencies(t *testing.T) {
 		BlockedBy:   []string{"1", "2"},
 	}
 	task3JSON, _ := sonic.MarshalString(task3)
-	_ = backend.Write(ctx, &WriteRequest{FilePath: filepath.Join(baseDir, "3.json"), Content: task3JSON})
+	_ = backend.Write(ctx, &WriteRequest{FilePath: path.Join(baseDir, "3.json"), Content: task3JSON})
 
 	tool := newTaskUpdateTool(backend, baseDir, lock)
 
@@ -624,17 +624,17 @@ func TestTaskUpdateToolDeleteCleansDependencies(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Contains(t, result, "deleted")
 
-	_, err = backend.Read(ctx, &ReadRequest{FilePath: filepath.Join(baseDir, "1.json")})
+	_, err = backend.Read(ctx, &ReadRequest{FilePath: path.Join(baseDir, "1.json")})
 	assert.Error(t, err)
 
-	content2, err := backend.Read(ctx, &ReadRequest{FilePath: filepath.Join(baseDir, "2.json")})
+	content2, err := backend.Read(ctx, &ReadRequest{FilePath: path.Join(baseDir, "2.json")})
 	assert.NoError(t, err)
 	var updatedTask2 task
 	_ = sonic.UnmarshalString(content2.Content, &updatedTask2)
 	assert.Equal(t, []string{"3"}, updatedTask2.Blocks)
 	assert.Empty(t, updatedTask2.BlockedBy)
 
-	content3, err := backend.Read(ctx, &ReadRequest{FilePath: filepath.Join(baseDir, "3.json")})
+	content3, err := backend.Read(ctx, &ReadRequest{FilePath: path.Join(baseDir, "3.json")})
 	assert.NoError(t, err)
 	var updatedTask3 task
 	_ = sonic.UnmarshalString(content3.Content, &updatedTask3)
@@ -657,7 +657,7 @@ func TestTaskUpdateToolAutoDeleteAllTasksWhenAllCompleted(t *testing.T) {
 		BlockedBy:   []string{},
 	}
 	task1JSON, _ := sonic.MarshalString(task1)
-	_ = backend.Write(ctx, &WriteRequest{FilePath: filepath.Join(baseDir, "1.json"), Content: task1JSON})
+	_ = backend.Write(ctx, &WriteRequest{FilePath: path.Join(baseDir, "1.json"), Content: task1JSON})
 
 	task2 := &task{
 		ID:          "2",
@@ -668,7 +668,7 @@ func TestTaskUpdateToolAutoDeleteAllTasksWhenAllCompleted(t *testing.T) {
 		BlockedBy:   []string{},
 	}
 	task2JSON, _ := sonic.MarshalString(task2)
-	_ = backend.Write(ctx, &WriteRequest{FilePath: filepath.Join(baseDir, "2.json"), Content: task2JSON})
+	_ = backend.Write(ctx, &WriteRequest{FilePath: path.Join(baseDir, "2.json"), Content: task2JSON})
 
 	task3 := &task{
 		ID:          "3",
@@ -679,18 +679,18 @@ func TestTaskUpdateToolAutoDeleteAllTasksWhenAllCompleted(t *testing.T) {
 		BlockedBy:   []string{},
 	}
 	task3JSON, _ := sonic.MarshalString(task3)
-	_ = backend.Write(ctx, &WriteRequest{FilePath: filepath.Join(baseDir, "3.json"), Content: task3JSON})
+	_ = backend.Write(ctx, &WriteRequest{FilePath: path.Join(baseDir, "3.json"), Content: task3JSON})
 
 	tool := newTaskUpdateTool(backend, baseDir, lock)
 
 	_, err := tool.InvokableRun(ctx, `{"taskId": "3", "status": "completed"}`)
 	assert.NoError(t, err)
 
-	_, err = backend.Read(ctx, &ReadRequest{FilePath: filepath.Join(baseDir, "1.json")})
+	_, err = backend.Read(ctx, &ReadRequest{FilePath: path.Join(baseDir, "1.json")})
 	assert.Error(t, err)
-	_, err = backend.Read(ctx, &ReadRequest{FilePath: filepath.Join(baseDir, "2.json")})
+	_, err = backend.Read(ctx, &ReadRequest{FilePath: path.Join(baseDir, "2.json")})
 	assert.Error(t, err)
-	_, err = backend.Read(ctx, &ReadRequest{FilePath: filepath.Join(baseDir, "3.json")})
+	_, err = backend.Read(ctx, &ReadRequest{FilePath: path.Join(baseDir, "3.json")})
 	assert.Error(t, err)
 }
 
@@ -709,7 +709,7 @@ func TestTaskUpdateToolNoDeleteWhenNotAllCompleted(t *testing.T) {
 		BlockedBy:   []string{},
 	}
 	task1JSON, _ := sonic.MarshalString(task1)
-	_ = backend.Write(ctx, &WriteRequest{FilePath: filepath.Join(baseDir, "1.json"), Content: task1JSON})
+	_ = backend.Write(ctx, &WriteRequest{FilePath: path.Join(baseDir, "1.json"), Content: task1JSON})
 
 	task2 := &task{
 		ID:          "2",
@@ -720,19 +720,19 @@ func TestTaskUpdateToolNoDeleteWhenNotAllCompleted(t *testing.T) {
 		BlockedBy:   []string{},
 	}
 	task2JSON, _ := sonic.MarshalString(task2)
-	_ = backend.Write(ctx, &WriteRequest{FilePath: filepath.Join(baseDir, "2.json"), Content: task2JSON})
+	_ = backend.Write(ctx, &WriteRequest{FilePath: path.Join(baseDir, "2.json"), Content: task2JSON})
 
 	tool := newTaskUpdateTool(backend, baseDir, lock)
 
 	_, err := tool.InvokableRun(ctx, `{"taskId": "1", "status": "completed"}`)
 	assert.NoError(t, err)
 
-	_, err = backend.Read(ctx, &ReadRequest{FilePath: filepath.Join(baseDir, "1.json")})
+	_, err = backend.Read(ctx, &ReadRequest{FilePath: path.Join(baseDir, "1.json")})
 	assert.NoError(t, err)
-	_, err = backend.Read(ctx, &ReadRequest{FilePath: filepath.Join(baseDir, "2.json")})
+	_, err = backend.Read(ctx, &ReadRequest{FilePath: path.Join(baseDir, "2.json")})
 	assert.NoError(t, err)
 
-	content1, _ := backend.Read(ctx, &ReadRequest{FilePath: filepath.Join(baseDir, "1.json")})
+	content1, _ := backend.Read(ctx, &ReadRequest{FilePath: path.Join(baseDir, "1.json")})
 	var updatedTask1 task
 	_ = sonic.UnmarshalString(content1.Content, &updatedTask1)
 	assert.Equal(t, taskStatusCompleted, updatedTask1.Status)

--- a/adk/middlewares/reduction/reduction.go
+++ b/adk/middlewares/reduction/reduction.go
@@ -21,7 +21,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"path/filepath"
+	"path"
 	"strings"
 	"unicode/utf8"
 
@@ -272,7 +272,7 @@ func (t *TypedConfig[M]) copyAndFillDefaults() (*TypedConfig[M], error) {
 			if tcID == "" {
 				tcID = uuid.NewString()
 			}
-			return filepath.Join(cfg.RootDir, "trunc", tcID), nil
+			return path.Join(cfg.RootDir, "trunc", tcID), nil
 		}
 	}
 	if cfg.GenClearOffloadFilePath == nil {
@@ -281,7 +281,7 @@ func (t *TypedConfig[M]) copyAndFillDefaults() (*TypedConfig[M], error) {
 			if tcID == "" {
 				tcID = uuid.NewString()
 			}
-			return filepath.Join(cfg.RootDir, "clear", tcID), nil
+			return path.Join(cfg.RootDir, "clear", tcID), nil
 		}
 	}
 	if cfg.MaxLengthForTrunc == 0 {

--- a/adk/middlewares/skill/filesystem_backend.go
+++ b/adk/middlewares/skill/filesystem_backend.go
@@ -19,7 +19,7 @@ package skill
 import (
 	"context"
 	"fmt"
-	"path/filepath"
+	"path"
 	"strings"
 
 	"gopkg.in/yaml.v3"
@@ -106,8 +106,8 @@ func (b *filesystemBackend) list(ctx context.Context) ([]Skill, error) {
 
 	for _, entry := range entries {
 		filePath := entry.Path
-		if !filepath.IsAbs(filePath) {
-			filePath = filepath.Join(b.baseDir, filePath)
+		if !path.IsAbs(filePath) {
+			filePath = path.Join(b.baseDir, filePath)
 		}
 		skill, loadErr := b.loadSkillFromFile(ctx, filePath)
 		if loadErr != nil {
@@ -120,9 +120,9 @@ func (b *filesystemBackend) list(ctx context.Context) ([]Skill, error) {
 	return skills, nil
 }
 
-func (b *filesystemBackend) loadSkillFromFile(ctx context.Context, path string) (Skill, error) {
+func (b *filesystemBackend) loadSkillFromFile(ctx context.Context, filePath string) (Skill, error) {
 	fileContent, err := b.backend.Read(ctx, &filesystem.ReadRequest{
-		FilePath: path,
+		FilePath: filePath,
 	})
 	if err != nil {
 		return Skill{}, fmt.Errorf("failed to read file: %w", err)
@@ -140,7 +140,7 @@ func (b *filesystemBackend) loadSkillFromFile(ctx context.Context, path string) 
 		return Skill{}, fmt.Errorf("failed to unmarshal frontmatter: %w", err)
 	}
 
-	absDir := filepath.Dir(path)
+	absDir := path.Dir(filePath)
 
 	return Skill{
 		FrontMatter:   fm,


### PR DESCRIPTION
#### What type of PR is this?

fix: A bug fix

#### Check the PR title.

- [x] This PR title match the format: \<type\>(optional scope): \<description\>
- [x] The description of this PR title is user-oriented and clear enough for others to understand.
- [ ] Attach the PR updating the user documentation if the current PR requires user awareness at the usage level.
  - Not applicable: no API or documented behaviour change; the same paths simply resolve identically on every platform now.

#### (Optional) Translate the PR title into Chinese.

fix(adk): 虚拟文件系统路径统一使用 slash 语义，修复 Windows 下 InMemoryBackend 及其中间件读不到文件

#### (Optional) More detailed description for this PR(en: English/zh: Chinese).

en:

`filesystem.Backend` paths are virtual and slash-separated — `InMemoryBackend`'s glob and prefix matching hard-code `/` (`strings.TrimPrefix(path, base+"/")`, `doublestar.Match`) — but the paths were built and cleaned with `path/filepath`, which rewrites separators to the host's. On Windows a stored `/skills/my-skill/SKILL.md` became `\skills\my-skill\SKILL.md` while matching still assumed `/`, so the backend returned an empty result set instead of the file, and the middlewares that read/write through it stopped finding files they had just written.

Two commits:

1. `adk/filesystem`: `normalizePath` and the `Base`/`Ext` call sites use the slash-only `path` package. The local identifier that shadowed the `path` import is renamed (that shadowing is the likely reason `filepath` was reached for originally).
2. `middlewares`: the same treatment for the call sites that build virtual paths — `skill`, `agentsmd`, `filesystem`, `plantask`, `reduction` — plus the test helpers and fixtures that construct virtual paths for the in-memory backend.

`filepath` is still used where it is correct: `adk/prebuilt/deep` reads testdata from, and writes to, the real filesystem.

Evidence (Windows, go1.26.2):

Before, seven packages failed:

```
FAIL github.com/cloudwego/eino/adk/filesystem
FAIL github.com/cloudwego/eino/adk/middlewares/agentsmd
FAIL github.com/cloudwego/eino/adk/middlewares/filesystem
FAIL github.com/cloudwego/eino/adk/middlewares/plantask
FAIL github.com/cloudwego/eino/adk/middlewares/reduction
FAIL github.com/cloudwego/eino/adk/middlewares/skill
```

After: those packages pass, and `go test ./... -count=1` on Windows reports no failures. `go vet ./adk/...` and `gofmt -l` are clean on the touched files.

On Linux and macOS `path.Clean == filepath.Clean` for slash paths, so behaviour there is unchanged by construction; CI on `ubuntu-latest` should stay green. That also means upstream CI could not have caught this, which is why a repro on Windows is included in the issue.

zh(optional):

`filesystem.Backend` 的路径是虚拟的、以 `/` 分隔的（`InMemoryBackend` 的 glob 与前缀匹配都硬编码 `/`），但这些路径却用 `path/filepath` 拼接与归一化，导致 Windows 上分隔符被改写，后端匹配不到任何文件，中间件写入的文件随后也"找不到"。修复方式：把 `adk/filesystem` 与 5 个中间件（skill/agentsmd/filesystem/plantask/reduction）以及构建虚拟路径的测试辅助代码统一改用只处理 `/` 的 `path` 包；`adk/prebuilt/deep` 中真正读写磁盘的地方保持 `filepath` 不变。

#### (Optional) Which issue(s) this PR fixes:

Fixes #1281
